### PR TITLE
Remove context.TODO and add context parameter

### DIFF
--- a/cmd/rook/ceph/cleanup.go
+++ b/cmd/rook/ceph/cleanup.go
@@ -59,6 +59,8 @@ func startCleanUp(cmd *cobra.Command, args []string) error {
 	rook.SetLogLevel()
 	rook.LogStartupInfo(cleanUpCmd.Flags())
 
+	ctx := cmd.Context()
+
 	logger.Info("starting cluster clean up")
 	// Delete dataDirHostPath
 	if dataDirHostPath != "" {
@@ -67,7 +69,7 @@ func startCleanUp(cmd *cobra.Command, args []string) error {
 	}
 
 	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
-	clusterInfo := client.AdminClusterInfo(namespace, "")
+	clusterInfo := client.AdminClusterInfo(ctx, namespace, "")
 	clusterInfo.FSID = clusterFSID
 
 	// Build Sanitizer

--- a/cmd/rook/discover.go
+++ b/cmd/rook/discover.go
@@ -51,8 +51,9 @@ func startDiscover(cmd *cobra.Command, args []string) error {
 	rook.LogStartupInfo(discoverCmd.Flags())
 
 	context := rook.NewContext()
+	ctx := cmd.Context()
 
-	err := discover.Run(context, discoverDevicesInterval, usesCVInventory)
+	err := discover.Run(ctx, context, discoverDevicesInterval, usesCVInventory)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -165,7 +165,7 @@ func (c *CephToolCommand) run() ([]byte, error) {
 	// Still forcing the check for the command if the behavior changes in the future
 	if command == RBDTool {
 		if c.RemoteExecution {
-			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
+			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
 			if stderr != "" || err != nil {
 				err = errors.Errorf("%s. %s", err.Error(), stderr)
 			}

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -89,7 +89,7 @@ func (c *ClusterInfo) NamespacedName() types.NamespacedName {
 
 // AdminClusterInfo() creates a ClusterInfo with the basic info to access the cluster
 // as an admin.
-func AdminClusterInfo(namespace, name string) *ClusterInfo {
+func AdminClusterInfo(ctx context.Context, namespace, name string) *ClusterInfo {
 	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(&metav1.OwnerReference{}, "")
 	return &ClusterInfo{
 		Namespace: namespace,
@@ -98,14 +98,14 @@ func AdminClusterInfo(namespace, name string) *ClusterInfo {
 		},
 		name:      name,
 		OwnerInfo: ownerInfo,
-		Context:   context.TODO(),
+		Context:   ctx,
 	}
 }
 
 // AdminTestClusterInfo() creates a ClusterInfo with the basic info to access the cluster
 // as an admin. This cluster info should only be used by unit or integration tests.
 func AdminTestClusterInfo(namespace string) *ClusterInfo {
-	return AdminClusterInfo(namespace, "testing")
+	return AdminClusterInfo(context.TODO(), namespace, "testing")
 }
 
 // IsInitialized returns true if the critical information in the ClusterInfo struct has been filled

--- a/pkg/daemon/ceph/osd/kms/kms.go
+++ b/pkg/daemon/ceph/osd/kms/kms.go
@@ -86,7 +86,7 @@ func (c *Config) PutSecret(secretName, secretValue string) error {
 	}
 	if c.IsVault() {
 		// Store the secret in Vault
-		v, err := InitVault(c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
+		v, err := InitVault(c.ClusterInfo.Context, c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
 		if err != nil {
 			return errors.Wrap(err, "failed to init vault kms")
 		}
@@ -123,7 +123,7 @@ func (c *Config) GetSecret(secretName string) (string, error) {
 	var value string
 	if c.IsVault() {
 		// Store the secret in Vault
-		v, err := InitVault(c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
+		v, err := InitVault(c.ClusterInfo.Context, c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to init vault")
 		}
@@ -153,7 +153,7 @@ func (c *Config) GetSecret(secretName string) (string, error) {
 func (c *Config) DeleteSecret(secretName string) error {
 	if c.IsVault() {
 		// Store the secret in Vault
-		v, err := InitVault(c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
+		v, err := InitVault(c.ClusterInfo.Context, c.context, c.ClusterInfo.Namespace, c.clusterSpec.Security.KeyManagementService.ConnectionDetails)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete secret in vault")
 		}
@@ -263,7 +263,7 @@ func ValidateConnectionDetails(ctx context.Context, clusterdContext *clusterd.Co
 	// Validate KMS provider connection details for each provider
 	switch provider {
 	case secrets.TypeVault:
-		err := validateVaultConnectionDetails(clusterdContext, ns, securitySpec.KeyManagementService.ConnectionDetails)
+		err := validateVaultConnectionDetails(ctx, clusterdContext, ns, securitySpec.KeyManagementService.ConnectionDetails)
 		if err != nil {
 			return errors.Wrap(err, "failed to validate vault connection details")
 		}
@@ -273,7 +273,7 @@ func ValidateConnectionDetails(ctx context.Context, clusterdContext *clusterd.Co
 		case VaultKVSecretEngineKey:
 			// Append Backend Version if not already present
 			if GetParam(securitySpec.KeyManagementService.ConnectionDetails, vault.VaultBackendKey) == "" {
-				backendVersion, err := BackendVersion(clusterdContext, ns, securitySpec.KeyManagementService.ConnectionDetails)
+				backendVersion, err := BackendVersion(ctx, clusterdContext, ns, securitySpec.KeyManagementService.ConnectionDetails)
 				if err != nil {
 					return errors.Wrap(err, "failed to get backend version")
 				}

--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -75,7 +75,7 @@ type removeCertFilesFunction func()
 */
 
 // InitVault inits the secret store
-func InitVault(context *clusterd.Context, namespace string, config map[string]string) (secrets.Secrets, error) {
+func InitVault(ctx context.Context, context *clusterd.Context, namespace string, config map[string]string) (secrets.Secrets, error) {
 	c := make(map[string]interface{})
 
 	// So that we don't alter the content of c.config for later iterations
@@ -86,7 +86,7 @@ func InitVault(context *clusterd.Context, namespace string, config map[string]st
 	}
 
 	// Populate TLS config
-	newConfigWithTLS, removeCertFiles, err := configTLS(context, namespace, oriConfig)
+	newConfigWithTLS, removeCertFiles, err := configTLS(ctx, context, namespace, oriConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize vault tls configuration")
 	}
@@ -111,8 +111,7 @@ func InitVault(context *clusterd.Context, namespace string, config map[string]st
 // The signature has named result parameters to help building 'defer' statements especially for the
 // content of removeCertFiles which needs to be populated by the files to remove if no errors and be
 // nil on errors
-func configTLS(clusterdContext *clusterd.Context, namespace string, config map[string]string) (newConfig map[string]string, removeCertFiles removeCertFilesFunction, retErr error) {
-	ctx := context.TODO()
+func configTLS(ctx context.Context, clusterdContext *clusterd.Context, namespace string, config map[string]string) (newConfig map[string]string, removeCertFiles removeCertFilesFunction, retErr error) {
 	var filesToRemove []*os.File
 
 	defer func() {
@@ -248,8 +247,7 @@ func (c *Config) IsVault() bool {
 	return c.Provider == secrets.TypeVault
 }
 
-func validateVaultConnectionDetails(clusterdContext *clusterd.Context, ns string, kmsConfig map[string]string) error {
-	ctx := context.TODO()
+func validateVaultConnectionDetails(ctx context.Context, clusterdContext *clusterd.Context, ns string, kmsConfig map[string]string) error {
 	for _, option := range vaultMandatoryConnectionDetails {
 		if GetParam(kmsConfig, option) == "" {
 			return errors.Errorf("failed to find connection details %q", option)

--- a/pkg/daemon/ceph/osd/kms/vault_api.go
+++ b/pkg/daemon/ceph/osd/kms/vault_api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kms
 
 import (
+	"context"
 	"strings"
 
 	"github.com/libopenstorage/secrets/vault"
@@ -38,7 +39,7 @@ var vaultClient = newVaultClient
 
 // newVaultClient returns a vault client, there is no need for any secretConfig validation
 // Since this is called after an already validated call InitVault()
-func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (*api.Client, error) {
+func newVaultClient(ctx context.Context, clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (*api.Client, error) {
 	// DefaultConfig uses the environment variables if present.
 	config := api.DefaultConfig()
 
@@ -56,7 +57,7 @@ func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretC
 	}
 
 	// Populate TLS config
-	newConfigWithTLS, removeCertFiles, err := configTLS(clusterdContext, namespace, localSecretConfig)
+	newConfigWithTLS, removeCertFiles, err := configTLS(ctx, clusterdContext, namespace, localSecretConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize vault tls configuration")
 	}
@@ -106,7 +107,7 @@ func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretC
 	return client, nil
 }
 
-func BackendVersion(clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (string, error) {
+func BackendVersion(ctx context.Context, clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (string, error) {
 	v1 := "v1"
 	v2 := "v2"
 
@@ -125,7 +126,7 @@ func BackendVersion(clusterdContext *clusterd.Context, namespace string, secretC
 		return v2, nil
 	default:
 		// Initialize Vault client
-		vaultClient, err := vaultClient(clusterdContext, namespace, secretConfig)
+		vaultClient, err := vaultClient(ctx, clusterdContext, namespace, secretConfig)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to initialize vault client")
 		}

--- a/pkg/daemon/ceph/osd/kms/vault_api_test.go
+++ b/pkg/daemon/ceph/osd/kms/vault_api_test.go
@@ -40,9 +40,10 @@ func TestBackendVersion(t *testing.T) {
 	core := cluster.Cores[0].Core
 	vault.TestWaitActive(t, core)
 	client := cluster.Cores[0].Client
+	ctx := context.TODO()
 
 	// Mock the client here
-	vaultClient = func(clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (*api.Client, error) {
+	vaultClient = func(ctx context.Context, clusterdContext *clusterd.Context, namespace string, secretConfig map[string]string) (*api.Client, error) {
 		return client, nil
 	}
 
@@ -76,7 +77,7 @@ func TestBackendVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BackendVersion(&clusterd.Context{}, "ns", tt.args.secretConfig)
+			got, err := BackendVersion(ctx, &clusterd.Context{}, "ns", tt.args.secretConfig)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BackendVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -186,7 +187,7 @@ cjLxGL8tcZjHKg==
 	}
 
 	// Populate TLS config
-	newConfigWithTLS, removeCertFiles, err := configTLS(context, ns, secretConfig)
+	newConfigWithTLS, removeCertFiles, err := configTLS(ctx, context, ns, secretConfig)
 	assert.NoError(t, err)
 	defer removeCertFiles()
 

--- a/pkg/daemon/ceph/osd/kms/vault_test.go
+++ b/pkg/daemon/ceph/osd/kms/vault_test.go
@@ -69,7 +69,7 @@ func Test_configTLS(t *testing.T) {
 			"VAULT_BACKEND_PATH": "vault",
 		}
 		// No tls config
-		_, removeCertFiles, err := configTLS(context, ns, config)
+		_, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		assert.NoError(t, err)
 		defer removeCertFiles()
 	})
@@ -83,7 +83,7 @@ func Test_configTLS(t *testing.T) {
 			"VAULT_CACERT":       "/etc/vault/cacert",
 			"VAULT_SKIP_VERIFY":  "false",
 		}
-		config, removeCertFiles, err := configTLS(context, ns, config)
+		config, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		assert.NoError(t, err)
 		assert.Equal(t, "/etc/vault/cacert", config["VAULT_CACERT"])
 		defer removeCertFiles()
@@ -98,7 +98,7 @@ func Test_configTLS(t *testing.T) {
 			"VAULT_CACERT":       "vault-ca-cert",
 			"VAULT_SKIP_VERIFY":  "false",
 		}
-		_, removeCertFiles, err := configTLS(context, ns, config)
+		_, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to fetch tls k8s secret \"vault-ca-cert\": secrets \"vault-ca-cert\" not found")
 		assert.Nil(t, removeCertFiles)
@@ -122,7 +122,7 @@ func Test_configTLS(t *testing.T) {
 		}
 		_, err := context.Clientset.CoreV1().Secrets(ns).Create(ctx, s, metav1.CreateOptions{})
 		assert.NoError(t, err)
-		config, removeCertFiles, err := configTLS(context, ns, config)
+		config, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		defer removeCertFiles()
 		assert.NoError(t, err)
 		assert.NotEqual(t, "vault-ca-cert", config["VAULT_CACERT"])
@@ -167,7 +167,7 @@ func Test_configTLS(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = context.Clientset.CoreV1().Secrets(ns).Create(ctx, sClKey, metav1.CreateOptions{})
 		assert.NoError(t, err)
-		config, removeCertFiles, err := configTLS(context, ns, config)
+		config, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		assert.NoError(t, err)
 		assert.NotEqual(t, "vault-ca-cert", config["VAULT_CACERT"])
 		assert.NotEqual(t, "vault-client-cert", config["VAULT_CLIENT_CERT"])
@@ -191,7 +191,7 @@ func Test_configTLS(t *testing.T) {
 			"VAULT_CLIENT_CERT":  "vault-client-cert",
 			"VAULT_CLIENT_KEY":   "vault-client-key",
 		}
-		config, removeCertFiles, err := configTLS(context, ns, config)
+		config, removeCertFiles, err := configTLS(ctx, context, ns, config)
 		assert.NoError(t, err)
 		assert.NotEqual(t, "vault-ca-cert", config["VAULT_CACERT"])
 		assert.NotEqual(t, "vault-client-cert", config["VAULT_CLIENT_CERT"])
@@ -246,7 +246,7 @@ func Test_configTLS(t *testing.T) {
 			"VAULT_CLIENT_CERT":  "vault-client-cert",
 			"VAULT_CLIENT_KEY":   "vault-client-key",
 		}
-		_, _, err := configTLS(context, ns, config)
+		_, _, err := configTLS(ctx, context, ns, config)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to generate temp file for k8s secret \"vault-ca-cert\" content: error creating tmp file")
 		assert.NoFileExists(t, os.Getenv("ROOK_TMP_FILE"))

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -67,19 +67,19 @@ type clusterHealth struct {
 	internalCancel context.CancelFunc
 }
 
-func newCluster(c *cephv1.CephCluster, context *clusterd.Context, ownerInfo *k8sutil.OwnerInfo) *cluster {
+func newCluster(ctx context.Context, c *cephv1.CephCluster, context *clusterd.Context, ownerInfo *k8sutil.OwnerInfo) *cluster {
 	return &cluster{
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's
 		// identity can be established.
-		ClusterInfo:        client.AdminClusterInfo(c.Namespace, c.Name),
+		ClusterInfo:        client.AdminClusterInfo(ctx, c.Namespace, c.Name),
 		Namespace:          c.Namespace,
 		Spec:               &c.Spec,
 		context:            context,
 		namespacedName:     types.NamespacedName{Namespace: c.Namespace, Name: c.Name},
 		monitoringRoutines: make(map[string]*clusterHealth),
 		ownerInfo:          ownerInfo,
-		mons:               mon.New(context, c.Namespace, c.Spec, ownerInfo),
+		mons:               mon.New(ctx, context, c.Namespace, c.Spec, ownerInfo),
 		// update observedGeneration with current generation value,
 		// because generation can be changed before reconile got completed
 		// CR status will be updated at end of reconcile, so to reflect the reconcile has finished

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -108,7 +108,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 
 	// Create CSI config map
-	err = csi.CreateCsiConfigMap(c.namespacedName.Namespace, c.context.Clientset, cluster.ownerInfo)
+	err = csi.CreateCsiConfigMap(c.OpManagerCtx, c.namespacedName.Namespace, c.context.Clientset, cluster.ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to create csi config map")
 	}

--- a/pkg/operator/ceph/cluster/mgr/drain.go
+++ b/pkg/operator/ceph/cluster/mgr/drain.go
@@ -17,8 +17,6 @@ limitations under the License.
 package mgr
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	policyv1 "k8s.io/api/policy/v1"
@@ -58,7 +56,7 @@ func (c *Cluster) reconcileMgrPDB() error {
 			}
 			return nil
 		}
-		op, err := controllerutil.CreateOrUpdate(context.TODO(), c.context.Client, pdb, mutateFunc)
+		op, err := controllerutil.CreateOrUpdate(c.clusterInfo.Context, c.context.Client, pdb, mutateFunc)
 		if err != nil {
 			return errors.Wrapf(err, "failed to reconcile mgr pdb on op %q", op)
 		}
@@ -74,7 +72,7 @@ func (c *Cluster) reconcileMgrPDB() error {
 		}
 		return nil
 	}
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), c.context.Client, pdb, mutateFunc)
+	op, err := controllerutil.CreateOrUpdate(c.clusterInfo.Context, c.context.Client, pdb, mutateFunc)
 	if err != nil {
 		return errors.Wrapf(err, "failed to reconcile mgr pdb on op %q", op)
 	}
@@ -90,7 +88,7 @@ func (c *Cluster) deleteMgrPDB() {
 	}
 	if usePDBV1Beta1 {
 		mgrPDB := &policyv1beta1.PodDisruptionBudget{}
-		err := c.context.Client.Get(context.TODO(), pdbRequest, mgrPDB)
+		err := c.context.Client.Get(c.clusterInfo.Context, pdbRequest, mgrPDB)
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
 				logger.Errorf("failed to get mgr pdb %q. %v", mgrPDBName, err)
@@ -98,14 +96,14 @@ func (c *Cluster) deleteMgrPDB() {
 			return
 		}
 		logger.Debugf("ensuring the mgr pdb %q is deleted", mgrPDBName)
-		err = c.context.Client.Delete(context.TODO(), mgrPDB)
+		err = c.context.Client.Delete(c.clusterInfo.Context, mgrPDB)
 		if err != nil {
 			logger.Errorf("failed to delete mgr pdb %q. %v", mgrPDBName, err)
 			return
 		}
 	}
 	mgrPDB := &policyv1.PodDisruptionBudget{}
-	err = c.context.Client.Get(context.TODO(), pdbRequest, mgrPDB)
+	err = c.context.Client.Get(c.clusterInfo.Context, pdbRequest, mgrPDB)
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			logger.Errorf("failed to get mgr pdb %q. %v", mgrPDBName, err)
@@ -113,7 +111,7 @@ func (c *Cluster) deleteMgrPDB() {
 		return
 	}
 	logger.Debugf("ensuring the mgr pdb %q is deleted", mgrPDBName)
-	err = c.context.Client.Delete(context.TODO(), mgrPDB)
+	err = c.context.Client.Delete(c.clusterInfo.Context, mgrPDB)
 	if err != nil {
 		logger.Errorf("failed to delete mgr pdb %q. %v", mgrPDBName, err)
 	}

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -137,7 +137,7 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 	}
 
 	// get the existing monitor config
-	clusterInfo.Monitors, maxMonID, monMapping, err = loadMonConfig(clusterdContext.Clientset, namespace)
+	clusterInfo.Monitors, maxMonID, monMapping, err = loadMonConfig(context, clusterdContext.Clientset, namespace)
 	if err != nil {
 		return nil, maxMonID, monMapping, errors.Wrap(err, "failed to get mon config")
 	}
@@ -175,8 +175,7 @@ func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephclient.Cl
 }
 
 // loadMonConfig returns the monitor endpoints and maxMonID
-func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string]*cephclient.MonInfo, int, *Mapping, error) {
-	ctx := context.TODO()
+func loadMonConfig(ctx context.Context, clientset kubernetes.Interface, namespace string) (map[string]*cephclient.MonInfo, int, *Mapping, error) {
 	monEndpointMap := map[string]*cephclient.MonInfo{}
 	maxMonID := -1
 	monMapping := &Mapping{

--- a/pkg/operator/ceph/cluster/mon/drain.go
+++ b/pkg/operator/ceph/cluster/mon/drain.go
@@ -17,8 +17,6 @@ limitations under the License.
 package mon
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	policyv1 "k8s.io/api/policy/v1"
@@ -75,7 +73,7 @@ func (c *Cluster) createOrUpdateMonPDB(maxUnavailable int32) (controllerutil.Ope
 			}
 			return nil
 		}
-		return controllerutil.CreateOrUpdate(context.TODO(), c.context.Client, pdb, mutateFunc)
+		return controllerutil.CreateOrUpdate(c.ClusterInfo.Context, c.context.Client, pdb, mutateFunc)
 	}
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: objectMeta}
@@ -87,7 +85,7 @@ func (c *Cluster) createOrUpdateMonPDB(maxUnavailable int32) (controllerutil.Ope
 		}
 		return nil
 	}
-	return controllerutil.CreateOrUpdate(context.TODO(), c.context.Client, pdb, mutateFunc)
+	return controllerutil.CreateOrUpdate(c.ClusterInfo.Context, c.context.Client, pdb, mutateFunc)
 }
 
 // blockMonDrain makes MaxUnavailable in mon PDB to 0 to block any voluntary mon drains

--- a/pkg/operator/ceph/cluster/mon/drain_test.go
+++ b/pkg/operator/ceph/cluster/mon/drain_test.go
@@ -38,6 +38,7 @@ const (
 )
 
 func createFakeCluster(t *testing.T, cephClusterObj *cephv1.CephCluster, k8sVersion string) *Cluster {
+	ctx := context.TODO()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	scheme := scheme.Scheme
 	err := policyv1.AddToScheme(scheme)
@@ -47,7 +48,7 @@ func createFakeCluster(t *testing.T, cephClusterObj *cephv1.CephCluster, k8sVers
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 	clientset := test.New(t, 3)
-	c := New(&clusterd.Context{Client: cl, Clientset: clientset}, mockNamespace, cephClusterObj.Spec, ownerInfo)
+	c := New(ctx, &clusterd.Context{Client: cl, Clientset: clientset}, mockNamespace, cephClusterObj.Spec, ownerInfo)
 	test.SetFakeKubernetesVersion(clientset, k8sVersion)
 	return c
 }

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -63,7 +63,7 @@ func TestCheckHealth(t *testing.T) {
 		Executor:  executor,
 	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	// clusterInfo is nil so we return err
 	err := c.checkHealth(ctx)
 	assert.NotNil(t, err)
@@ -151,7 +151,7 @@ func TestCheckHealth(t *testing.T) {
 }
 
 func TestSkipMonFailover(t *testing.T) {
-	c := New(&clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
+	c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	monName := "arb"
 
@@ -196,7 +196,7 @@ func TestEvictMonOnSameNode(t *testing.T) {
 	}
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: configDir, Executor: executor}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 0}, "myversion")
 	c.maxMonID = 2
 	c.waitForStart = false
@@ -251,7 +251,7 @@ func TestScaleMonDeployment(t *testing.T) {
 	clientset := test.New(t, 1)
 	context := &clusterd.Context{Clientset: clientset}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 0, AllowMultiplePerNode: true}, "myversion")
 
 	name := "a"
@@ -301,7 +301,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 		Executor:  executor,
 	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 
@@ -362,7 +362,7 @@ func TestAddRemoveMons(t *testing.T) {
 		Executor:  executor,
 	}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0 // "a" is max mon id
 	c.waitForStart = false

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -20,6 +20,7 @@ limitations under the License.
 package mon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -163,9 +164,9 @@ type SchedulingResult struct {
 }
 
 // New creates an instance of a mon cluster
-func New(context *clusterd.Context, namespace string, spec cephv1.ClusterSpec, ownerInfo *k8sutil.OwnerInfo) *Cluster {
+func New(ctx context.Context, clusterdContext *clusterd.Context, namespace string, spec cephv1.ClusterSpec, ownerInfo *k8sutil.OwnerInfo) *Cluster {
 	return &Cluster{
-		context:        context,
+		context:        clusterdContext,
 		spec:           spec,
 		Namespace:      namespace,
 		maxMonID:       -1,
@@ -175,6 +176,9 @@ func New(context *clusterd.Context, namespace string, spec cephv1.ClusterSpec, o
 			Schedule: map[string]*MonScheduleInfo{},
 		},
 		ownerInfo: ownerInfo,
+		ClusterInfo: &cephclient.ClusterInfo{
+			Context: ctx,
+		},
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -270,7 +270,7 @@ func validateStart(t *testing.T, c *Cluster) {
 func TestPersistMons(t *testing.T) {
 	clientset := test.New(t, 1)
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{Annotations: cephv1.AnnotationsSpec{cephv1.KeyClusterMetadata: cephv1.Annotations{"key": "value"}}}, ownerInfo)
+	c := New(context.TODO(), &clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{Annotations: cephv1.AnnotationsSpec{cephv1.KeyClusterMetadata: cephv1.Annotations{"key": "value"}}}, ownerInfo)
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// Persist mon a
@@ -298,7 +298,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir := t.TempDir()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(ctx, &clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// create the initial config map
@@ -345,7 +345,7 @@ func TestMaxMonID(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir := t.TempDir()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
+	c := New(context.TODO(), &clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// when the configmap is not found, the maxMonID is -1

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -36,7 +36,7 @@ import (
 func TestNodeAffinity(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 4)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
+	c := New(ctx, &clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Placement = map[cephv1.KeyType]cephv1.Placement{}
@@ -166,7 +166,7 @@ func TestPodMemory(t *testing.T) {
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(t, 3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
+	c := New(context.TODO(), &clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Network.HostNetwork = true

--- a/pkg/operator/ceph/cluster/mon/service_test.go
+++ b/pkg/operator/ceph/cluster/mon/service_test.go
@@ -32,7 +32,7 @@ import (
 func TestCreateService(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
+	c := New(ctx, &clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
 	c.ClusterInfo = client.AdminTestClusterInfo("rook-ceph")
 	m := &monConfig{ResourceName: "rook-ceph-mon-b", DaemonName: "b"}
 	clusterIP, err := c.createService(m)

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mon
 
 import (
+	"context"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -43,6 +44,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 	clientset := testop.New(t, 1)
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	c := New(
+		context.TODO(),
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
 		cephv1.ClusterSpec{},
@@ -104,6 +106,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 	clientset := testop.New(t, 1)
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	c := New(
+		context.TODO(),
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
 		cephv1.ClusterSpec{},
@@ -163,6 +166,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 
 func testRequiredDuringScheduling(t *testing.T, hostNetwork, allowMultiplePerNode, required bool) {
 	c := New(
+		context.TODO(),
 		&clusterd.Context{},
 		"ns",
 		cephv1.ClusterSpec{},

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -80,7 +80,7 @@ func (c *Cluster) PrepareStorageClassDeviceSets() error {
 func (c *Cluster) prepareStorageClassDeviceSets(errs *provisionErrors) {
 	c.deviceSets = []deviceSet{}
 
-	existingPVCs, uniqueOSDsPerDeviceSet, err := GetExistingPVCs(c.context, c.clusterInfo.Namespace)
+	existingPVCs, uniqueOSDsPerDeviceSet, err := GetExistingPVCs(c.clusterInfo.Context, c.context, c.clusterInfo.Namespace)
 	if err != nil {
 		errs.addError("failed to detect existing OSD PVCs. %v", err)
 		return
@@ -257,8 +257,7 @@ func makeDeviceSetPVC(deviceSetName, pvcID string, setIndex int, pvcTemplate v1.
 }
 
 // GetExistingPVCs fetches the list of OSD PVCs
-func GetExistingPVCs(clusterdContext *clusterd.Context, namespace string) (map[string]*v1.PersistentVolumeClaim, map[string]sets.String, error) {
-	ctx := context.TODO()
+func GetExistingPVCs(ctx context.Context, clusterdContext *clusterd.Context, namespace string) (map[string]*v1.PersistentVolumeClaim, map[string]sets.String, error) {
 	selector := metav1.ListOptions{LabelSelector: CephDeviceSetPVCIDLabelKey}
 	pvcs, err := clusterdContext.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, selector)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -35,16 +35,16 @@ import (
 )
 
 // predicateForNodeWatcher is the predicate function to trigger reconcile on Node events
-func predicateForNodeWatcher(client client.Client, context *clusterd.Context) predicate.Funcs {
+func predicateForNodeWatcher(ctx context.Context, client client.Client, context *clusterd.Context) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			clientCluster := newClientCluster(client, e.Object.GetNamespace(), context)
-			return clientCluster.onK8sNode(e.Object)
+			return clientCluster.onK8sNode(ctx, e.Object)
 		},
 
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			clientCluster := newClientCluster(client, e.ObjectNew.GetNamespace(), context)
-			return clientCluster.onK8sNode(e.ObjectNew)
+			return clientCluster.onK8sNode(ctx, e.ObjectNew)
 		},
 
 		DeleteFunc: func(e event.DeleteEvent) bool {

--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -60,7 +60,7 @@ func checkStorageForNode(cluster *cephv1.CephCluster) bool {
 }
 
 // onK8sNodeAdd is triggered when a node is added in the Kubernetes cluster
-func (c *clientCluster) onK8sNode(object runtime.Object) bool {
+func (c *clientCluster) onK8sNode(ctx context.Context, object runtime.Object) bool {
 	node, ok := object.(*v1.Node)
 	if !ok {
 		return false
@@ -106,7 +106,7 @@ func (c *clientCluster) onK8sNode(object runtime.Object) bool {
 		// Is the node in the CRUSH map already?
 		// If so we don't need to reconcile, this is done to avoid double reconcile on operator restart
 		// Assume the admin key since we are watching for node status to create OSDs
-		clusterInfo := cephclient.AdminClusterInfo(cluster.Namespace, cluster.Name)
+		clusterInfo := cephclient.AdminClusterInfo(ctx, cluster.Namespace, cluster.Name)
 		osds, err := cephclient.GetOSDOnHost(c.context, clusterInfo, nodeName)
 		if err != nil {
 			if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -87,6 +88,7 @@ func TestCheckStorageForNode(t *testing.T) {
 
 func TestOnK8sNode(t *testing.T) {
 	ns := "rook-ceph"
+	ctx := context.TODO()
 	cephCluster := fakeCluster(ns)
 	objects := []runtime.Object{
 		cephCluster,
@@ -136,11 +138,11 @@ func TestOnK8sNode(t *testing.T) {
 	cephCluster.Status.Phase = k8sutil.ReadyStatus
 	client = getFakeClient(objects...)
 	clientCluster.client = client
-	b := clientCluster.onK8sNode(node)
+	b := clientCluster.onK8sNode(ctx, node)
 	assert.True(t, b)
 
 	// node will not reconcile
-	b = clientCluster.onK8sNode(node)
+	b = clientCluster.onK8sNode(ctx, node)
 	assert.False(t, b)
 }
 

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -141,7 +141,7 @@ func SetOrRemoveDefaultConfigs(
 	// Apply Multus if needed
 	if clusterSpec.Network.IsMultus() {
 		logger.Info("configuring ceph network(s) with multus")
-		cephNetworks, err := generateNetworkSettings(context, clusterInfo.Namespace, clusterSpec.Network.Selectors)
+		cephNetworks, err := generateNetworkSettings(clusterInfo.Context, context, clusterInfo.Namespace, clusterSpec.Network.Selectors)
 		if err != nil {
 			return errors.Wrap(err, "failed to generate network settings")
 		}

--- a/pkg/operator/ceph/config/network.go
+++ b/pkg/operator/ceph/config/network.go
@@ -45,8 +45,7 @@ var (
 	NetworkSelectors = []string{PublicNetworkSelectorKeyName, ClusterNetworkSelectorKeyName}
 )
 
-func generateNetworkSettings(clusterdContext *clusterd.Context, namespace string, networkSelectors map[string]string) ([]Option, error) {
-	ctx := context.TODO()
+func generateNetworkSettings(ctx context.Context, clusterdContext *clusterd.Context, namespace string, networkSelectors map[string]string) ([]Option, error) {
 	cephNetworks := []Option{}
 
 	for _, selectorKey := range NetworkSelectors {

--- a/pkg/operator/ceph/config/network_test.go
+++ b/pkg/operator/ceph/config/network_test.go
@@ -32,14 +32,15 @@ import (
 
 func TestGenerateNetworkSettings(t *testing.T) {
 	t.Run("no network definition exists", func(*testing.T) {
+		ctx := context.TODO()
 		ns := "rook-ceph"
 		clientset := testop.New(t, 1)
-		ctx := &clusterd.Context{
+		clusterdContext := &clusterd.Context{
 			Clientset:     clientset,
 			NetworkClient: fakenetclient.NewSimpleClientset().K8sCniCncfIoV1(),
 		}
 		netSelector := map[string]string{"public": "public-network-attach-def"}
-		_, err := generateNetworkSettings(ctx, ns, netSelector)
+		_, err := generateNetworkSettings(ctx, clusterdContext, ns, netSelector)
 		assert.Error(t, err)
 
 	})
@@ -57,25 +58,25 @@ func TestGenerateNetworkSettings(t *testing.T) {
 		ctxt := context.TODO()
 		ns := "rook-ceph"
 		clientset := testop.New(t, 1)
-		ctx := &clusterd.Context{
+		clusterdContext := &clusterd.Context{
 			Clientset:     clientset,
 			NetworkClient: fakenetclient.NewSimpleClientset().K8sCniCncfIoV1(),
 		}
 
 		for i := range networks {
-			_, err := ctx.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctxt, &networks[i], metav1.CreateOptions{})
+			_, err := clusterdContext.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctxt, &networks[i], metav1.CreateOptions{})
 			assert.NoError(t, err)
 		}
-		cephNetwork, err := generateNetworkSettings(ctx, ns, netSelector)
+		cephNetwork, err := generateNetworkSettings(context.TODO(), clusterdContext, ns, netSelector)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, cephNetwork, expectedNetworks, fmt.Sprintf("networks: %+v", cephNetwork))
 	})
 
 	t.Run("only public network", func(*testing.T) {
-		ctxt := context.TODO()
+		ctx := context.TODO()
 		ns := "rook-ceph"
 		clientset := testop.New(t, 1)
-		ctx := &clusterd.Context{
+		clusterdContext := &clusterd.Context{
 			Clientset:     clientset,
 			NetworkClient: fakenetclient.NewSimpleClientset().K8sCniCncfIoV1(),
 		}
@@ -89,20 +90,20 @@ func TestGenerateNetworkSettings(t *testing.T) {
 			},
 		}
 		for i := range networks {
-			_, err := ctx.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctxt, &networks[i], metav1.CreateOptions{})
+			_, err := clusterdContext.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctx, &networks[i], metav1.CreateOptions{})
 			assert.NoError(t, err)
 		}
-		cephNetwork, err := generateNetworkSettings(ctx, ns, netSelector)
+		cephNetwork, err := generateNetworkSettings(ctx, clusterdContext, ns, netSelector)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, cephNetwork, expectedNetworks, fmt.Sprintf("networks: %+v", cephNetwork))
 
 	})
 
 	t.Run("public and cluster network", func(*testing.T) {
-		ctxt := context.TODO()
+		ctx := context.TODO()
 		ns := "rook-ceph"
 		clientset := testop.New(t, 1)
-		ctx := &clusterd.Context{
+		clusterdContext := &clusterd.Context{
 			Clientset:     clientset,
 			NetworkClient: fakenetclient.NewSimpleClientset().K8sCniCncfIoV1(),
 		}
@@ -124,10 +125,10 @@ func TestGenerateNetworkSettings(t *testing.T) {
 			},
 		}
 		for i := range networks {
-			_, err := ctx.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctxt, &networks[i], metav1.CreateOptions{})
+			_, err := clusterdContext.NetworkClient.NetworkAttachmentDefinitions(ns).Create(ctx, &networks[i], metav1.CreateOptions{})
 			assert.NoError(t, err)
 		}
-		cephNetwork, err := generateNetworkSettings(ctx, ns, netSelector)
+		cephNetwork, err := generateNetworkSettings(ctx, clusterdContext, ns, netSelector)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, cephNetwork, expectedNetworks, fmt.Sprintf("networks: %+v", cephNetwork))
 

--- a/pkg/operator/ceph/controller.go
+++ b/pkg/operator/ceph/controller.go
@@ -52,7 +52,7 @@ type ReconcileConfig struct {
 // Add creates a new Operator configuration Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
-	return add(mgr, newReconciler(mgr, context, opManagerContext, opConfig))
+	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -65,7 +65,7 @@ func newReconciler(mgr manager.Manager, context *clusterd.Context, opManagerCont
 	}
 }
 
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -75,14 +75,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for ConfigMap (operator config)
 	err = c.Watch(&source.Kind{
-		Type: &v1.ConfigMap{TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(mgr.GetClient()))
+		Type: &v1.ConfigMap{TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
 	if err != nil {
 		return err
 	}
 
 	// Watch for Secret (admission controller secret)
 	err = c.Watch(&source.Kind{
-		Type: &v1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(mgr.GetClient()))
+		Type: &v1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -155,8 +155,7 @@ func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *C
 // CreateCsiConfigMap creates an empty config map that will be later used
 // to provide cluster configuration to ceph-csi. If a config map already
 // exists, it will return it.
-func CreateCsiConfigMap(namespace string, clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo) error {
-	ctx := context.TODO()
+func CreateCsiConfigMap(ctx context.Context, namespace string, clientset kubernetes.Interface, ownerInfo *k8sutil.OwnerInfo) error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ConfigName,

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -184,7 +184,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, r.opConfig.OperatorNamespace)
 	// create an empty config map. config map will be filled with data
 	// later when clusters have mons
-	err = CreateCsiConfigMap(r.opConfig.OperatorNamespace, r.context.Clientset, ownerInfo)
+	err = CreateCsiConfigMap(r.opManagerContext, r.opConfig.OperatorNamespace, r.context.Clientset, ownerInfo)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed creating csi config map")
 	}

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -448,15 +448,16 @@ func TestPGHealthcheckTimeout(t *testing.T) {
 
 func TestHasNodeDrained(t *testing.T) {
 	osdPOD := fakeOSDPod(0, nodeName)
+	ctx := context.TODO()
 	// Not expecting node drain because OSD pod is assigned to a schedulable node
 	r := getFakeReconciler(t, nodeObj, osdPOD.DeepCopy(), &corev1.ConfigMap{})
-	expected, err := hasOSDNodeDrained(r.client, namespace, "0")
+	expected, err := hasOSDNodeDrained(ctx, r.client, namespace, "0")
 	assert.NoError(t, err)
 	assert.False(t, expected)
 
 	// Expecting node drain because OSD pod is assigned to an unschedulable node
 	r = getFakeReconciler(t, unschedulableNodeObj, osdPOD.DeepCopy(), &corev1.ConfigMap{})
-	expected, err = hasOSDNodeDrained(r.client, namespace, "0")
+	expected, err = hasOSDNodeDrained(ctx, r.client, namespace, "0")
 	assert.NoError(t, err)
 	assert.True(t, expected)
 
@@ -464,7 +465,7 @@ func TestHasNodeDrained(t *testing.T) {
 	osdPodObj := osdPOD.DeepCopy()
 	osdPodObj.Spec.NodeName = ""
 	r = getFakeReconciler(t, nodeObj, osdPodObj, &corev1.ConfigMap{})
-	expected, err = hasOSDNodeDrained(r.client, namespace, "0")
+	expected, err = hasOSDNodeDrained(ctx, r.client, namespace, "0")
 	assert.NoError(t, err)
 	assert.True(t, expected)
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterdisruption
 
 import (
-	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +39,7 @@ func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*c
 	poolSpecs := make([]cephv1.PoolSpec, 0)
 	poolCount := 0
 	cephBlockPoolList := &cephv1.CephBlockPoolList{}
-	err := r.client.List(context.TODO(), cephBlockPoolList, namespaceListOpt)
+	err := r.client.List(r.context.OpManagerContext, cephBlockPoolList, namespaceListOpt)
 	if err != nil {
 		return nil, nil, "", poolCount, errors.Wrapf(err, "could not list the CephBlockpools %v", request.NamespacedName)
 	}
@@ -50,7 +49,7 @@ func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*c
 	}
 
 	cephFilesystemList := &cephv1.CephFilesystemList{}
-	err = r.client.List(context.TODO(), cephFilesystemList, namespaceListOpt)
+	err = r.client.List(r.context.OpManagerContext, cephFilesystemList, namespaceListOpt)
 	if err != nil {
 		return nil, nil, "", poolCount, errors.Wrapf(err, "could not list the CephFilesystems %v", request.NamespacedName)
 	}
@@ -64,7 +63,7 @@ func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*c
 	}
 
 	cephObjectStoreList := &cephv1.CephObjectStoreList{}
-	err = r.client.List(context.TODO(), cephObjectStoreList, namespaceListOpt)
+	err = r.client.List(r.context.OpManagerContext, cephObjectStoreList, namespaceListOpt)
 	if err != nil {
 		return nil, nil, "", poolCount, errors.Wrapf(err, "could not list the CephObjectStores %v", request.NamespacedName)
 	}

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -86,7 +86,7 @@ func (r *ReconcileClusterDisruption) reconcile(request reconcile.Request) (recon
 
 	// get the ceph cluster
 	cephClusters := &cephv1.CephClusterList{}
-	if err := r.client.List(context.TODO(), cephClusters, client.InNamespace(request.Namespace)); err != nil {
+	if err := r.client.List(r.context.OpManagerContext, cephClusters, client.InNamespace(request.Namespace)); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "could not get cephclusters in namespace %q", request.Namespace)
 	}
 	if len(cephClusters.Items) == 0 {
@@ -244,7 +244,7 @@ func (c *ClusterMap) GetClusterNamespaces() []string {
 }
 
 func (r *ReconcileClusterDisruption) deleteDrainCanaryPods(namespace string) error {
-	err := r.client.DeleteAllOf(context.TODO(), &appsv1.Deployment{}, client.InNamespace(namespace),
+	err := r.client.DeleteAllOf(r.context.OpManagerContext, &appsv1.Deployment{}, client.InNamespace(namespace),
 		client.MatchingLabels{k8sutil.AppAttr: legacyDrainCanaryLabel})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to delete all the legacy drain-canary pods with label %q", legacyDrainCanaryLabel)

--- a/pkg/operator/ceph/disruption/clusterdisruption/static_pdb.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/static_pdb.go
@@ -17,8 +17,6 @@ limitations under the License.
 package clusterdisruption
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,7 +28,7 @@ import (
 )
 
 func (r *ReconcileClusterDisruption) createStaticPDB(pdb client.Object) error {
-	err := r.client.Create(context.TODO(), pdb)
+	err := r.client.Create(r.context.OpManagerContext, pdb)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create pdb %q", pdb.GetName())
 	}
@@ -48,7 +46,7 @@ func (r *ReconcileClusterDisruption) reconcileStaticPDB(request types.Namespaced
 	} else {
 		existingPDB = &policyv1.PodDisruptionBudget{}
 	}
-	err = r.client.Get(context.TODO(), request, existingPDB)
+	err = r.client.Get(r.context.OpManagerContext, request, existingPDB)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return r.createStaticPDB(pdb)

--- a/pkg/operator/ceph/disruption/machinelabel/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinelabel/reconcile.go
@@ -70,7 +70,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 
 	// Fetch list of osd pods for the requested ceph cluster
 	pods := &corev1.PodList{}
-	err := r.client.List(context.TODO(), pods, client.InNamespace(request.Namespace),
+	err := r.client.List(r.options.OpManagerContext, pods, client.InNamespace(request.Namespace),
 		client.MatchingLabels{k8sutil.AppAttr: osd.AppName, k8sutil.ClusterAttr: request.Name})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -78,7 +78,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 
 	// Fetching the cephCluster
 	cephClusterInstance := &cephv1.CephCluster{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, cephClusterInstance)
+	err = r.client.Get(r.options.OpManagerContext, request.NamespacedName, cephClusterInstance)
 	if kerrors.IsNotFound(err) {
 		logger.Infof("cephCluster instance not found for %s", request.NamespacedName)
 		return reconcile.Result{}, nil
@@ -94,7 +94,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 
 	// Fetch list of machines available
 	machines := &mapiv1.MachineList{}
-	err = r.client.List(context.TODO(), machines, client.InNamespace(cephClusterInstance.Spec.DisruptionManagement.MachineDisruptionBudgetNamespace))
+	err = r.client.List(r.options.OpManagerContext, machines, client.InNamespace(cephClusterInstance.Spec.DisruptionManagement.MachineDisruptionBudgetNamespace))
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed tp fetch machine list")
 	}
@@ -128,7 +128,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 			labels[MachineFencingLabelKey] = request.Name
 			labels[MachineFencingNamespaceLabelKey] = request.Namespace
 			machine.RawMachine.SetLabels(labels)
-			err = r.client.Update(context.TODO(), &machine.RawMachine)
+			err = r.client.Update(r.options.OpManagerContext, &machine.RawMachine)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrapf(err, "failed to update machine %s", machine.RawMachine.GetName())
 			}
@@ -140,7 +140,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 			labels[MachineFencingLabelKey] = ""
 			labels[MachineFencingNamespaceLabelKey] = ""
 			machine.RawMachine.SetLabels(labels)
-			err = r.client.Update(context.TODO(), &machine.RawMachine)
+			err = r.client.Update(r.options.OpManagerContext, &machine.RawMachine)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrapf(err, "failed to update machine %s", machine.RawMachine.GetName())
 			}

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -253,10 +253,10 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 			return reconcile.Result{}, *cephFilesystem, err
 		}
 		if !deps.Empty() {
-			err := reporting.ReportDeletionBlockedDueToDependents(logger, r.client, cephFilesystem, deps)
+			err := reporting.ReportDeletionBlockedDueToDependents(r.opManagerContext, logger, r.client, cephFilesystem, deps)
 			return opcontroller.WaitForRequeueIfFinalizerBlocked, *cephFilesystem, err
 		}
-		reporting.ReportDeletionNotBlockedDueToDependents(logger, r.client, r.recorder, cephFilesystem)
+		reporting.ReportDeletionNotBlockedDueToDependents(r.opManagerContext, logger, r.client, r.recorder, cephFilesystem)
 
 		runningCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, clusterInfo, config.MonType)
 		if err != nil {

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -217,7 +217,7 @@ func TestCephClientController(t *testing.T) {
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
-		err = csi.CreateCsiConfigMap(namespace, c.Clientset, ownerInfo)
+		err = csi.CreateCsiConfigMap(ctx, namespace, c.Clientset, ownerInfo)
 		assert.NoError(t, err)
 
 		res, err := r.Reconcile(ctx, req)
@@ -264,7 +264,7 @@ func TestCephClientController(t *testing.T) {
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
-		err := csi.CreateCsiConfigMap(namespace, c.Clientset, ownerInfo)
+		err := csi.CreateCsiConfigMap(ctx, namespace, c.Clientset, ownerInfo)
 		assert.NoError(t, err)
 
 		res, err := r.Reconcile(ctx, req)

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -92,7 +92,7 @@ func (c *bucketChecker) checkObjectStore(context context.Context) {
 	// check the object store health immediately before starting the loop
 	err := c.checkObjectStoreHealth()
 	if err != nil {
-		updateStatusBucket(c.client, c.namespacedName, cephv1.ConditionFailure, err.Error())
+		updateStatusBucket(context, c.client, c.namespacedName, cephv1.ConditionFailure, err.Error())
 		logger.Debugf("failed to check rgw health for object store %q. %v", c.namespacedName.Name, err)
 	}
 
@@ -109,7 +109,7 @@ func (c *bucketChecker) checkObjectStore(context context.Context) {
 			logger.Debugf("checking rgw health of object store %q", c.namespacedName.Name)
 			err := c.checkObjectStoreHealth()
 			if err != nil {
-				updateStatusBucket(c.client, c.namespacedName, cephv1.ConditionFailure, err.Error())
+				updateStatusBucket(context, c.client, c.namespacedName, cephv1.ConditionFailure, err.Error())
 				logger.Debugf("failed to check rgw health for object store %q. %v", c.namespacedName.Name, err)
 			}
 		}
@@ -182,7 +182,7 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	logger.Debugf("successfully checked object store endpoint for object store %q", c.namespacedName.String())
 
 	// Update the EndpointStatus in the CR to reflect the healthyness
-	updateStatusBucket(c.client, c.namespacedName, cephv1.ConditionConnected, "")
+	updateStatusBucket(c.objContext.clusterInfo.Context, c.client, c.namespacedName, cephv1.ConditionConnected, "")
 
 	return nil
 }

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -558,6 +558,7 @@ func Test_createMultisite(t *testing.T) {
 func TestGetRealmKeySecret(t *testing.T) {
 	ns := "my-ns"
 	realmName := "my-realm"
+	ctx := context.TODO()
 
 	t.Run("secret exists", func(t *testing.T) {
 		secret := &v1.Secret{
@@ -576,7 +577,7 @@ func TestGetRealmKeySecret(t *testing.T) {
 			Clientset: k8sfake.NewSimpleClientset(secret),
 		}
 
-		secret, err := GetRealmKeySecret(c, types.NamespacedName{Namespace: ns, Name: realmName})
+		secret, err := GetRealmKeySecret(ctx, c, types.NamespacedName{Namespace: ns, Name: realmName})
 		assert.NoError(t, err)
 		assert.NotNil(t, secret)
 	})
@@ -586,7 +587,7 @@ func TestGetRealmKeySecret(t *testing.T) {
 			Clientset: k8sfake.NewSimpleClientset(),
 		}
 
-		secret, err := GetRealmKeySecret(c, types.NamespacedName{Namespace: ns, Name: realmName})
+		secret, err := GetRealmKeySecret(ctx, c, types.NamespacedName{Namespace: ns, Name: realmName})
 		assert.Error(t, err)
 		assert.Nil(t, secret)
 	})
@@ -648,6 +649,7 @@ func TestGetRealmKeyArgsFromSecret(t *testing.T) {
 func TestGetRealmKeyArgs(t *testing.T) {
 	ns := "my-ns"
 	realmName := "my-realm"
+	ctx := context.TODO()
 
 	baseSecret := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -674,7 +676,7 @@ func TestGetRealmKeyArgs(t *testing.T) {
 			Clientset: k8sfake.NewSimpleClientset(s),
 		}
 
-		access, secret, err := GetRealmKeyArgs(c, realmName, ns)
+		access, secret, err := GetRealmKeyArgs(ctx, c, realmName, ns)
 		assert.NoError(t, err)
 		assert.Equal(t, "--access-key=my-access-key", access)
 		assert.Equal(t, "--secret-key=my-secret-key", secret)
@@ -685,7 +687,7 @@ func TestGetRealmKeyArgs(t *testing.T) {
 			Clientset: k8sfake.NewSimpleClientset(),
 		}
 
-		access, secret, err := GetRealmKeyArgs(c, realmName, ns)
+		access, secret, err := GetRealmKeyArgs(ctx, c, realmName, ns)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get CephObjectRealm \"my-ns/my-realm\" keys secret")
 		assert.Equal(t, "", access)
@@ -700,7 +702,7 @@ func TestGetRealmKeyArgs(t *testing.T) {
 			Clientset: k8sfake.NewSimpleClientset(s),
 		}
 
-		access, secret, err := GetRealmKeyArgs(c, realmName, ns)
+		access, secret, err := GetRealmKeyArgs(ctx, c, realmName, ns)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode CephObjectRealm \"my-ns/my-realm\"")
 		assert.Equal(t, "", access)

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -216,7 +216,7 @@ func (r *ReconcileObjectRealm) pullCephRealm(realm *cephv1.CephObjectRealm) (rec
 	realmArg := fmt.Sprintf("--rgw-realm=%s", realm.Name)
 	urlArg := fmt.Sprintf("--url=%s", realm.Spec.Pull.Endpoint)
 	logger.Debug("getting keys to pull realm for CephObjectRealm %q", realm.Name)
-	accessKeyArg, secretKeyArg, err := object.GetRealmKeyArgs(r.context, realm.Name, realm.Namespace)
+	accessKeyArg, secretKeyArg, err := object.GetRealmKeyArgs(r.opManagerContext, r.context, realm.Name, realm.Namespace)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return waitForRequeueIfRealmNotReady, err
@@ -264,7 +264,7 @@ func (r *ReconcileObjectRealm) createRealmKeys(realm *cephv1.CephObjectRealm) (r
 	secretName := realm.Name + "-keys"
 
 	// Check if the secret exists first, and check that it has the access information needed.
-	secret, err := object.GetRealmKeySecret(r.context, realmName)
+	secret, err := object.GetRealmKeySecret(r.opManagerContext, r.context, realmName)
 	if err == nil {
 		// secret exists, now verify access info. We don't need the args, but we do want to get the
 		// error if the args can't be built

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -31,17 +31,17 @@ import (
 )
 
 func (r *ReconcileCephObjectStore) setFailedStatus(observedGeneration int64, name types.NamespacedName, errMessage string, err error) (reconcile.Result, error) {
-	updateStatus(observedGeneration, r.client, name, cephv1.ConditionFailure, map[string]string{})
+	updateStatus(r.opManagerContext, observedGeneration, r.client, name, cephv1.ConditionFailure, map[string]string{})
 	return reconcile.Result{}, errors.Wrapf(err, "%s", errMessage)
 }
 
 // updateStatus updates an object with a given status
-func updateStatus(observedGeneration int64, client client.Client, namespacedName types.NamespacedName, status cephv1.ConditionType, info map[string]string) {
+func updateStatus(ctx context.Context, observedGeneration int64, client client.Client, namespacedName types.NamespacedName, status cephv1.ConditionType, info map[string]string) {
 	// Updating the status is important to users, but we can still keep operating if there is a
 	// failure. Retry a few times to give it our best effort attempt.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		objectStore := &cephv1.CephObjectStore{}
-		if err := client.Get(context.TODO(), namespacedName, objectStore); err != nil {
+		if err := client.Get(ctx, namespacedName, objectStore); err != nil {
 			if kerrors.IsNotFound(err) {
 				logger.Debug("CephObjectStore resource not found. Ignoring since object must be deleted.")
 				return nil
@@ -76,12 +76,12 @@ func updateStatus(observedGeneration int64, client client.Client, namespacedName
 }
 
 // updateStatusBucket updates an object with a given status
-func updateStatusBucket(client client.Client, name types.NamespacedName, status cephv1.ConditionType, details string) {
+func updateStatusBucket(ctx context.Context, client client.Client, name types.NamespacedName, status cephv1.ConditionType, details string) {
 	// Updating the status is important to users, but we can still keep operating if there is a
 	// failure. Retry a few times to give it our best effort attempt.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		objectStore := &cephv1.CephObjectStore{}
-		if err := client.Get(context.TODO(), name, objectStore); err != nil {
+		if err := client.Get(ctx, name, objectStore); err != nil {
 			if kerrors.IsNotFound(err) {
 				logger.Debug("CephObjectStore resource not found. Ignoring since object must be deleted.")
 				return nil

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -86,7 +86,7 @@ func TestCephBucketTopicController(t *testing.T) {
 			},
 		},
 	}
-	clusterInfo := cephclient.AdminClusterInfo(namespace, "rook")
+	clusterInfo := cephclient.AdminClusterInfo(ctx, namespace, "rook")
 	clusterSpec := cephv1.ClusterSpec{}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileObjectZone) createPoolsAndZone(objContext *object.Context, zon
 	}
 	logger.Debugf("created pools ceph zone %q", zone.Name)
 
-	accessKeyArg, secretKeyArg, err := object.GetRealmKeyArgs(r.context, realmName, zone.Namespace)
+	accessKeyArg, secretKeyArg, err := object.GetRealmKeyArgs(r.opManagerContext, r.context, realmName, zone.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to get keys for realm")
 	}

--- a/pkg/operator/ceph/pool/status.go
+++ b/pkg/operator/ceph/pool/status.go
@@ -30,9 +30,9 @@ import (
 )
 
 // updateStatus updates a pool CR with the given status
-func updateStatus(client client.Client, poolName types.NamespacedName, status cephv1.ConditionType, info map[string]string, observedGeneration int64) {
+func updateStatus(ctx context.Context, client client.Client, poolName types.NamespacedName, status cephv1.ConditionType, info map[string]string, observedGeneration int64) {
 	pool := &cephv1.CephBlockPool{}
-	err := client.Get(context.TODO(), poolName, pool)
+	err := client.Get(ctx, poolName, pool)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.Debug("CephBlockPool resource not found. Ignoring since object must be deleted.")

--- a/pkg/operator/ceph/predicate.go
+++ b/pkg/operator/ceph/predicate.go
@@ -30,14 +30,14 @@ import (
 )
 
 // predicateOpController is the predicate function to trigger reconcile on operator configuration cm change
-func predicateController(client client.Client) predicate.Funcs {
+func predicateController(ctx context.Context, client client.Client) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if cm, ok := e.Object.(*v1.ConfigMap); ok {
 				return cm.Name == controller.OperatorSettingConfigMapName
 			} else if s, ok := e.Object.(*v1.Secret); ok {
 				if s.Name == admissionControllerAppName {
-					err := client.Get(context.TODO(), types.NamespacedName{Name: admissionControllerAppName, Namespace: e.Object.GetNamespace()}, &v1.Service{})
+					err := client.Get(ctx, types.NamespacedName{Name: admissionControllerAppName, Namespace: e.Object.GetNamespace()}, &v1.Service{})
 					if err != nil {
 						if kerrors.IsNotFound(err) {
 							// If the service is present we don't need to reload again. If we don't perform

--- a/pkg/operator/ceph/reporting/reporting.go
+++ b/pkg/operator/ceph/reporting/reporting.go
@@ -164,7 +164,7 @@ func ReportReconcileResult(
 // 2. as a condition on the object (added to the object's conditions list given)
 // 3. as the returned error which should be included in the FailedReconcile message
 func ReportDeletionBlockedDueToDependents(
-	logger *capnslog.PackageLogger, client client.Client, obj cephv1.StatusConditionGetter, deps *dependents.DependentList,
+	ctx context.Context, logger *capnslog.PackageLogger, client client.Client, obj cephv1.StatusConditionGetter, deps *dependents.DependentList,
 ) error {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 	nsName := types.NamespacedName{
@@ -179,7 +179,7 @@ func ReportDeletionBlockedDueToDependents(
 	// 2. condition
 	blockedCond := dependents.DeletionBlockedDueToDependentsCondition(true, blockedMsg)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := client.Get(context.TODO(), nsName, obj); err != nil {
+		if err := client.Get(ctx, nsName, obj); err != nil {
 			return errors.Wrapf(err, "failed to get latest %s %q", kind, nsName.String())
 		}
 		if err := UpdateStatusCondition(client, obj, blockedCond); err != nil {
@@ -201,7 +201,7 @@ func ReportDeletionBlockedDueToDependents(
 // 2. as an event on the object (via the given event recorder)
 // 3. as a condition on the object (added to the object's conditions list given)
 func ReportDeletionNotBlockedDueToDependents(
-	logger *capnslog.PackageLogger, client client.Client, recorder record.EventRecorder, obj cephv1.StatusConditionGetter,
+	ctx context.Context, logger *capnslog.PackageLogger, client client.Client, recorder record.EventRecorder, obj cephv1.StatusConditionGetter,
 ) {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 	nsName := types.NamespacedName{
@@ -220,7 +220,7 @@ func ReportDeletionNotBlockedDueToDependents(
 	// 3. condition
 	unblockedCond := dependents.DeletionBlockedDueToDependentsCondition(false, safeMsg)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := client.Get(context.TODO(), nsName, obj); err != nil {
+		if err := client.Get(ctx, nsName, obj); err != nil {
 			return errors.Wrapf(err, "failed to get latest %s %q", kind, nsName.String())
 		}
 		if err := UpdateStatusCondition(client, obj, unblockedCond); err != nil {

--- a/pkg/util/exec/exec_pod.go
+++ b/pkg/util/exec/exec_pod.go
@@ -92,9 +92,9 @@ func (e *RemotePodCommandExecutor) ExecWithOptions(options ExecOptions) (string,
 
 // ExecCommandInContainerWithFullOutput executes a command in the
 // specified container and return stdout, stderr and error
-func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutput(appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
+func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutput(ctx context.Context, appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
 	options := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appLabel)}
-	pods, err := e.ClientSet.CoreV1().Pods(namespace).List(context.TODO(), options)
+	pods, err := e.ClientSet.CoreV1().Pods(namespace).List(ctx, options)
 	if err != nil {
 		return "", "", err
 	}
@@ -130,6 +130,6 @@ func execute(method string, url *url.URL, config *rest.Config, stdin io.Reader, 
 	})
 }
 
-func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeout(appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
-	return e.ExecCommandInContainerWithFullOutput(appLabel, containerName, namespace, append([]string{"timeout", strconv.Itoa(int(CephCommandsTimeout.Seconds()))}, cmd...)...)
+func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeout(ctx context.Context, appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
+	return e.ExecCommandInContainerWithFullOutput(ctx, appLabel, containerName, namespace, append([]string{"timeout", strconv.Itoa(int(CephCommandsTimeout.Seconds()))}, cmd...)...)
 }

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -222,7 +222,7 @@ func (k8sh *K8sHelper) ExecRemoteWithRetry(retries int, namespace, command strin
 	var output, stderr string
 	cliFinal := append([]string{command}, commandArgs...)
 	for i := 0; i < retries; i++ {
-		output, stderr, err = k8sh.remoteExecutor.ExecCommandInContainerWithFullOutput("rook-ceph-tools", "rook-ceph-tools", namespace, cliFinal...)
+		output, stderr, err = k8sh.remoteExecutor.ExecCommandInContainerWithFullOutput(context.TODO(), "rook-ceph-tools", "rook-ceph-tools", namespace, cliFinal...)
 		if err == nil {
 			return output, nil
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


This pull request removes the usage of context.TODO in rook, and passes down context variable from top level calling functions.


Resolves #8701 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
