### PR TITLE
core: retry on update conflict

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -268,7 +268,7 @@ func (r *ReconcileCephCluster) reconcileDelete(cephCluster *cephv1.CephCluster) 
 	var err error
 
 	// Set the deleting status
-	opcontroller.UpdateClusterCondition(r.context, cephCluster, nsName,
+	opcontroller.UpdateClusterCondition(r.opManagerContext, r.context, cephCluster, nsName,
 		cephv1.ConditionDeleting, corev1.ConditionTrue, cephv1.ClusterDeletingReason, "Deleting the CephCluster",
 		true /* keep all other conditions to be safe */)
 

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -59,10 +58,7 @@ func updateStatus(client client.Client, namespacedName types.NamespacedName, sta
 		objectStore.Status.Phase = status
 		objectStore.Status.Info = info
 
-		if err := reporting.UpdateStatus(client, objectStore); err != nil {
-			return errors.Wrapf(err, "failed to set object store %q status to %q", namespacedName.String(), status)
-		}
-		return nil
+		return client.Status().Update(context.TODO(), objectStore)
 	})
 	if err != nil {
 		logger.Error(err)
@@ -95,10 +91,7 @@ func updateStatusBucket(client client.Client, name types.NamespacedName, status 
 		}
 
 		// but we still need to update the health checker status
-		if err := reporting.UpdateStatus(client, objectStore); err != nil {
-			return errors.Wrapf(err, "failed to set object store %q status to %v", name.String(), status)
-		}
-		return nil
+		return client.Status().Update(context.TODO(), objectStore)
 	})
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
**Description of your changes:**

The API server will return `Conflict` when we try to update an outdated
resource. This can happen in scenarios where we try to update the status
but the CR object spec has been updated by the user.
We will retry we back off 5 times.

We finally get rid of all log messages like:
    
    "the object has been modified
    please apply your changes to the latest version and try again"

Signed-off-by: Sébastien Han <seb@redhat.com>

Will rebase on top of https://github.com/rook/rook/pull/9685.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
