### PR TITLE
test: update bucket notification integration test with http server

### DIFF
--- a/tests/framework/clients/notification.go
+++ b/tests/framework/clients/notification.go
@@ -17,6 +17,9 @@ limitations under the License.
 package clients
 
 import (
+	"strings"
+	"time"
+
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 )
@@ -55,4 +58,18 @@ func (t *NotificationOperation) CheckNotificationCR(notificationName string) boo
 	}
 
 	return true
+}
+
+func (t *NotificationOperation) CheckNotificationFromHTTPEndPoint(appLabel, eventName, fileName string) (bool, error) {
+	// wait for the notification to reach http-server
+	time.Sleep(5 * time.Second)
+	selectorName := "--selector=" + appLabel
+	l, err := t.k8sh.Kubectl("logs", selectorName, "--tail", "5")
+	if err != nil {
+		return false, err
+	}
+	if strings.Contains(l, eventName) && strings.Contains(l, fileName) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -508,7 +508,11 @@ kind: CephBucketNotification
 metadata:
   name: ` + notificationName + `
 spec:
-  topic: ` + topicName
+  topic: ` + topicName + `
+  events:
+    - s3:ObjectCreated:Put
+    - s3:ObjectRemoved:Delete
+`
 }
 
 //GetBucketTopic returns the manifest to create ceph bucket topic
@@ -520,7 +524,7 @@ metadata:
 spec:
   endpoint:
     http:
-      uri: http://` + httpEndpointService + `
+      uri: ` + httpEndpointService + `
       sendCloudEvents: false
   objectStoreName: ` + storeName + `
   objectStoreNamespace: ` + m.settings.Namespace

--- a/tests/scripts/pythonwebserver/Dockerfile
+++ b/tests/scripts/pythonwebserver/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3
+ADD server.py /
+EXPOSE 8080
+CMD [ "python", "./server.py"]

--- a/tests/scripts/pythonwebserver/server.py
+++ b/tests/scripts/pythonwebserver/server.py
@@ -1,0 +1,54 @@
+'''
+Copyright 2022 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+#!/usr/bin/env python3
+"""
+Very simple HTTP server in python for logging requests
+Usage::
+    ./server.py [<port>]
+"""
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+
+class S(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length']) # <--- Gets the size of data
+        post_data = self.rfile.read(content_length) # <--- Gets the data itself
+        logging.info("POST request\nBody:\n%s\n", post_data.decode('utf-8'))
+
+def run(server_class=HTTPServer, handler_class=S, port=8080):
+    logging.basicConfig(level=logging.INFO)
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    logging.info('Starting httpd...\n')
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+    logging.info('Stopping httpd...\n')
+
+if __name__ == '__main__':
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add test cases to check notification is received by http server. For
this a sample HTTP server in https://github.com/thotz/pythonwebserver
used.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
