### PR TITLE
object: Update object pool properties during reconcile

### DIFF
--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -93,7 +93,7 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, AdminTestClusterInfo("mycluster"), "mypoolprofile", p, DefaultPGCount, "myapp", overwrite)
+	err := createECPoolForApp(context, AdminTestClusterInfo("mycluster"), "mypoolprofile", p, DefaultPGCount, "myapp", overwrite)
 	assert.Nil(t, err)
 	if compressionMode != "" {
 		assert.True(t, compressionModeCreated)
@@ -234,7 +234,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 		p.CompressionMode = compressionMode
 	}
 	clusterSpec := &cephv1.ClusterSpec{Storage: cephv1.StorageScopeSpec{Config: map[string]string{CrushRootConfigKey: "cluster-crush-root"}}}
-	err := CreateReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, p, DefaultPGCount, "myapp")
+	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, p, DefaultPGCount, "myapp")
 	assert.Nil(t, err)
 	assert.True(t, crushRuleCreated)
 	if compressionMode != "" {
@@ -542,7 +542,7 @@ func testCreatePoolWithReplicasPerFailureDomain(t *testing.T, failureDomain, cru
 	}
 	context := &clusterd.Context{Executor: executor}
 	clusterSpec := &cephv1.ClusterSpec{Storage: cephv1.StorageScopeSpec{Config: map[string]string{CrushRootConfigKey: "cluster-crush-root"}}}
-	err := CreateReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, poolSpec, DefaultPGCount, "myapp")
+	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, poolSpec, DefaultPGCount, "myapp")
 	assert.Nil(t, err)
 	assert.True(t, poolRuleCreated)
 	assert.True(t, poolRuleSet)

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -158,7 +158,7 @@ func createOrUpdatePools(f *Filesystem, context *clusterd.Context, clusterInfo *
 		Name:     generateMetaDataPoolName(f),
 		PoolSpec: spec.MetadataPool,
 	}
-	err := cephclient.CreatePoolWithProfile(context, clusterInfo, clusterSpec, metadataPool, "")
+	err := cephclient.CreatePool(context, clusterInfo, clusterSpec, metadataPool, "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to update metadata pool %q", metadataPool.Name)
 	}
@@ -166,7 +166,7 @@ func createOrUpdatePools(f *Filesystem, context *clusterd.Context, clusterInfo *
 	dataPoolNames := generateDataPoolNames(f, spec)
 	for i, dataPool := range spec.DataPools {
 		dataPool.Name = dataPoolNames[i]
-		err := cephclient.CreatePoolWithProfile(context, clusterInfo, clusterSpec, dataPool, "")
+		err := cephclient.CreatePool(context, clusterInfo, clusterSpec, dataPool, "")
 		if err != nil {
 			return errors.Wrapf(err, "failed to update datapool  %q", dataPool.Name)
 		}
@@ -239,7 +239,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, clusterInfo *
 		PoolSpec: spec.MetadataPool,
 	}
 	if _, poolFound := reversedPoolMap[metadataPool.Name]; !poolFound {
-		err = cephclient.CreatePoolWithProfile(context, clusterInfo, clusterSpec, metadataPool, "")
+		err = cephclient.CreatePool(context, clusterInfo, clusterSpec, metadataPool, "")
 		if err != nil {
 			return errors.Wrapf(err, "failed to create metadata pool %q", metadataPool.Name)
 		}
@@ -249,7 +249,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, clusterInfo *
 	for i, dataPool := range spec.DataPools {
 		dataPool.Name = dataPoolNames[i]
 		if _, poolFound := reversedPoolMap[dataPool.Name]; !poolFound {
-			err = cephclient.CreatePoolWithProfile(context, clusterInfo, clusterSpec, dataPool, "")
+			err = cephclient.CreatePool(context, clusterInfo, clusterSpec, dataPool, "")
 			if err != nil {
 				return errors.Wrapf(err, "failed to create data pool %q", dataPool.Name)
 			}

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -197,6 +197,8 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 				} else if reflect.DeepEqual(args[0:4], []string{"fs", "add_data_pool", fsName, fsName + "-named-pool"}) {
 					*addDataPoolCount++
 					return "", nil
+				} else if reflect.DeepEqual(args[0:3], []string{"osd", "pool", "get"}) {
+					return "", errors.New("test pool does not exist yet")
 				} else if contains(args, "versions") {
 					versionStr, _ := json.Marshal(
 						map[string]map[string]int{
@@ -267,6 +269,8 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 				return "", nil
 			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-named-pool", "size", "1"}) {
 				return "", nil
+			} else if reflect.DeepEqual(args[0:3], []string{"osd", "pool", "get"}) {
+				return "", errors.New("test pool does not exist yet")
 			} else if reflect.DeepEqual(args[0:4], []string{"fs", "add_data_pool", fsName, fsName + "-named-pool"}) {
 				*addDataPoolCount++
 				return "", nil
@@ -487,6 +491,8 @@ func TestUpgradeFilesystem(t *testing.T) {
 			return "", nil
 		} else if contains(args, "config") && contains(args, "get") {
 			return "{}", nil
+		} else if reflect.DeepEqual(args[0:3], []string{"osd", "pool", "get"}) {
+			return "", errors.New("test pool does not exist yet")
 		} else if contains(args, "versions") {
 			versionStr, _ := json.Marshal(
 				map[string]map[string]int{

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -308,7 +308,7 @@ func TestCephObjectStoreController(t *testing.T) {
 				Name:      store,
 				Namespace: namespace,
 			},
-			Spec:     cephv1.ObjectStoreSpec{},
+			Spec:     cephv1.ObjectStoreSpec{MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}, DataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}},
 			TypeMeta: controllerTypeMeta,
 		}
 		objectStore.Spec.Gateway.Port = 80
@@ -445,6 +445,9 @@ func TestCephObjectStoreController(t *testing.T) {
 				}
 				if args[0] == "versions" {
 					return dummyVersionsRaw, nil
+				}
+				if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+					return "", errors.New("test pool does not exit yet")
 				}
 				if args[0] == "osd" && args[1] == "lspools" {
 					// ceph actually outputs this all on one line, but this parses the same
@@ -630,6 +633,9 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 			}
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return rgwCephAuthGetOrCreateKey, nil
+			}
+			if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+				return "", errors.New("test pool does not exit yet")
 			}
 			if args[0] == "versions" {
 				return dummyVersionsRaw, nil

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -375,7 +375,7 @@ func createPool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 
 	// create the pool
 	logger.Infof("creating pool %q in namespace %q", p.Name, clusterInfo.Namespace)
-	if err := cephclient.CreatePoolWithProfile(context, clusterInfo, clusterSpec, *p, appName); err != nil {
+	if err := cephclient.CreatePool(context, clusterInfo, clusterSpec, *p, appName); err != nil {
 		return errors.Wrapf(err, "failed to create pool %q", p.Name)
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The reconcile was skipping updating most pool properties for object stores. The implementation of pools between the file, object, and pool controllers had some duplicate code, so this change also factors out the common code for better reuse in a single place. Anytime a pool is created or updated, it will now consistently update all the pool properties that are expected to be modifiable.

**Which issue is resolved by this Pull Request:**
Resolves #9443 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
