### PR TITLE
osd: re-enable raw mode on disk

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -56,8 +56,12 @@ var (
 
 	// The Ceph Octopus to include a retry to acquire device lock
 	cephFlockFixOctopusMinCephVersion = cephver.CephVersion{Major: 15, Minor: 2, Extra: 9}
-	isEncrypted                       = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
-	isOnPVC                           = os.Getenv(oposd.PVCBackedOSDVarName) == "true"
+
+	// The mitigation of phantom ATARI partition problem is fixed in Ceph v16.2.6. Quincy doesn't have this problem from the beginning
+	// See https://github.com/ceph/ceph/pull/42469
+	cephIgnorePhantomAtariPartitionCephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}
+	isEncrypted                                = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
+	isOnPVC                                    = os.Getenv(oposd.PVCBackedOSDVarName) == "true"
 )
 
 type osdInfoBlock struct {
@@ -469,6 +473,16 @@ func (a *OsdAgent) allowRawMode(context *clusterd.Context) (bool, error) {
 	return allowRawMode, nil
 }
 
+func isSafeToUseRawMode(deviceType string, cephVersion cephver.CephVersion) bool {
+	if deviceType != sys.DiskType {
+		return true
+	}
+	if cephVersion.IsAtLeast(cephIgnorePhantomAtariPartitionCephVersion) {
+		return true
+	}
+	return false
+}
+
 func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceOsdMapping) error {
 	// Should we allow ceph-volume raw mode?
 	allowRawMode, err := a.allowRawMode(context)
@@ -494,7 +508,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 	}
 
 	for name, device := range devices.Entries {
-		// Even if we can use raw mode, do NOT use raw mode on disks. Ceph bluestore disks can
+		// Even if we can use raw mode, do NOT use raw mode on disks in Ceph < 16.2.6. Ceph bluestore disks can
 		// sometimes appear as though they have "phantom" Atari (AHDI) partitions created on them
 		// when they don't in reality. This is due to a series of bugs in the Linux kernel when it
 		// is built with Atari support enabled. This behavior does not appear for raw mode OSDs on
@@ -503,7 +517,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		// which reports only the phantom partitions (and malformed OSD info) when they exist and
 		// ignores the original (correct) OSDs created on the raw disk.
 		// See: https://github.com/rook/rook/issues/7940
-		if device.DeviceInfo.Type != sys.DiskType && allowRawMode {
+		if allowRawMode && isSafeToUseRawMode(device.DeviceInfo.Type, a.clusterInfo.CephVersion) {
 			rawDevices.Entries[name] = device
 			continue
 		}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1374,3 +1374,9 @@ func TestAppendOSDInfo(t *testing.T) {
 		assert.Equal(t, 3, len(trimmedOSDs))
 	}
 }
+
+func TestIsSafeToUseRawMode(t *testing.T) {
+	assert.Equal(t, true, isSafeToUseRawMode(sys.PartType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 5}))
+	assert.Equal(t, false, isSafeToUseRawMode(sys.DiskType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 5}))
+	assert.Equal(t, true, isSafeToUseRawMode(sys.DiskType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}))
+}


### PR DESCRIPTION
**Description of your changes:**

We can re-enable raw mode OSD on disk if Ceph version is at least v16.2.6.

**Which issue is resolved by this Pull Request:**
Resolves #9659

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
