### PR TITLE
csi: cleanup csi driver resources when zero cephclusters exist

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -47,21 +47,13 @@ func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, 
 	}
 
 	if CSIEnabled() {
-		maxRetries := 3
-		for i := 0; i < maxRetries; i++ {
-			if err = r.startDrivers(serverVersion, ownerInfo, v); err != nil {
-				logger.Errorf("failed to start Ceph csi drivers, will retry starting csi drivers %d more times. %v", maxRetries-i-1, err)
-			} else {
-				break
-			}
+		if err = r.startDrivers(serverVersion, ownerInfo, v); err != nil {
+			return errors.Wrap(err, "failed to start ceph csi drivers")
 		}
-		return errors.Wrap(err, "failed to start ceph csi drivers")
 	}
 
 	// Check whether RBD or CephFS needs to be disabled
-	r.stopDrivers(serverVersion)
-
-	return nil
+	return r.stopDrivers(serverVersion)
 }
 
 func (r *ReconcileCSI) setParams() error {

--- a/pkg/operator/ceph/csi/predicate.go
+++ b/pkg/operator/ceph/csi/predicate.go
@@ -94,6 +94,13 @@ func predicateController(ctx context.Context, c client.Client, opNamespace strin
 			if cm, ok := e.Object.(*v1.ConfigMap); ok {
 				return cm.Name == opcontroller.OperatorSettingConfigMapName
 			}
+
+			// if cephCluster is deleted, trigger reconcile to cleanup the csi driver resources
+			// if zero cephClusters exist.
+			if _, ok := e.Object.(*cephv1.CephCluster); ok {
+				return true
+			}
+
 			return false
 		},
 


### PR DESCRIPTION
This commit modifies ceph-csi controller to be able to cleanup
ceph-csi deployment,daemonset,services & csidriver objects
when no cephcluster exists.

It makes the following changes:
- redundant check for tp.DriverNamePrefix is removed.
- retry to start drivers within reconcile loop is removed,
  controller will retry in case of error now.
- stopDrivers() will now return error in case of failure.
- predicate delete func will now respond to cephcluster deletion.
- CSI resources will be cleaned up when cephcluster does not exist.

Fixes: #9697

Signed-off-by: Rakshith R <rar@redhat.com>


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
