### PR TITLE
osd: add namespace in vault client

### DIFF
--- a/pkg/daemon/ceph/osd/kms/vault_api.go
+++ b/pkg/daemon/ceph/osd/kms/vault_api.go
@@ -84,6 +84,11 @@ func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretC
 		return nil, err
 	}
 
+	// Set the namespace if the config has a namespace
+	if backendPath := GetParam(secretConfig, api.EnvVaultNamespace); backendPath != "" {
+		client.SetNamespace(secretConfig[api.EnvVaultNamespace])
+	}
+
 	// Configure the authentication method, either Token or Kubernetes.
 	// Both return a token
 	token, _, err := utils.Authenticate(client, c)


### PR DESCRIPTION
**Description of your changes:**

If the KMS connection details for Vault have a VAULT_NAMESPACE we must
use it when building the vault client to auto-detect the KV internal
version.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
