### PR TITLE
osd: Return error if fail to list osds in prepare job

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -140,7 +140,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// List THE existing OSD configured with ceph-volume lvm mode
 			lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, lvPath, skipLVRelease, lvBackedPV)
 			if err != nil {
-				logger.Infof("failed to get device already provisioned by ceph-volume lvm. %v", err)
+				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume lvm")
 			}
 			osds = append(osds, lvmOsds...)
 			if len(osds) > 0 {
@@ -162,7 +162,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 
 			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
 			if err != nil {
-				logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
+				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
 			osds = append(osds, rawOsds...)
 		} else {
@@ -170,14 +170,14 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// List existing OSD(s) configured with ceph-volume lvm mode
 			lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, lvPath, false, false)
 			if err != nil {
-				logger.Infof("failed to get devices already provisioned by ceph-volume. %v", err)
+				return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume")
 			}
 			osds = append(osds, lvmOsds...)
 
 			// List existing OSD(s) configured with ceph-volume raw mode
 			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false)
 			if err != nil {
-				logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
+				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
 			osds = appendOSDInfo(osds, rawOsds)
 		}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -412,7 +412,7 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "sgdisk" {
 				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
 			}
-			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" && args[6] == mapperDev {
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
 				return `{}`, nil
 			}
 			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" && args[6] == mountedDev {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD prepare job was succeeding even if the OSDs failed to be listed by ceph-volume. These errors should be returned and fail the job, resulting in a retry to retrieve the OSDs. Otherwise, the failure is masked and the admin needs to dig through logs to find why the OSDs were not configured on that node.

This issue was seen in the following osd prepare log:
```
2022-01-26 23:10:36.953577 D | cephosd: desiredDevices are [{Name:/mnt/default-1-data-0f8266 OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2022-01-26 23:10:36.953580 D | cephosd: context.Devices are:
2022-01-26 23:10:36.953596 D | cephosd: &{Name:/mnt/default-1-data-0f8266 Parent: HasChildren:false DevLinks:/dev/disk/by-path/pci-0000:00:1e.0-nvme-1 /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0a81c0ace9c400b63 /dev/disk/by-id/nvme-nvme.1d0f-766f6c3061383163306163653963343030623633-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001 Size:1099511627776 UUID:2740c1cc-8977-4d32-bb36-5643e44e4a59 Serial:Amazon Elastic Block Store_vol0a81c0ace9c400b63 Type:data Rotational:false Readonly:false Partitions:[] Filesystem: Vendor: Model:Amazon Elastic Block Store WWN:nvme.1d0f-766f6c3061383163306163653963343030623633-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001 WWNVendorExtension:nvme.1d0f-766f6c3061383163306163653963343030623633-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001 Empty:false CephVolumeData: RealPath:/dev/nvme1n1 KernelName:nvme1n1 Encrypted:false}
2022-01-26 23:10:36.953704 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list /mnt/default-1-data-0f8266 --format json
2022-01-26 23:10:37.200585 E | cephosd: . Traceback (most recent call last):
  File "/usr/sbin/ceph-volume", line 11, in <module>
    load_entry_point('ceph-volume==1.0.0', 'console_scripts', 'ceph-volume')()
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 39, in __init__
    self.main(self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 59, in newfunc
    return f(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 151, in main
    terminal.dispatch(self.mapper, subcommand_args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/main.py", line 32, in main
    terminal.dispatch(self.mapper, self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 136, in main
    self.list(args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 16, in is_root
    return func(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 92, in list
    report = self.generate(args.device)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 80, in generate
    whoami = oj[dev]['whoami']
KeyError: 'whoami'
2022-01-26 23:10:37.200608 E | cephosd: [2022-01-26 23:10:37,131][ceph_volume.main][INFO  ] Running command: ceph-volume --log-path /tmp/ceph-log raw list /mnt/default-1-data-0f8266 --format json
[2022-01-26 23:10:37,132][ceph_volume.devices.raw.list][DEBUG ] Examining /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,132][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph-bluestore-tool show-label --dev /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout {
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "/mnt/default-1-data-0f8266": {
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "osd_uuid": "2837c75c-6bc8-444a-aa13-dd45bc3b49b0",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "size": 1099511627776,
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "btime": "2022-01-26 23:04:37.887625",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "description": "main",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "bluefs": "1",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "kv_backend": "rocksdb",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "mkfs_done": "yes"
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,182][ceph_volume][ERROR ] exception caught by decorator
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 59, in newfunc
    return f(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 151, in main
    terminal.dispatch(self.mapper, subcommand_args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/main.py", line 32, in main
    terminal.dispatch(self.mapper, self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 136, in main
    self.list(args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 16, in is_root
    return func(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 92, in list
    report = self.generate(args.device)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 80, in generate
    whoami = oj[dev]['whoami']
KeyError: 'whoami'
2022-01-26 23:10:37.200648 I | cephosd: skipping device "/mnt/default-1-data-0f8266": failed to detect if there is already an osd. failed to retrieve ceph-volume raw list results: failed ceph-volume call (see ceph-volume log above for more details): exit status 1.
2022-01-26 23:10:37.213129 I | cephosd: configuring osd devices: {"Entries":{}}
2022-01-26 23:10:37.213144 I | cephosd: no new devices to configure. returning devices already configured with ceph-volume.
2022-01-26 23:10:37.213151 D | exec: Running command: pvdisplay -C -o lvpath --noheadings /mnt/default-1-data-0f8266
2022-01-26 23:10:37.260747 W | cephosd: failed to retrieve logical volume path for "/mnt/default-1-data-0f8266". exit status 5
2022-01-26 23:10:37.260765 D | exec: Running command: lsblk /mnt/default-1-data-0f8266 --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME
2022-01-26 23:10:37.262724 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log lvm list  --format json
2022-01-26 23:10:37.501252 D | cephosd: {}
2022-01-26 23:10:37.501282 I | cephosd: 0 ceph-volume lvm osd devices configured on this node
2022-01-26 23:10:37.501305 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list /mnt/default-1-data-0f8266 --format json
2022-01-26 23:10:37.741228 E | cephosd: . Traceback (most recent call last):
  File "/usr/sbin/ceph-volume", line 11, in <module>
    load_entry_point('ceph-volume==1.0.0', 'console_scripts', 'ceph-volume')()
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 39, in __init__
    self.main(self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 59, in newfunc
    return f(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 151, in main
    terminal.dispatch(self.mapper, subcommand_args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/main.py", line 32, in main
    terminal.dispatch(self.mapper, self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 136, in main
    self.list(args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 16, in is_root
    return func(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 92, in list
    report = self.generate(args.device)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 80, in generate
    whoami = oj[dev]['whoami']
KeyError: 'whoami'
2022-01-26 23:10:37.741253 E | cephosd: [2022-01-26 23:10:37,131][ceph_volume.main][INFO  ] Running command: ceph-volume --log-path /tmp/ceph-log raw list /mnt/default-1-data-0f8266 --format json
[2022-01-26 23:10:37,132][ceph_volume.devices.raw.list][DEBUG ] Examining /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,132][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph-bluestore-tool show-label --dev /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout {
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "/mnt/default-1-data-0f8266": {
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "osd_uuid": "2837c75c-6bc8-444a-aa13-dd45bc3b49b0",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "size": 1099511627776,
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "btime": "2022-01-26 23:04:37.887625",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "description": "main",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "bluefs": "1",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "kv_backend": "rocksdb",
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout "mkfs_done": "yes"
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,181][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,182][ceph_volume][ERROR ] exception caught by decorator
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 59, in newfunc
    return f(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 151, in main
    terminal.dispatch(self.mapper, subcommand_args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/main.py", line 32, in main
    terminal.dispatch(self.mapper, self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 136, in main
    self.list(args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 16, in is_root
    return func(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 92, in list
    report = self.generate(args.device)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 80, in generate
    whoami = oj[dev]['whoami']
KeyError: 'whoami'
[2022-01-26 23:10:37,434][ceph_volume.main][INFO  ] Running command: ceph-volume --log-path /tmp/ceph-log lvm list  --format json
[2022-01-26 23:10:37,434][ceph_volume.process][INFO  ] Running command: /usr/sbin/lvs --noheadings --readonly --separator=";" -a -S  -o lv_tags,lv_path,lv_name,vg_name,lv_uuid,lv_size
[2022-01-26 23:10:37,484][ceph_volume.process][INFO  ] stderr Udev is running and DM_DISABLE_UDEV environment variable is set. Bypassing udev, LVM will manage logical volume symlinks in device directory.
[2022-01-26 23:10:37,484][ceph_volume.process][INFO  ] stderr Udev is running and DM_DISABLE_UDEV environment variable is set. Bypassing udev, LVM will obtain device list by scanning device directory.
[2022-01-26 23:10:37,674][ceph_volume.main][INFO  ] Running command: ceph-volume --log-path /tmp/ceph-log raw list /mnt/default-1-data-0f8266 --format json
[2022-01-26 23:10:37,674][ceph_volume.devices.raw.list][DEBUG ] Examining /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,674][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph-bluestore-tool show-label --dev /mnt/default-1-data-0f8266
[2022-01-26 23:10:37,722][ceph_volume.process][INFO  ] stdout {
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "/mnt/default-1-data-0f8266": {
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "osd_uuid": "2837c75c-6bc8-444a-aa13-dd45bc3b49b0",
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "size": 1099511627776,
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "btime": "2022-01-26 23:04:37.887625",
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "description": "main",
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "bluefs": "1",
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "kv_backend": "rocksdb",
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout "mkfs_done": "yes"
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,723][ceph_volume.process][INFO  ] stdout }
[2022-01-26 23:10:37,723][ceph_volume][ERROR ] exception caught by decorator
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 59, in newfunc
    return f(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/main.py", line 151, in main
    terminal.dispatch(self.mapper, subcommand_args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/main.py", line 32, in main
    terminal.dispatch(self.mapper, self.argv)
  File "/usr/lib/python3.6/site-packages/ceph_volume/terminal.py", line 194, in dispatch
    instance.main()
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 136, in main
    self.list(args)
  File "/usr/lib/python3.6/site-packages/ceph_volume/decorators.py", line 16, in is_root
    return func(*a, **kw)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 92, in list
    report = self.generate(args.device)
  File "/usr/lib/python3.6/site-packages/ceph_volume/devices/raw/list.py", line 80, in generate
    whoami = oj[dev]['whoami']
KeyError: 'whoami'
2022-01-26 23:10:37.741293 I | cephosd: failed to get device already provisioned by ceph-volume raw. failed to retrieve ceph-volume raw list results: failed ceph-volume call (see ceph-volume log above for more details): exit status 1
2022-01-26 23:10:37.741299 W | cephosd: skipping OSD configuration as no devices matched the storage settings for this node "default-1-data-0f8266"
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
