### PR TITLE
ceph: remove rbd_default_features setting

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -138,10 +138,6 @@ func SetOrRemoveDefaultConfigs(
 		}
 	}
 
-	if err := monStore.SetAll(DefaultLegacyConfigs()...); err != nil {
-		return errors.Wrapf(err, "failed to apply legacy config overrides")
-	}
-
 	// Apply Multus if needed
 	if clusterSpec.Network.IsMultus() {
 		logger.Info("configuring ceph network(s) with multus")

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -80,16 +80,6 @@ func DefaultCentralizedConfigs(cephVersion version.CephVersion) []Option {
 	return overrides
 }
 
-// DefaultLegacyConfigs need to be added to the Ceph config file until the integration tests can be
-// made to override these options for the Ceph clusters it creates.
-func DefaultLegacyConfigs() []Option {
-	overrides := []Option{
-		// TODO: move this under LegacyConfigs() when FlexVolume is no longer supported
-		configOverride("global", "rbd_default_features", "3"),
-	}
-	return overrides
-}
-
 // LegacyConfigs represents old configuration that were applied to a cluster and not needed anymore
 func LegacyConfigs() []Option {
 	return []Option{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Instead of setting the default values in the Rook, we should use the defaults provided by the ceph itself. This configuration is causing a problem for the rbd image creation, this is not allowing the rbd images to have default image features that come with librbd.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

* Without this Fix, the rbd images are created with layering features as Rook is setting its own default

```
sh-4.4# rbd create replicapool/test1 --size=1G -m=10.104.250.35:6789 --user=csi-rbd-provisioner --key=AQBnnwRi82AkBRAAzJAGOjbwxppY9KQeYrD6dA==
sh-4.4# 
sh-4.4# rbd info replicapool/test1  -m=10.104.250.35:6789 --user=csi-rbd-provisioner --key=AQBnnwRi82AkBRAAzJAGOjbwxppY9KQeYrD6dA==
rbd image 'test1':
	size 1 GiB in 256 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: 13189d19650b2
	block_name_prefix: rbd_data.13189d19650b2
	format: 2
	features: layering
	op_features: 
	flags: 
	create_timestamp: Thu Feb 17 05:58:30 2022
	access_timestamp: Thu Feb 17 05:58:30 2022
	modify_timestamp: Thu Feb 17 05:58:30 2022
```

* With this fix am able to create the rbd images with default image features that come with default ceph

```
# kubectl exec -it rook-ceph-tools-7bbd566fd9-m9zrr -nrook-ceph -- sh
sh-4.4$ rbd create replicapool/test --size=1G
sh-4.4$ rbd info replicapool/test
rbd image 'test':
	size 1 GiB in 256 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: 10679128b9f7
	block_name_prefix: rbd_data.10679128b9f7
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	op_features: 
	flags: 
	create_timestamp: Thu Feb 17 10:31:48 2022
	access_timestamp: Thu Feb 17 10:31:48 2022
	modify_timestamp: Thu Feb 17 10:31:48 2022
sh-4.4$ 
```
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

Thanks to @idryomov for finding this one. can you please also check this PR?
