### PR TITLE
test: fix upgrade test namespace in daily-nightly CI

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -248,8 +248,8 @@ jobs:
         if: always()
         run: |
           export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
-          export CLUSTER_NAMESPACE="upgrade-ns"
-          export OPERATOR_NAMESPACE="upgrade-ns-system"
+          export CLUSTER_NAMESPACE="upgrade"
+          export OPERATOR_NAMESPACE="upgrade-system"
           tests/scripts/collect-logs.sh
 
       - name: Artifact
@@ -282,8 +282,8 @@ jobs:
         if: always()
         run: |
           export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
-          export CLUSTER_NAMESPACE="upgrade-ns"
-          export OPERATOR_NAMESPACE="upgrade-ns-system"
+          export CLUSTER_NAMESPACE="upgrade"
+          export OPERATOR_NAMESPACE="upgrade-system"
           tests/scripts/collect-logs.sh
 
       - name: Artifact


### PR DESCRIPTION
PR #9546 missed updating the daily-nightly CI jobs, and logs are no
longer properly collected from the upgrade jobs there.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

Of note the [upgrade-from-pacific-stable-to-pacific-devel](https://github.com/rook/rook/runs/5170432545?check_suite_focus=true#logs) test seems flaky, and I wasn't able to debug it since the logs were missing.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
