### PR TITLE
core: remove rbd_default_features setting in upgrades

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -138,6 +138,21 @@ func SetOrRemoveDefaultConfigs(
 		}
 	}
 
+	// remove `rbd_default_features` since it is no longer used in the
+	// upgraded clusters. This was set to `3` previously from Rook.
+	rbdDefaultFeatures := "rbd_default_features"
+	val, err := monStore.Get("mon", rbdDefaultFeatures)
+	if err != nil {
+		// This should not happen in normal case, this should fetch the ceph defaults.
+		return errors.Wrapf(err, "failed to get rbd_default_features configuration")
+	}
+	if val == "3" {
+		logger.Debug("removing rbd_default_features config")
+		err = monStore.Delete("global", rbdDefaultFeatures)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete rbd_default_features configuration")
+		}
+	}
 	// Apply Multus if needed
 	if clusterSpec.Network.IsMultus() {
 		logger.Info("configuring ceph network(s) with multus")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
PR #9758 was sent to remove rbd_default_features as a default setting. This PR will help us to remove the rbd_default_features set in the already existing clusters.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Logs
* Setting Before Upgrade

```
sh-4.4$ ceph config get mon rbd_default_features
3
```

* After updating Rook image

```
sh-4.4$ ceph config get mon rbd_default_features
layering,exclusive-lock,object-map,fast-diff,deep-flatten
sh-4.4$ 

```
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
