### PR TITLE
core: add k8s events in blockpool reconciler

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -46,6 +46,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 )
 
 const (
@@ -69,6 +70,7 @@ type ReconcileCephClient struct {
 	context          *clusterd.Context
 	clusterInfo      *cephclient.ClusterInfo
 	opManagerContext context.Context
+	recorder         record.EventRecorder
 }
 
 // Add creates a new CephClient Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -84,6 +86,7 @@ func newReconciler(mgr manager.Manager, context *clusterd.Context, opManagerCont
 		scheme:           mgr.GetScheme(),
 		context:          context,
 		opManagerContext: opManagerContext,
+		recorder:         mgr.GetEventRecorderFor("rook-" + controllerName),
 	}
 }
 
@@ -119,31 +122,27 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCephClient) Reconcile(context context.Context, request reconcile.Request) (reconcile.Result, error) {
 	// workaround because the rook logging mechanism is not compatible with the controller-runtime logging interface
-	reconcileResponse, err := r.reconcile(request)
-	if err != nil {
-		logger.Errorf("failed to reconcile %v", err)
-	}
-
-	return reconcileResponse, err
+	reconcileResponse, cephClient, err := r.reconcile(request)
+	return reporting.ReportReconcileResult(logger, r.recorder, request, &cephClient, reconcileResponse, err)
 }
 
-func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Result, cephv1.CephClient, error) {
 	// Fetch the CephClient instance
 	cephClient := &cephv1.CephClient{}
 	err := r.client.Get(r.opManagerContext, request.NamespacedName, cephClient)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.Debug("cephClient resource not found. Ignoring since object must be deleted.")
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, *cephClient, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, errors.Wrap(err, "failed to get cephClient")
+		return reconcile.Result{}, *cephClient, errors.Wrap(err, "failed to get cephClient")
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
 	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephClient)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
+		return reconcile.Result{}, *cephClient, errors.Wrap(err, "failed to add finalizer")
 	}
 
 	// The CR was just created, initializing status fields
@@ -164,19 +163,19 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 			// Remove finalizer
 			err = opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephClient)
 			if err != nil {
-				return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to remove finalizer")
+				return opcontroller.ImmediateRetryResult, *cephClient, errors.Wrap(err, "failed to remove finalizer")
 			}
 
 			// Return and do not requeue. Successful deletion.
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, *cephClient, nil
 		}
-		return reconcileResponse, nil
+		return reconcileResponse, *cephClient, nil
 	}
 
 	// Populate clusterInfo during each reconcile
 	r.clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
+		return reconcile.Result{}, *cephClient, errors.Wrap(err, "failed to populate cluster info")
 	}
 	r.clusterInfo.Context = r.opManagerContext
 
@@ -185,23 +184,25 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 		logger.Debugf("deleting pool %q", cephClient.Name)
 		err := r.deleteClient(cephClient)
 		if err != nil {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to delete ceph client %q", cephClient.Name)
+			return reconcile.Result{}, *cephClient, errors.Wrapf(err, "failed to delete ceph client %q", cephClient.Name)
 		}
+		r.recorder.Eventf(cephClient, v1.EventTypeNormal, string(cephv1.ReconcileStarted), "deleting CephClient %q", cephClient.Name)
 
 		// Remove finalizer
 		err = opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephClient)
 		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
+			return reconcile.Result{}, *cephClient, errors.Wrap(err, "failed to remove finalizer")
 		}
+		r.recorder.Event(cephClient, v1.EventTypeNormal, string(cephv1.ReconcileSucceeded), "successfully removed finalizer")
 
 		// Return and do not requeue. Successful deletion.
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, *cephClient, nil
 	}
 
 	// validate the client settings
 	err = ValidateClient(r.context, cephClient)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to validate client %q arguments", cephClient.Name)
+		return reconcile.Result{}, *cephClient, errors.Wrapf(err, "failed to validate client %q arguments", cephClient.Name)
 	}
 
 	// Create or Update client
@@ -209,10 +210,10 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	if err != nil {
 		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
 			logger.Info(opcontroller.OperatorNotInitializedMessage)
-			return opcontroller.WaitForRequeueIfOperatorNotInitialized, nil
+			return opcontroller.WaitForRequeueIfOperatorNotInitialized, *cephClient, nil
 		}
 		r.updateStatus(r.client, request.NamespacedName, cephv1.ConditionFailure)
-		return reconcile.Result{}, errors.Wrapf(err, "failed to create or update client %q", cephClient.Name)
+		return reconcile.Result{}, *cephClient, errors.Wrapf(err, "failed to create or update client %q", cephClient.Name)
 	}
 
 	// Success! Let's update the status
@@ -220,7 +221,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 
 	// Return and do not requeue
 	logger.Debug("done reconciling")
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, *cephClient, nil
 }
 
 // Create the client

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -172,6 +173,7 @@ func TestCephClientController(t *testing.T) {
 		scheme:           s,
 		context:          c,
 		opManagerContext: ctx,
+		recorder:         record.NewFakeRecorder(5),
 	}
 
 	// Mock request to simulate Reconcile() being called on an event for a
@@ -220,6 +222,7 @@ func TestCephClientController(t *testing.T) {
 		scheme:           s,
 		context:          c,
 		opManagerContext: ctx,
+		recorder:         record.NewFakeRecorder(5),
 	}
 	assert.True(t, res.Requeue)
 
@@ -278,6 +281,7 @@ func TestCephClientController(t *testing.T) {
 		scheme:           s,
 		context:          c,
 		opManagerContext: context.TODO(),
+		recorder:         record.NewFakeRecorder(5),
 	}
 
 	res, err = r.Reconcile(ctx, req)

--- a/pkg/operator/ceph/file/mirror/controller_test.go
+++ b/pkg/operator/ceph/file/mirror/controller_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -113,6 +114,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 			ServiceAccount:    "foo",
 		},
 		opManagerContext: ctx,
+		recorder:         record.NewFakeRecorder(5),
 	}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -163,6 +165,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 				ServiceAccount:    "foo",
 			},
 			opManagerContext: ctx,
+			recorder:         record.NewFakeRecorder(5),
 		}
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
@@ -205,9 +208,10 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 				ServiceAccount:    "foo",
 			},
 			opManagerContext: ctx,
+			recorder:         record.NewFakeRecorder(5),
 		}
 		res, err := r.Reconcile(ctx, req)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
 	})
 
@@ -229,8 +233,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 		}
 
 		res, err := r.Reconcile(ctx, req)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "waiting for ceph monitors upgrade to finish. current version: 16.0.0-0 pacific. expected version: 15.0.0-0 octopus. will reconcile again in 1m0s")
+		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
 	})
 

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -40,6 +40,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -201,7 +202,7 @@ func TestCephNFSController(t *testing.T) {
 
 	newReconcile := func(clusterCtx *clusterd.Context, cl client.WithWatch) *ReconcileCephNFS {
 		// Create a ReconcileCephNFS object with the scheme and fake client.
-		return &ReconcileCephNFS{client: cl, scheme: testScheme, context: clusterCtx, opManagerContext: ctx}
+		return &ReconcileCephNFS{client: cl, scheme: testScheme, context: clusterCtx, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}
 	}
 
 	// Mock request to simulate Reconcile() being called on an event for a

--- a/pkg/operator/ceph/object/realm/controller_test.go
+++ b/pkg/operator/ceph/object/realm/controller_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -98,7 +99,7 @@ func TestCephObjectRealmController(t *testing.T) {
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithScheme(r.scheme).WithRuntimeObjects(object...).Build()
 	// Create a ReconcileObjectRealm object with the scheme and fake client.
-	r = &ReconcileObjectRealm{client: cl, scheme: r.scheme, context: r.context}
+	r = &ReconcileObjectRealm{client: cl, scheme: r.scheme, context: r.context, recorder: record.NewFakeRecorder(5)}
 	res, err = r.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.True(t, res.Requeue)
@@ -154,7 +155,7 @@ func TestCephObjectRealmController(t *testing.T) {
 	r.context.Executor = executor
 
 	// Create a ReconcileObjectRealm object with the scheme and fake client.
-	r = &ReconcileObjectRealm{client: cl, scheme: r.scheme, context: r.context}
+	r = &ReconcileObjectRealm{client: cl, scheme: r.scheme, context: r.context, recorder: record.NewFakeRecorder(5)}
 
 	res, err = r.Reconcile(ctx, req)
 	assert.NoError(t, err)
@@ -256,7 +257,7 @@ func getObjectRealmAndReconcileObjectRealm(t *testing.T) (*ReconcileObjectRealm,
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 	// Create a ReconcileObjectRealm object with the scheme and fake client.
 	clusterInfo := cephclient.AdminTestClusterInfo("rook")
-	r := &ReconcileObjectRealm{client: cl, scheme: s, context: c, clusterInfo: clusterInfo}
+	r := &ReconcileObjectRealm{client: cl, scheme: s, context: c, clusterInfo: clusterInfo, recorder: record.NewFakeRecorder(5)}
 
 	return r, objectRealm
 }
@@ -284,7 +285,8 @@ func TestReconcileObjectRealm_createRealmKeys(t *testing.T) {
 			context: &clusterd.Context{
 				Clientset: k8sfake.NewSimpleClientset(),
 			},
-			scheme: scheme,
+			scheme:   scheme,
+			recorder: record.NewFakeRecorder(5),
 		}
 
 		for _, tName := range []string{"first reconcile", "second reconcile"} {
@@ -322,7 +324,8 @@ func TestReconcileObjectRealm_createRealmKeys(t *testing.T) {
 			context: &clusterd.Context{
 				Clientset: k8sfake.NewSimpleClientset(secret),
 			},
-			scheme: scheme,
+			scheme:   scheme,
+			recorder: record.NewFakeRecorder(5),
 		}
 
 		_, err := r.createRealmKeys(realm)

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -150,7 +151,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 	// Create a ReconcileObjectStoreUser object with the scheme and fake client.
-	r := &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx}
+	r := &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}
 
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
@@ -185,7 +186,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		// Create a fake client to mock API calls.
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 		// Create a ReconcileObjectStoreUser object with the scheme and fake client.
-		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx}
+		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
@@ -233,7 +234,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		c.Executor = executor
 
 		// Create a ReconcileObjectStoreUser object with the scheme and fake client.
-		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx}
+		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}
 
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
@@ -265,7 +266,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		// Create a fake client to mock API calls.
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 		// Create a ReconcileObjectStoreUser object with the scheme and fake client.
-		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx}
+		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}
 
 		err := r.client.Get(context.TODO(), types.NamespacedName{Name: store, Namespace: namespace}, cephObjectStore)
 		assert.NoError(t, err, cephObjectStore)

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -184,7 +185,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	// Create a ReconcileObjectZone object with the scheme and fake client.
 	clusterInfo := cephclient.AdminTestClusterInfo("rook")
 
-	r := &ReconcileObjectZone{client: cl, scheme: s, context: c, clusterInfo: clusterInfo}
+	r := &ReconcileObjectZone{client: cl, scheme: s, context: c, clusterInfo: clusterInfo, recorder: record.NewFakeRecorder(5)}
 
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
@@ -226,7 +227,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	// Create a ReconcileObjectZone object with the scheme and fake client.
-	r = &ReconcileObjectZone{client: cl, scheme: r.scheme, context: r.context}
+	r = &ReconcileObjectZone{client: cl, scheme: r.scheme, context: r.context, recorder: record.NewFakeRecorder(5)}
 	res, err = r.Reconcile(ctx, req)
 	assert.NoError(t, err)
 	assert.True(t, res.Requeue)
@@ -277,10 +278,10 @@ func TestCephObjectZoneController(t *testing.T) {
 	}
 	r.context.Executor = executor
 
-	r = &ReconcileObjectZone{client: cl, scheme: r.scheme, context: r.context}
+	r = &ReconcileObjectZone{client: cl, scheme: r.scheme, context: r.context, recorder: record.NewFakeRecorder(5)}
 
 	res, err = r.Reconcile(ctx, req)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.True(t, res.Requeue)
 
 	//
@@ -342,7 +343,7 @@ func TestCephObjectZoneController(t *testing.T) {
 
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
-	r = &ReconcileObjectZone{client: cl, scheme: s, context: c, clusterInfo: clusterInfo}
+	r = &ReconcileObjectZone{client: cl, scheme: s, context: c, clusterInfo: clusterInfo, recorder: record.NewFakeRecorder(5)}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: zonegroup, Namespace: namespace}, objectZoneGroup)
 	assert.NoError(t, err, objectZoneGroup)

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -245,6 +246,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		context:           c,
 		blockPoolContexts: make(map[string]*blockPoolHealth),
 		opManagerContext:  context.TODO(),
+		recorder:          record.NewFakeRecorder(5),
 	}
 
 	// Mock request to simulate Reconcile() being called on an event for a
@@ -300,6 +302,7 @@ func TestCephBlockPoolController(t *testing.T) {
 			context:           c,
 			blockPoolContexts: make(map[string]*blockPoolHealth),
 			opManagerContext:  context.TODO(),
+			recorder:          record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -357,6 +360,7 @@ func TestCephBlockPoolController(t *testing.T) {
 			context:           c,
 			blockPoolContexts: make(map[string]*blockPoolHealth),
 			opManagerContext:  context.TODO(),
+			recorder:          record.NewFakeRecorder(5),
 		}
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
@@ -372,7 +376,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		err := r.client.Update(context.TODO(), pool)
 		assert.NoError(t, err)
 		res, err := r.Reconcile(ctx, req)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
 	})
 
@@ -428,6 +432,7 @@ func TestCephBlockPoolController(t *testing.T) {
 			context:           c,
 			blockPoolContexts: make(map[string]*blockPoolHealth),
 			opManagerContext:  context.TODO(),
+			recorder:          record.NewFakeRecorder(5),
 		}
 
 		pool.Spec.Mirroring.Mode = "image"
@@ -469,6 +474,7 @@ func TestCephBlockPoolController(t *testing.T) {
 			context:           c,
 			blockPoolContexts: make(map[string]*blockPoolHealth),
 			opManagerContext:  context.TODO(),
+			recorder:          record.NewFakeRecorder(5),
 		}
 
 		pool.Spec.Mirroring.Peers.SecretNames = []string{peerSecretName}
@@ -476,7 +482,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		assert.NoError(t, err)
 		res, err := r.Reconcile(ctx, req)
 		// assert reconcile failure because peer token secert was not created
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
 	})
 
@@ -506,6 +512,7 @@ func TestCephBlockPoolController(t *testing.T) {
 			context:           c,
 			blockPoolContexts: make(map[string]*blockPoolHealth),
 			opManagerContext:  context.TODO(),
+			recorder:          record.NewFakeRecorder(5),
 		}
 		pool.Spec.Mirroring.Enabled = false
 		pool.Spec.Mirroring.Mode = "image"


### PR DESCRIPTION
adding k8s event in blockpool reconciler when
1. when blockpool reconciler starts
2. when blockpool deletion reconcile triggered.

Closes: https://github.com/rook/rook/issues/9462
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #9462 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
