### PR TITLE
mgr: Set the default count of mgr daemons to 2

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -196,7 +196,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
 * `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health doc](ceph-mon-health.md).
 * `mgr`: manager top level section
-  * `count`: set number of ceph managers between `1` to `2`. The default value is 1. This is only needed if two ceph managers are needed.
+  * `count`: set number of ceph managers between `1` to `2`. The default value is 2.
     If there are two managers, it is important for all mgr services point to the active mgr and not the passive mgr. Therefore, Rook will
     automatically update all services (in the cluster namespace) that have a label `app=rook-ceph-mgr` with a selector pointing to the
     active mgr. This commonly applies to services for the dashboard or the prometheus metrics collector.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,10 +2,11 @@
 
 ## Breaking Changes
 
-*  The mds liveness and startup probes are now configured by the filesystem CR instead of the cluster CR. To apply the mds probes, they need to be specified in the filesystem CR. See the [filesystem CR doc](Documentation/ceph-filesystem-crd.md#metadata-server-settings) for more details. 
-Pr: https://github.com/rook/rook/pull/9550
+* The mds liveness and startup probes are now configured by the filesystem CR instead of the cluster CR. To apply the mds probes, they need to be specified in the filesystem CR. See the [filesystem CR doc](Documentation/ceph-filesystem-crd.md#metadata-server-settings) for more details. See #9550
 
 ## Features
 
-*  Add support for custom ceph.conf for csi pods.
-Pr: https://github.com/rook/rook/pull/9567
+* The number of mgr daemons for example clusters is increased to 2 from 1, resulting in a standby mgr daemon.
+  If the active mgr goes down, Ceph will update the passive mgr to be active, and rook will update all the services
+  with the label app=rook-ceph-mgr to direct traffic to the new active mgr.
+* Add support for custom ceph.conf for csi pods. See #9567

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -89,7 +89,8 @@ cephClusterSpec:
     # When higher availability of the mgr is needed, increase the count to 2.
     # In that case, one mgr will be active and one in standby. When Ceph updates which
     # mgr is active, Rook will update the mgr services to match the active mgr.
-    count: 1
+    count: 2
+    allowMultiplePerNode: false
     modules:
       # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
       # are already enabled by other settings in the cluster CR.

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -54,7 +54,8 @@ spec:
     # When higher availability of the mgr is needed, increase the count to 2.
     # In that case, one mgr will be active and one in standby. When Ceph updates which
     # mgr is active, Rook will update the mgr services to match the active mgr.
-    count: 1
+    count: 2
+    allowMultiplePerNode: false
     modules:
       # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
       # are already enabled by other settings in the cluster CR.

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -217,6 +217,8 @@ spec:
       databaseSizeMB: "1024"
       journalSizeMB: "1024"
   mgr:
+    count: ` + strconv.Itoa(mgrCount) + `
+    allowMultiplePerNode: true
     modules:
     - name: pg_autoscaler
       enabled: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
To ensure the mgr is not the single point of failure, the mgr daemon count is now set to 2 by default in the cluster examples.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
