### PR TITLE
operator: Document that the `rook-ceph-operator-config` ConfigMap is …

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -537,6 +537,8 @@ version of CSI.
 The operator configuration variables have recently moved from the operator deployment to the
 `rook-ceph-operator-config` ConfigMap. The values in the operator deployment can still be set,
 but if the ConfigMap settings are applied, they will override the operator deployment settings.
+The ConfigMap must exist for the operator to work correctly, even if all configuration is
+supplied through the environment.
 
 ```console
 kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-ceph-operator-config


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

We discovered the hard way that configuration through the environment
does not work if this ConfigMap is not present altogether. Document this
in all the places someone might look for hints.

**Which issue is resolved by this Pull Request:**

Closes #9806.

cc @travisn

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
