### PR TITLE
core: Disruption controller log ceph errors in debug level

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -329,10 +329,11 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 		// If the error contains that message, this means the cluster is not up and running
 		// No monitors are present and thus no ceph configuration has been created
 		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
-			logger.Infof("Ceph %q cluster not ready, cannot check Ceph status yet.", request.Namespace)
+			logger.Debugf("ceph %q cluster not ready, cannot check status yet.", request.Namespace)
 			return opcontroller.WaitForRequeueIfOperatorNotInitialized, nil
 		}
-		return reconcile.Result{}, errors.Wrapf(err, "failed to check cluster health")
+		logger.Debugf("ceph %q cluster failed to check cluster health. %v", request.Namespace, err)
+		return opcontroller.WaitForRequeueIfCephClusterNotReady, nil
 	}
 
 	switch {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The controller for disruption budgets is verbose at cluster creation when the cluster is not yet created, which generates a lot of noise in the log that makes the cluster look unhealthy. This is an expected condition, so we can change this logging to debug level.

For example, lots of these messages:
```
2022-03-03 20:29:42.206920 E | clusterdisruption-controller: failed to check cluster health: failed to get status. . unable to get monitor info from DNS SRV with service name: ceph-mon
[errno 2] RADOS object not found (error connecting to the cluster): exit status 1
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
