### PR TITLE
helm: add cephFileSystems storageClass.pool

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -100,6 +100,7 @@ The `cephFileSystems` array in the values file will define a list of CephFileSys
 | `spec`                       | The CephFileSystem spec, see the [CephFilesystem CRD](ceph-filesystem-crd.md) documentation.                                                                | see values.yaml   |
 | `storageClass.enabled`       | Whether a storage class is deployed alongside the CephFileSystem                                                                                            | `true`            |
 | `storageClass.name`          | The name of the storage class                                                                                                                               | `ceph-filesystem` |
+| `storageClass.pool`          | The name of [Data Pool](ceph-filesystem-crd.md#pools), without the filesystem name prefix                                                                   | `data0`           |
 | `storageClass.parameters`    | See [Shared Filesystem](ceph-filesystem.md) documentation or the helm values.yaml for suitable values                                                       | see values.yaml   |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete`          |
 | `storageClass.mountOptions`  | Specifies the mount options for storageClass                                                                                                                | `[]`              |

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -18,7 +18,7 @@ metadata:
 provisioner: {{ $root.Values.operatorNamespace }}.cephfs.csi.ceph.com
 parameters:
   fsName: {{ $filesystem.name }}
-  pool: {{ $filesystem.name }}-data0
+  pool: {{ $filesystem.name }}-{{ default "data0" $filesystem.storageClass.pool }}
   clusterID: {{ $root.Release.Namespace }}
 {{ toYaml $filesystem.storageClass.parameters | indent 2 }}
 reclaimPolicy: {{ default "Delete" $filesystem.storageClass.reclaimPolicy }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -377,6 +377,8 @@ cephFileSystems:
         - failureDomain: host
           replicated:
             size: 3
+          # Optional and highly recommended, 'data0' by default, see https://github.com/rook/rook/blob/master/Documentation/ceph-filesystem-crd.md#pools
+          name: data0
       metadataServer:
         activeCount: 1
         activeStandby: true
@@ -384,6 +386,8 @@ cephFileSystems:
       enabled: true
       isDefault: false
       name: ceph-filesystem
+      # (Optional) specify a data pool to use, must be the name of one of the data pools above, 'data0' by default
+      pool: data0
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       mountOptions: []


### PR DESCRIPTION
CephFileSystem StorageClass created by helm chart should use the specified pool
in values.yaml rather than hardcode 'data0'

Signed-off-by: mtt0 <retmain@foxmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #9826

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
