### PR TITLE
osd: disable raw mode for specific disk configs

### DIFF
--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1376,7 +1376,65 @@ func TestAppendOSDInfo(t *testing.T) {
 }
 
 func TestIsSafeToUseRawMode(t *testing.T) {
-	assert.Equal(t, true, isSafeToUseRawMode(sys.PartType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 5}))
-	assert.Equal(t, false, isSafeToUseRawMode(sys.DiskType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 5}))
-	assert.Equal(t, true, isSafeToUseRawMode(sys.DiskType, cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}))
+	baseDisk := func() *DeviceOsdIDEntry {
+		return &DeviceOsdIDEntry{
+			Config: DesiredDevice{
+				Name: "vda",
+			},
+			DeviceInfo: &sys.LocalDisk{
+				Name: "vda",
+				Type: sys.DiskType,
+			},
+		}
+	}
+	basePart := func() *DeviceOsdIDEntry {
+		return &DeviceOsdIDEntry{
+			Config: DesiredDevice{
+				Name: "vda1",
+			},
+			DeviceInfo: &sys.LocalDisk{
+				Name: "vda1",
+				Type: sys.PartType,
+			},
+		}
+	}
+
+	cephPrevMajor := cephver.CephVersion{Major: 15, Minor: 2, Extra: 15}
+	cephBeforeAtariPatch := cephver.CephVersion{Major: 16, Minor: 2, Extra: 5}
+	cephWithAtariPatch := cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}
+	cephNextMajor := cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
+
+	t.Run("safe for partitions with all Ceph versions", func(t *testing.T) {
+		device := basePart()
+		assert.True(t, isSafeToUseRawMode(device, cephPrevMajor))
+		assert.True(t, isSafeToUseRawMode(device, cephBeforeAtariPatch))
+		assert.True(t, isSafeToUseRawMode(device, cephWithAtariPatch))
+		assert.True(t, isSafeToUseRawMode(device, cephNextMajor))
+	})
+
+	t.Run("safe for disks only with atari patch", func(t *testing.T) {
+		device := baseDisk()
+		// make sure it's still unsafe for previous ceph version
+		assert.False(t, isSafeToUseRawMode(device, cephPrevMajor))
+		assert.False(t, isSafeToUseRawMode(device, cephBeforeAtariPatch))
+		assert.True(t, isSafeToUseRawMode(device, cephWithAtariPatch))
+		// make sure it's still safe when next ceph version comes out
+		assert.True(t, isSafeToUseRawMode(device, cephNextMajor))
+	})
+
+	t.Run("not safe if OSDs per device > 1", func(t *testing.T) {
+		device := baseDisk()
+		device.Config.OSDsPerDevice = 2
+		// we only care about the cases where disks would otherwise be safe
+		assert.False(t, isSafeToUseRawMode(device, cephWithAtariPatch))
+		assert.False(t, isSafeToUseRawMode(device, cephNextMajor))
+	})
+
+	t.Run("not safe if metadata device specified", func(t *testing.T) {
+		device := baseDisk()
+		device.Config.MetadataDevice = "vdb1"
+		// we only care about the cases where disks would otherwise be safe
+		assert.False(t, isSafeToUseRawMode(device, cephWithAtariPatch))
+		assert.False(t, isSafeToUseRawMode(device, cephNextMajor))
+	})
 }


### PR DESCRIPTION
If a specific disk is configured to have more than one OSD per device,
or if it has a metadata device specified, exclude it from raw mode on an
individual basis.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**manual tests run:**
- [x] select one disk with 2 osds per device
- [x] select one disk with another disk as metadata
- [x] select one disk with 2 osds per device, another disk with default config (one should be lvm, the other raw)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #9822 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
