### PR TITLE
helm: fix rook-ceph-cluster helm chart for cephobjectstore storageclass without/empty parameters

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -19,7 +19,9 @@ provisioner: {{ $root.Values.operatorNamespace }}.rbd.csi.ceph.com
 parameters:
   pool: {{ $blockpool.name }}
   clusterID: {{ $root.Release.Namespace }}
-{{ toYaml $blockpool.storageClass.parameters | indent 2 }}
+{{ with $blockpool.storageClass.parameters }}
+{{ toYaml . | indent 2 }}
+{{ end }}
 reclaimPolicy: {{ default "Delete" $blockpool.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $blockpool.storageClass.allowVolumeExpansion }}
 {{- if $blockpool.storageClass.mountOptions }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -20,7 +20,9 @@ parameters:
   fsName: {{ $filesystem.name }}
   pool: {{ $filesystem.name }}-{{ default "data0" $filesystem.storageClass.pool }}
   clusterID: {{ $root.Release.Namespace }}
-{{ toYaml $filesystem.storageClass.parameters | indent 2 }}
+{{ with $filesystem.storageClass.parameters }}
+{{ toYaml . | indent 2 }}
+{{ end }}
 reclaimPolicy: {{ default "Delete" $filesystem.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $filesystem.storageClass.allowVolumeExpansion }}
 {{- if $filesystem.storageClass.mountOptions }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -18,6 +18,8 @@ reclaimPolicy: {{ default "Delete" $objectstore.storageClass.reclaimPolicy }}
 parameters:
   objectStoreName: {{ $objectstore.name }}
   objectStoreNamespace: {{ $root.Release.Namespace }}
-{{ toYaml $objectstore.storageClass.parameters | indent 2 }}
+{{ with $objectstore.storageClass.parameters }}
+{{ toYaml . | indent 2 }}
+{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Fix rook-ceph-cluster helm chart with passing no parameter on CephObjectStore storageclass

Before pull-request:
```
cephObjectStores:
  - name: ceph-objectstore
    [...]
    storageClass:
      parameters: {}
```
gives
```
$ helm template . -f values.yaml --debug
Error: YAML parse error on rook-ceph-cluster/templates/cephobjectstore.yaml: error converting YAML to JSON: yaml: line 9: did not find expected key
[...]                                                               
---                                     
apiVersion: storage.k8s.io/v1           
kind: StorageClass                      
metadata:                               
  name: s3                              
provisioner: default.ceph.rook.io/bucket
reclaimPolicy: Delete                   
parameters:                             
  objectStoreName: ceph-objectstore     
  objectStoreNamespace: default         
  {}                                    
```
And
```
cephObjectStores:
  - name: ceph-objectstore
    [...]
    storageClass:
      parameters:
```
gives 
```
Error: YAML parse error on rook-ceph-cluster/templates/cephobjectstore.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'                                                            
---                                      
apiVersion: storage.k8s.io/v1            
kind: StorageClass                       
metadata:                                
  name: s3                               
provisioner: default.ceph.rook.io/bucket 
reclaimPolicy: Delete                    
parameters:                              
  objectStoreName: ceph-objectstore      
  objectStoreNamespace: default          
  null                                   
```

After the PR this is fixed (and obviously supports putting parameters)

Note: this was not really evident for me that `region: us-east-1` is the "magic" default value to use if not using Zone/ZoneGroup, may be we could add a comment in the default `values.yaml`