### PR TITLE
helm: add resources to rook-ceph-tools pod

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -62,6 +62,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `toolbox.enabled`      | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
 | `toolbox.tolerations`  | Toolbox tolerations                                                  | `[]`        |
 | `toolbox.affinity`     | Toolbox affinity                                                     | `{}`        |
+| `toolbox.resources`    | Toolbox resources                                                    | `{}`        |
 | `monitoring.enabled`   | Enable Prometheus integration, will also create necessary RBAC rules | `false`     |
 | `cephClusterSpec.*`    | Cluster configuration, see below                                     | See below   |
 | `ingress.dashboard`    | Enable an ingress for the ceph-dashboard                             | `{}`        |

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
                 secretKeyRef:
                   name: rook-ceph-mon
                   key: ceph-secret
+{{- if .Values.toolbox.resources }}
+          resources:
+{{- toYaml .Values.toolbox.resources | nindent 12 }}
+{{- end }}
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -24,6 +24,13 @@ toolbox:
   image: rook/ceph:VERSION
   tolerations: []
   affinity: {}
+  resources: {}
+  # limits:
+  #   cpu: "500m"
+  #   memory: "1024Mi"
+  # requests:
+  #   cpu: "100m"
+  #   memory: "128Mi"
   # Set the priority class for the toolbox if desired
   # priorityClassName: class
 


### PR DESCRIPTION
The rook-ceph-tools pod doesn't allow the ability to set a resource requests/limits. This commit allows the ability to set those values.

Closes: #9855
Signed-off-by: Tom Hellier <me@tomhellier.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
