### PR TITLE
helm: .Values.image.prefix is not referenced anywhere

### DIFF
--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 image:
-  prefix: rook
   repository: rook/ceph
   tag: VERSION
   pullPolicy: IfNotPresent


### PR DESCRIPTION
helm: `.Values.image.prefix` is not referenced anywhere

Signed-off-by: kahirokunn <okinakahiro@gmail.com>

**Description of your changes:**

I looked up what `image.prefix` was and it wasn't used from anywhere.
Values that are not used anywhere should be removed as they invite unnecessary questions.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
