### PR TITLE
core: fix empty string bug

### DIFF
--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -99,10 +99,9 @@ func applyResourcesToContainers(opConfig map[string]string, key string, podspec 
 func getComputeResource(opConfig map[string]string, key string) []k8sutil.ContainerResource {
 	// Add Resource list if any
 	resource := []k8sutil.ContainerResource{}
-	resourceRaw := ""
 	var err error
 
-	if k8sutil.GetValue(opConfig, key, "") != "" {
+	if resourceRaw := k8sutil.GetValue(opConfig, key, ""); resourceRaw != "" {
 		resource, err = k8sutil.YamlToContainerResource(resourceRaw)
 		if err != nil {
 			logger.Warningf("failed to parse %q. %v", resourceRaw, err)


### PR DESCRIPTION
This function was always using an empty string, instead of the extracted resources

Closes: #9867

**Description of your changes:**
There is a bug where the configuration items:
* csi.csiCephFSProvisionerResource
* csi.csiCephFSPluginResource
* csi.csiRBDPluginResource
* csi.csiRBDProvisionerResource

Didn't take effect due to using an empty string instead of the serialised resources passed in via configuration

**Which issue is resolved by this Pull Request:**
Resolves #9867 

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
