### PR TITLE
osd: clarify vault auth error message

### DIFF
--- a/pkg/daemon/ceph/osd/kms/vault_api.go
+++ b/pkg/daemon/ceph/osd/kms/vault_api.go
@@ -93,6 +93,9 @@ func newVaultClient(clusterdContext *clusterd.Context, namespace string, secretC
 	// Both return a token
 	token, _, err := utils.Authenticate(client, c)
 	if err != nil {
+		if authType := GetParam(secretConfig, vault.AuthMethod); authType == vault.AuthMethodKubernetes {
+			return nil, errors.Wrap(err, "failed to get vault authentication token for kubernetes authentication (missing Service Account?)")
+		}
 		return nil, errors.Wrap(err, "failed to get vault authentication token")
 	}
 


### PR DESCRIPTION
**Description of your changes:**

When kube authentication is used, let's clarify the error message and
hopefully lead to a better understanding on where to look for.
It could be misleading to print "token auth" when using kube auth,
although internally a token is used (the JWT from the Service
Account).

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
