### PR TITLE
test: Support Ceph Quincy v17 and Rook v1.9 with updated integration tests

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -123,6 +123,40 @@ jobs:
           name: ceph-smoke-suite-pacific-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
+  smoke-suite-quincy-devel:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          kubernetes-version: "1.23.0"
+
+      - name: TestCephSmokeSuite
+        run: |
+          export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+          SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="quincy-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
+
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="smoke-ns"
+          export OPERATOR_NAMESPACE="smoke-ns-system"
+          tests/scripts/collect-logs.sh
+
+      - name: Artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ceph-smoke-suite-quincy-artifact
+          path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
   smoke-suite-ceph-master:
     runs-on: ubuntu-18.04
     steps:

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -115,6 +115,7 @@ spec:
                   enum:
                     - device_health_metrics
                     - .nfs
+                    - .mgr
                   type: string
                 parameters:
                   additionalProperties:

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v16.2.7
+    image: quay.io/ceph/ceph:v17
     allowUnsupported: true
   mon:
     count: 1
@@ -55,11 +55,10 @@ spec:
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
-  name: device-health-metrics
+  name: mgr
   namespace: rook-ceph # namespace:cluster
 spec:
-  name: device_health_metrics
-  failureDomain: host
+  name: .mgr
   replicated:
     size: 1
     requireSafeReplicaSize: false

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -118,6 +118,7 @@ spec:
                   enum:
                     - device_health_metrics
                     - .nfs
+                    - .mgr
                   type: string
                 parameters:
                   additionalProperties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -650,7 +650,7 @@ type PoolSpec struct {
 // allowed pool names that can be specified.
 type NamedBlockPoolSpec struct {
 	// The desired name of the pool if different from the CephBlockPool CR name.
-	// +kubebuilder:validation:Enum=device_health_metrics;.nfs
+	// +kubebuilder:validation:Enum=device_health_metrics;.nfs;.mgr
 	// +optional
 	Name string `json:"name,omitempty"`
 	// The core pool configuration

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -171,16 +171,20 @@ func TestSupportedVersion(t *testing.T) {
 	c := testSpec(t)
 	c.ClusterInfo = &client.ClusterInfo{Context: context.TODO()}
 
-	// Supported versions are valid
+	// Octopus is supported
 	v := &cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}
 	assert.NoError(t, c.validateCephVersion(v))
 
-	// Supported versions are valid
+	// Pacific is supported
 	v = &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
 	assert.NoError(t, c.validateCephVersion(v))
 
-	// Unsupported versions are not valid
+	// Quincy is supported
 	v = &cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
+	assert.NoError(t, c.validateCephVersion(v))
+
+	// v18 is not supported
+	v = &cephver.CephVersion{Major: 18, Minor: 2, Extra: 0}
 	assert.Error(t, c.validateCephVersion(v))
 
 	// Unsupported versions are now valid

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -375,6 +375,8 @@ func createPool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 	appName := poolApplicationNameRBD
 	if p.Name == "device_health_metrics" {
 		appName = "mgr_devicehealth"
+	} else if p.Name == ".mgr" {
+		appName = "mgr"
 	} else if p.Name == ".nfs" {
 		appName = "nfs"
 	}

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -49,7 +49,7 @@ var (
 	Quincy = CephVersion{17, 0, 0, 0, ""}
 
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions = []CephVersion{Octopus, Pacific}
+	supportedVersions = []CephVersion{Octopus, Pacific, Quincy}
 
 	// unsupportedVersions are possibly Ceph pin-point release that introduced breaking changes and not recommended
 	unsupportedVersions = []CephVersion{}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -46,9 +46,12 @@ const (
 	octopusTestImage = "quay.io/ceph/ceph:v15"
 	// test with the latest pacific build
 	pacificTestImage = "quay.io/ceph/ceph:v16"
+	// test with the latest pacific build
+	quincyTestImage = "quay.io/ceph/ceph:v17"
 	// test with the current development version of Pacific
-	pacificDevelTestImage = "quay.io/ceph/daemon-base:latest-pacific-devel"
 	octopusDevelTestImage = "quay.io/ceph/daemon-base:latest-octopus-devel"
+	pacificDevelTestImage = "quay.io/ceph/daemon-base:latest-pacific-devel"
+	quincyDevelTestImage  = "quay.io/ceph/daemon-base:latest-quincy-devel"
 	// test with the latest master image
 	masterTestImage    = "quay.io/ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"
@@ -67,6 +70,8 @@ var (
 	OctopusDevelVersion          = cephv1.CephVersionSpec{Image: octopusDevelTestImage}
 	PacificVersion               = cephv1.CephVersionSpec{Image: pacificTestImage}
 	PacificDevelVersion          = cephv1.CephVersionSpec{Image: pacificDevelTestImage}
+	QuincyVersion                = cephv1.CephVersionSpec{Image: quincyTestImage}
+	QuincyDevelVersion           = cephv1.CephVersionSpec{Image: quincyDevelTestImage}
 	MasterVersion                = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
 	volumeReplicationBaseURL     = fmt.Sprintf("https://raw.githubusercontent.com/csi-addons/volume-replication-operator/%s/config/crd/bases/", volumeReplicationVersion)
 	volumeReplicationCRDURL      = volumeReplicationBaseURL + "replication.storage.openshift.io_volumereplications.yaml"
@@ -91,8 +96,10 @@ func ReturnCephVersion() cephv1.CephVersionSpec {
 		return MasterVersion
 	case "pacific-devel":
 		return PacificDevelVersion
+	case "quincy-devel":
+		return QuincyDevelVersion
 	default:
-		return PacificVersion
+		return QuincyVersion
 	}
 }
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -62,7 +62,7 @@ func NewCephManifests(settings *TestCephSettings) CephManifests {
 	switch settings.RookVersion {
 	case LocalBuildTag:
 		return &CephManifestsMaster{settings}
-	case Version1_7:
+	case Version1_8:
 		return &CephManifestsPreviousVersion{settings, &CephManifestsMaster{settings}}
 	}
 	panic(fmt.Errorf("unrecognized ceph manifest version: %s", settings.RookVersion))

--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// The version from which the upgrade test will start
-	Version1_7 = "v1.7.10"
+	Version1_8 = "v1.8.6"
 )
 
 // CephManifestsPreviousVersion wraps rook yaml definitions

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -71,7 +71,7 @@ func (h *HelmSuite) SetupSuite() {
 		ChangeHostName:            true,
 		ConnectionsEncrypted:      true,
 		RookVersion:               installer.LocalBuildTag,
-		CephVersion:               installer.OctopusVersion,
+		CephVersion:               installer.PacificVersion,
 	}
 	h.settings.ApplyEnvVars()
 	h.installer, h.k8shelper = StartTestCluster(h.T, h.settings)

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -83,7 +83,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		MultipleMgrs:              true,
 		EnableAdmissionController: true,
 		RookVersion:               installer.LocalBuildTag,
-		CephVersion:               installer.OctopusVersion,
+		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()
 	externalSettings := &installer.TestCephSettings{

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -87,7 +87,7 @@ func (s *UpgradeSuite) baseSetup(useHelm bool, initialCephVersion v1.CephVersion
 		UsePVC:                      false,
 		Mons:                        1,
 		EnableDiscovery:             true,
-		RookVersion:                 installer.Version1_7,
+		RookVersion:                 installer.Version1_8,
 		CephVersion:                 initialCephVersion,
 	}
 
@@ -123,9 +123,9 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	}()
 
 	//
-	// Upgrade Rook from v1.7 to master
+	// Upgrade Rook from v1.8 to master
 	//
-	logger.Infof("*** UPGRADING ROOK FROM %s to master ***", installer.Version1_7)
+	logger.Infof("*** UPGRADING ROOK FROM %s to master ***", installer.Version1_8)
 	s.gatherLogs(s.settings.OperatorNamespace, "_before_master_upgrade")
 	s.upgradeToMaster()
 
@@ -134,8 +134,8 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	err := s.installer.WaitForToolbox(s.namespace)
 	assert.NoError(s.T(), err)
 
-	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_7)
-	newFile := "post-upgrade-1_7-to-master-file"
+	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_8)
+	newFile := "post-upgrade-1_8-to-master-file"
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
@@ -146,7 +146,7 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	// do not need retry b/c the OBC controller runs parallel to Rook-Ceph orchestration
 	assert.True(s.T(), s.helper.BucketClient.CheckOBC(obcName, "bound"))
 
-	logger.Infof("Verified upgrade from %s to master", installer.Version1_7)
+	logger.Infof("Verified upgrade from %s to master", installer.Version1_8)
 
 	// SKIP the Ceph version upgrades for the helm test
 	if s.settings.UseHelm {
@@ -282,7 +282,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(objectUserID, preFilename string)
 	require.True(s.T(), created)
 
 	// verify that we're actually running the right pre-upgrade image
-	s.verifyOperatorImage(installer.Version1_7)
+	s.verifyOperatorImage(installer.Version1_8)
 
 	assert.NoError(s.T(), s.k8sh.WriteToPod("", rbdPodName, preFilename, simpleTestMessage))
 	assert.NoError(s.T(), s.k8sh.ReadFromPod("", rbdPodName, preFilename, simpleTestMessage))

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -96,7 +96,7 @@ func (s *UpgradeSuite) baseSetup(useHelm bool, initialCephVersion v1.CephVersion
 }
 
 func (s *UpgradeSuite) TestUpgradeRook() {
-	s.testUpgrade(false, installer.OctopusVersion)
+	s.testUpgrade(false, installer.PacificVersion)
 }
 
 func (s *UpgradeSuite) TestUpgradeHelm() {
@@ -154,15 +154,15 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	}
 
 	//
-	// Upgrade from octopus to pacific
+	// Upgrade from pacific to quincy
 	//
-	logger.Infof("*** UPGRADING CEPH FROM OCTOPUS TO PACIFIC ***")
-	s.gatherLogs(s.settings.OperatorNamespace, "_before_pacific_upgrade")
-	s.upgradeCephVersion(installer.PacificVersion.Image, numOSDs)
+	logger.Infof("*** UPGRADING CEPH FROM PACIFIC TO QUINCY ***")
+	s.gatherLogs(s.settings.OperatorNamespace, "_before_quincy_upgrade")
+	s.upgradeCephVersion(installer.QuincyVersion.Image, numOSDs)
 	// Verify reading and writing to the test clients
-	newFile = "post-pacific-upgrade-file"
+	newFile = "post-quincy-upgrade-file"
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
-	logger.Infof("Verified upgrade from octopus to pacific")
+	logger.Infof("Verified upgrade from pacific to quincy")
 
 	checkCephObjectUser(s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, true, false)
 }
@@ -201,7 +201,7 @@ func (s *UpgradeSuite) TestUpgradeCephToOctopusDevel() {
 }
 
 func (s *UpgradeSuite) TestUpgradeCephToPacificDevel() {
-	s.baseSetup(false, installer.OctopusVersion)
+	s.baseSetup(false, installer.PacificVersion)
 
 	objectUserID := "upgraded-user"
 	preFilename := "pre-upgrade-file"

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -96,7 +96,7 @@ func (s *UpgradeSuite) baseSetup(useHelm bool, initialCephVersion v1.CephVersion
 }
 
 func (s *UpgradeSuite) TestUpgradeRook() {
-	s.testUpgrade(false, installer.PacificVersion)
+	s.testUpgrade(false, installer.OctopusVersion)
 }
 
 func (s *UpgradeSuite) TestUpgradeHelm() {
@@ -152,6 +152,20 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	if s.settings.UseHelm {
 		return
 	}
+
+	//
+	// Upgrade from octopus to pacific
+	//
+	logger.Infof("*** UPGRADING CEPH FROM OCTOPUS TO PACIFIC ***")
+	s.gatherLogs(s.settings.OperatorNamespace, "_before_pacific_upgrade")
+	s.upgradeCephVersion(installer.PacificVersion.Image, numOSDs)
+	// Verify reading and writing to the test clients
+	newFile = "post-pacific-upgrade-file"
+	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
+	logger.Infof("Verified upgrade from octopus to pacific")
+
+	rbdFilesToRead = append(rbdFilesToRead, newFile)
+	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
 
 	//
 	// Upgrade from pacific to quincy


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the Ceph Quincy release coming up at the end of March and the Rook v1.9 release early April:
1. Update the integration tests to add Quincy to the matrix. 
2. Test upgrades from Rook v1.8 to master (instead of v1.7 to master)
3. Add support for the new built-in `.mgr` pool name, which was renamed from `device_health_metrics`.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
