### PR TITLE
build: Clean the olm dir for crd generation

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -103,8 +103,13 @@ build_helm_resources() {
 ########
 # MAIN #
 ########
+# clean the directory where CRDs are generated
+rm -fr "$OLM_CATALOG_DIR"
+
+# generate the CRDs
 generating_crds_v1
 
+# get the OBC CRDs
 if [ -z "$NO_OB_OBC_VOL_GEN" ]; then
   echo "Generating obcs in crds.yaml"
   copy_ob_obc_crds


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The volume replication crds were being added to the generation directory and causing subsequent builds to pick up those crds in the generation of crds.yaml and the helm chart. To keep the volume replication crds out of the generation, the directory needs to be cleaned with each run.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
