### PR TITLE
core: fix GetLogCollectorResources to get the right resources

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -90,7 +90,7 @@ func GetCrashCollectorResources(p ResourceSpec) v1.ResourceRequirements {
 
 // GetLogCollectorResources returns the placement for the crash daemon
 func GetLogCollectorResources(p ResourceSpec) v1.ResourceRequirements {
-	return p[ResourcesKeyCrashCollector]
+	return p[ResourcesKeyLogCollector]
 }
 
 // GetCleanupResources returns the placement for the cleanup job


### PR DESCRIPTION
Signed-off-by: Yuval Manor <yuvalman958@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Fix  GetLogCollectorResources function to use the log collector key instead of the crash collector key, for getting the right resources.

**Which issue is resolved by this Pull Request:**
Resolves #9897

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
