### PR TITLE
docs: Add annotations to restart ceph daemons

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -242,6 +242,11 @@ After the pod restart, the new settings should be in effect. Note that if the Co
 cluster's namespace is created before the cluster is created, the daemons will pick up the settings
 at first launch.
 
+To automate the restart of the Ceph daemon pods, you will need to trigger an update to the pod specs.
+The simplest way to trigger the update is to add [annotations or labels](ceph-cluster-crd.md#annotations-and-labels)
+to the CephCluster CR for the daemons you want to restart. The operator will then proceed with a rolling
+update, similar to any other update to the cluster.
+
 ### Example
 
 In this example we will set the default pool `size` to two, and tell OSD


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the ceph daemons need to be restarted after applying the custom ceph.conf, adding annotations or labels to the cluster CR is perhaps the simplest way to automate the rolling update.

**Which issue is resolved by this Pull Request:**
Resolves #9802 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
