### PR TITLE
file: block deletion on more dependents

### DIFF
--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -71,9 +71,6 @@ var controllerTypeMeta = metav1.TypeMeta{
 
 var currentAndDesiredCephVersion = opcontroller.CurrentAndDesiredCephVersion
 
-// allow this to be overridden for unit tests
-var cephFilesystemDependents = CephFilesystemDependents
-
 // ReconcileCephFilesystem reconciles a CephFilesystem object
 type ReconcileCephFilesystem struct {
 	client           client.Client
@@ -248,7 +245,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 
 	// DELETE: the CR was deleted
 	if !cephFilesystem.GetDeletionTimestamp().IsZero() {
-		deps, err := cephFilesystemDependents(r.context, r.clusterInfo, cephFilesystem)
+		deps, err := CephFilesystemDependents(r.context, r.clusterInfo, cephFilesystem)
 		if err != nil {
 			return reconcile.Result{}, *cephFilesystem, err
 		}

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -108,6 +108,13 @@ func deleteFilesystem(
 		logger.Warningf("continuing to remove filesystem CR even though downing the filesystem failed. %v", err)
 	}
 
+	// TODO: should we move the `RemoveFilesystem()` call to be before removing MDSes? If the below
+	// fails because the FS isn't empty, is it better to leave the filesystem active in case admins
+	// want to recover data from it?
+	//
+	// Additionally, if PreserveFilesystemOnDelete is set, we won't have Ceph's safety net to do one
+	// last check to see if the FS is in use before we delete it.
+
 	// Permanently remove the filesystem if it was created by rook and the spec does not prevent it.
 	if len(fs.Spec.DataPools) != 0 && !fs.Spec.PreserveFilesystemOnDelete {
 		if err := cephclient.RemoveFilesystem(context, clusterInfo, fs.Name, fs.Spec.PreservePoolsOnDelete); err != nil {

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -50,6 +50,7 @@ type CephManifests interface {
 	GetBucketNotification(notificationName string, topicName string) string
 	GetBucketTopic(topicName string, storeName string, httpEndpointService string) string
 	GetClient(name string, caps map[string]string) string
+	GetFilesystemSubvolumeGroup(fsName, groupName string) string
 }
 
 // CephManifestsMaster wraps rook yaml definitions
@@ -593,4 +594,14 @@ metadata:
   namespace: ` + m.settings.Namespace + `
 spec:
   count: ` + strconv.Itoa(count)
+}
+
+func (m *CephManifestsMaster) GetFilesystemSubvolumeGroup(fsName, groupName string) string {
+	return `apiVersion: ceph.rook.io/v1
+kind: CephFilesystemSubVolumeGroup
+metadata:
+  name: ` + groupName + `
+  namespace: ` + m.settings.Namespace + `
+spec:
+  filesystemName: ` + fsName
 }

--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -164,3 +164,7 @@ func (m *CephManifestsPreviousVersion) GetExternalCephCluster() string {
 func (m *CephManifestsPreviousVersion) GetRBDMirror(name string, count int) string {
 	return m.latest.GetRBDMirror(name, count)
 }
+
+func (m *CephManifestsPreviousVersion) GetFilesystemSubvolumeGroup(fsName, groupName string) string {
+	return m.latest.GetFilesystemSubvolumeGroup(fsName, groupName)
+}


### PR DESCRIPTION
Block deletion of CephFilesystems when there are any raw Ceph
subvolumegroups present that have subvolumes in them. Empty
subvolumegroups will not block deletion.

One important subvolume group is "csi" which is the default location
where CSI subvolumes are kept. If this group is empty, it means that
there are no PVCs created based on the CephFilesystem in question. This
also holds true if there are external consumers of the filesystem in
external cluster mode.

Similarly, if there are any subvolumegroups (for example "_nogroup",
which includes subvolumes in the filesystem root) that contain
manually-created subvolumes, Rook will also see this and block deletion.
This comes into play currently with manually-created NFS exports.

A work-in progress aims to create a Ceph-CSI NFS export provisioner
which will likely create subvolumes in the "csi" group as well. This
implementation will catch this case also.

Rook still checks for CephFilesystemSubVolumeGroups explicitly in
addition to the check added here. This is to ensure that even empty
groups will block deletion if they are created via this CR type.


Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
