### PR TITLE
csi: mount serviceaccount oidc-token into csi-driver

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -60,6 +60,7 @@ type Param struct {
 	EnableVolumeReplicationSideCar bool
 	EnableCSIAddonsSideCar         bool
 	MountCustomCephConf            bool
+	EnableOIDCTokenProjection      bool
 	LogLevel                       uint8
 	CephFSGRPCMetricsPort          uint16
 	CephFSLivenessMetricsPort      uint16
@@ -130,10 +131,11 @@ var (
 )
 
 const (
-	KubeMinMajor                = "1"
-	kubeMinVerForSnapshot       = "17"
-	kubeMinVerForV1csiDriver    = "18"
-	kubeMaxVerForBeta1csiDriver = "21"
+	KubeMinMajor                     = "1"
+	kubeMinVerForSnapshot            = "17"
+	KubeMinVerForOIDCTokenProjection = "20"
+	kubeMinVerForV1csiDriver         = "18"
+	kubeMaxVerForBeta1csiDriver      = "21"
 
 	// common tolerations and node affinity
 	provisionerTolerationsEnv  = "CSI_PROVISIONER_TOLERATIONS"
@@ -292,6 +294,11 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_OMAP_GENERATOR", "false"), "true") {
 		tp.EnableOMAPGenerator = true
+	}
+
+	// SA token projection is stable only from kubernetes version 1.20.
+	if ver.Major == KubeMinMajor && ver.Minor >= KubeMinVerForOIDCTokenProjection {
+		tp.EnableOIDCTokenProjection = true
 	}
 
 	// if k8s >= v1.17 enable RBD and CephFS snapshotter by default

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -225,6 +225,11 @@ spec:
               mountPath: /etc/ceph/ceph.conf
               subPath: ceph.conf
             {{ end }}
+            {{ if .EnableOIDCTokenProjection }}
+            - name: oidc-token
+              mountPath: /run/secrets/tokens
+              readOnly: true
+            {{ end }}
         - name: liveness-prometheus
           image: {{ .CSIPluginImage }}
           args:
@@ -286,3 +291,12 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        {{ if .EnableOIDCTokenProjection }}
+        - name: oidc-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: oidc-token
+                expirationSeconds: 3600
+                audience: ceph-csi-kms
+        {{ end }}

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -123,6 +123,11 @@ spec:
               mountPath: /etc/ceph/ceph.conf
               subPath: ceph.conf
             {{ end }}
+            {{ if .EnableOIDCTokenProjection }}
+            - name: oidc-token
+              mountPath: /run/secrets/tokens
+              readOnly: true
+            {{ end }}
         {{ if .EnableCSIAddonsSideCar }}
         - name: csi-addons
           securityContext:
@@ -250,4 +255,13 @@ spec:
             items:
             - key: ceph.conf
               path: ceph.conf
+        {{ end }}
+        {{ if .EnableOIDCTokenProjection }}
+        - name: oidc-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: oidc-token
+                expirationSeconds: 3600
+                audience: ceph-csi-kms
         {{ end }}


### PR DESCRIPTION
This oidc-token is used to authenticate with OpenID Connect (OIDC)
Provider. Ceph-CSI may use it to assume role with amazon STS
to get access to aws kms for encryption.

Signed-off-by: Rakshith R <rar@redhat.com>

Refer: https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-rbd.md#configuring-amazon-kms-with-amazon-sts

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
