### PR TITLE
csi: rbd node secret was misspelled

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -841,7 +841,7 @@ class RadosJSON:
         self.out_map['ROOK_EXTERNAL_CEPH_MON_DATA'] = self.get_ceph_external_mon_data()
         self.out_map['ROOK_EXTERNAL_USER_SECRET'] = self.create_checkerKey()
         self.out_map['ROOK_EXTERNAL_DASHBOARD_LINK'] = self.get_ceph_dashboard_link()
-        self.out_map['CSI_RBD_NODE_SECRET_SECRET'] = self.create_cephCSIKeyring_user(
+        self.out_map['CSI_RBD_NODE_SECRET'] = self.create_cephCSIKeyring_user(
             "client.csi-rbd-node")
         self.out_map['CSI_RBD_PROVISIONER_SECRET'] = self.create_cephCSIKeyring_user(
             "client.csi-rbd-provisioner")
@@ -952,7 +952,7 @@ class RadosJSON:
                 "kind": "Secret",
                 "data": {
                     "userID": 'csi-rbd-node-{}-{}-{}'.format(cluster_name, rbd_pool_name, rados_namespace),
-                    "userKey": self.out_map['CSI_RBD_NODE_SECRET_SECRET']
+                    "userKey": self.out_map['CSI_RBD_NODE_SECRET']
                 }
             })
             # if 'CSI_RBD_PROVISIONER_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
@@ -1009,7 +1009,7 @@ class RadosJSON:
                 "kind": "Secret",
                 "data": {
                     "userID": 'csi-rbd-node',
-                    "userKey": self.out_map['CSI_RBD_NODE_SECRET_SECRET']
+                    "userKey": self.out_map['CSI_RBD_NODE_SECRET']
                 }
             })
             # if 'CSI_RBD_PROVISIONER_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret


### PR DESCRIPTION
Corrected CSI_RBD_NODE_SECRET name so it should be
output correctely when called script with
bash format output

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
