### PR TITLE
osd: add NixOS specific PATHs

### DIFF
--- a/pkg/daemon/ceph/osd/nsenter.go
+++ b/pkg/daemon/ceph/osd/nsenter.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	binPathsToCheck = []string{"/usr/sbin", "/sbin/"}
+	binPathsToCheck = []string{"/usr/sbin", "/sbin/", "/run/current-system/sw/bin", "/run/current-system/sw/sbin"}
 )
 
 // NSEnter is an nsenter object


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Basically nothing else, but `/usr/bin/env` exists on the NixOS-based systems and "installed" binaries reside in `/run/current-system/sw/bin` and `/run/current-system/sw/sbin`

I got a suggestion on [Slack](https://rook-io.slack.com/archives/CK9CF5H2R/p1648820974211349?thread_ts=1648820683.395979&cid=CK9CF5H2R) to simply add those NixOS specific paths

**Which issue is resolved by this Pull Request:**
None, didn't create it.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
