### PR TITLE
object: add details about route for rgw's https endpoint

### DIFF
--- a/deploy/examples/object-openshift.yaml
+++ b/deploy/examples/object-openshift.yaml
@@ -138,6 +138,14 @@ metadata:
   name: rook-ceph-rgw-my-store # We recommend name to be the same as the service name below, but it is not required
   namespace: rook-ceph # namespace:cluster
 spec:
+  port:
+    targetPort: http
+# if TLS is enabled, remove the above http port and uncomment the https port and tls settings
+#  port:
+#    targetPort: https
+#  tls:
+#    insecureEdgeTerminationPolicy: Redirect
+#    termination: reencrypt
   to:
     kind: Service
     name: rook-ceph-rgw-my-store # The name of the RGW service is in the form 'rook-ceph-rgw-<objectstore-name>'


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In the `object-openshift.yaml` details about exposing `Routes` for RGW
service, currently, it exposes both ports if they are available. This is
very difficult to manage via the same route like adding a termination policy
etc.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
