### PR TITLE
docs: use generated bucket name in PUT/GET example

### DIFF
--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -239,17 +239,18 @@ EOF
 
 ### PUT or GET an object
 
-Upload a file to the newly created bucket
+Upload a file to the newly created bucket. Since we defined the bucket name to be generated and not hardcoded we would need to fetch it before we upload the object.
 
 ```console
+export BUCKET_NAME=$(kubectl get objectbucketclaim ceph-bucket -o jsonpath='{.spec.bucketName}')
 echo "Hello Rook" > /tmp/rookObj
-s5cmd --endpoint-url http://$AWS_ENDPOINT cp /tmp/rookObj s3://rookbucket
+s5cmd --endpoint-url http://"$AWS_ENDPOINT" cp /tmp/rookObj s3://"$BUCKET_NAME"
 ```
 
 Download and verify the file from the bucket
 
 ```console
-s5cmd --endpoint-url http://$AWS_ENDPOINT cp s3://rookbucket/rookObj /tmp/rookObj-download
+s5cmd --endpoint-url http://"$AWS_ENDPOINT" cp s3://"$BUCKET_NAME"/rookObj /tmp/rookObj-download
 cat /tmp/rookObj-download
 ```
 


### PR DESCRIPTION
before there was a mismatch between the way the OBC was created
and the way that the bucket was consumed

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
