### PR TITLE
helm: control CEPH services to depoly

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -54,22 +54,25 @@ helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter              | Description                                                          | Default          |
-| ---------------------- | -------------------------------------------------------------------- | ---------------- |
-| `operatorNamespace`    | Namespace of the Rook Operator                                       | `rook-ceph`      |
-| `kubeVersion`          | Optional override of the target kubernetes version                   | ``               |
-| `configOverride`       | Cluster ceph.conf override                                           | <empty>          |
-| `toolbox.enabled`      | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`          |
-| `toolbox.tolerations`  | Toolbox tolerations                                                  | `[]`             |
-| `toolbox.affinity`     | Toolbox affinity                                                     | `{}`             |
-| `toolbox.resources`    | Toolbox resources                                                    | see values.yaml  |
-| `monitoring.enabled`   | Enable Prometheus integration, will also create necessary RBAC rules | `false`          |
-| `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts   | `false`          |
-| `cephClusterSpec.*`    | Cluster configuration, see below                                     | See below        |
-| `ingress.dashboard`    | Enable an ingress for the ceph-dashboard                             | `{}`             |
-| `cephBlockPools.[*]`   | A list of CephBlockPool configurations to deploy                     | See below        |
-| `cephFileSystems.[*]`  | A list of CephFileSystem configurations to deploy                    | See below        |
-| `cephObjectStores.[*]` | A list of CephObjectStore configurations to deploy                   | See below        |
+| Parameter                  | Description                                                          | Default     |
+| -------------------------- | -------------------------------------------------------------------- | ----------- |
+| `operatorNamespace`        | Namespace of the Rook Operator                                       | `rook-ceph` |
+| `kubeVersion`              | Optional override of the target kubernetes version                   | ``          |
+| `configOverride`           | Cluster ceph.conf override                                           | <empty>     |
+| `toolbox.enabled`          | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
+| `toolbox.tolerations`      | Toolbox tolerations                                                  | `[]`        |
+| `toolbox.affinity`         | Toolbox affinity                                                     | `{}`        |
+| `toolbox.resources`        | Toolbox resources                                                    | `{}`        |
+| `monitoring.enabled`       | Enable Prometheus integration, will also create necessary RBAC rules | `false`     |
+| `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts       | `false`     |
+| `cephClusterSpec.*`        | Cluster configuration, see below                                     | See below   |
+| `ingress.dashboard`        | Enable an ingress for the ceph-dashboard                             | `{}`        |
+| `service.cephBlockPools`   | Enable a CephBlookPool to deploy configurations                      | `true`      |
+| `service.cephFileSystems`  | Enable a CephFileSystem to deploy configurations                     | `true`      |
+| `service.cephObjectStores` | Enable a CephObjectStore to deploy configurations                    | `true`      |
+| `cephBlockPools.[*]`       | A list of CephBlockPool configurations to deploy                     | See below   |
+| `cephFileSystems.[*]`      | A list of CephFileSystem configurations to deploy                    | See below   |
+| `cephObjectStores.[*]`     | A list of CephObjectStore configurations to deploy                   | See below   |
 
 ### Ceph Cluster Spec
 

--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.service.cephBlockPools }}
 {{- range $blockpool := .Values.cephBlockPools -}}
 ---
 apiVersion: ceph.rook.io/v1
@@ -30,5 +31,6 @@ mountOptions:
   - {{ . }}
   {{- end }}
 {{- end }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.service.cephFileSystems }}
 {{- range $filesystem := .Values.cephFileSystems -}}
 ---
 apiVersion: ceph.rook.io/v1
@@ -31,5 +32,6 @@ mountOptions:
   - {{ . }}
   {{- end }}
 {{- end }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.service.cephObjectStores }}
 {{- range $objectstore := .Values.cephObjectStores -}}
 ---
 apiVersion: ceph.rook.io/v1
@@ -20,6 +21,7 @@ parameters:
   objectStoreNamespace: {{ $root.Release.Namespace }}
 {{ with $objectstore.storageClass.parameters }}
 {{ toYaml . | indent 2 }}
+{{ end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -372,6 +372,12 @@ ingress:
     #   path: "/ceph-dashboard(/|$)(.*)"
     # tls:
 
+# Enable (true) or disable (false) Ceph Services
+service:
+  cephBlockPools: true
+  cephFileSystems: true
+  cephObjectStores: true
+
 cephBlockPools:
   - name: ceph-blockpool
     # see https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md#spec for available configuration


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Not all services will be need to be deployed in a k8s-cluster. The CEPH services (like `cephBlookPool`, `cephFileSystem`, `cephObjectStores`) can be controlled in the helm-chart `rook-ceph-cluster` under `service.<cephServiceName>`

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
