### PR TITLE
rgw: validate rgw endpoint ip

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -164,6 +164,71 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
+  external-rgw-quincy-test:
+    runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    
+    - name: setup cluster resources
+      uses: ./.github/workflows/setup-cluster-resources
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        CEPH_VERSION: v17.2.0-20220420
+
+    - name: validate-yaml
+      run: tests/scripts/github-action-helper.sh validate_yaml
+
+    - name: use local disk and create partitions for osds
+      run: |
+        tests/scripts/github-action-helper.sh use_local_disk
+        tests/scripts/github-action-helper.sh create_partitions_for_osds
+
+    - name: deploy cluster
+      run: tests/scripts/github-action-helper.sh deploy_cluster
+
+    - name: wait for prepare pod
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+
+    - name: wait for ceph to be ready
+      run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2 
+
+    - name: validate-rgw-endpoint
+      run: | 
+        rgw_endpoint=$(kubectl get service -n rook-ceph |  awk '/rgw/ {print $3":80"}')
+        toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+        timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph mgr dump -f json|jq --raw-output .active_addr|grep -Eosq \"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\" ; do sleep 1 && echo 'waiting for the manager IP to be available'; done"
+        mgr_raw=$(kubectl -n rook-ceph exec $toolbox -- ceph mgr dump -f json|jq --raw-output .active_addr)
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- curl --silent --show-error ${mgr_raw%%:*}:9283; do echo 'waiting for mgr prometheus exporter to be ready' && sleep 1; done"
+        kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources.py $toolbox:/etc/ceph
+        # pass the valid rgw-endpoint of same ceph cluster
+        timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"        
+        # pass the invalid rgw-endpoint of different ceph cluster
+        if output=$(timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint 10.108.96.128:80; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"); then
+          echo $output
+        else
+          echo "validation failed because wrong endpoint was provided"
+        fi    
+        # pass the valid rgw-endpoint of same ceph cluster with --rgw-tls-cert-path
+        timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-tls-cert-path my-cert; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+        # pass the valid rgw-endpoint of same ceph cluster with --rgw-skip-tls
+        timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-skip-tls true; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+
+    - name: collect common logs
+      if: always()
+      uses: ./.github/workflows/collect-logs
+      with:
+        name: external-rgw-quincy-test
+
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+
   raw-disk:
     runs-on: ubuntu-18.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"

--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -34,8 +34,7 @@ ext = importlib.import_module("create-external-cluster-resources")
 class TestRadosJSON(unittest.TestCase):
     def setUp(self):
         print("\nI am in setup")
-        self.rjObj = ext.RadosJSON(['--rbd-data-pool-name=abc',
-                                    '--rgw-endpoint=10.10.212.122:9000', '--format=json'])
+        self.rjObj = ext.RadosJSON(['--rbd-data-pool-name=abc', '--rgw-endpoint=10.10.212.122:9000', '--format=json'])
         # for testing, we are using 'DummyRados' object
         self.rjObj.cluster = ext.DummyRados.Rados()
 

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -920,13 +920,13 @@ class RadosJSON:
             self._invalid_endpoint(self._arg_parser.rgw_endpoint)
             self.endpoint_dial(self._arg_parser.rgw_endpoint,
                                cert=self.validate_rgw_endpoint_tls_cert())
-            rgw_pool_to_validate = ["{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
-                                    ".rgw.root",
-                                    "{0}.rgw.control".format(
-                self._arg_parser.rgw_pool_prefix),
-                "{0}.rgw.log".format(
-                self._arg_parser.rgw_pool_prefix)]
-            pools_to_validate.extend(rgw_pool_to_validate)
+            # only validate if rgw_pool_prefix is passed else it will take default value and we don't create these default pools
+            if self._arg_parser.rgw_pool_prefix != "default":
+                rgw_pool_to_validate = ["{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
+                                        ".rgw.root",
+                                        "{0}.rgw.control".format(self._arg_parser.rgw_pool_prefix),
+                                        "{0}.rgw.log".format(self._arg_parser.rgw_pool_prefix)]
+                pools_to_validate.extend(rgw_pool_to_validate)
 
         for pool in pools_to_validate:
             if not self.cluster.pool_exists(pool):

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -314,7 +314,7 @@ class RadosJSON:
 
         upgrade_group = argP.add_argument_group('upgrade')
         upgrade_group.add_argument("--upgrade", action='store_true', default=False,
-                                   help="Upgrades the 'csi-user'(For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied." +
+                                   help="Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied." +
                                    "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade`, this will upgrade all the default csi users(non-restricted)" +
                                    "For restricted users(For example: client.csi-cephfs-provisioner-openshift-storage-myfs), users created using --restricted-auth-permission flag need to pass mandatory flags" +
                                    "mandatory flags: '--rbd-data-pool-name, --rados-namespace, --cluster-name and --run-as-user' flags while upgrading" +

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -15,14 +15,19 @@ limitations under the License.
 '''
 
 import errno
+from inspect import signature
 import sys
 import json
 import argparse
 import re
+from tokenize import single_quoted
 import requests
 import subprocess
+import hmac
+from hashlib import sha1 as sha
 from os import linesep as LINESEP
 from os import path
+import urllib.parse
 
 ModuleNotFoundError = ImportError
 
@@ -52,6 +57,19 @@ except ModuleNotFoundError:
     # for 3.x
     from urllib.parse import urlparse
 
+py3k = False
+try:
+    from urlparse import urlparse, unquote
+    from base64 import encodestring
+except:
+    py3k = True
+    from urllib.parse import urlparse, unquote
+    from base64 import encodebytes as encodestring
+
+from email.utils import formatdate
+
+from requests.auth import AuthBase
+import requests
 
 class ExecutionFailureException(Exception):
     pass
@@ -149,6 +167,89 @@ class DummyRados(object):
     def Rados(conffile=None):
         return DummyRados()
 
+class S3Auth(AuthBase):
+
+    """Attaches AWS Authentication to the given Request object."""
+    service_base_url = 's3.amazonaws.com'
+    
+    def __init__(self, access_key, secret_key, service_url=None):
+        if service_url:
+            self.service_base_url = service_url
+        self.access_key = str(access_key)
+        self.secret_key = str(secret_key)
+
+    def __call__(self, r):
+        # Create date header if it is not created yet.
+        if 'date' not in r.headers and 'x-amz-date' not in r.headers:
+            r.headers['date'] = formatdate(
+                timeval=None,
+                localtime=False,
+                usegmt=True)
+        signature = self.get_signature(r)
+        if py3k:
+            signature = signature.decode('utf-8')
+        r.headers['Authorization'] = 'AWS %s:%s' % (self.access_key, signature)
+        return r
+
+    def get_signature(self, r):
+        canonical_string = self.get_canonical_string(
+            r.url, r.headers, r.method)
+        if py3k:
+            key = self.secret_key.encode('utf-8')
+            msg = canonical_string.encode('utf-8')
+        else:
+            key = self.secret_key
+            msg = canonical_string
+        h = hmac.new(key, msg, digestmod=sha)
+        return encodestring(h.digest()).strip()
+
+    def get_canonical_string(self, url, headers, method):
+        parsedurl = urlparse(url)
+        objectkey = parsedurl.path[1:]
+
+        bucket = parsedurl.netloc[:-len(self.service_base_url)]
+        if len(bucket) > 1:
+            # remove last dot
+            bucket = bucket[:-1]
+
+        interesting_headers = {
+            'content-md5': '',
+            'content-type': '',
+            'date': ''}
+        for key in headers:
+            lk = key.lower()
+            try:
+                lk = lk.decode('utf-8')
+            except:
+                pass
+            if headers[key] and (lk in interesting_headers.keys()
+                                 or lk.startswith('x-amz-')):
+                interesting_headers[lk] = headers[key].strip()
+
+        # If x-amz-date is used it supersedes the date header.
+        if not py3k:
+            if 'x-amz-date' in interesting_headers:
+                interesting_headers['date'] = ''
+        else:
+            if 'x-amz-date' in interesting_headers:
+                interesting_headers['date'] = ''
+
+        buf = '%s\n' % method
+        for key in sorted(interesting_headers.keys()):
+            val = interesting_headers[key]
+            if key.startswith('x-amz-'):
+                buf += '%s:%s\n' % (key, val)
+            else:
+                buf += '%s\n' % val
+
+        # append the bucket if it exists
+        if bucket != '':
+            buf += '/%s' % bucket
+
+        # add the objectkey. even if it doesn't exist, add the slash
+        buf += '/%s' % objectkey
+
+        return buf
 
 class RadosJSON:
     EXTERNAL_USER_NAME = "client.healthchecker"
@@ -331,7 +432,7 @@ class RadosJSON:
                 else:
                     r = requests.head(ep, timeout=timeout)
                 if r.status_code == 200:
-                    return
+                    return prefix
             except:
                 continue
         raise ExecutionFailureException(
@@ -768,7 +869,7 @@ class RadosJSON:
 
     def create_rgw_admin_ops_user(self):
         cmd = ['radosgw-admin', 'user', 'create', '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME, '--display-name',
-               'Rook RGW Admin Ops user', '--caps', 'buckets=*;users=*;usage=read;metadata=read;zone=read']
+               'Rook RGW Admin Ops user', '--caps', 'info=read;buckets=*;users=*;usage=read;metadata=read;zone=read']
         if self._arg_parser.dry_run:
             return self.dry_run("ceph " + " ".join(cmd))
         try:
@@ -791,9 +892,26 @@ class RadosJSON:
                 err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
                     cmd, execErr.output, execErr.returncode, execErr.stderr)
                 raise Exception(err_msg)
+        
 
+        # separately add info=read caps, because sometimes users already exited and the cap doesn't update
+        info_cap_supported = True
+        cmd = ['radosgw-admin', 'caps', 'add', '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
+            '--caps', 'info=read']
+        try:
+            output = subprocess.check_output(cmd,
+                                            stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as execErr:
+            # if the ceph version not supported for adding `info=read` cap(rgw_validation)
+            if 'could not add caps: unable to add caps: info=read\n' in execErr.stderr.decode("utf-8") and execErr.returncode == 244:
+                info_cap_supported = False
+            else:
+                err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
+                        cmd, execErr.output, execErr.returncode, execErr.stderr)
+                raise Exception(err_msg)
+        
         jsonoutput = json.loads(output)
-        return jsonoutput["keys"][0]['access_key'], jsonoutput["keys"][0]['secret_key']
+        return jsonoutput["keys"][0]['access_key'], jsonoutput["keys"][0]['secret_key'], info_cap_supported
 
     def validate_pool(self):
         pools_to_validate = [self._arg_parser.rbd_data_pool_name]
@@ -826,7 +944,46 @@ class RadosJSON:
             raise ExecutionFailureException(
                 ("The provided rados Namespace, '{}', is not found in the pool '{}'").format(
                     rados_namespace, rbd_pool_name))
-
+    
+    def get_rgw_fsid(self):
+        access_key = self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY']
+        secret_key = self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY']
+        rgw_endpoint = self._arg_parser.rgw_endpoint
+        cert = None
+        verify = None
+        if self._arg_parser.rgw_tls_cert_path and not self._arg_parser.rgw_skip_tls:
+            cert = self.validate_rgw_endpoint_tls_cert()
+            verify = True
+        if self._arg_parser.rgw_skip_tls:
+            verify = False
+        base_url =  self.endpoint_dial(rgw_endpoint,cert=cert) + "://"
+        base_url = base_url + rgw_endpoint + "/admin/info?"   
+        params = {'format': 'json'}
+        request_url = base_url + urllib.parse.urlencode(params)
+            
+        try:
+            r = requests.get(request_url, auth=S3Auth(access_key, secret_key,rgw_endpoint), cert=cert, verify=verify)
+        except requests.exceptions.Timeout:
+            raise ExecutionFailureException(
+                    "invalid endpoint:, not able to call admin-ops api{}".format(rgw_endpoint))
+        r1 = r.json()
+        if r1 is None or r1.get('info') is None:
+            return ""  # Invalid rgw-endpoint exception will returned by validate_rgw_endpoint()
+        
+        return r1['info']['storage_backends'][0]['cluster_id']
+            
+    def validate_rgw_endpoint(self):
+        # if the 'cluster' instance is a dummy one,
+        # don't try to reach out to the endpoint
+        if isinstance(self.cluster, DummyRados):
+            return
+        fsid = self.get_fsid()
+        rgw_fsid = self.get_rgw_fsid()
+        if fsid != rgw_fsid:
+            raise ExecutionFailureException(
+                ("The provided rgw Endpoint, '{}', is invalid. We are validating by calling the adminops api through rgw-endpoint and validating the cluster_id '{}' is equal to the ceph cluster fsid '{}'").format(
+                    self._arg_parser.rgw_endpoint,rgw_fsid,fsid))
+    
     def _gen_output_map(self):
         if self.out_map:
             return
@@ -869,7 +1026,9 @@ class RadosJSON:
             if self._arg_parser.dry_run:
                 self.create_rgw_admin_ops_user()
             else:
-                self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY'], self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY'] = self.create_rgw_admin_ops_user()
+                self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY'], self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY'], info_cap_supported = self.create_rgw_admin_ops_user()
+                if info_cap_supported:
+                    self.validate_rgw_endpoint()
             if self._arg_parser.rgw_tls_cert_path:
                 self.out_map['RGW_TLS_CERT'] = self.validate_rgw_endpoint_tls_cert()
 

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v16.2.7-20220216
+CEPH_VERSION ?= v16.2.7-20220216
 else
-CEPH_VERSION = v16.2.7-20220216
+CEPH_VERSION ?= v16.2.7-20220216
 endif
 REGISTRY_NAME = quay.io
 BASEIMAGE = $(REGISTRY_NAME)/ceph/ceph-$(GOARCH):$(CEPH_VERSION)


### PR DESCRIPTION
The ceph-external-cluster-details-exporter.py
generates the json output even with
rgw-endpoint IP from different cluster
Added a check validate_rgw_endpoint which will validate
the above rgw_endpoint Ip by matching the cluster fsid

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
