### PR TITLE
helm: Monitoring rbac only created by cluster chart

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -96,8 +96,6 @@ A guide to how you can write your own Prometheus consoles can be found on the of
 ## Prometheus Alerts
 
 To enable the Ceph Prometheus alerts via the helm charts, set the following properties in values.yaml:
-- rook-ceph chart:
-  `monitoring.enabled: true`
 - rook-ceph-cluster chart:
   `monitoring.enabled: true`
   `monitoring.createPrometheusRules: true`

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -150,7 +150,6 @@ The following tables lists the configurable parameters of the rook-operator char
 | `csi.csiAddons.image`       | CSIAddons Sidecar image.                                                                                        | `quay.io/csiaddons/k8s-sidecar:v0.2.1`     |
 | `admissionController.tolerations`   | Array of tolerations in YAML format which will be added to admission controller deployment.                                 | <none>                                                    |
 | `admissionController.nodeAffinity`  | The node labels for affinity of the admission controller deployment (***)                                                   | <none>                                                    |
-| `monitoring.enabled`                | Create necessary RBAC rules for Rook to integrate with Prometheus monitoring in the operator namespace. Requires Prometheus to be pre-installed. | `false` |
 
 &ast; &ast; &ast; `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
 

--- a/deploy/charts/rook-ceph-cluster/templates/rbac.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/rbac.yaml
@@ -1,5 +1,5 @@
+# RBAC for the cluster if in a different namespace from the operator
 {{- if ne .Release.Namespace .Values.operatorNamespace -}}
-
 {{/*
 serviceaccounts
 */}}
@@ -22,20 +22,18 @@ roles
 ---
 {{ include "library.cluster.roles" . }}
 
-{{- if .Values.monitoring.enabled }}
----
-{{ include "library.cluster.monitoring.roles" . }}
-{{- end }}
-
 {{/*
 rolebindings
 */}}
 ---
 {{ include "library.cluster.rolebindings" . }}
-
-{{- if .Values.monitoring.enabled }}
----
-{{ include "library.cluster.monitoring.rolebindings" . }}
 {{- end }}
 
+
+# RBAC for monitoring if enabled
+{{- if .Values.monitoring.enabled }}
+---
+{{ include "library.cluster.monitoring.roles" . }}
+---
+{{ include "library.cluster.monitoring.rolebindings" . }}
 {{- end }}

--- a/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
+++ b/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
@@ -26,18 +26,8 @@ roles
 ---
 {{ include "library.cluster.roles" . }}
 
-{{- if .Values.monitoring.enabled }}
----
-{{ include "library.cluster.monitoring.roles" . }}
-{{- end }}
-
 {{/*
 rolebindings
 */}}
 ---
 {{ include "library.cluster.rolebindings" . }}
-
-{{- if .Values.monitoring.enabled }}
----
-{{ include "library.cluster.monitoring.rolebindings" . }}
-{{- end }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -354,8 +354,3 @@ admissionController:
   #      operator: Exists
   #      effect: NoSchedule
   # nodeAffinity: key1=value1,value2; key2=value3
-
-monitoring:
-  # requires Prometheus to be pre-installed
-  # enabling will also create RBAC rules to allow Operator to create ServiceMonitors
-  enabled: false

--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -56,13 +56,12 @@ func (h *CephInstaller) configureRookOperatorViaHelm(upgrade bool) error {
 	values := map[string]interface{}{
 		"enableDiscoveryDaemon": h.settings.EnableDiscovery,
 		"image":                 map[string]interface{}{"tag": h.settings.RookVersion},
-		"monitoring":            map[string]interface{}{"enabled": true},
 	}
 	values["csi"] = map[string]interface{}{
-		"csiRBDProvisionerResource": nil,
-		"csiRBDPluginResource": nil,
+		"csiRBDProvisionerResource":    nil,
+		"csiRBDPluginResource":         nil,
 		"csiCephFSProvisionerResource": nil,
-		"csiCephFSPluginResource": nil,
+		"csiCephFSPluginResource":      nil,
 	}
 
 	// create the operator namespace before the admission controller is created
@@ -116,8 +115,8 @@ func (h *CephInstaller) configureRookCephClusterViaHelm(upgrade bool) error {
 	values["operatorNamespace"] = h.settings.OperatorNamespace
 	values["configOverride"] = clusterCustomSettings
 	values["toolbox"] = map[string]interface{}{
-		"enabled": true,
-		"image":   "rook/ceph:" + h.settings.RookVersion,
+		"enabled":   true,
+		"image":     "rook/ceph:" + h.settings.RookVersion,
 		"resources": nil,
 	}
 	values["monitoring"] = map[string]interface{}{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator chart was creating the rbac for monitoring, which was confusing because the monitoring is a cluster setting. Now the rbac is only created by the cluster chart according to a single monitoring.enabled setting, instead of the monitoring setting be included in both charts unnecessarily.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
