### PR TITLE
helm: Correctly check external cluster for prometheus rules

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
@@ -11,13 +11,21 @@ metadata:
 spec:
 # Import the raw prometheus rules since they have descriptions that should not be processed with the helm templates
 {{- $root := . }}
+{{- if .Values.cephClusterSpec.external }}
 {{- if .Values.cephClusterSpec.external.enable }}
   {{- range $path, $bytes := .Files.Glob "prometheus/externalrules.yaml" }}
   {{ $root.Files.Get $path }}
   {{- end }}
 {{- else }}
+  # The local rules are included in two different else statements because helm does not short-circuit
+  # the checks to allow the check for external settings in a single if statement.
   {{- range $path, $bytes := .Files.Glob "prometheus/localrules.yaml" }}
-  {{ $root.Files.Get $path }}
+  {{ $root.Files.Get $path | indent 2 }}
+  {{- end }}
+{{- end }}
+{{- else }}
+  {{- range $path, $bytes := .Files.Glob "prometheus/localrules.yaml" }}
+  {{ $root.Files.Get $path | indent 2 }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the prometheus rules are created, if external settings were not specified, the helm chart would fail due to a nil ref in the external settings. Now we check both for the existence of external settings and whether the external settings are enabled.

There was also an indentation issue with the local rules.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
