### PR TITLE
monitoring: Only set prometheus rules ownerref in same namespace

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -523,9 +523,12 @@ func (c *Cluster) DeployPrometheusRule(name, namespace string) error {
 	}
 	prometheusRule.SetName(name)
 	prometheusRule.SetNamespace(namespace)
-	err = c.clusterInfo.OwnerInfo.SetControllerReference(prometheusRule)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set owner reference to prometheus rule %q", prometheusRule.Name)
+	if namespace == c.clusterInfo.Namespace {
+		// only set the ownerref if in the same namespace
+		err = c.clusterInfo.OwnerInfo.SetControllerReference(prometheusRule)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set owner reference to prometheus rule %q", prometheusRule.Name)
+		}
 	}
 	cephv1.GetMonitoringLabels(c.spec.Labels).OverwriteApplyToObjectMeta(&prometheusRule.ObjectMeta)
 	if _, err := k8sutil.CreateOrUpdatePrometheusRule(c.clusterInfo.Context, prometheusRule); err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The ownerref of the prometheus rules should not be set if in a different namespace than the cluster CR.

**Which issue is resolved by this Pull Request:**
Resolves #10022 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
