### PR TITLE
docs: update migraton doc

### DIFF
--- a/Documentation/flex-to-csi-migration.md
+++ b/Documentation/flex-to-csi-migration.md
@@ -40,7 +40,7 @@ These are the options for converting a single PVC. For more options, see the [to
 
 1. `--pvc`: **required**: name of the pvc to migrate
 2. `--pvc-ns`: **required**: namespace in which the target PVC is present.
-3. `--destination-sc`: **required**: name of the ceph-csi storage class in which you want to migrate.
+3. `--destination-sc`: **required**: name of the ceph-csi storage class in which you want to migrate. The destination StroageClass pool name should be same as PVC you want to migrate.
 4. `--rook-ns`: **optional** namespace where the rook operator is running. **default: rook-ceph**.
 5. `--ceph-cluster-ns`: **optional** namespace where the ceph cluster is running. **default: rook-ceph**.
 


### PR DESCRIPTION
update migraton doc to mentions that
destination storageclass pool name should be
same as one pvc which is going to migrate.

Closes: https://github.com/rook/rook/issues/9986
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
