### PR TITLE
pool: built-in pools must be replicated

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -53,34 +53,46 @@ func (p *ReplicatedSpec) IsTargetRatioEnabled() bool {
 func (p *CephBlockPool) ValidateCreate() error {
 	logger.Infof("validate create cephblockpool %v", p)
 
-	err := validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err := ValidateCephBlockPool(&p.Spec)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
+// ValidateCephBlockPool validates specifically a CephBlockPool's spec (not just any NamedPoolSpec)
+func ValidateCephBlockPool(s *NamedBlockPoolSpec) error {
+	if s.Name == "device_health_metrics" || s.Name == ".mgr" || s.Name == ".nfs" {
+		if s.IsErasureCoded() {
+			return errors.Errorf("invalid CephBlockPool spec: ceph built-in pool %q cannot be erasure coded", s.Name)
+		}
+	}
+
+	return validatePoolSpec(s.ToNamedPoolSpec())
+}
+
+// validate any NamedPoolSpec
 func validatePoolSpec(ps NamedPoolSpec) error {
 	// Checks if either ErasureCoded or Replicated fields are set
 	if ps.ErasureCoded.CodingChunks <= 0 && ps.ErasureCoded.DataChunks <= 0 && ps.Replicated.TargetSizeRatio <= 0 && ps.Replicated.Size <= 0 {
-		return errors.New("invalid create: either of erasurecoded or replicated fields should be set")
+		return errors.New("invalid pool spec: either of erasurecoded or replicated fields should be set")
 	}
 	// Check if any of the ErasureCoded fields are populated. Then check if replicated is populated. Both can't be populated at same time.
 	if ps.ErasureCoded.CodingChunks > 0 || ps.ErasureCoded.DataChunks > 0 || ps.ErasureCoded.Algorithm != "" {
 		if ps.Replicated.Size > 0 || ps.Replicated.TargetSizeRatio > 0 {
-			return errors.New("invalid create: both erasurecoded and replicated fields cannot be set at the same time")
+			return errors.New("invalid pool spec: both erasurecoded and replicated fields cannot be set at the same time")
 		}
 	}
 
 	if ps.Replicated.Size == 0 && ps.Replicated.TargetSizeRatio == 0 {
 		// Check if datachunks is set and has value less than 2.
 		if ps.ErasureCoded.DataChunks < 2 && ps.ErasureCoded.DataChunks != 0 {
-			return errors.New("invalid create: erasurecoded.datachunks needs minimum value of 2")
+			return errors.New("invalid pool spec: erasurecoded.datachunks needs minimum value of 2")
 		}
 
 		// Check if codingchunks is set and has value less than 1.
 		if ps.ErasureCoded.CodingChunks < 1 && ps.ErasureCoded.CodingChunks != 0 {
-			return errors.New("invalid create: erasurecoded.codingchunks needs minimum value of 1")
+			return errors.New("invalid pool spec: erasurecoded.codingchunks needs minimum value of 1")
 		}
 	}
 	return nil
@@ -96,7 +108,7 @@ func (p *NamedBlockPoolSpec) ToNamedPoolSpec() NamedPoolSpec {
 func (p *CephBlockPool) ValidateUpdate(old runtime.Object) error {
 	logger.Info("validate update cephblockpool")
 	ocbp := old.(*CephBlockPool)
-	err := validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err := ValidateCephBlockPool(&p.Spec)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -20,6 +20,7 @@ package pool
 import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
@@ -33,6 +34,11 @@ func validatePool(context *clusterd.Context, clusterInfo *client.ClusterInfo, cl
 	if p.Namespace == "" {
 		return errors.New("missing namespace")
 	}
+
+	if err := v1.ValidateCephBlockPool(&p.Spec); err != nil {
+		return err
+	}
+
 	if err := ValidatePoolSpec(context, clusterInfo, clusterSpec, &p.Spec.PoolSpec); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Built in Ceph pools (device_health_metrics, .mgr, .nfs) must be
replicated and not erasure coded.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
