### PR TITLE
nfs: create config pool automatically

### DIFF
--- a/deploy/examples/nfs-test.yaml
+++ b/deploy/examples/nfs-test.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: rook-ceph # namespace:cluster
 spec:
   name: .nfs
-  failureDomain: host
+  failureDomain: osd
   replicated:
     size: 1
     requireSafeReplicaSize: false

--- a/deploy/examples/nfs.yaml
+++ b/deploy/examples/nfs.yaml
@@ -55,17 +55,21 @@ spec:
     #priorityClassName:
     # The logging levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG |NIV_FULL_DEBUG |NB_LOG_LEVEL
     logLevel: NIV_INFO
----
-apiVersion: ceph.rook.io/v1
-kind: CephBlockPool
-metadata:
-  name: builtin-nfs
-  namespace: rook-ceph # namespace:cluster
-spec:
-  # The required pool name ".nfs" cannot be specified as a K8s resource name, thus we override
-  # the pool name created in Ceph with this name property
-  name: .nfs
-  failureDomain: host
-  replicated:
-    size: 3
-    requireSafeReplicaSize: true
+# ---
+# # The built-in Ceph pool ".nfs" is used for storing configuration for all CephNFS clusters. If this
+# # shared pool needs to be configured with alternate settings, create this pool (once) with any of
+# # the pool properties. Create this pool before creating any CephNFSes, or else some properties may
+# # not be applied when the pool is created by default. This pool must be replicated.
+# apiVersion: ceph.rook.io/v1
+# kind: CephBlockPool
+# metadata:
+#   name: builtin-nfs
+#   namespace: rook-ceph # namespace:cluster
+# spec:
+#   # The required pool name ".nfs" cannot be specified as a K8s resource name, thus we override
+#   # the pool name created in Ceph with this name property
+#   name: .nfs
+#   failureDomain: host
+#   replicated:
+#     size: 3
+#     requireSafeReplicaSize: true

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -88,7 +88,7 @@ func TestCephNFSController(t *testing.T) {
 					if args[0] == "auth" && args[1] == "get-or-create-key" {
 						return nfsCephAuthGetOrCreateKey, nil
 					}
-					if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+					if args[0] == "osd" && args[1] == "pool" && args[2] == "create" {
 						return "", nil
 					}
 					if args[0] == "osd" && args[1] == "crush" && args[2] == "rule" {

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -303,12 +303,13 @@ func (r *ReconcileCephNFS) configureNFSPool(n *cephv1.CephNFS) error {
 	poolName := n.Spec.RADOS.Pool
 	logger.Infof("configuring pool %q for nfs", poolName)
 
-	_, err := cephclient.GetPoolDetails(r.context, r.clusterInfo, poolName)
+	args := []string{"osd", "pool", "create", poolName}
+	output, err := cephclient.NewCephCommand(r.context, r.clusterInfo, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "pool %q could not be retrieved, ensure the pool is defined with a CephBlockPool", poolName)
+		return errors.Wrapf(err, "failed to create default NFS pool %q. %s", poolName, string(output))
 	}
 
-	args := []string{"osd", "pool", "application", "enable", poolName, "nfs", "--yes-i-really-mean-it"}
+	args = []string{"osd", "pool", "application", "enable", poolName, "nfs", "--yes-i-really-mean-it"}
 	_, err = cephclient.NewCephCommand(r.context, r.clusterInfo, args).Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to enable application 'nfs' on pool %q", poolName)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Create the ".nfs" config pool by default so that users aren't required
to create it via CephBlockPool.

Is built on top of #10053

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
