### PR TITLE
build: Remove requirement for ibm test in backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -145,7 +145,6 @@ pull_request_rules:
       - 'check-success=encryption-pvc-db-wal'
       - 'check-success=encryption-pvc-kms-vault-token-auth'
       - 'check-success=encryption-pvc-kms-vault-k8s-auth'
-      - 'check-success=encryption-pvc-kms-ibm-kp'
       - 'check-success=lvm-pvc'
       - 'check-success=multi-cluster-mirroring'
       - 'check-success=rgw-multisite-testing'


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The ibm test is not expected to run in PRs, so we can remove it from the list of required backports for the release-1.9 branch.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
