### PR TITLE
csi: enable csi nfs to generate nfs rbac for csv

### DIFF
--- a/deploy/olm/generate-rook-csv.sh
+++ b/deploy/olm/generate-rook-csv.sh
@@ -232,6 +232,8 @@ generate_operator_yaml "$@"
 # Do not include Pod Security Policy (PSP) resources for CSV generation since OLM uses
 # Security Context Constraints (SCC).
 export DO_NOT_INCLUDE_POD_SECURITY_POLICY_RESOURCES=true
+# Generate csi nfs rbac too.
+export ADDITIONAL_HELM_CLI_OPTIONS="--set csi.nfs.enabled=true"
 ./build/rbac/get-helm-rbac.sh > "$OLM_RBAC_YAML_FILE"
 
 # TODO: do we need separate clusterrole/clusterrolebinding/role/rolebinding/servicaccount files, or


### PR DESCRIPTION
This commit enables csi.nfs during rbac generation
for csv, so that it can used when deployed with olm.

Signed-off-by: Rakshith R <rar@redhat.com>

Refer: https://github.com/rook/rook/pull/10058

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
