### PR TITLE
osd: Enable quincy osd release version

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -735,13 +735,13 @@ func (c *Cluster) applyUpgradeOSDFunctionality() {
 				logger.Warningf("failed to extract ceph version. %v", err)
 				return
 			}
-			// if the version of these OSDs is Octopus then we run the command
-			if osdVersion.IsOctopus() {
-				err = cephclient.EnableReleaseOSDFunctionality(c.context, c.clusterInfo, "octopus")
-				if err != nil {
-					logger.Warningf("failed to enable new osd functionality. %v", err)
-					return
-				}
+			// Ensure the required version of OSDs is set to the current consistent version,
+			// enabling the latest osd functionality and also preventing downgrades to a
+			// previous major ceph version.
+			err = cephclient.EnableReleaseOSDFunctionality(c.context, c.clusterInfo, osdVersion.ReleaseName())
+			if err != nil {
+				logger.Warningf("failed to enable new osd functionality. %v", err)
+				return
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
After all OSDs are updated to each major release of Ceph, the require-osd-release version is set to that release so all the latest functionality for osds can be enabled by Ceph. In Quincy there is a warning if all osds are on Quincy and this flag is not set, so this will resolve the health warning.

**Which issue is resolved by this Pull Request:**
Resolves #10084 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
