### PR TITLE
helm: fix missing default resources in rook components

### DIFF
--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -115,6 +115,7 @@ csi:
   allowUnsupportedVersion: false
     # CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
+  # csi-omap-generator resources will be applied only if enableOMAPGenerator is set to true
   csiRBDProvisionerResource: |
     - name : csi-provisioner
       resource:
@@ -149,6 +150,14 @@ csi:
           memory: 256Mi
           cpu: 200m
     - name : csi-rbdplugin
+      resource:
+        requests:
+          memory: 512Mi
+          cpu: 250m
+        limits:
+          memory: 1Gi
+          cpu: 500m
+    - name : csi-omap-generator
       resource:
         requests:
           memory: 512Mi
@@ -211,6 +220,14 @@ csi:
           memory: 256Mi
           cpu: 200m
     - name : csi-attacher
+      resource:
+        requests:
+          memory: 128Mi
+          cpu: 100m
+        limits:
+          memory: 256Mi
+          cpu: 200m
+    - name : csi-snapshotter
       resource:
         requests:
           memory: 128Mi

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -283,7 +283,7 @@ data:
 
   # (Optional) CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # CSI_RBD_PROVISIONER_RESOURCE: |
+  #CSI_RBD_PROVISIONER_RESOURCE: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -324,6 +324,14 @@ data:
   #      limits:
   #        memory: 1Gi
   #        cpu: 500m
+  #  - name : csi-omap-generator
+  #    resource:
+  #      requests:
+  #        memory: 512Mi
+  #        cpu: 250m
+  #      limits:
+  #        memory: 1Gi
+  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -334,7 +342,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI RBD plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # CSI_RBD_PLUGIN_RESOURCE: |
+  #CSI_RBD_PLUGIN_RESOURCE: |
   #  - name : driver-registrar
   #    resource:
   #      requests:
@@ -361,7 +369,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # CSI_CEPHFS_PROVISIONER_RESOURCE: |
+  #CSI_CEPHFS_PROVISIONER_RESOURCE: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -379,6 +387,14 @@ data:
   #        memory: 256Mi
   #        cpu: 200m
   #  - name : csi-attacher
+  #    resource:
+  #      requests:
+  #        memory: 128Mi
+  #        cpu: 100m
+  #      limits:
+  #        memory: 256Mi
+  #        cpu: 200m
+  #  - name : csi-snapshotter
   #    resource:
   #      requests:
   #        memory: 128Mi
@@ -404,7 +420,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # CSI_CEPHFS_PLUGIN_RESOURCE: |
+  #CSI_CEPHFS_PLUGIN_RESOURCE: |
   #  - name : driver-registrar
   #    resource:
   #      requests:

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -206,7 +206,7 @@ data:
 
   # (Optional) CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # CSI_RBD_PROVISIONER_RESOURCE: |
+  #CSI_RBD_PROVISIONER_RESOURCE: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -247,6 +247,14 @@ data:
   #      limits:
   #        memory: 1Gi
   #        cpu: 500m
+  #  - name : csi-omap-generator
+  #    resource:
+  #      requests:
+  #        memory: 512Mi
+  #        cpu: 250m
+  #      limits:
+  #        memory: 1Gi
+  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -257,7 +265,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI RBD plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # CSI_RBD_PLUGIN_RESOURCE: |
+  #CSI_RBD_PLUGIN_RESOURCE: |
   #  - name : driver-registrar
   #    resource:
   #      requests:
@@ -284,7 +292,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # CSI_CEPHFS_PROVISIONER_RESOURCE: |
+  #CSI_CEPHFS_PROVISIONER_RESOURCE: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -302,6 +310,14 @@ data:
   #        memory: 256Mi
   #        cpu: 200m
   #  - name : csi-attacher
+  #    resource:
+  #      requests:
+  #        memory: 128Mi
+  #        cpu: 100m
+  #      limits:
+  #        memory: 256Mi
+  #        cpu: 200m
+  #  - name : csi-snapshotter
   #    resource:
   #      requests:
   #        memory: 128Mi
@@ -327,7 +343,7 @@ data:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # CSI_CEPHFS_PLUGIN_RESOURCE: |
+  #CSI_CEPHFS_PLUGIN_RESOURCE: |
   #  - name : driver-registrar
   #    resource:
   #      requests:


### PR DESCRIPTION
Signed-off-by: Yuval Manor <yuvalman958@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
1. Add csi-snapshotter resources for csiCephFSProvisioner
2. Add csi-omap-generator resources for csiRBDProvisioner (only if omap generator is enabled)

**Which issue is resolved by this Pull Request:**
Resolves #10083

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
