### PR TITLE
core: Examples set default priority class names

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -211,7 +211,7 @@ For more details on the mons and when to choose a number other than `3`, see the
 * `labels`: [labels configuration settings](#annotations-and-labels)
 * `placement`: [placement configuration settings](#placement-configuration-settings)
 * `resources`: [resources configuration settings](#cluster-wide-resources-configuration-settings)
-* `priorityClassNames`: [priority class names configuration settings](#priority-class-names-configuration-settings)
+* `priorityClassNames`: [priority class names configuration settings](#priority-class-names)
 * `storage`: Storage selection and configuration that will be used across the cluster.  Note that these settings can be overridden for specific nodes.
   * `useAllNodes`: `true` or `false`, indicating if all nodes in the cluster should be used for storage according to the cluster level storage selection and configuration values.
   If individual nodes are specified under the `nodes` field, then `useAllNodes` must be set to `false`.
@@ -619,16 +619,16 @@ For more information on resource requests/limits see the official Kubernetes doc
   * `cpu`: Limit for CPU (example: one CPU core `1`, 50% of one CPU core `500m`).
   * `memory`: Limit for Memory (example: one gigabyte of memory `1Gi`, half a gigabyte of memory `512Mi`).
 
-### Priority Class Names Configuration Settings
+### Priority Class Names
 
 Priority class names can be specified so that the Rook components will have those priority class names added to them.
 
 You can set priority class names for Rook components for the list of key value pairs:
 
 * `all`: Set priority class names for MGRs, Mons, OSDs, and crashcollectors.
-* `mgr`: Set priority class names for MGRs.
-* `mon`: Set priority class names for Mons.
-* `osd`: Set priority class names for OSDs.
+* `mgr`: Set priority class names for MGRs. Examples default to system-cluster-critical.
+* `mon`: Set priority class names for Mons. Examples default to system-node-critical.
+* `osd`: Set priority class names for OSDs. Examples default to system-node-critical.
 * `crashcollector`: Set priority class names for crashcollectors.
 
 The specific component keys will act as overrides to `all`.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -288,12 +288,10 @@ cephClusterSpec:
   removeOSDsIfOutAndSafeToRemove: false
 
   # priority classes to apply to ceph resources
-  # priorityClassNames:
-  #   all: rook-ceph-default-priority-class
-  #   mon: rook-ceph-mon-priority-class
-  #   osd: rook-ceph-osd-priority-class
-  #   mgr: rook-ceph-mgr-priority-class
-  #   crashcollector: rook-ceph-crashcollector-priority-class
+  priorityClassNames:
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
 
   storage: # cluster level storage configuration and selection
     useAllNodes: true
@@ -442,6 +440,7 @@ cephFileSystems:
           requests:
             cpu: "1000m"
             memory: "4Gi"
+        priorityClassName: system-cluster-critical
     storageClass:
       enabled: true
       isDefault: false
@@ -511,6 +510,7 @@ cephObjectStores:
         # securePort: 443
         # sslCertificateRef:
         instances: 1
+        priorityClassName: system-cluster-critical
       healthCheck:
         bucket:
           interval: 60s

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -69,14 +69,15 @@ csi:
   # set to false to disable deployment of snapshotter container in RBD provisioner pod.
   enableRBDSnapshotter: true
   # set to false if the selinux is not enabled or unavailable in cluster nodes.
-  enablePluginSelinuxHostMount : false
+  enablePluginSelinuxHostMount: false
   # set to true to enable Ceph CSI pvc encryption support.
   enableCSIEncryption: false
+
   # (Optional) set user created priorityclassName for csi plugin pods.
-  # pluginPriorityClassName: system-node-critical
+  pluginPriorityClassName: system-node-critical
 
   # (Optional) set user created priorityclassName for csi provisioner pods.
-  # provisionerPriorityClassName: system-cluster-critical
+  provisionerPriorityClassName: system-cluster-critical
 
   # (Optional) policy for modifying a volume's ownership or permissions when the RBD PVC is being mounted.
   # supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html
@@ -85,7 +86,7 @@ csi:
   # (Optional) policy for modifying a volume's ownership or permissions when the CephFS PVC is being mounted.
   # supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html
   cephFSFSGroupPolicy: "ReadWriteOnceWithFSType"
-  
+
   # (Optional) policy for modifying a volume's ownership or permissions when the NFS PVC is being mounted.
   # supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html
   nfsFSGroupPolicy: "ReadWriteOnceWithFSType"
@@ -117,7 +118,7 @@ csi:
 
   # Allow starting unsupported ceph-csi image
   allowUnsupportedVersion: false
-    # CEPH CSI RBD provisioner resource requirement list, Put here list of resource
+  # CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
   # csi-omap-generator resources will be applied only if enableOMAPGenerator is set to true
   csiRBDProvisionerResource: |

--- a/deploy/examples/cluster-on-local-pvc.yaml
+++ b/deploy/examples/cluster-on-local-pvc.yaml
@@ -256,6 +256,10 @@ spec:
   #   requests:
   #      cpu: "200m"
   #      memory: "200Mi"
+  priorityClassNames:
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -169,6 +169,12 @@ spec:
   #   requests:
   #      cpu: "200m"
   #      memory: "200Mi"
+  priorityClassNames:
+    # If there are multiple nodes available in a failure domain (e.g. zones), the
+    # mons and osds can be portable and set the system-cluster-critical priority class.
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
     osdMaintenanceTimeout: 30

--- a/deploy/examples/cluster-stretched-aws.yaml
+++ b/deploy/examples/cluster-stretched-aws.yaml
@@ -132,5 +132,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+  priorityClassNames:
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true

--- a/deploy/examples/cluster-stretched.yaml
+++ b/deploy/examples/cluster-stretched.yaml
@@ -70,5 +70,9 @@ spec:
                   values:
                     - b
                     - c
+  priorityClassNames:
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -49,6 +49,9 @@ spec:
       mon:
         interval: 45s
         timeout: 600s
+  priorityClassNames:
+    all: system-node-critical
+    mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
 ---

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -214,12 +214,12 @@ spec:
 #    cleanup:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
-#  priorityClassNames:
-#    all: rook-ceph-default-priority-class
-#    mon: rook-ceph-mon-priority-class
-#    osd: rook-ceph-osd-priority-class
-#    mgr: rook-ceph-mgr-priority-class
-#    crashcollector: rook-ceph-crashcollector-priority-class
+  priorityClassNames:
+    #all: rook-ceph-default-priority-class
+    mon: system-node-critical
+    osd: system-node-critical
+    mgr: system-cluster-critical
+    #crashcollector: rook-ceph-crashcollector-priority-class
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true

--- a/deploy/examples/filesystem.yaml
+++ b/deploy/examples/filesystem.yaml
@@ -101,7 +101,7 @@ spec:
     #  requests:
     #    cpu: "500m"
     #    memory: "1024Mi"
-    # priorityClassName: my-priority-class
+    priorityClassName: system-cluster-critical
     livenessProbe:
       disabled: false
     startupProbe:

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -99,7 +99,7 @@ spec:
     #  requests:
     #    cpu: "500m"
     #    memory: "1024Mi"
-    # priorityClassName: my-priority-class
+    priorityClassName: system-cluster-critical
   #zone:
     #name: zone-a
   # service endpoint healthcheck

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -182,10 +182,10 @@ data:
   # ROOK_CSI_NFS_IMAGE: "mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.
-  # CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
+  CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
 
   # (Optional) set user created priorityclassName for csi provisioner pods.
-  # CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
 
   # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -97,10 +97,10 @@ data:
   # ROOK_CSI_NFS_IMAGE: "mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.
-  # CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
+  CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
 
   # (Optional) set user created priorityclassName for csi provisioner pods.
-  # CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
 
   # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/tests/framework/utils"
 )
 
 // TestCephSettings struct for handling panic and test suite tear down
@@ -50,6 +51,7 @@ type TestCephSettings struct {
 	ChangeHostName              bool
 	RookVersion                 string
 	CephVersion                 cephv1.CephVersionSpec
+	KubernetesVersion           string
 }
 
 func (s *TestCephSettings) ApplyEnvVars() {
@@ -86,6 +88,11 @@ func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
 	manifest = strings.ReplaceAll(manifest, `# CSI_LOG_LEVEL: "0"`, `CSI_LOG_LEVEL: "5"`)
 	manifest = strings.ReplaceAll(manifest, `ROOK_ENABLE_DISCOVERY_DAEMON: "false"`, fmt.Sprintf(`ROOK_ENABLE_DISCOVERY_DAEMON: "%t"`, s.EnableDiscovery))
 	manifest = strings.ReplaceAll(manifest, `CSI_ENABLE_VOLUME_REPLICATION: "false"`, fmt.Sprintf(`CSI_ENABLE_VOLUME_REPLICATION: "%t"`, s.EnableVolumeReplication))
+	if !utils.VersionAtLeast(s.KubernetesVersion, "v1.17.0") {
+		// Older than K8s 1.17 does not support priority classes
+		manifest = strings.ReplaceAll(manifest, `CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"`, `CSI_PLUGIN_PRIORITY_CLASSNAME: ""`)
+		manifest = strings.ReplaceAll(manifest, `CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"`, `CSI_PROVISIONER_PRIORITY_CLASSNAME: ""`)
+	}
 	return manifest
 }
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -126,6 +126,11 @@ func (k8sh *K8sHelper) GetK8sServerVersion() string {
 	return versionInfo.GitVersion
 }
 
+func VersionAtLeast(actualVersion, minVersion string) bool {
+	v := version.MustParseSemantic(actualVersion)
+	return v.AtLeast(version.MustParseSemantic(minVersion))
+}
+
 func (k8sh *K8sHelper) VersionAtLeast(minVersion string) bool {
 	v := version.MustParseSemantic(k8sh.GetK8sServerVersion())
 	return v.AtLeast(version.MustParseSemantic(minVersion))

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -76,7 +76,7 @@ func checkIfRookClusterIsHealthy(s suite.Suite, testClient *clients.TestClient, 
 
 func checkIfRookClusterHasHealthyIngress(s suite.Suite, k8sh *utils.K8sHelper, clusterNamespace string) {
 	logger.Infof("Testing ingress %s health", clusterNamespace)
-	_, err := k8sh.GetResourceStatus("Ingress", clusterNamespace + "-dashboard", clusterNamespace)
+	_, err := k8sh.GetResourceStatus("Ingress", clusterNamespace+"-dashboard", clusterNamespace)
 	assert.NoError(s.T(), err)
 }
 
@@ -93,6 +93,7 @@ func HandlePanics(r interface{}, uninstaller func(), t func() *testing.T) {
 func StartTestCluster(t func() *testing.T, settings *installer.TestCephSettings) (*installer.CephInstaller, *utils.K8sHelper) {
 	k8shelper, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
+	settings.KubernetesVersion = k8shelper.GetK8sServerVersion()
 
 	// Turn on DEBUG logging
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
By default, we should set the priority class to one of the built-in priority class names to ensure that pods critical to the storage will be able to remain running when resources are low. Otherwise, critical rook pods could be evicted and affect many other pods that rely on the storage to continue functioning. 

The options have been available in the CRs, but until now we have just not set the defaults in the examples. Critical rook components are now set to the priority class system-node-critical if they are generally pinned to a node, and system-cluster-critical if they are critical to the storage. Some pods such as the operator and crash collector do not have a default priority class set in the examples since they don't affect the data path.

**Which issue is resolved by this Pull Request:**
Resolves #10090 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
