### PR TITLE
block: validate updating names in BlockPool CR

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -112,6 +112,9 @@ func (p *CephBlockPool) ValidateUpdate(old runtime.Object) error {
 	if err != nil {
 		return err
 	}
+	if ocbp.Spec.Name != p.Spec.Name {
+		return errors.New("invalid update: pool name cannot be changed")
+	}
 	if p.Spec.ErasureCoded.CodingChunks > 0 || p.Spec.ErasureCoded.DataChunks > 0 || p.Spec.ErasureCoded.Algorithm != "" {
 		if ocbp.Spec.Replicated.Size > 0 || ocbp.Spec.Replicated.TargetSizeRatio > 0 {
 			return errors.New("invalid update: replicated field is set already in previous object. cannot be changed to use erasurecoded")

--- a/pkg/apis/ceph.rook.io/v1/pool_test.go
+++ b/pkg/apis/ceph.rook.io/v1/pool_test.go
@@ -61,6 +61,12 @@ func TestCephBlockPoolValidateUpdate(t *testing.T) {
 	up.Spec.ErasureCoded.CodingChunks = 1
 	err := up.ValidateUpdate(p)
 	assert.Error(t, err)
+
+	// validate with different name in Spec.Name
+	ip := p.DeepCopy()
+	ip.Spec.Name = "new-ec-pool"
+	err = ip.ValidateUpdate(p)
+	assert.Error(t, err)
 }
 
 func TestMirroringSpec_SnapshotSchedulesEnabled(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Currently, we are allowing users to change the name of the pool to be created in the BlockPool CR. with this we have a bug of leaving stale resources in the cluster. With new changes, we are blocking the update of the pool name in the BlockPool CR.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
