### PR TITLE
monitoring: Disable new alerts that are not applicable to rook

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -717,19 +717,6 @@ groups:
 
   - name: pools
     rules:
-      - alert: CephPoolGrowthWarning
-        expr: |
-          (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
-              group_right ceph_pool_metadata) >= 95
-        labels:
-          severity: warning
-          type: ceph_default
-          oid: 1.3.6.1.4.1.50495.1.2.1.9.2
-        annotations:
-          summary: Pool growth rate may soon exceed it's capacity
-          description: >
-            Pool '{{ $labels.name }}' will be full in less than 5 days
-            assuming the average fill-up rate of the past 48 hours.
       - alert: CephPoolBackfillFull
         expr: ceph_health_detail{name="POOL_BACKFILLFULL"} > 0
         labels:
@@ -793,7 +780,7 @@ groups:
           summary: MON/OSD operations are slow to complete
           description: >
             {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
-# cephadm alerts
+  # cephadm alerts
   - name: cephadm
     rules:
       - alert: CephadmUpgradeFailed
@@ -837,25 +824,7 @@ groups:
             orchestrator from service management and reconciliation. If this is
             not intentional, resume cephadm operations with 'ceph orch resume'
 
-# prometheus alerts
-  - name: PrometheusServer
-    rules:
-      - alert: PrometheusJobMissing
-        expr: absent(up{job="ceph"})
-        for: 30s
-        labels:
-          severity: critical
-          type: ceph_default
-          oid: 1.3.6.1.4.1.50495.1.2.1.12.1
-        annotations:
-          summary: The scrape job for Ceph is missing from Prometheus
-          description: |
-            The prometheus job that scrapes from Ceph is no longer defined, this
-            will effectively mean you'll have no metrics or alerts for the cluster.
-
-            Please review the job definitions in the prometheus.yml file of the prometheus
-            instance.
-# Object related events
+  # Object related events
   - name: rados
     rules:
       - alert: CephObjectMissing
@@ -872,7 +841,7 @@ groups:
             A version of a RADOS object can not be found, even though all OSDs are up. I/O
             requests for this object from clients will block (hang). Resolving this issue may
             require the object to be rolled back to a prior version manually, and manually verified.
-# Generic
+  # Generic
   - name: generic
     rules:
       - alert: CephDaemonCrash

--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -780,49 +780,6 @@ groups:
           summary: MON/OSD operations are slow to complete
           description: >
             {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
-  # cephadm alerts
-  - name: cephadm
-    rules:
-      - alert: CephadmUpgradeFailed
-        expr: ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0
-        for: 30s
-        labels:
-          severity: critical
-          type: ceph_default
-          oid: 1.3.6.1.4.1.50495.1.2.1.11.2
-        annotations:
-          summary: Ceph version upgrade has failed
-          description: >
-            The cephadm cluster upgrade process has failed. The cluster remains in
-            an undetermined state.
-
-            Please review the cephadm logs, to understand the nature of the issue
-      - alert: CephadmDaemonFailed
-        expr: ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0
-        for: 30s
-        labels:
-          severity: critical
-          type: ceph_default
-          oid: 1.3.6.1.4.1.50495.1.2.1.11.1
-        annotations:
-          summary: A ceph daemon manged by cephadm is down
-          description: >
-            A daemon managed by cephadm is no longer active. Determine, which
-            daemon is down with 'ceph health detail'. you may start daemons with
-            the 'ceph orch daemon start <daemon_id>'
-      - alert: CephadmPaused
-        expr: ceph_health_detail{name="CEPHADM_PAUSED"} > 0
-        for: 1m
-        labels:
-          severity: warning
-          type: ceph_default
-        annotations:
-          documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
-          summary: Orchestration tasks via cephadm are PAUSED
-          description: >
-            Cluster management has been paused manually. This will prevent the
-            orchestrator from service management and reconciliation. If this is
-            not intentional, resume cephadm operations with 'ceph orch resume'
 
   # Object related events
   - name: rados

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -726,19 +726,6 @@ spec:
 
     - name: pools
       rules:
-        - alert: CephPoolGrowthWarning
-          expr: |
-            (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
-                group_right ceph_pool_metadata) >= 95
-          labels:
-            severity: warning
-            type: ceph_default
-            oid: 1.3.6.1.4.1.50495.1.2.1.9.2
-          annotations:
-            summary: Pool growth rate may soon exceed it's capacity
-            description: >
-              Pool '{{ $labels.name }}' will be full in less than 5 days
-              assuming the average fill-up rate of the past 48 hours.
         - alert: CephPoolBackfillFull
           expr: ceph_health_detail{name="POOL_BACKFILLFULL"} > 0
           labels:
@@ -802,7 +789,7 @@ spec:
             summary: MON/OSD operations are slow to complete
             description: >
               {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
-  # cephadm alerts
+    # cephadm alerts
     - name: cephadm
       rules:
         - alert: CephadmUpgradeFailed
@@ -846,25 +833,7 @@ spec:
               orchestrator from service management and reconciliation. If this is
               not intentional, resume cephadm operations with 'ceph orch resume'
 
-  # prometheus alerts
-    - name: PrometheusServer
-      rules:
-        - alert: PrometheusJobMissing
-          expr: absent(up{job="ceph"})
-          for: 30s
-          labels:
-            severity: critical
-            type: ceph_default
-            oid: 1.3.6.1.4.1.50495.1.2.1.12.1
-          annotations:
-            summary: The scrape job for Ceph is missing from Prometheus
-            description: |
-              The prometheus job that scrapes from Ceph is no longer defined, this
-              will effectively mean you'll have no metrics or alerts for the cluster.
-
-              Please review the job definitions in the prometheus.yml file of the prometheus
-              instance.
-  # Object related events
+    # Object related events
     - name: rados
       rules:
         - alert: CephObjectMissing
@@ -881,7 +850,7 @@ spec:
               A version of a RADOS object can not be found, even though all OSDs are up. I/O
               requests for this object from clients will block (hang). Resolving this issue may
               require the object to be rolled back to a prior version manually, and manually verified.
-  # Generic
+    # Generic
     - name: generic
       rules:
         - alert: CephDaemonCrash

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -789,49 +789,6 @@ spec:
             summary: MON/OSD operations are slow to complete
             description: >
               {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
-    # cephadm alerts
-    - name: cephadm
-      rules:
-        - alert: CephadmUpgradeFailed
-          expr: ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0
-          for: 30s
-          labels:
-            severity: critical
-            type: ceph_default
-            oid: 1.3.6.1.4.1.50495.1.2.1.11.2
-          annotations:
-            summary: Ceph version upgrade has failed
-            description: >
-              The cephadm cluster upgrade process has failed. The cluster remains in
-              an undetermined state.
-
-              Please review the cephadm logs, to understand the nature of the issue
-        - alert: CephadmDaemonFailed
-          expr: ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0
-          for: 30s
-          labels:
-            severity: critical
-            type: ceph_default
-            oid: 1.3.6.1.4.1.50495.1.2.1.11.1
-          annotations:
-            summary: A ceph daemon manged by cephadm is down
-            description: >
-              A daemon managed by cephadm is no longer active. Determine, which
-              daemon is down with 'ceph health detail'. you may start daemons with
-              the 'ceph orch daemon start <daemon_id>'
-        - alert: CephadmPaused
-          expr: ceph_health_detail{name="CEPHADM_PAUSED"} > 0
-          for: 1m
-          labels:
-            severity: warning
-            type: ceph_default
-          annotations:
-            documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
-            summary: Orchestration tasks via cephadm are PAUSED
-            description: >
-              Cluster management has been paused manually. This will prevent the
-              orchestrator from service management and reconciliation. If this is
-              not intentional, resume cephadm operations with 'ceph orch resume'
 
     # Object related events
     - name: rados


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The new alerts picked up for Rook v1.9 directly from the ceph repo were not all rook-compliant. The alert for the prometheus job not running is not needed since Rook and K8s go to great lengths to keep the mgr pod running already.

The alert for the cluster filling up soon is also disabled until we find how to get the formula working in rook clusters.

@pcuzner Let's discuss the right approach for these alerts in the long term, if there is something better than disabling them.

**Which issue is resolved by this Pull Request:**
Resolves #10070 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
