### PR TITLE
test: Improve reliability of mon failover test

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -138,7 +138,7 @@ spec:
   cephVersion:
     image: ` + m.settings.CephVersion.Image + `
     allowUnsupported: ` + strconv.FormatBool(m.settings.CephVersion.AllowUnsupported) + `
-  skipUpgradeChecks: false
+  skipUpgradeChecks: true
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   mgr:
     count: ` + strconv.Itoa(mgrCount) + `

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -143,52 +143,45 @@ func (s *SmokeSuite) TestMonFailover() {
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), 3, len(deployments))
 
+	// Scale down a mon so the operator won't trigger a reconcile
 	monToKill := deployments[0].Name
-	logger.Infof("Killing mon %s", monToKill)
-	propagation := metav1.DeletePropagationForeground
-	delOptions := &metav1.DeleteOptions{PropagationPolicy: &propagation}
-	err = s.k8sh.Clientset.AppsV1().Deployments(s.settings.Namespace).Delete(ctx, monToKill, *delOptions)
-	require.NoError(s.T(), err)
+	logger.Infof("Scaling down mon %s", monToKill)
+	scale, err := s.k8sh.Clientset.AppsV1().Deployments(s.settings.Namespace).GetScale(ctx, monToKill, metav1.GetOptions{})
+	assert.NoError(s.T(), err)
+	scale.Spec.Replicas = 0
+	_, err = s.k8sh.Clientset.AppsV1().Deployments(s.settings.Namespace).UpdateScale(ctx, monToKill, scale, metav1.UpdateOptions{})
+	assert.NoError(s.T(), err)
 
 	// Wait for the health check to start a new monitor
-	originalMonDeleted := false
 	for i := 0; i < 30; i++ {
 		deployments, err := s.getNonCanaryMonDeployments()
 		require.NoError(s.T(), err)
 
-		// Make sure the old mon is not still alive
-		foundOldMon := false
-		for _, mon := range deployments {
+		var currentMons []string
+		var originalMonDeployment *appsv1.Deployment
+		for i, mon := range deployments {
+			currentMons = append(currentMons, mon.Name)
 			if mon.Name == monToKill {
-				foundOldMon = true
+				originalMonDeployment = &deployments[i]
 			}
 		}
+		logger.Infof("mon deployments: %v", currentMons)
 
-		// Check if we have three monitors
-		if foundOldMon {
-			if originalMonDeleted {
-				// Depending on the state of the orchestration, the operator might trigger
-				// re-creation of the deleted mon. In this case, consider the test successful
-				// rather than wait for the failover which will never occur.
-				logger.Infof("Original mon created again, no need to wait for mon failover")
-				return
-			}
-			logger.Infof("Waiting for old monitor to stop")
-		} else {
-			logger.Infof("Waiting for a new monitor to start")
-			originalMonDeleted = true
-			if len(deployments) == 3 {
-				var newMons []string
-				for _, mon := range deployments {
-					newMons = append(newMons, mon.Name)
-				}
-				logger.Infof("Found a new monitor! monitors=%v", newMons)
-				return
-			}
-
-			assert.Equal(s.T(), 2, len(deployments))
+		// Check if the original mon was scaled up again
+		// Depending on the state of the orchestration, the operator might trigger
+		// re-creation of the deleted mon. In this case, consider the test successful
+		// rather than wait for the failover which will never occur.
+		if originalMonDeployment != nil && *originalMonDeployment.Spec.Replicas > 0 {
+			logger.Infof("Original mon created again, no need to wait for mon failover")
+			return
 		}
 
+		if len(deployments) == 3 && originalMonDeployment == nil {
+			logger.Infof("Found a new monitor!")
+			return
+		}
+
+		logger.Infof("Waiting for a new monitor to start and previous one to be deleted")
 		time.Sleep(5 * time.Second)
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon failover test was failing if the cluster reconcile was being triggered in the middle of the failover and if the ordering of the mons happened to attempt to start the mons that were not failed over. The other mons couldn't be updated due to the upgrade checks, so the test would timeout waiting for the mons that would never update in time.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
