### PR TITLE
csi: Rework how to save csi configmap details

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -114,7 +114,8 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 
 	// Save CSI configmap
-	err = csi.SaveClusterConfig(c.context.Clientset, c.namespacedName.Namespace, cluster.ClusterInfo, &csi.CsiClusterConfigEntry{Monitors: csi.MonEndpoints(cluster.ClusterInfo.Monitors)})
+	clusterConfig := &csi.CsiClusterConfigEntry{ClusterID: c.namespacedName.Namespace, Monitors: csi.MonEndpoints(cluster.ClusterInfo.Monitors)}
+	err = csi.SaveClusterConfig(c.context.Clientset, cluster.ClusterInfo, clusterConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to update csi cluster config")
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1050,7 +1050,8 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to write connection config for new mons")
 	}
 
-	if err := csi.SaveClusterConfig(c.context.Clientset, c.Namespace, c.ClusterInfo, &csi.CsiClusterConfigEntry{Monitors: csi.MonEndpoints(c.ClusterInfo.Monitors)}); err != nil {
+	clusterConfig := &csi.CsiClusterConfigEntry{ClusterID: c.Namespace, Monitors: csi.MonEndpoints(c.ClusterInfo.Monitors)}
+	if err := csi.SaveClusterConfig(c.context.Clientset, c.ClusterInfo, clusterConfig); err != nil {
 		return errors.Wrap(err, "failed to update csi cluster config")
 	}
 

--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -17,41 +17,58 @@ limitations under the License.
 package csi
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func TestUpdateCsiClusterConfig(t *testing.T) {
-	csiClusterConfigEntry := CsiClusterConfigEntry{
-		Monitors: []string{"1.2.3.4:5000"},
+	csiClusterConfigEntry := &CsiClusterConfigEntry{
+		ClusterID: "alpha",
+		Monitors:  []string{"1.2.3.4:5000"},
 	}
-	csiClusterConfigEntry2 := CsiClusterConfigEntry{
-		Monitors: []string{"20.1.1.1:5000", "20.1.1.2:5000", "20.1.1.3:5000"},
+	csiClusterConfigEntry2 := &CsiClusterConfigEntry{
+		ClusterID: "beta",
+		Monitors:  []string{"20.1.1.1:5000", "20.1.1.2:5000", "20.1.1.3:5000"},
 	}
-	csiClusterConfigEntry3 := CsiClusterConfigEntry{
-		Monitors: []string{"10.1.1.1:5000", "10.1.1.2:5000", "10.1.1.3:5000"},
-		CephFS: &CsiCephFSSpec{
-			SubvolumeGroup: "mygroup",
-		},
-	}
-	var s string
-	var err error
+	clientset := test.New(t, 3)
+	clusterInfo := &client.ClusterInfo{Context: context.TODO()}
+	clusterNamespace := "ns"
+	os.Setenv("POD_NAMESPACE", clusterNamespace)
+	defer os.Unsetenv("POD_NAMESPACE")
+	// Create the CSI config map
+	ownerRef := &metav1.OwnerReference{}
+	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
+	err := CreateCsiConfigMap(clusterInfo.Context, clusterNamespace, clientset, ownerInfo)
+	assert.NoError(t, err)
 
 	t.Run("add a simple mons list", func(t *testing.T) {
-		s, err = updateCsiClusterConfig("[]", "alpha", &csiClusterConfigEntry)
+		err := SaveClusterConfig(clientset, clusterInfo, csiClusterConfigEntry)
 		assert.NoError(t, err)
-		assert.Equal(t, s,
-			`[{"clusterID":"alpha","monitors":["1.2.3.4:5000"]}]`)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(cc))
+		assert.Equal(t, "alpha", cc[0].ClusterID)
+		assert.Contains(t, cc[0].Monitors, "1.2.3.4:5000")
 	})
 
 	t.Run("add a 2nd mon to the current cluster", func(t *testing.T) {
 		csiClusterConfigEntry.Monitors = append(csiClusterConfigEntry.Monitors, "10.11.12.13:5000")
-		s, err = updateCsiClusterConfig(s, "alpha", &csiClusterConfigEntry)
+		err := SaveClusterConfig(clientset, clusterInfo, csiClusterConfigEntry)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(cc))
+		require.Equal(t, 1, len(cc))
 		assert.Equal(t, "alpha", cc[0].ClusterID)
 		assert.Contains(t, cc[0].Monitors, "1.2.3.4:5000")
 		assert.Contains(t, cc[0].Monitors, "10.11.12.13:5000")
@@ -59,11 +76,11 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 	})
 
 	t.Run("add a 2nd cluster with 3 mons", func(t *testing.T) {
-		s, err = updateCsiClusterConfig(s, "beta", &csiClusterConfigEntry2)
+		err := SaveClusterConfig(clientset, clusterInfo, csiClusterConfigEntry2)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(cc))
+		require.Equal(t, 2, len(cc))
 		assert.Equal(t, "alpha", cc[0].ClusterID)
 		assert.Contains(t, cc[0].Monitors, "1.2.3.4:5000")
 		assert.Contains(t, cc[0].Monitors, "10.11.12.13:5000")
@@ -79,82 +96,90 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 		i := 2
 		// Remove last element of the slice
 		csiClusterConfigEntry2.Monitors = append(csiClusterConfigEntry2.Monitors[:i], csiClusterConfigEntry2.Monitors[i+1:]...)
-		s, err = updateCsiClusterConfig(s, "beta", &csiClusterConfigEntry2)
+		err := SaveClusterConfig(clientset, clusterInfo, csiClusterConfigEntry2)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(cc))
+		require.Equal(t, 2, len(cc))
 		assert.Equal(t, "alpha", cc[0].ClusterID)
 		assert.Contains(t, cc[0].Monitors, "1.2.3.4:5000")
 		assert.Contains(t, cc[0].Monitors, "10.11.12.13:5000")
-		assert.Equal(t, 2, len(cc[0].Monitors))
+		require.Equal(t, 2, len(cc[0].Monitors))
 		assert.Equal(t, "beta", cc[1].ClusterID)
 		assert.Contains(t, cc[1].Monitors, "20.1.1.1:5000")
 		assert.Contains(t, cc[1].Monitors, "20.1.1.2:5000")
 		assert.Equal(t, 2, len(cc[1].Monitors))
 	})
 
-	t.Run("add a 3rd cluster with subvolumegroup", func(t *testing.T) {
-		s, err = updateCsiClusterConfig(s, "baba", &csiClusterConfigEntry3)
+	t.Run("add a subvolumegroup", func(t *testing.T) {
+		group := &cephv1.CephFilesystemSubVolumeGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "mygroup", Namespace: csiClusterConfigEntry2.ClusterID},
+			Spec: cephv1.CephFilesystemSubVolumeGroupSpec{
+				FilesystemName: "testfs",
+			},
+		}
+		err = AddSubvolumeGroup(clientset, clusterInfo, group)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(cc))
+		assert.Equal(t, 2, len(cc))
 		assert.Equal(t, "alpha", cc[0].ClusterID)
 		assert.Equal(t, 2, len(cc[0].Monitors))
 		assert.Equal(t, "beta", cc[1].ClusterID)
-		assert.Equal(t, "baba", cc[2].ClusterID)
-		assert.Equal(t, "10.1.1.1:5000", cc[2].Monitors[0])
-		assert.Equal(t, 3, len(cc[2].Monitors))
-		assert.Equal(t, "mygroup", cc[2].CephFS.SubvolumeGroup)
-
+		assert.Equal(t, "20.1.1.1:5000", cc[1].Monitors[0])
+		assert.Equal(t, 2, len(cc[1].Monitors))
+		assert.Equal(t, "mygroup", cc[1].SubvolumeGroups[0].Name)
+		assert.Equal(t, "testfs", cc[1].SubvolumeGroups[0].Filesystem)
 	})
 
-	t.Run("add a 4th mon to the 3rd cluster and subvolumegroup is preserved", func(t *testing.T) {
-		csiClusterConfigEntry3.Monitors = append(csiClusterConfigEntry3.Monitors, "10.11.12.13:5000")
-		s, err = updateCsiClusterConfig(s, "baba", &csiClusterConfigEntry3)
+	t.Run("add another mon and subvolumegroup is preserved", func(t *testing.T) {
+		csiClusterConfigEntry2.Monitors = append(csiClusterConfigEntry2.Monitors, "10.11.12.13:5000")
+		err := SaveClusterConfig(clientset, clusterInfo, csiClusterConfigEntry2)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(cc))
-		assert.Equal(t, 4, len(cc[2].Monitors))
-		assert.Equal(t, "mygroup", cc[2].CephFS.SubvolumeGroup)
+		assert.Equal(t, 2, len(cc))
+		assert.Equal(t, 3, len(cc[1].Monitors))
+		assert.Equal(t, "10.11.12.13:5000", cc[1].Monitors[2])
+		assert.Equal(t, "mygroup", cc[1].SubvolumeGroups[0].Name)
 	})
 
-	t.Run("remove subvolumegroup", func(t *testing.T) {
-		csiClusterConfigEntry3.CephFS.SubvolumeGroup = ""
-		s, err = updateCsiClusterConfig(s, "baba", nil)
-		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(cc)) // we only have 2 clusters now
-	})
-
-	t.Run("add subvolumegroup and mons after", func(t *testing.T) {
-		csiClusterConfigEntry4 := CsiClusterConfigEntry{
-			CephFS: &CsiCephFSSpec{
-				SubvolumeGroup: "mygroup2",
+	t.Run("add and remove subvolumegroup", func(t *testing.T) {
+		group := &cephv1.CephFilesystemSubVolumeGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "addedgroup", Namespace: csiClusterConfigEntry2.ClusterID},
+			Spec: cephv1.CephFilesystemSubVolumeGroupSpec{
+				FilesystemName: "fsname",
 			},
 		}
-		s, err = updateCsiClusterConfig(s, "quatre", &csiClusterConfigEntry4)
+		err := AddSubvolumeGroup(clientset, clusterInfo, group)
 		assert.NoError(t, err)
-		cc, err := parseCsiClusterConfig(s)
+		cc, err := getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(cc), cc)
-		assert.Equal(t, 0, len(cc[2].Monitors))
-		assert.Equal(t, "mygroup2", cc[2].CephFS.SubvolumeGroup, cc)
+		assert.Equal(t, 2, len(cc))
+		assert.Equal(t, 2, len(cc[1].SubvolumeGroups))
+		logger.Infof("Subvolumegroups: %v", cc[1].SubvolumeGroups)
+		assert.Equal(t, "mygroup", cc[1].SubvolumeGroups[0].Name)
+		assert.Equal(t, "testfs", cc[1].SubvolumeGroups[0].Filesystem)
+		assert.Equal(t, "addedgroup", cc[1].SubvolumeGroups[1].Name)
+		assert.Equal(t, "fsname", cc[1].SubvolumeGroups[1].Filesystem)
 
-		csiClusterConfigEntry4.Monitors = []string{"10.1.1.1:5000", "10.1.1.2:5000", "10.1.1.3:5000"}
-		s, err = updateCsiClusterConfig(s, "quatre", &csiClusterConfigEntry4)
+		err = RemoveSubvolumeGroup(clientset, clusterInfo, group)
 		assert.NoError(t, err)
-		cc, err = parseCsiClusterConfig(s)
+		cc, err = getTestConfigmapContents(clientset, clusterInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "mygroup2", cc[2].CephFS.SubvolumeGroup)
-		assert.Equal(t, 3, len(cc[2].Monitors))
+		assert.Equal(t, 2, len(cc))
+		assert.Equal(t, 1, len(cc[1].SubvolumeGroups))
+		assert.Equal(t, "mygroup", cc[1].SubvolumeGroups[0].Name)
+		assert.Equal(t, "testfs", cc[1].SubvolumeGroups[0].Filesystem)
 	})
+}
 
-	t.Run("does it return error on garbage input?", func(t *testing.T) {
-		_, err = updateCsiClusterConfig("qqq", "beta", &csiClusterConfigEntry2)
-		assert.Error(t, err)
-	})
+func getTestConfigmapContents(clientset kubernetes.Interface, clusterInfo *client.ClusterInfo) ([]CsiClusterConfigEntry, error) {
+	// fetch current ConfigMap contents
+	configMap, err := clientset.CoreV1().ConfigMaps(os.Getenv("POD_NAMESPACE")).Get(clusterInfo.Context, ConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch current csi config map")
+	}
+	return parseCsiClusterConfig(configMap.Data[ConfigKey])
 }

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -28,6 +28,7 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -37,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -213,12 +215,7 @@ func TestCephClientController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
-		// Create CSI config map
-		ownerRef := &metav1.OwnerReference{}
-		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
-		err = csi.CreateCsiConfigMap(ctx, namespace, c.Clientset, ownerInfo)
-		assert.NoError(t, err)
+		initializeTestCSI(t, c.Clientset, namespace)
 
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
@@ -260,12 +257,7 @@ func TestCephClientController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
-		// Create CSI config map
-		ownerRef := &metav1.OwnerReference{}
-		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
-		err := csi.CreateCsiConfigMap(ctx, namespace, c.Clientset, ownerInfo)
-		assert.NoError(t, err)
+		initializeTestCSI(t, c.Clientset, namespace)
 
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
@@ -283,6 +275,18 @@ func TestCephClientController(t *testing.T) {
 		assert.Contains(t, cm.Data[csi.ConfigKey], "clusterID")
 		assert.Contains(t, cm.Data[csi.ConfigKey], "group-a")
 	})
+}
+
+func initializeTestCSI(t *testing.T, clientset kubernetes.Interface, namespace string) {
+	os.Setenv("POD_NAMESPACE", namespace)
+	// Create CSI config map
+	ownerRef := &metav1.OwnerReference{}
+	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
+	err := csi.CreateCsiConfigMap(context.TODO(), namespace, clientset, ownerInfo)
+	assert.NoError(t, err)
+	clusterConfig := &csi.CsiClusterConfigEntry{ClusterID: namespace}
+	clusterInfo := &client.ClusterInfo{Context: context.TODO()}
+	csi.SaveClusterConfig(clientset, clusterInfo, clusterConfig)
 }
 
 func Test_buildClusterID(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The rados namespace and subvolume groups were being saved to the csi configmap in their own entries, but their mons were not being updated since rook can't tell which cluster they belonged to. Now the rados namespaces and subvolume groups are added within the same cluster entries so the mons only need to be updated in a single place whenever there is an update.

From a test cluster with several subvolume groups and rados namespaces it looks like the following:
```yaml
data:
  csi-cluster-config-json: '[{"clusterID":"rook-ceph","monitors":["10.99.242.255:6789","10.100.159.135:6789","10.105.182.218:6789"],
        "subvolumeGroups":[{"name":"group-a","filesystem":"myfs"},{"name":"group-b","filesystem":"myfs"}],
        "radosNamespaces":[{"pool":"replicapool","namespace":"namespace-a"},{"pool":"replicapool","namespace":"namespace-b"},{"pool":"replicapool","namespace":"namespace-c"}]}]'
```

This way we don't need to have separate key mappings and extra mounts in the csi pods, we can just keep it in a single json blob. 
@Madhu-1 Does this format work for the CSI driver? 

Conversion of the previous format for subvolume groups and rados namespaces is not yet implemented, this is so far just tested for new clusters.

**Which issue is resolved by this Pull Request:**
Resolves #10126 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
