### PR TITLE
rgw: fix dashboard admin creation for multiple object stores

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -441,7 +441,7 @@ func GetAdminOPSUserCredentials(objContext *Context, spec *cephv1.ObjectStoreSpe
 		DisplayName:  &rgwAdminOpsUserDisplayName,
 		AdminOpsUser: true,
 	}
-	logger.Debugf("creating s3 user object %q for object store %q", userConfig.UserID, ns)
+	logger.Debugf("creating s3 user object %q for object store %q", userConfig.UserID, objContext.Name)
 
 	forceUserCreation := false
 	// If the cluster where we are running the rgw user create for the admin ops user is configured

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -370,11 +370,11 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 		client:      r.client,
 		ownerInfo:   ownerInfo,
 	}
-	objContext := NewContext(r.context, r.clusterInfo, cephObjectStore.Name)
-	objContext.UID = string(cephObjectStore.UID)
+	objContext, err := NewMultisiteContext(r.context, r.clusterInfo, cephObjectStore)
+	if err != nil {
+		return r.setFailedStatus(k8sutil.ObservedGenerationNotAvailable, namespacedName, "failed to setup object store context", err)
+	}
 	objContext.CephClusterSpec = cluster
-
-	var err error
 
 	if cephObjectStore.Spec.IsExternal() {
 		logger.Info("reconciling external object store")

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -676,9 +676,14 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 
 	clientset := test.New(t, 3)
 	c := &clusterd.Context{
-		Executor:      executor,
-		RookClientset: rookfake.NewSimpleClientset(),
-		Clientset:     clientset,
+		Executor: executor,
+		RookClientset: rookfake.NewSimpleClientset(
+			objectRealm,
+			objectZoneGroup,
+			objectZone,
+			objectStore,
+		),
+		Clientset: clientset,
 	}
 
 	// Register operator types with the runtime scheme.

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -75,9 +75,13 @@ func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName s
 		return errors.Wrap(err, "failed to start rgw pods")
 	}
 
-	objContext := NewContext(c.context, c.clusterInfo, c.store.Namespace)
-	err := enableRGWDashboard(objContext)
+	objContext, err := NewMultisiteContext(c.context, c.clusterInfo, c.store)
 	if err != nil {
+		logger.Warningf("failed to get object context for rgw %q. %v", c.store.Name, err)
+		return nil
+	}
+
+	if err = enableRGWDashboard(objContext); err != nil {
 		logger.Warningf("failed to enable dashboard for rgw. %v", err)
 	}
 

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -106,5 +106,5 @@ func (h *HelmSuite) TestFileStoreOnRookInstalledViaHelm() {
 func (h *HelmSuite) TestObjectStoreOnRookInstalledViaHelm() {
 	deleteStore := true
 	tls := false
-	runObjectE2ETestLite(h.T(), h.helper, h.k8shelper, h.settings.Namespace, "default", 3, deleteStore, tls)
+	runObjectE2ETestLite(h.T(), h.helper, h.k8shelper, h.installer, h.settings.Namespace, "default", 3, deleteStore, tls)
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -97,7 +97,7 @@ func (s *ObjectSuite) TestWithTLS() {
 
 	tls := true
 	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.Suite, s.settings.Namespace, tls)
+	runObjectE2ETest(s.helper, s.k8sh, s.installer, s.Suite, s.settings.Namespace, tls)
 	err := s.k8sh.Clientset.CoreV1().Secrets(s.settings.Namespace).Delete(context.TODO(), objectTLSSecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -114,21 +114,21 @@ func (s *ObjectSuite) TestWithoutTLS() {
 
 	tls := false
 	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.Suite, s.settings.Namespace, tls)
+	runObjectE2ETest(s.helper, s.k8sh, s.installer, s.Suite, s.settings.Namespace, tls)
 }
 
 // Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
 // Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,
 // Check issues in MGRs, Delete Bucket and Delete user
 // Test for ObjectStore with and without TLS enabled
-func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, tlsEnable bool) {
+func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, installer *installer.CephInstaller, s suite.Suite, namespace string, tlsEnable bool) {
 	storeName := "test-store"
 	if tlsEnable {
 		storeName = objectStoreTLSName
 	}
 
 	logger.Infof("Running on Rook Cluster %s", namespace)
-	createCephObjectStore(s.T(), helper, k8sh, namespace, storeName, 3, tlsEnable)
+	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 3, tlsEnable)
 
 	// test that a second object store can be created (and deleted) while the first exists
 	s.T().Run("run a second object store", func(t *testing.T) {
@@ -136,7 +136,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 		// The lite e2e test is perfect, as it only creates a cluster, checks that it is healthy,
 		// and then deletes it.
 		deleteStore := true
-		runObjectE2ETestLite(t, helper, k8sh, namespace, otherStoreName, 1, deleteStore, tlsEnable)
+		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable)
 	})
 	if tlsEnable {
 		// test that a third object store can be created (and deleted) while the first exists
@@ -146,7 +146,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 			// and then deletes it.
 			deleteStore := true
 			objectStoreServicePrefix = objectStoreServicePrefixUniq
-			runObjectE2ETestLite(t, helper, k8sh, namespace, otherStoreName, 1, deleteStore, tlsEnable)
+			runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable)
 			objectStoreServicePrefix = objectStoreServicePrefixUniq
 		})
 	}
@@ -155,7 +155,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	testObjectStoreOperations(s, helper, k8sh, namespace, storeName)
 
 	bucketNotificationTestStoreName := "bucket-notification-" + storeName
-	createCephObjectStore(s.T(), helper, k8sh, namespace, bucketNotificationTestStoreName, 1, tlsEnable)
+	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, bucketNotificationTestStoreName, 1, tlsEnable)
 	testBucketNotifications(s, helper, k8sh, namespace, bucketNotificationTestStoreName)
 }
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -125,7 +125,7 @@ func (s *SmokeSuite) TestObjectStorage_SmokeTest() {
 	storeName := "lite-store"
 	deleteStore := true
 	tls := false
-	runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.settings.Namespace, storeName, 2, deleteStore, tls)
+	runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.installer, s.settings.Namespace, storeName, 2, deleteStore, tls)
 }
 
 // Test to make sure all rook components are installed and Running

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -277,7 +277,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(objectUserID, preFilename string)
 		logger.Infof("Initializing object before the upgrade")
 		deleteStore := false
 		tls := false
-		runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName, 1, deleteStore, tls)
+		runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.installer, s.settings.Namespace, installer.ObjectStoreName, 1, deleteStore, tls)
 	}
 
 	logger.Infof("Initializing object user before the upgrade")


### PR DESCRIPTION
**Description of your changes:**

Check the radosgw-admin realm user list per object store instead of relying
on the ceph dashboard get-rgw-api- command.

**Which issue is resolved by this Pull Request:**

Resolves #9099

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.