### PR TITLE
build: Add a placeholder rule to the RGW RBAC

### DIFF
--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -27,7 +27,14 @@ metadata:
   namespace: {{ .Release.Namespace }} # namespace:cluster
 rules:
   # Placeholder role so the rgw service account will
-  # be generated in the csv
+  # be generated in the csv. Remove this role and role binding
+  # when fixing https://github.com/rook/rook/issues/10141.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
 ---
 # Aspects of ceph-mgr that operate within the cluster's namespace
 kind: Role

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -1011,8 +1011,15 @@ metadata:
   name: rook-ceph-rgw
   namespace: rook-ceph # namespace:cluster
 rules:
-# Placeholder role so the rgw service account will
-# be generated in the csv
+  # Placeholder role so the rgw service account will
+  # be generated in the csv. Remove this role and role binding
+  # when fixing https://github.com/rook/rook/issues/10141.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
 ---
 # Allow the operator to manage resources in its own namespace
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With https://github.com/rook/rook/pull/10108 a placeholder role and role binding were added for the rgw service account so the csv generation would generate the service account. That workaround also requires a rule to be added to the role or else the generation is invalid. Now a rule is added to avoid that issue. In the future we need to remove this role and binding when the operator sdk is updated as explained in https://github.com/rook/rook/issues/10141

**Which issue is resolved by this Pull Request:**
Related to #10141

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
