### PR TITLE
core: remove double imported packages

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -36,7 +36,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
-	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -59,7 +58,7 @@ type cluster struct {
 	mons               *mon.Cluster
 	ownerInfo          *k8sutil.OwnerInfo
 	isUpgrade          bool
-	monitoringRoutines map[string]*opcontroller.ClusterHealth
+	monitoringRoutines map[string]*controller.ClusterHealth
 	observedGeneration int64
 }
 
@@ -73,7 +72,7 @@ func newCluster(ctx context.Context, c *cephv1.CephCluster, context *clusterd.Co
 		Spec:               &c.Spec,
 		context:            context,
 		namespacedName:     types.NamespacedName{Namespace: c.Namespace, Name: c.Name},
-		monitoringRoutines: make(map[string]*opcontroller.ClusterHealth),
+		monitoringRoutines: make(map[string]*controller.ClusterHealth),
 		ownerInfo:          ownerInfo,
 		mons:               mon.New(ctx, context, c.Namespace, c.Spec, ownerInfo),
 		// update observedGeneration with current generation value,

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -35,7 +35,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -183,7 +182,7 @@ func TestRemoveFinalizers(t *testing.T) {
 				tt.object,
 			}
 			s.AddKnownTypes(tt.schema, tt.object)
-			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
+			cl := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 			assert.NotEmpty(t, fakeObject.GetFinalizers())
 			name := types.NamespacedName{Name: fakeObject.GetName(), Namespace: fakeObject.GetNamespace()}

--- a/pkg/operator/ceph/cluster/crash/crash_test.go
+++ b/pkg/operator/ceph/cluster/crash/crash_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	cntrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestGenerateCrashEnvVar(t *testing.T) {
@@ -87,9 +86,9 @@ func TestCreateOrUpdateCephCron(t *testing.T) {
 	}
 
 	// check if v1beta1 cronJob is present and v1 cronJob is not
-	controllerutil, err := r.createOrUpdateCephCron(cephCluster, cephVersion, false)
+	cntrlutil, err := r.createOrUpdateCephCron(cephCluster, cephVersion, false)
 	assert.NoError(t, err)
-	assert.Equal(t, controllerutil, cntrlutil.OperationResult("created"))
+	assert.Equal(t, cntrlutil, controllerutil.OperationResult("created"))
 
 	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1Beta1)
 	assert.NoError(t, err)
@@ -99,9 +98,9 @@ func TestCreateOrUpdateCephCron(t *testing.T) {
 	assert.True(t, kerrors.IsNotFound(err))
 
 	// check if v1 cronJob is present and v1beta1 cronJob is not
-	controllerutil, err = r.createOrUpdateCephCron(cephCluster, cephVersion, true)
+	cntrlutil, err = r.createOrUpdateCephCron(cephCluster, cephVersion, true)
 	assert.NoError(t, err)
-	assert.Equal(t, controllerutil, cntrlutil.OperationResult("created"))
+	assert.Equal(t, cntrlutil, controllerutil.OperationResult("created"))
 
 	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1)
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -21,7 +21,6 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
@@ -88,7 +87,7 @@ func TestPodSpec(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(d.Spec.Template.Annotations))                                                                                                                              // Multus annotations
 		assert.Equal(t, 2, len(d.Spec.Template.Spec.Containers))                                                                                                                          // mgr pod + sidecar
-		assert.Equal(t, client.CommandProxyInitContainerName, d.Spec.Template.Spec.Containers[1].Name)                                                                                    // sidecar pod
+		assert.Equal(t, cephclient.CommandProxyInitContainerName, d.Spec.Template.Spec.Containers[1].Name)                                                                                // sidecar pod
 		assert.Equal(t, 6, len(d.Spec.Template.Spec.Containers[1].VolumeMounts))                                                                                                          // + admin keyring
 		assert.Equal(t, "CEPH_ARGS", d.Spec.Template.Spec.Containers[1].Env[len(d.Spec.Template.Spec.Containers[1].Env)-1].Name)                                                          // connection info to the cluster
 		assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/admin-keyring-store/keyring", d.Spec.Template.Spec.Containers[1].Env[len(d.Spec.Template.Spec.Containers[1].Env)-1].Value) // connection info to the cluster

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -52,7 +51,7 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 	if includeNewLabels {
 		monVolumeClaimTemplate := c.monVolumeClaimTemplate(monConfig)
 		if monVolumeClaimTemplate != nil {
-			size := monVolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
+			size := monVolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage]
 			labels["pvc_name"] = monConfig.ResourceName
 			labels["pvc_size"] = size.String()
 		}
@@ -320,10 +319,10 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 
 	if !c.spec.RequireMsgr2() {
 		// Add messenger 1 port
-		container.Ports = append(container.Ports, v1.ContainerPort{
+		container.Ports = append(container.Ports, corev1.ContainerPort{
 			Name:          "tcp-msgr1",
 			ContainerPort: DefaultMsgr1Port,
-			Protocol:      v1.ProtocolTCP,
+			Protocol:      corev1.ProtocolTCP,
 		})
 	}
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -436,7 +436,8 @@ func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 		if name == "" {
 			return "", errors.Errorf("node name not found on the osd pod %q", pod.Name)
 		}
-		return name, nil //nolint // no need for else statement
+		//nolint SA4004 (go-staticcheck)
+		return name, nil
 	}
 
 	return "", errors.Errorf("node selector not found on deployment for osd with pvc %q", pvcName)

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -43,14 +42,14 @@ func TestPodContainer(t *testing.T) {
 	osdProps := osdProperties{
 		crushHostname: "node",
 		devices:       []cephv1.Device{},
-		resources:     v1.ResourceRequirements{},
+		resources:     corev1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
 		schedulerName: "custom-scheduler",
 	}
 	dataPathMap := &provisionConfig{
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(cluster.clusterInfo.Namespace, "/var/lib/rook"),
 	}
-	c, err := cluster.provisionPodTemplateSpec(osdProps, v1.RestartPolicyAlways, dataPathMap)
+	c, err := cluster.provisionPodTemplateSpec(osdProps, corev1.RestartPolicyAlways, dataPathMap)
 	assert.NotNil(t, c)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.Spec.InitContainers))
@@ -122,7 +121,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	osdProp := osdProperties{
 		crushHostname: n.Name,
 		selection:     n.Selection,
-		resources:     v1.ResourceRequirements{},
+		resources:     corev1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
 		schedulerName: "custom-scheduler",
 	}
@@ -139,8 +138,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, c.clusterInfo.Namespace, deployment.Namespace)
 	assert.Equal(t, serviceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
 	assert.Equal(t, int32(1), *(deployment.Spec.Replicas))
-	assert.Equal(t, "node1", deployment.Spec.Template.Spec.NodeSelector[v1.LabelHostname])
-	assert.Equal(t, v1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
+	assert.Equal(t, "node1", deployment.Spec.Template.Spec.NodeSelector[corev1.LabelHostname])
+	assert.Equal(t, corev1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, "my-priority-class", deployment.Spec.Template.Spec.PriorityClassName)
 	if devMountNeeded && len(dataDir) > 0 {
 		assert.Equal(t, 8, len(deployment.Spec.Template.Spec.Volumes))
@@ -177,9 +176,9 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	osdProp = osdProperties{
 		crushHostname: n.Name,
 		selection:     n.Selection,
-		resources:     v1.ResourceRequirements{},
+		resources:     corev1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
-		pvc:           v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc"},
+		pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc"},
 	}
 	// Not needed when running on PVC
 	osd = OSDInfo{
@@ -247,7 +246,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		ID:     0,
 		CVMode: "raw",
 	}
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
@@ -272,7 +271,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		CVMode: "raw",
 	}
 	osdProp.encrypted = true
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
@@ -303,8 +302,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		ID:     0,
 		CVMode: "raw",
 	}
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
-	osdProp.walPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
+	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
@@ -330,8 +329,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		CVMode: "raw",
 	}
 	osdProp.encrypted = true
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
-	osdProp.walPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
+	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
@@ -361,8 +360,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 
 	// Test with encrypted OSD on PVC with RAW with KMS
 	osdProp.encrypted = true
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{}
-	osdProp.walPVC = v1.PersistentVolumeClaimVolumeSource{}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{}
+	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{}
 	c.spec.Security.KeyManagementService.ConnectionDetails = map[string]string{"KMS_PROVIDER": "vault"}
 	c.spec.Security.KeyManagementService.TokenSecretName = "vault-token"
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
@@ -385,8 +384,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 
 	// Test with encrypted OSD on PVC with RAW with KMS with TLS
 	osdProp.encrypted = true
-	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{}
-	osdProp.walPVC = v1.PersistentVolumeClaimVolumeSource{}
+	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{}
+	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{}
 	c.spec.Security.KeyManagementService.ConnectionDetails = map[string]string{"KMS_PROVIDER": "vault", "VAULT_CACERT": "vault-ca-cert-secret", "VAULT_CLIENT_CERT": "vault-client-cert-secret", "VAULT_CLIENT_KEY": "vault-client-key-secret"}
 	c.spec.Security.KeyManagementService.TokenSecretName = "vault-token"
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
@@ -452,9 +451,9 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 
 	t.Run(("check osd ConfigureProbe"), func(t *testing.T) {
 		c.spec.HealthCheck.StartupProbe = make(map[cephv1.KeyType]*cephv1.ProbeSpec)
-		c.spec.HealthCheck.StartupProbe[cephv1.KeyOSD] = &cephv1.ProbeSpec{Disabled: false, Probe: &v1.Probe{InitialDelaySeconds: 1000}}
+		c.spec.HealthCheck.StartupProbe[cephv1.KeyOSD] = &cephv1.ProbeSpec{Disabled: false, Probe: &corev1.Probe{InitialDelaySeconds: 1000}}
 		c.spec.HealthCheck.LivenessProbe = make(map[cephv1.KeyType]*cephv1.ProbeSpec)
-		c.spec.HealthCheck.LivenessProbe[cephv1.KeyOSD] = &cephv1.ProbeSpec{Disabled: false, Probe: &v1.Probe{InitialDelaySeconds: 900}}
+		c.spec.HealthCheck.LivenessProbe[cephv1.KeyOSD] = &cephv1.ProbeSpec{Disabled: false, Probe: &corev1.Probe{InitialDelaySeconds: 900}}
 		deployment, err := c.makeDeployment(osdProp, osd, dataPathMap)
 		assert.Nil(t, err)
 		assert.NotNil(t, deployment)
@@ -465,7 +464,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	})
 }
 
-func verifyEnvVar(t *testing.T, envVars []v1.EnvVar, expectedName, expectedValue string, expectedFound bool) {
+func verifyEnvVar(t *testing.T, envVars []corev1.EnvVar, expectedName, expectedValue string, expectedFound bool) {
 	found := false
 	for _, envVar := range envVars {
 		if envVar.Name == expectedName {
@@ -502,14 +501,14 @@ func TestStorageSpecConfig(t *testing.T) {
 						"metadataDevice": "nvme093",
 					},
 					Selection: cephv1.Selection{},
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceCPU:    *resource.NewQuantity(1024.0, resource.BinarySI),
-							v1.ResourceMemory: *resource.NewQuantity(4096.0, resource.BinarySI),
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    *resource.NewQuantity(1024.0, resource.BinarySI),
+							corev1.ResourceMemory: *resource.NewQuantity(4096.0, resource.BinarySI),
 						},
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    *resource.NewQuantity(500.0, resource.BinarySI),
-							v1.ResourceMemory: *resource.NewQuantity(2048.0, resource.BinarySI),
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    *resource.NewQuantity(500.0, resource.BinarySI),
+							corev1.ResourceMemory: *resource.NewQuantity(2048.0, resource.BinarySI),
 						},
 					},
 				},
@@ -601,7 +600,7 @@ func TestHostNetwork(t *testing.T) {
 
 	assert.Equal(t, "rook-ceph-osd-0", r.ObjectMeta.Name)
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
-	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
+	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
 }
 
 func TestOsdPrepareResources(t *testing.T) {
@@ -612,12 +611,12 @@ func TestOsdPrepareResources(t *testing.T) {
 	clusterInfo.SetName("test")
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	spec := cephv1.ClusterSpec{
-		Resources: map[string]v1.ResourceRequirements{"prepareosd": {
-			Limits: v1.ResourceList{
-				v1.ResourceCPU: *resource.NewQuantity(2000.0, resource.BinarySI),
+		Resources: map[string]corev1.ResourceRequirements{"prepareosd": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewQuantity(2000.0, resource.BinarySI),
 			},
-			Requests: v1.ResourceList{
-				v1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
 			},
 		},
 		},
@@ -634,7 +633,7 @@ func TestOsdPrepareResources(t *testing.T) {
 func TestClusterGetPVCEncryptionOpenInitContainerActivate(t *testing.T) {
 	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{OwnerInfo: &k8sutil.OwnerInfo{}}, cephv1.ClusterSpec{}, "rook/rook:myversion")
 	osdProperties := osdProperties{
-		pvc: v1.PersistentVolumeClaimVolumeSource{
+		pvc: corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "pvc1",
 		},
 	}
@@ -658,10 +657,10 @@ func TestClusterGetPVCEncryptionOpenInitContainerActivate(t *testing.T) {
 func TestClusterGetPVCEncryptionInitContainerActivate(t *testing.T) {
 	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{OwnerInfo: &k8sutil.OwnerInfo{}}, cephv1.ClusterSpec{}, "rook/rook:myversion")
 	osdProperties := osdProperties{
-		pvc: v1.PersistentVolumeClaimVolumeSource{
+		pvc: corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "pvc1",
 		},
-		resources: v1.ResourceRequirements{},
+		resources: corev1.ResourceRequirements{},
 	}
 	mountPath := "/var/lib/ceph/osd/ceph-0"
 
@@ -690,7 +689,7 @@ func getDummyDeploymentOnPVC(clientset *fake.Clientset, c *Cluster, pvcName stri
 	}
 	c.deviceSets = append(c.deviceSets, deviceSet{
 		Name: pvcName,
-		PVCSources: map[string]v1.PersistentVolumeClaimVolumeSource{
+		PVCSources: map[string]corev1.PersistentVolumeClaimVolumeSource{
 			bluestorePVCData: {ClaimName: pvcName},
 		},
 		Portable: true,
@@ -733,13 +732,13 @@ func TestOSDPlacement(t *testing.T) {
 	spec := cephv1.ClusterSpec{
 		Placement: cephv1.PlacementSpec{
 			"all": {
-				NodeAffinity: &v1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-						NodeSelectorTerms: []v1.NodeSelectorTerm{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
 							{
-								MatchExpressions: []v1.NodeSelectorRequirement{{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
 									Key:      "role",
-									Operator: v1.NodeSelectorOpIn,
+									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{"storage-node1"},
 								}},
 							},
@@ -748,13 +747,13 @@ func TestOSDPlacement(t *testing.T) {
 				},
 			},
 			"osd": {
-				NodeAffinity: &v1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-						NodeSelectorTerms: []v1.NodeSelectorTerm{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
 							{
-								MatchExpressions: []v1.NodeSelectorRequirement{{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
 									Key:      "role",
-									Operator: v1.NodeSelectorOpIn,
+									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{"storage-node1"},
 								}},
 							},
@@ -763,13 +762,13 @@ func TestOSDPlacement(t *testing.T) {
 				},
 			},
 			"prepareosd": {
-				NodeAffinity: &v1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-						NodeSelectorTerms: []v1.NodeSelectorTerm{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
 							{
-								MatchExpressions: []v1.NodeSelectorRequirement{{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
 									Key:      "role",
-									Operator: v1.NodeSelectorOpIn,
+									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{"storage-node1"},
 								}},
 							},
@@ -784,7 +783,7 @@ func TestOSDPlacement(t *testing.T) {
 	}
 
 	osdProps := osdProperties{
-		pvc: v1.PersistentVolumeClaimVolumeSource{
+		pvc: corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "pvc1",
 		},
 	}
@@ -795,7 +794,7 @@ func TestOSDPlacement(t *testing.T) {
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
 							Key:      "role",
-							Operator: v1.NodeSelectorOpIn,
+							Operator: corev1.NodeSelectorOpIn,
 							Values:   []string{"storage-node3"},
 						},
 					},
@@ -812,7 +811,7 @@ func TestOSDPlacement(t *testing.T) {
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
 							Key:      "role",
-							Operator: v1.NodeSelectorOpIn,
+							Operator: corev1.NodeSelectorOpIn,
 							Values:   []string{"storage-node3"},
 						},
 					},

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -27,7 +27,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/version"
@@ -214,7 +213,7 @@ func TestNetworkBindingFlags(t *testing.T) {
 	ipv6FlagTrue := "--ms-bind-ipv6=true"
 	ipv6FlagFalse := "--ms-bind-ipv6=false"
 	type args struct {
-		cluster *client.ClusterInfo
+		cluster *cephclient.ClusterInfo
 		spec    *cephv1.ClusterSpec
 	}
 	tests := []struct {
@@ -222,13 +221,13 @@ func TestNetworkBindingFlags(t *testing.T) {
 		args args
 		want []string
 	}{
-		{"octopus-ipv4", args{cluster: &client.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4}}}, []string{ipv4FlagTrue, ipv6FlagFalse}},
-		{"octopus-ipv6", args{cluster: &client.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6}}}, []string{ipv4FlagFalse, ipv6FlagTrue}},
-		{"octopus-dualstack-unsupported", args{cluster: &client.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4, DualStack: true}}}, []string{}},
-		{"octopus-dualstack-unsupported-by-ipv6", args{cluster: &client.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}}}, []string{ipv6FlagTrue}},
-		{"pacific-ipv4", args{cluster: &client.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4}}}, []string{ipv4FlagTrue, ipv6FlagFalse}},
-		{"pacific-ipv6", args{cluster: &client.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6}}}, []string{ipv4FlagFalse, ipv6FlagTrue}},
-		{"pacific-dualstack-supported", args{cluster: &client.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}}}, []string{ipv4FlagTrue, ipv6FlagTrue}},
+		{"octopus-ipv4", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4}}}, []string{ipv4FlagTrue, ipv6FlagFalse}},
+		{"octopus-ipv6", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6}}}, []string{ipv4FlagFalse, ipv6FlagTrue}},
+		{"octopus-dualstack-unsupported", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4, DualStack: true}}}, []string{}},
+		{"octopus-dualstack-unsupported-by-ipv6", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Octopus}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}}}, []string{ipv6FlagTrue}},
+		{"pacific-ipv4", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4}}}, []string{ipv4FlagTrue, ipv6FlagFalse}},
+		{"pacific-ipv6", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6}}}, []string{ipv4FlagFalse, ipv6FlagTrue}},
+		{"pacific-dualstack-supported", args{cluster: &cephclient.ClusterInfo{CephVersion: version.Pacific}, spec: &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}}}, []string{ipv4FlagTrue, ipv6FlagTrue}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -24,10 +24,8 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	"github.com/rook/rook/pkg/operator/ceph/version"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/k8sutil/cmdreporter"
@@ -38,9 +36,9 @@ const detectCephVersionTimeout = 15 * time.Minute
 
 // ValidateCephVersionsBetweenLocalAndExternalClusters makes sure an external cluster can be connected
 // by checking the external ceph versions available and comparing it with the local image provided
-func ValidateCephVersionsBetweenLocalAndExternalClusters(context *clusterd.Context, clusterInfo *client.ClusterInfo) (cephver.CephVersion, error) {
+func ValidateCephVersionsBetweenLocalAndExternalClusters(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo) (cephver.CephVersion, error) {
 	// health check should tell us if the external cluster has been upgraded and display a message
-	externalVersion, err := client.GetCephMonVersion(context, clusterInfo)
+	externalVersion, err := cephclient.GetCephMonVersion(context, clusterInfo)
 	if err != nil {
 		return cephver.CephVersion{}, errors.Wrap(err, "failed to get ceph mon version")
 	}
@@ -62,7 +60,7 @@ func GetImageVersion(cephCluster cephv1.CephCluster) (*cephver.CephVersion, erro
 
 // DetectCephVersion loads the ceph version from the image and checks that it meets the version requirements to
 // run in the cluster
-func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string, ownerInfo *k8sutil.OwnerInfo, clientset kubernetes.Interface, cephClusterSpec *cephv1.ClusterSpec) (*version.CephVersion, error) {
+func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string, ownerInfo *k8sutil.OwnerInfo, clientset kubernetes.Interface, cephClusterSpec *cephv1.ClusterSpec) (*cephver.CephVersion, error) {
 	cephImage := cephClusterSpec.CephVersion.Image
 	logger.Infof("detecting the ceph image version for image %s...", cephImage)
 	versionReporter, err := cmdreporter.New(
@@ -109,7 +107,7 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 	return version, nil
 }
 
-func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, jobName string, ownerInfo *k8sutil.OwnerInfo, context *clusterd.Context, cephClusterSpec *cephv1.ClusterSpec, clusterInfo *cephclient.ClusterInfo) (*version.CephVersion, *version.CephVersion, error) {
+func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, jobName string, ownerInfo *k8sutil.OwnerInfo, context *clusterd.Context, cephClusterSpec *cephv1.ClusterSpec, clusterInfo *cephclient.ClusterInfo) (*cephver.CephVersion, *cephver.CephVersion, error) {
 	// Detect desired CephCluster version
 	desiredCephVersion, err := DetectCephVersion(ctx, rookImage, namespace, fmt.Sprintf("%s-detect-version", jobName), ownerInfo, context.Clientset, cephClusterSpec)
 	if err != nil {
@@ -117,7 +115,7 @@ func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, job
 	}
 
 	// Check the ceph version of the running monitors
-	runningMonDaemonVersion, err := client.LeastUptodateDaemonVersion(context, clusterInfo, config.MonType)
+	runningMonDaemonVersion, err := cephclient.LeastUptodateDaemonVersion(context, clusterInfo, config.MonType)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
 	}
@@ -125,7 +123,7 @@ func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, job
 	return desiredCephVersion, &runningMonDaemonVersion, nil
 }
 
-func ErrorCephUpgradingRequeue(runningCephVersion, desiredCephVersion *version.CephVersion) error {
+func ErrorCephUpgradingRequeue(runningCephVersion, desiredCephVersion *cephver.CephVersion) error {
 	return errors.Errorf(`waiting for ceph monitors upgrade to finish. `+
 		`current version: %s. `+
 		`expected version: %s. `+

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -134,7 +133,7 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 
 	if !c.clusterSpec.Network.IsHost() {
 		args = append(args,
-			config.NewFlag("public-addr", controller.ContainerEnvVarReference(podIPEnvVar)))
+			cephconfig.NewFlag("public-addr", controller.ContainerEnvVarReference(podIPEnvVar)))
 	}
 
 	container := v1.Container{
@@ -148,16 +147,16 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 		Env:             append(controller.DaemonEnvVars(c.clusterSpec.CephVersion.Image), k8sutil.PodIPEnvVar(podIPEnvVar)),
 		Resources:       c.fs.Spec.MetadataServer.Resources,
 		SecurityContext: controller.PodSecurityContext(),
-		StartupProbe:    controller.GenerateStartupProbeExecDaemon(config.MdsType, mdsConfig.DaemonID),
-		LivenessProbe:   controller.GenerateLivenessProbeExecDaemon(config.MdsType, mdsConfig.DaemonID),
-		WorkingDir:      config.VarLogCephDir,
+		StartupProbe:    controller.GenerateStartupProbeExecDaemon(cephconfig.MdsType, mdsConfig.DaemonID),
+		LivenessProbe:   controller.GenerateLivenessProbeExecDaemon(cephconfig.MdsType, mdsConfig.DaemonID),
+		WorkingDir:      cephconfig.VarLogCephDir,
 	}
 
 	return container
 }
 
 func (c *Cluster) podLabels(mdsConfig *mdsConfig, includeNewLabels bool) map[string]string {
-	labels := controller.CephDaemonAppLabels(AppName, c.fs.Namespace, config.MdsType, mdsConfig.DaemonID, c.fs.Name, "cephfilesystems.ceph.rook.io", includeNewLabels)
+	labels := controller.CephDaemonAppLabels(AppName, c.fs.Namespace, cephconfig.MdsType, mdsConfig.DaemonID, c.fs.Name, "cephfilesystems.ceph.rook.io", includeNewLabels)
 	labels["rook_file_system"] = c.fs.Name
 	return labels
 }

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -19,17 +19,17 @@ package object
 
 import (
 	"context"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	rookfake "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
@@ -334,7 +334,7 @@ func TestCephObjectStoreController(t *testing.T) {
 		clientset := test.New(t, 3)
 		c := &clusterd.Context{
 			Executor:      executor,
-			RookClientset: rookclient.NewSimpleClientset(),
+			RookClientset: rookfake.NewSimpleClientset(),
 			Clientset:     clientset,
 		}
 
@@ -677,7 +677,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 	clientset := test.New(t, 3)
 	c := &clusterd.Context{
 		Executor:      executor,
-		RookClientset: rookclient.NewSimpleClientset(),
+		RookClientset: rookfake.NewSimpleClientset(),
 		Clientset:     clientset,
 	}
 
@@ -843,7 +843,7 @@ func TestCephObjectExternalStoreController(t *testing.T) {
 
 		c := &clusterd.Context{
 			Executor:      executor,
-			RookClientset: rookclient.NewSimpleClientset(),
+			RookClientset: rookfake.NewSimpleClientset(),
 			Clientset:     clientset,
 			Client:        cl,
 		}

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -749,7 +749,7 @@ func CreatePools(context *Context, clusterSpec *cephv1.ClusterSpec, metadataPool
 // configurePoolsConcurrently checks if operator pod resources are set or not
 func configurePoolsConcurrently() bool {
 	// if operator resources are specified return false as it will lead to operator pod killed due to resource limit
-	// nolint #S1008, we can safely suppress this
+	// nolint S1008 (go-staticcheck), we can safely suppress this
 	if os.Getenv("OPERATOR_RESOURCES_SPECIFIED") == "true" {
 		return false
 	}

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
-	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -603,7 +602,7 @@ func addPortToEndpoint(endpoints *v1.Endpoints, name string, port int32) {
 }
 
 func getLabels(name, namespace string, includeNewLabels bool) map[string]string {
-	labels := controller.CephDaemonAppLabels(AppName, namespace, config.RgwType, name, name, "cephobjectstores.ceph.rook.io", includeNewLabels)
+	labels := controller.CephDaemonAppLabels(AppName, namespace, cephconfig.RgwType, name, name, "cephobjectstores.ceph.rook.io", includeNewLabels)
 	labels["rook_object_store"] = name
 	return labels
 }

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -28,7 +28,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -50,7 +49,7 @@ func TestCreatePool(t *testing.T) {
 	p := &cephv1.NamedPoolSpec{}
 	enabledMetricsApp := false
 	enabledMgrApp := false
-	clusterInfo := client.AdminTestClusterInfo("mycluster")
+	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -20,14 +20,12 @@ package pool
 import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 )
 
 // validatePool Validate the pool arguments
-func validatePool(context *clusterd.Context, clusterInfo *client.ClusterInfo, clusterSpec *cephv1.ClusterSpec, p *cephv1.CephBlockPool) error {
+func validatePool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, clusterSpec *cephv1.ClusterSpec, p *cephv1.CephBlockPool) error {
 	if p.Name == "" {
 		return errors.New("missing name")
 	}
@@ -35,7 +33,7 @@ func validatePool(context *clusterd.Context, clusterInfo *client.ClusterInfo, cl
 		return errors.New("missing namespace")
 	}
 
-	if err := v1.ValidateCephBlockPool(&p.Spec); err != nil {
+	if err := cephv1.ValidateCephBlockPool(&p.Spec); err != nil {
 		return err
 	}
 
@@ -77,10 +75,10 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 		}
 	}
 
-	var crush client.CrushMap
+	var crush cephclient.CrushMap
 	var err error
 	if p.FailureDomain != "" || p.CrushRoot != "" {
-		crush, err = client.GetCrushMap(context, clusterInfo)
+		crush, err = cephclient.GetCrushMap(context, clusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to get crush map")
 		}
@@ -150,7 +148,7 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 
 	// Test the same for Parameters
 	if p.Parameters != nil {
-		compression, ok := p.Parameters[client.CompressionModeProperty]
+		compression, ok := p.Parameters[cephclient.CompressionModeProperty]
 		if ok && compression != "" {
 			switch compression {
 			case "none", "passive", "aggressive", "force":

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -27,7 +27,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,21 +49,21 @@ func New(t *testing.T, nodes int) *fake.Clientset {
 // AddReadyNode adds a new Node with status "Ready" and the given name and IP.
 func AddReadyNode(t *testing.T, clientset *fake.Clientset, name, ip string) {
 	t.Helper()
-	ready := v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue}
-	n := &v1.Node{
+	ready := corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue}
+	n := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				corev1.LabelHostname: name,
 			},
 			Name: name,
 		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
 				ready,
 			},
-			Addresses: []v1.NodeAddress{
+			Addresses: []corev1.NodeAddress{
 				{
-					Type:    v1.NodeInternalIP,
+					Type:    corev1.NodeInternalIP,
 					Address: ip,
 				},
 			},

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/tests/framework/clients"
@@ -440,7 +439,7 @@ spec:
 `
 }
 
-func waitForFilesystemActive(k8sh *utils.K8sHelper, clusterInfo *client.ClusterInfo, filesystemName string) error {
+func waitForFilesystemActive(k8sh *utils.K8sHelper, clusterInfo *cephclient.ClusterInfo, filesystemName string) error {
 	command, args := cephclient.FinalizeCephCommandArgs("ceph", clusterInfo, []string{"fs", "status", filesystemName}, k8sh.MakeContext().ConfigDir)
 	var stat string
 	var err error


### PR DESCRIPTION
**Description of your changes:**

This removes double package imports. Example:
```
"github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
```
Only one is now being used as shown in [go-staticcheck
ST1019](https://staticcheck.io/docs/checks#ST1019).

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
