### PR TITLE
ci: use stringData instead of data for secret

### DIFF
--- a/tests/manifests/test-kms-ibm-kp-secret.in
+++ b/tests/manifests/test-kms-ibm-kp-secret.in
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: rook-ibm-kp-token
   namespace: rook-ceph
-data:
+stringData:
   IBM_KP_SERVICE_API_KEY: $IBM_KP_SERVICE_API_KEY


### PR DESCRIPTION
**Description of your changes:**

The "data" field only accepts base64 strings and our env var is not. So
let's use stringData to prevent an error from the API server:

```
"v1" cannot be handled as a Secret: illegal base64 data at input byte 29
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


**PR is opened directly against rook/rook so that the secrets can be passed to the runner**