### PR TITLE
operator: set 'rook-version' in mon k/v store

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -40,6 +40,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	rookversion "github.com/rook/rook/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -486,6 +487,9 @@ func (c *cluster) skipMDSSanityChecks(skip bool) error {
 // It gets executed right after the main mon Start() method
 // Basically, it is executed between the monitors and the manager sequence
 func (c *cluster) postMonStartupActions() error {
+	// Identify this as a rook cluster for Ceph telemetry by setting the Rook version.
+	c.setRookVersionInCephKVStore()
+
 	// Create CSI Kubernetes Secrets
 	err := csi.CreateCSISecrets(c.context, c.ClusterInfo)
 	if err != nil {
@@ -571,4 +575,15 @@ func (c *cluster) configureMsgr2() error {
 		}
 	}
 	return nil
+}
+
+// set the Rook version in Ceph's k/v store to allow Rook clusters that enable Ceph telemetry to be
+// identified easily as Rook clusters while additionally providing potentially useful information
+// about the version of Rook that is managing the cluster.
+// e.g., rook-version=v1.8.7
+func (c *cluster) setRookVersionInCephKVStore() {
+	ms := config.GetMonStore(c.context, c.ClusterInfo)
+	if err := ms.SetKeyValue(k8sutil.RookVersionLabelKey, rookversion.Version); err != nil {
+		logger.Warningf("failed to set telemetry key; this cluster may not be identifiable by ceph telemetry as a Rook cluster. %v", err)
+	}
 }

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -192,3 +192,18 @@ func (m *MonStore) DeleteAll(options ...Option) error {
 	}
 	return nil
 }
+
+// SetKeyValue sets an arbitrary key/value pair in Ceph's general purpose (as opposed to
+// configuration-specific) key/value store. Keys and values can be any arbitrary string including
+// spaces, underscores, dashes, and slashes.
+// See: https://docs.ceph.com/en/quincy/man/8/ceph/#config-key
+func (m *MonStore) SetKeyValue(key, value string) error {
+	logger.Debugf("setting %q=%q option in the mon config-key store", key, value)
+	args := []string{"config-key", "set", key, value}
+	cephCmd := client.NewCephCommand(m.context, m.clusterInfo, args)
+	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set %q in the mon config-key store. output: %s", key, string(out))
+	}
+	return nil
+}


### PR DESCRIPTION
Beginning with a Draft PR, I'd like to solicit some feedback from the Ceph community members most involved with telemetry to ensure that:
1. This does not risk the anonymity of Ceph clusters, AND
2. That this field will actually allow telemetry to identify Rook clusters

-----

Ceph upstream telemetry (which Rook users could optionally enable via
Ceph CLI or Dashboard) does not easily identify if a cluster is managed
by Rook. Identifying Rook clusters is possible only if users also enable
the rook mgr module, which is optional and not often used.

To get better upstream insights into Ceph clusters managed by Rook, set
a new 'rook-version' field in Ceph's generic k/v store. This field can
be used to determine if a cluster is managed by Rook by its presence.
It additionally provides information about the Rook version used to
manage the cluster, which is another piece of potentially useful
information.

Regarding Ceph cluster identification via telemetry:
Ceph telemetry is anonymous and uses a different ID from the Ceph
cluster ID. Identifying the Rook version in telemetry does not add
directly identifying information. Therefore, there should be little
risk that adding the Rook version field will decrease anonymity of Ceph
clusters via telemetry.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
