### PR TITLE
ci: wait for cert while deploying vault

### DIFF
--- a/tests/scripts/generate-tls-config.sh
+++ b/tests/scripts/generate-tls-config.sh
@@ -74,6 +74,13 @@ kubectl create -f "${DIR}/"csr.yaml
 
 kubectl certificate approve "${CSR_NAME}"
 
+timeout 10 bash <<-'EOF'
+    until [ $(kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.certificate}' | wc -c) -gt 1  ]; do
+      echo "waiting for certificate "${CSR_NAME}" to be filled"
+      sleep 1
+    done
+EOF
+
 serverCert=$(kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.certificate}')
 echo "${serverCert}" | openssl base64 -d -A -out "${DIR}"/"${SERVICE}".crt
 kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 -d > "${DIR}"/"${SERVICE}".ca


### PR DESCRIPTION
sometimes, it take few seconds to fill certificate
after certificate approval. So, let's wait for few seconds.

Closes: https://github.com/rook/rook/issues/10158
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #10158 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
