### PR TITLE
object: handle hpa scenarios for object store reconcilation

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -266,13 +266,15 @@ spec:
 
 Using metrics exported from the Prometheus service, the horizontal pod scaling can use the custom metrics other than CPU and memory consumption. It can be done with help of Prometheus Scaler provided by the [KEDA](https://keda.sh/docs/2.5/scalers/prometheus/). See the [KEDA deployment guide](https://keda.sh/docs/2.5/deploy/) for details.
 
-Following is an example to autoscale RGW:
+Following is an example to autoscale RGW, the label `rook_object_store: <store_name>` added here so that Rook Operator does not reset the value during reconciliation:
 ```YAML
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
  name: rgw-scale
  namespace: rook-ceph
+ labels:
+ rook_object_store: my-store
 spec:
  scaleTargetRef:
    kind: Deployment

--- a/build/rbac/rbac.yaml
+++ b/build/rbac/rbac.yaml
@@ -963,6 +963,13 @@ rules:
       - cronjobs
     verbs:
       - delete
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/rook-ceph/templates/role.yaml
+++ b/deploy/charts/rook-ceph/templates/role.yaml
@@ -53,6 +53,13 @@ rules:
   - get
   - create
   - delete
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -1068,6 +1068,13 @@ rules:
       - get
       - create
       - delete
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/monitoring/keda-rgw.yaml
+++ b/deploy/examples/monitoring/keda-rgw.yaml
@@ -3,6 +3,8 @@ kind: ScaledObject
 metadata:
   name: rgw-scale
   namespace: rook-ceph
+  labels:
+    rook_object_store: my-store
 spec:
   scaleTargetRef:
     kind: Deployment


### PR DESCRIPTION
If Horizontal Pod Scalers is configured scaled up replica count for ceph
object store, then during reconcilation Rook Operator will reset the
value for replica and suddenly HPA set it back. To avoid this sceneraios
reconcilation check whether HPA is configured or not and set the replica
value according to that.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
