### PR TITLE
tweak rook-ceph-cluster dashboard values comments and fix indentation in commitlintrc config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -30,7 +30,7 @@
         "rgw",
         "security",
         "subvolumegroup",
-	"namespace",
+        "namespace",
         "test"
       ]
     ],

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -116,7 +116,8 @@ cephClusterSpec:
     # urlPrefix: /ceph-dashboard
     # serve the dashboard at the given port.
     # port: 8443
-    # serve the dashboard using SSL
+    # Serve the dashboard using SSL (if using ingress to expose the dashboard and `ssl: true` you need to set
+    # the corresponding "backend protocol" annotation(s) for your ingress controller of choice)
     ssl: true
 
   # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/ceph-cluster-crd.md#network-configuration-settings
@@ -362,18 +363,23 @@ cephClusterSpec:
 ingress:
   dashboard: {}
     # annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #   external-dns.alpha.kubernetes.io/hostname: example.com
+    #   external-dns.alpha.kubernetes.io/hostname: dashboard.example.com
     #   nginx.ingress.kubernetes.io/rewrite-target: /ceph-dashboard/$2
+    #   kubernetes.io/ingress.class: nginx
     # If the dashboard has ssl: true the following will make sure the NGINX Ingress controller can expose the dashboard correctly
     #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     #   nginx.ingress.kubernetes.io/server-snippet: |
     #     proxy_ssl_verify off;
     # host:
-    #   name: example.com
+    #   name: dashboard.example.com
     #   path: "/ceph-dashboard(/|$)(.*)"
     # tls:
-    # ingressClassName:
+    # - hosts:
+    #     - dashboard.example.com
+    #   secretName: testsecret-tls
+    ## Note: Only one of ingress class annotation or the `ingressClassName:` can be used at a time
+    ## to set the ingress class
+    # ingressClassName: nginx
 
 cephBlockPools:
   - name: ceph-blockpool


### PR DESCRIPTION
**Description of your changes:**

Two small changes to address the following:

* [helm: update rook-ceph-cluster dashboard values comments](https://github.com/rook/rook/commit/8b6e5e8ba149582965e6f78016b42aa95bfff46c)
* [ci: fix indentation in .commitlintrc.json](https://github.com/rook/rook/commit/f657cb7861dab8963567770aea856200a80b76d5)

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.