### PR TITLE
core: use client.rookoperator instead of client.admin

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -92,7 +92,7 @@ jobs:
     - name: wait for the subvolumegroup to be created
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs |jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
 
     - name: test subvolumegroup validation
       run: |
@@ -111,7 +111,7 @@ jobs:
       run: |
         kubectl create -f deploy/examples/radosnamespace.yaml
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool  --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
         kubectl delete -f deploy/examples/radosnamespace.yaml
 
     - name: test rados namespace validation
@@ -192,7 +192,7 @@ jobs:
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         kubectl -n rook-ceph exec $toolbox -- ceph status
         # wait until osd.1 is removed from the osd tree
-        timeout 120 sh -c "while kubectl -n rook-ceph exec $toolbox -- ceph osd tree|grep -qE 'osd.1'; do echo 'waiting for ceph osd 1 to be purged'; sleep 1; done"
+        timeout 120 sh -c "while kubectl -n rook-ceph exec $toolbox -- ceph osd tree |grep -qE 'osd.1'; do echo 'waiting for ceph osd 1 to be purged'; sleep 1; done"
         kubectl -n rook-ceph exec $toolbox -- ceph status
         kubectl -n rook-ceph exec $toolbox -- ceph osd tree
 
@@ -1195,12 +1195,12 @@ jobs:
     - name: verify image has been mirrored for replicapool
       run: |
         # let's wait a bit for the image to be present
-        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool" && sleep 1; done'
+        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls |grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool" && sleep 1; done'
 
     - name: verify image has been mirrored for replicapool2
       run: |
         # let's wait a bit for the image to be present
-        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool2 ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool2" && sleep 1; done'
+        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool2 ls |grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool2" && sleep 1; done'
 
     - name: display cephblockpool and image status
       run: |

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -92,7 +92,7 @@ jobs:
     - name: wait for the subvolumegroup to be created
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs |jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
 
     - name: test subvolumegroup validation
       run: |
@@ -111,7 +111,7 @@ jobs:
       run: |
         kubectl create -f deploy/examples/radosnamespace.yaml
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool  --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
         kubectl delete -f deploy/examples/radosnamespace.yaml
 
     - name: test rados namespace validation
@@ -192,7 +192,7 @@ jobs:
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         kubectl -n rook-ceph exec $toolbox -- ceph status
         # wait until osd.1 is removed from the osd tree
-        timeout 120 sh -c "while kubectl -n rook-ceph exec $toolbox -- ceph osd tree |grep -qE 'osd.1'; do echo 'waiting for ceph osd 1 to be purged'; sleep 1; done"
+        timeout 120 sh -c "while kubectl -n rook-ceph exec $toolbox -- ceph osd tree|grep -qE 'osd.1'; do echo 'waiting for ceph osd 1 to be purged'; sleep 1; done"
         kubectl -n rook-ceph exec $toolbox -- ceph status
         kubectl -n rook-ceph exec $toolbox -- ceph osd tree
 
@@ -1195,12 +1195,12 @@ jobs:
     - name: verify image has been mirrored for replicapool
       run: |
         # let's wait a bit for the image to be present
-        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls |grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool" && sleep 1; done'
+        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool" && sleep 1; done'
 
     - name: verify image has been mirrored for replicapool2
       run: |
         # let's wait a bit for the image to be present
-        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool2 ls |grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool2" && sleep 1; done'
+        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool2 ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool2" && sleep 1; done'
 
     - name: display cephblockpool and image status
       run: |

--- a/Documentation/Troubleshooting/ceph-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-common-issues.md
@@ -130,11 +130,11 @@ Likely you will see an error similar to the following that the operator is timin
 followed by a timeout message five minutes later.
 
 ```console
-2018-01-21 21:47:32.375833 I | exec: Running command: ceph mon_status --cluster=rook --conf=/var/lib/rook/rook-ceph/rook.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/442263890
+2018-01-21 21:47:32.375833 I | exec: Running command: ceph mon_status --cluster=rook --conf=/var/lib/rook/rook-ceph/rook.config --keyring=/var/lib/rook/rook-ceph/client.rookoperator.keyring --format json --out-file /tmp/442263890
 2018-01-21 21:52:35.370533 I | exec: 2018-01-21 21:52:35.071462 7f96a3b82700  0 monclient(hunting): authenticate timed out after 300
 2018-01-21 21:52:35.071462 7f96a3b82700  0 monclient(hunting): authenticate timed out after 300
-2018-01-21 21:52:35.071524 7f96a3b82700  0 librados: client.admin authentication error (110) Connection timed out
-2018-01-21 21:52:35.071524 7f96a3b82700  0 librados: client.admin authentication error (110) Connection timed out
+2018-01-21 21:52:35.071524 7f96a3b82700  0 librados: client.rookoperator authentication error (110) Connection timed out
+2018-01-21 21:52:35.071524 7f96a3b82700  0 librados: client.rookoperator authentication error (110) Connection timed out
 [errno 110] error connecting to the cluster
 ```
 

--- a/Documentation/Troubleshooting/disaster-recovery.md
+++ b/Documentation/Troubleshooting/disaster-recovery.md
@@ -373,7 +373,7 @@ Assuming `dataHostPathData` is `/var/lib/rook`, and the `CephCluster` trying to 
 1. SSH to the host where `rook-ceph-mon-a` in the new Kubernetes cluster resides.
     1. Remove `/var/lib/rook/mon-a`
     2. Pick a healthy `rook-ceph-mon-ID` directory (`/var/lib/rook/mon-ID`) in the previous backup, copy to `/var/lib/rook/mon-a`. `ID` is any healthy mon node ID of the old cluster.
-    3. Replace `/var/lib/rook/mon-a/keyring` with the saved keyring, preserving only the `[mon.]` section, remove `[client.admin]` section.
+    3. Replace `/var/lib/rook/mon-a/keyring` with the saved keyring, preserving only the `[mon.]` section, remove `[client.rookoperator]` section.
     4. Run `docker run -it --rm -v /var/lib/rook:/var/lib/rook ceph/ceph:v14.2.1-20190430 bash`. The Docker image tag should match the Ceph version used in the Rook cluster. The `/etc/ceph/ceph.conf` file needs to exist for `ceph-mon` to work.
 
         ```console

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -19,8 +19,8 @@ ROOK_EXTERNAL_MAPPING={}
 RBD_STORAGE_CLASS_NAME=ceph-rbd
 CEPHFS_STORAGE_CLASS_NAME=cephfs
 ROOK_EXTERNAL_MONITOR_SECRET=mon-secret
-OPERATOR_NAMESPACE=rook-ceph                                 # default set to rook-ceph
-RBD_PROVISIONER=$OPERATOR_NAMESPACE".rbd.csi.ceph.com"       # driver:namespace:operator
+OPERATOR_NAMESPACE=rook-ceph # default set to rook-ceph
+RBD_PROVISIONER=$OPERATOR_NAMESPACE".rbd.csi.ceph.com" # driver:namespace:operator
 CEPHFS_PROVISIONER=$OPERATOR_NAMESPACE".cephfs.csi.ceph.com" # driver:namespace:operator
 CLUSTER_ID_RBD=$NAMESPACE
 CLUSTER_ID_CEPHFS=$NAMESPACE
@@ -35,7 +35,7 @@ function checkEnvVars() {
     echo "Please populate the environment variable NAMESPACE"
     exit 1
   fi
-  if [ -z "$RBD_POOL_NAME" ]; then
+   if [ -z "$RBD_POOL_NAME" ]; then
     echo "Please populate the environment variable RBD_POOL_NAME"
     exit 1
   fi
@@ -89,7 +89,7 @@ function checkEnvVars() {
       exit 1
     fi
   fi
-  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ]; then
+  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ] ; then
     echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
     exit 1
   fi
@@ -106,86 +106,86 @@ function importClusterID() {
 
 function importSecret() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "$MON_SECRET_NAME" \
-    --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
-    --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
-    --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
-    --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
-    --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
-    --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$MON_SECRET_NAME" \
+  --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
+  --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
+  --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
+  --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
+  --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
+  --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
 }
 
 function importConfigMap() {
   kubectl -n "$NAMESPACE" \
-    create \
-    configmap \
-    "$MON_ENDPOINT_CONFIGMAP_NAME" \
-    --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
-    --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
-    --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
+  create \
+  configmap \
+  "$MON_ENDPOINT_CONFIGMAP_NAME" \
+  --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
+  --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
+  --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
 }
 
 function importCsiRBDNodeSecret() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "rook-""$CSI_RBD_NODE_SECRET_NAME" \
-    --from-literal=userID="$CSI_RBD_NODE_SECRET_NAME" \
-    --from-literal=userKey="$CSI_RBD_NODE_SECRET"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "rook-""$CSI_RBD_NODE_SECRET_NAME" \
+  --from-literal=userID="$CSI_RBD_NODE_SECRET_NAME" \
+  --from-literal=userKey="$CSI_RBD_NODE_SECRET"
 }
 
 function importCsiRBDProvisionerSecret() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "rook-""$CSI_RBD_PROVISIONER_SECRET_NAME" \
-    --from-literal=userID="$CSI_RBD_PROVISIONER_SECRET_NAME" \
-    --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "rook-""$CSI_RBD_PROVISIONER_SECRET_NAME" \
+  --from-literal=userID="$CSI_RBD_PROVISIONER_SECRET_NAME" \
+  --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
 }
 
 function importCsiCephFSNodeSecret() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "rook-""$CSI_CEPHFS_NODE_SECRET_NAME" \
-    --from-literal=adminID="$CSI_CEPHFS_NODE_SECRET_NAME" \
-    --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "rook-""$CSI_CEPHFS_NODE_SECRET_NAME" \
+  --from-literal=adminID="$CSI_CEPHFS_NODE_SECRET_NAME" \
+  --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
 }
 
 function importCsiCephFSProvisionerSecret() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-    --from-literal=adminID="$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-    --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+  --from-literal=adminID="$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+  --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
 }
 
 function importRGWAdminOpsUser() {
   kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    --type="kubernetes.io/rook" \
-    "$RGW_ADMIN_OPS_USER_SECRET_NAME" \
-    --from-literal=accessKey="$RGW_ADMIN_OPS_USER_ACCESS_KEY" \
-    --from-literal=secretKey="$RGW_ADMIN_OPS_USER_SECRET_KEY"
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$RGW_ADMIN_OPS_USER_SECRET_NAME" \
+  --from-literal=accessKey="$RGW_ADMIN_OPS_USER_ACCESS_KEY" \
+  --from-literal=secretKey="$RGW_ADMIN_OPS_USER_SECRET_KEY"
 }
 
 function createECRBDStorageClass() {
-  cat <<eof | kubectl create -f -
+cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -210,7 +210,7 @@ eof
 }
 
 function createRBDStorageClass() {
-  cat <<eof | kubectl create -f -
+cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -234,7 +234,7 @@ eof
 }
 
 function createCephFSStorageClass() {
-  cat <<eof | kubectl create -f -
+cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -19,8 +19,8 @@ ROOK_EXTERNAL_MAPPING={}
 RBD_STORAGE_CLASS_NAME=ceph-rbd
 CEPHFS_STORAGE_CLASS_NAME=cephfs
 ROOK_EXTERNAL_MONITOR_SECRET=mon-secret
-OPERATOR_NAMESPACE=rook-ceph # default set to rook-ceph
-RBD_PROVISIONER=$OPERATOR_NAMESPACE".rbd.csi.ceph.com" # driver:namespace:operator
+OPERATOR_NAMESPACE=rook-ceph                                 # default set to rook-ceph
+RBD_PROVISIONER=$OPERATOR_NAMESPACE".rbd.csi.ceph.com"       # driver:namespace:operator
 CEPHFS_PROVISIONER=$OPERATOR_NAMESPACE".cephfs.csi.ceph.com" # driver:namespace:operator
 CLUSTER_ID_RBD=$NAMESPACE
 CLUSTER_ID_CEPHFS=$NAMESPACE
@@ -35,7 +35,7 @@ function checkEnvVars() {
     echo "Please populate the environment variable NAMESPACE"
     exit 1
   fi
-   if [ -z "$RBD_POOL_NAME" ]; then
+  if [ -z "$RBD_POOL_NAME" ]; then
     echo "Please populate the environment variable RBD_POOL_NAME"
     exit 1
   fi
@@ -89,7 +89,7 @@ function checkEnvVars() {
       exit 1
     fi
   fi
-  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ] ; then
+  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ]; then
     echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
     exit 1
   fi
@@ -106,86 +106,86 @@ function importClusterID() {
 
 function importSecret() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "$MON_SECRET_NAME" \
-  --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
-  --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
-  --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
-  --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
-  --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
-  --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "$MON_SECRET_NAME" \
+    --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
+    --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
+    --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
+    --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
+    --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
+    --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
 }
 
 function importConfigMap() {
   kubectl -n "$NAMESPACE" \
-  create \
-  configmap \
-  "$MON_ENDPOINT_CONFIGMAP_NAME" \
-  --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
-  --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
-  --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
+    create \
+    configmap \
+    "$MON_ENDPOINT_CONFIGMAP_NAME" \
+    --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
+    --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
+    --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
 }
 
 function importCsiRBDNodeSecret() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "rook-""$CSI_RBD_NODE_SECRET_NAME" \
-  --from-literal=userID="$CSI_RBD_NODE_SECRET_NAME" \
-  --from-literal=userKey="$CSI_RBD_NODE_SECRET"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "rook-""$CSI_RBD_NODE_SECRET_NAME" \
+    --from-literal=userID="$CSI_RBD_NODE_SECRET_NAME" \
+    --from-literal=userKey="$CSI_RBD_NODE_SECRET"
 }
 
 function importCsiRBDProvisionerSecret() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "rook-""$CSI_RBD_PROVISIONER_SECRET_NAME" \
-  --from-literal=userID="$CSI_RBD_PROVISIONER_SECRET_NAME" \
-  --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "rook-""$CSI_RBD_PROVISIONER_SECRET_NAME" \
+    --from-literal=userID="$CSI_RBD_PROVISIONER_SECRET_NAME" \
+    --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
 }
 
 function importCsiCephFSNodeSecret() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "rook-""$CSI_CEPHFS_NODE_SECRET_NAME" \
-  --from-literal=adminID="$CSI_CEPHFS_NODE_SECRET_NAME" \
-  --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "rook-""$CSI_CEPHFS_NODE_SECRET_NAME" \
+    --from-literal=adminID="$CSI_CEPHFS_NODE_SECRET_NAME" \
+    --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
 }
 
 function importCsiCephFSProvisionerSecret() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-  --from-literal=adminID="$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-  --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+    --from-literal=adminID="$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+    --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
 }
 
 function importRGWAdminOpsUser() {
   kubectl -n "$NAMESPACE" \
-  create \
-  secret \
-  generic \
-  --type="kubernetes.io/rook" \
-  "$RGW_ADMIN_OPS_USER_SECRET_NAME" \
-  --from-literal=accessKey="$RGW_ADMIN_OPS_USER_ACCESS_KEY" \
-  --from-literal=secretKey="$RGW_ADMIN_OPS_USER_SECRET_KEY"
+    create \
+    secret \
+    generic \
+    --type="kubernetes.io/rook" \
+    "$RGW_ADMIN_OPS_USER_SECRET_NAME" \
+    --from-literal=accessKey="$RGW_ADMIN_OPS_USER_ACCESS_KEY" \
+    --from-literal=secretKey="$RGW_ADMIN_OPS_USER_SECRET_KEY"
 }
 
 function createECRBDStorageClass() {
-cat <<eof | kubectl create -f -
+  cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -210,7 +210,7 @@ eof
 }
 
 function createRBDStorageClass() {
-cat <<eof | kubectl create -f -
+  cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -234,7 +234,7 @@ eof
 }
 
 function createCephFSStorageClass() {
-cat <<eof | kubectl create -f -
+  cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -45,7 +45,7 @@ spec:
               [global]
               mon_host = ${mon_endpoints}
 
-              [client.rookoperator]
+              [client.admin]
               keyring = ${KEYRING_FILE}
               EOF
               }

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -45,7 +45,7 @@ spec:
               [global]
               mon_host = ${mon_endpoints}
 
-              [client.admin]
+              [client.rookoperator]
               keyring = ${KEYRING_FILE}
               EOF
               }

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -34,7 +34,7 @@ write_endpoints() {
 [global]
 mon_host = ${mon_endpoints}
 
-[client.rookoperator]
+[client.admin]
 keyring = ${KEYRING_FILE}
 EOF
 }

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -22,19 +22,19 @@ KEYRING_FILE="/etc/ceph/keyring"
 # without specifying any arguments
 write_endpoints() {
   endpoints=$(cat ${MON_CONFIG})
-  
+
   # filter out the mon names
   # external cluster can have numbers or hyphens in mon names, handling them in regex
   # shellcheck disable=SC2001
   mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
-  
+
   DATE=$(date)
   echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
     cat <<EOF > ${CEPH_CONFIG}
 [global]
 mon_host = ${mon_endpoints}
 
-[client.admin]
+[client.rookoperator]
 keyring = ${KEYRING_FILE}
 EOF
 }
@@ -47,12 +47,12 @@ watch_endpoints() {
   while true; do
     real_path=$(realpath ${MON_CONFIG})
     latest_time=$(stat -c %Z "${real_path}")
-    
+
     if [[ "${latest_time}" != "${initial_time}" ]]; then
       write_endpoints
       initial_time=${latest_time}
     fi
-    
+
     sleep 10
   done
 }

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -33,8 +33,10 @@ import (
 var RunAllCephCommandsInToolboxPod string
 
 const (
-	// AdminUsername is the name of the admin user
-	AdminUsername = "client.admin"
+	// OperatorAdminUsername is the name of the operator admin user
+	OperatorAdminUsername = "client.rookoperator"
+	// NonOperatorAdminUsername is the name of the older admin user
+	NonOperatorAdminUsername = "client.admin"
 	// CephTool is the name of the CLI tool for 'ceph'
 	CephTool = "ceph"
 	// RBDTool is the name of the CLI tool for 'rbd'
@@ -75,7 +77,8 @@ func FinalizeCephCommandArgs(command string, clusterInfo *ClusterInfo, args []st
 	if RunAllCephCommandsInToolboxPod != "" {
 		toolArgs := []string{"exec", "-i", RunAllCephCommandsInToolboxPod, "-n", clusterInfo.Namespace,
 			"--", "timeout", timeout, command}
-		return Kubectl, append(toolArgs, args...)
+		toolArgs = append(toolArgs, args...)
+		return Kubectl, toolArgs
 	}
 
 	// Append the args to find the config and keyring
@@ -141,8 +144,8 @@ func (c *CephToolCommand) run() ([]byte, error) {
 	// these args are not needed since those paths don't exist inside the cmd-proxy container:
 	//      --cluster=openshift-storage
 	//		--conf=/var/lib/rook/openshift-storage/openshift-storage.config
-	//		--name=client.admin
-	//		--keyring=/var/lib/rook/openshift-storage/client.admin.keyring
+	//		--name=client.rookoperator
+	//		--keyring=/var/lib/rook/openshift-storage/client.rookoperator.keyring
 	//
 	// The cmd-proxy container will take care of the rest with the help of the env CEPH_ARGS
 	if !c.RemoteExecution {

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -35,8 +35,8 @@ var RunAllCephCommandsInToolboxPod string
 const (
 	// OperatorAdminUsername is the name of the operator admin user
 	OperatorAdminUsername = "client.rookoperator"
-	// NonOperatorAdminUsername is the name of the older admin user
-	NonOperatorAdminUsername = "client.admin"
+	// CephAdminUsername is the name of the older admin user
+	CephAdminUsername = "client.admin"
 	// CephTool is the name of the CLI tool for 'ceph'
 	CephTool = "ceph"
 	// RBDTool is the name of the CLI tool for 'rbd'

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -40,8 +40,8 @@ func TestFinalizeCephCommandArgs(t *testing.T) {
 		"--connect-timeout=" + strconv.Itoa(int(exec.CephCommandsTimeout.Seconds())),
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
-		"--name=client.admin",
-		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
+		"--name=client.rookoperator",
+		"--keyring=/var/lib/rook/rook-ceph/rook/client.rookoperator.keyring",
 	}
 
 	clusterInfo := AdminTestClusterInfo("rook")
@@ -70,8 +70,8 @@ func TestFinalizeRadosGWAdminCommandArgs(t *testing.T) {
 		"--rgw-zonegroup=default-rook",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
-		"--name=client.admin",
-		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
+		"--name=client.rookoperator",
+		"--keyring=/var/lib/rook/rook-ceph/rook/client.rookoperator.keyring",
 	}
 
 	clusterInfo := AdminTestClusterInfo("rook")

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -40,8 +40,8 @@ func TestFinalizeCephCommandArgs(t *testing.T) {
 		"--connect-timeout=" + strconv.Itoa(int(exec.CephCommandsTimeout.Seconds())),
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
-		"--name=client.rookoperator",
-		"--keyring=/var/lib/rook/rook-ceph/rook/client.rookoperator.keyring",
+		"--name=client.admin",
+		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
 	}
 
 	clusterInfo := AdminTestClusterInfo("rook")
@@ -70,8 +70,8 @@ func TestFinalizeRadosGWAdminCommandArgs(t *testing.T) {
 		"--rgw-zonegroup=default-rook",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
-		"--name=client.rookoperator",
-		"--keyring=/var/lib/rook/rook-ceph/rook/client.rookoperator.keyring",
+		"--name=client.admin",
+		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
 	}
 
 	clusterInfo := AdminTestClusterInfo("rook")

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -125,7 +125,7 @@ func generateConfigFile(context *clusterd.Context, clusterInfo *ClusterInfo, pat
 		return "", errors.Wrapf(err, "failed to merge global config with %q", k8sutil.ConfigOverrideName)
 	}
 
-	clusterInfo.CephCred.Username = NonOperatorAdminUsername
+	clusterInfo.CephCred.Username = CephAdminUsername
 	root := path.Join(context.ConfigDir, clusterInfo.Namespace)
 	keyringPath = path.Join(root, fmt.Sprintf("%s.keyring", clusterInfo.CephCred.Username))
 	qualifiedUser := getQualifiedUser(clusterInfo.CephCred.Username)

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -110,7 +110,6 @@ func GenerateConnectionConfigWithSettings(context *clusterd.Context, clusterInfo
 // generateConfigFile generates and writes a config file to disk.
 func generateConfigFile(context *clusterd.Context, clusterInfo *ClusterInfo, pathRoot, keyringPath string, globalConfig *CephConfig, clientSettings map[string]string) (string, error) {
 
-	temp := clusterInfo.CephCred.Username
 	// create the config directory
 	if err := os.MkdirAll(pathRoot, 0744); err != nil {
 		return "", errors.Wrapf(err, "failed to create config directory at %q", pathRoot)
@@ -125,19 +124,9 @@ func generateConfigFile(context *clusterd.Context, clusterInfo *ClusterInfo, pat
 		return "", errors.Wrapf(err, "failed to merge global config with %q", k8sutil.ConfigOverrideName)
 	}
 
-	clusterInfo.CephCred.Username = CephAdminUsername
-	root := path.Join(context.ConfigDir, clusterInfo.Namespace)
-	keyringPath = path.Join(root, fmt.Sprintf("%s.keyring", clusterInfo.CephCred.Username))
 	qualifiedUser := getQualifiedUser(clusterInfo.CephCred.Username)
 	if err := addClientConfigFileSection(configFile, qualifiedUser, keyringPath, clientSettings); err != nil {
 		return "", errors.Wrap(err, "failed to add admin client config section")
-	}
-
-	clusterInfo.CephCred.Username = OperatorAdminUsername
-	keyringPath = path.Join(root, fmt.Sprintf("%s.keyring", clusterInfo.CephCred.Username))
-	qualifiedUser = getQualifiedUser(clusterInfo.CephCred.Username)
-	if err := addClientConfigFileSection(configFile, qualifiedUser, keyringPath, clientSettings); err != nil {
-		return "", errors.Wrap(err, "failed to add operator admin client config section")
 	}
 
 	// write the entire config to disk
@@ -146,7 +135,6 @@ func generateConfigFile(context *clusterd.Context, clusterInfo *ClusterInfo, pat
 	if err := configFile.SaveTo(filePath); err != nil {
 		return "", errors.Wrapf(err, "failed to save config file %s", filePath)
 	}
-	clusterInfo.CephCred.Username = temp
 
 	return filePath, nil
 }

--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -95,7 +95,7 @@ func TestGenerateConfigFile(t *testing.T) {
 			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6789"},
 		},
 		CephVersion: cephver.Quincy,
-		CephCred:    CephCred{Username: "admin", Secret: "mysecret"},
+		CephCred:    CephCred{Username: "rookoperator", Secret: "mysecret"},
 		Context:     ctx,
 	}
 

--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -154,7 +154,7 @@ func GetSnapshotScheduleStatus(context *clusterd.Context, clusterInfo *ClusterIn
 	var filesystemSnapshotSchedulesStatusSpec []cephv1.FilesystemSnapshotSchedulesSpec
 
 	/* Replace new line since the command outputs a new line first and breaks the json parsing...
-	[root@rook-ceph-operator-75c6d6bbfc-wqlnc /]# ceph --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json fs snap-schedule status /
+	[root@rook-ceph-operator-75c6d6bbfc-wqlnc /]# ceph --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.rookoperator --keyring=/var/lib/rook/rook-ceph/client.rookoperator.keyring --format json fs snap-schedule status /
 
 	[{"fs": "myfs", "subvol": null, "path": "/", "rel_path": "/", "schedule": "24h", "retention": {"h": 24}, "start": "2021-07-01T00:00:00", "created": "2021-07-01T12:19:12", "first": null, "last": null, "last_pruned": null, "created_count": 0, "pruned_count": 0, "active": true},{"fs": "myfs", "subvol": null, "path": "/", "rel_path": "/", "schedule": "25h", "retention": {"h": 24}, "start": "2021-07-01T00:00:00", "created": "2021-07-01T12:31:25", "first": null, "last": null, "last_pruned": null, "created_count": 0, "pruned_count": 0, "active": true}]
 	*/

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -95,7 +95,7 @@ func AdminClusterInfo(ctx context.Context, namespace, name string) *ClusterInfo 
 	return &ClusterInfo{
 		Namespace: namespace,
 		CephCred: CephCred{
-			Username: NonOperatorAdminUsername,
+			Username: OperatorAdminUsername,
 		},
 		name:      name,
 		OwnerInfo: ownerInfo,

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -95,7 +95,7 @@ func AdminClusterInfo(ctx context.Context, namespace, name string) *ClusterInfo 
 	return &ClusterInfo{
 		Namespace: namespace,
 		CephCred: CephCred{
-			Username: AdminUsername,
+			Username: NonOperatorAdminUsername,
 		},
 		name:      name,
 		OwnerInfo: ownerInfo,

--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -31,7 +31,7 @@ const (
 	// AdminKeyringTemplate is a string template of Ceph keyring settings which allow connection
 	// as admin. The key value must be filled in by the admin auth key for the cluster.
 	AdminKeyringTemplate = `
-[client.admin]
+[client.rookoperator]
 	key = %s
 	caps mds = "allow *"
 	caps mon = "allow *"
@@ -48,7 +48,7 @@ const (
 
 // CephKeyring returns the filled-out user keyring
 func CephKeyring(cred CephCred) string {
-	if cred.Username == AdminUsername {
+	if cred.Username == OperatorAdminUsername {
 		return fmt.Sprintf(AdminKeyringTemplate, cred.Secret)
 	}
 	return fmt.Sprintf(UserKeyringTemplate, cred.Username, cred.Secret)

--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -48,7 +48,7 @@ const (
 
 // CephKeyring returns the filled-out user keyring
 func CephKeyring(cred CephCred) string {
-	if cred.Username == OperatorAdminUsername || cred.Username == NonOperatorAdminUsername {
+	if cred.Username == OperatorAdminUsername || cred.Username == CephAdminUsername {
 		return fmt.Sprintf(AdminKeyringTemplate, cred.Username, cred.Secret)
 	}
 	return fmt.Sprintf(UserKeyringTemplate, cred.Username, cred.Secret)

--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -31,7 +31,7 @@ const (
 	// AdminKeyringTemplate is a string template of Ceph keyring settings which allow connection
 	// as admin. The key value must be filled in by the admin auth key for the cluster.
 	AdminKeyringTemplate = `
-[client.rookoperator]
+[%s]
 	key = %s
 	caps mds = "allow *"
 	caps mon = "allow *"
@@ -48,8 +48,8 @@ const (
 
 // CephKeyring returns the filled-out user keyring
 func CephKeyring(cred CephCred) string {
-	if cred.Username == OperatorAdminUsername {
-		return fmt.Sprintf(AdminKeyringTemplate, cred.Secret)
+	if cred.Username == OperatorAdminUsername || cred.Username == NonOperatorAdminUsername {
+		return fmt.Sprintf(AdminKeyringTemplate, cred.Username, cred.Secret)
 	}
 	return fmt.Sprintf(UserKeyringTemplate, cred.Username, cred.Secret)
 }

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -38,8 +38,8 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, "--connect-timeout=15", args[0])
 	assert.Equal(t, "--cluster=a", args[1])
 	assert.Equal(t, "--conf=/etc/a/a.config", args[2])
-	assert.Equal(t, "--name=client.admin", args[3])
-	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", args[4])
+	assert.Equal(t, "--name=client.rookoperator", args[3])
+	assert.Equal(t, "--keyring=/etc/a/client.rookoperator.keyring", args[4])
 
 	RunAllCephCommandsInToolboxPod = "rook-ceph-tools"
 	args = []string{}
@@ -64,8 +64,8 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, "myarg", args[0])
 	assert.Equal(t, "--cluster="+clusterInfo.Namespace, args[1])
 	assert.Equal(t, "--conf=/var/lib/rook/a/a.config", args[2])
-	assert.Equal(t, "--name=client.admin", args[3])
-	assert.Equal(t, "--keyring=/var/lib/rook/a/client.admin.keyring", args[4])
+	assert.Equal(t, "--name=client.rookoperator", args[3])
+	assert.Equal(t, "--keyring=/var/lib/rook/a/client.rookoperator.keyring", args[4])
 }
 
 func TestStretchElectionStrategy(t *testing.T) {

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -38,8 +38,8 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, "--connect-timeout=15", args[0])
 	assert.Equal(t, "--cluster=a", args[1])
 	assert.Equal(t, "--conf=/etc/a/a.config", args[2])
-	assert.Equal(t, "--name=client.rookoperator", args[3])
-	assert.Equal(t, "--keyring=/etc/a/client.rookoperator.keyring", args[4])
+	assert.Equal(t, "--name=client.admin", args[3])
+	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", args[4])
 
 	RunAllCephCommandsInToolboxPod = "rook-ceph-tools"
 	args = []string{}
@@ -64,8 +64,8 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, "myarg", args[0])
 	assert.Equal(t, "--cluster="+clusterInfo.Namespace, args[1])
 	assert.Equal(t, "--conf=/var/lib/rook/a/a.config", args[2])
-	assert.Equal(t, "--name=client.rookoperator", args[3])
-	assert.Equal(t, "--keyring=/var/lib/rook/a/client.rookoperator.keyring", args[4])
+	assert.Equal(t, "--name=client.admin", args[3])
+	assert.Equal(t, "--keyring=/var/lib/rook/a/client.admin.keyring", args[4])
 }
 
 func TestStretchElectionStrategy(t *testing.T) {

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -233,6 +233,10 @@ func checkForImagesInPool(context *clusterd.Context, clusterInfo *ClusterInfo, n
 // DeletePool purges a pool from Ceph
 func DeletePool(context *clusterd.Context, clusterInfo *ClusterInfo, name string) error {
 	// check if the pool exists
+
+	clusterInfo.CephCred.Username = NonOperatorAdminUsername
+	logger.Info("PRINTING CLUSTER INFO in pool. %v", clusterInfo)
+
 	pool, err := GetPoolDetails(context, clusterInfo, name)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pool %q details", name)

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -234,7 +234,6 @@ func checkForImagesInPool(context *clusterd.Context, clusterInfo *ClusterInfo, n
 func DeletePool(context *clusterd.Context, clusterInfo *ClusterInfo, name string) error {
 	// check if the pool exists
 
-	clusterInfo.CephCred.Username = NonOperatorAdminUsername
 	logger.Info("PRINTING CLUSTER INFO in pool. %v", clusterInfo)
 
 	pool, err := GetPoolDetails(context, clusterInfo, name)

--- a/pkg/daemon/ceph/client/test/info.go
+++ b/pkg/daemon/ceph/client/test/info.go
@@ -31,7 +31,7 @@ func CreateConfigDir(configDir string) error {
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return errors.Wrap(err, "error while creating directory")
 	}
-	if err := ioutil.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0600); err != nil {
+	if err := ioutil.WriteFile(path.Join(configDir, "client.rookoperator.keyring"), []byte("key = adminsecret"), 0600); err != nil {
 		return errors.Wrap(err, "admin writefile error")
 	}
 	if err := ioutil.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0600); err != nil {
@@ -49,7 +49,7 @@ func CreateTestClusterInfo(monCount int) *client.ClusterInfo {
 		Namespace:     "default",
 		MonitorSecret: "monsecret",
 		CephCred: client.CephCred{
-			Username: client.AdminUsername,
+			Username: client.OperatorAdminUsername,
 			Secret:   "adminkey",
 		},
 		Monitors:  map[string]*client.MonInfo{},

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -259,9 +259,10 @@ func TestCephClientController(t *testing.T) {
 
 	// Mock clusterInfo
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -249,7 +249,7 @@ func (c *ClusterController) getCephHosts(namespace string) ([]string, error) {
 }
 
 func (c *ClusterController) getCleanUpDetails(namespace string) (string, string, error) {
-	clusterInfo, _, _, err := controller.LoadClusterInfo(c.context, c.OpManagerCtx, namespace)
+	clusterInfo, _, _, err := controller.LoadClusterInfo(c.context, c.OpManagerCtx, namespace, false)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get cluster info")
 	}

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -187,7 +187,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 			return errors.Wrap(err, "failed to configure external ceph cluster")
 		}
 	} else {
-		clusterInfo, _, _, err := controller.LoadClusterInfo(c.context, c.OpManagerCtx, cluster.Namespace)
+		clusterInfo, _, _, err := controller.LoadClusterInfoAnyUser(c.context, c.OpManagerCtx, cluster.Namespace)
 		if err != nil {
 			if errors.Is(err, controller.ClusterInfoNoClusterNoSecret) {
 				logger.Info("clusterInfo not yet found, must be a new cluster.")

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -49,7 +49,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	// loop until we find the secret necessary to connect to the external cluster
 	// then populate clusterInfo
 
-	cluster.ClusterInfo, err = opcontroller.PopulateExternalClusterInfo(c.context, c.OpManagerCtx, c.namespacedName.Namespace, cluster.ownerInfo)
+	cluster.ClusterInfo, err = opcontroller.PopulateExternalClusterInfo(c.context, c.OpManagerCtx, c.namespacedName.Namespace, cluster.ownerInfo, cluster.Spec.External.Enable)
 	if err != nil {
 		return errors.Wrap(err, "failed to populate external cluster info")
 	}
@@ -100,7 +100,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	logger.Info("external cluster identity established")
 
 	// Create CSI Secrets only if the user has provided the admin key
-	if cluster.ClusterInfo.CephCred.Username == client.AdminUsername {
+	if cluster.ClusterInfo.CephCred.Username == client.NonOperatorAdminUsername {
 		err = csi.CreateCSISecrets(c.context, cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to create csi kubernetes secrets")

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -100,7 +100,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	logger.Info("external cluster identity established")
 
 	// Create CSI Secrets only if the user has provided the admin key
-	if cluster.ClusterInfo.CephCred.Username == client.NonOperatorAdminUsername {
+	if cluster.ClusterInfo.CephCred.Username == client.CephAdminUsername {
 		err = csi.CreateCSISecrets(c.context, cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to create csi kubernetes secrets")

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -41,12 +41,12 @@ func SecretEnvVar() v1.EnvVar {
 
 // CephUsernameEnvVar is the ceph username environment var
 func CephUsernameEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephNonOperatorUsernameKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUsernameKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_USERNAME", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
 
 // CephSecretEnvVar is the ceph secret environment var
 func CephSecretEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephNonOperatorUserSecretKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUserSecretKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -41,12 +41,12 @@ func SecretEnvVar() v1.EnvVar {
 
 // CephUsernameEnvVar is the ceph username environment var
 func CephUsernameEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUsernameKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephOperatorUsernameKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_USERNAME", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
 
 // CephSecretEnvVar is the ceph secret environment var
 func CephSecretEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephUserSecretKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephOperatorUserSecretKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -41,12 +41,12 @@ func SecretEnvVar() v1.EnvVar {
 
 // CephUsernameEnvVar is the ceph username environment var
 func CephUsernameEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephOperatorUsernameKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephNonOperatorUsernameKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_USERNAME", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
 
 // CephSecretEnvVar is the ceph secret environment var
 func CephSecretEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephOperatorUserSecretKey}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: opcontroller.CephNonOperatorUserSecretKey}
 	return v1.EnvVar{Name: "ROOK_CEPH_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -480,7 +480,7 @@ func (c *Cluster) initClusterInfo(cephVersion cephver.CephVersion, clusterName s
 
 	context := c.ClusterInfo.Context
 	// get the cluster info from secret
-	c.ClusterInfo, c.maxMonID, c.mapping, err = controller.CreateOrLoadClusterInfo(c.context, context, c.Namespace, c.ownerInfo)
+	c.ClusterInfo, c.maxMonID, c.mapping, err = controller.CreateOrLoadClusterInfo(c.context, context, c.Namespace, c.ownerInfo, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster info")
 	}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -261,7 +261,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 func validateStart(t *testing.T, c *Cluster) {
 	s, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(c.ClusterInfo.Context, AppName, metav1.GetOptions{})
 	assert.NoError(t, err) // there shouldn't be an error due the secret existing
-	assert.Equal(t, 4, len(s.Data))
+	assert.Equal(t, 6, len(s.Data))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start
 	_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(c.ClusterInfo.Context, "rook-ceph-mon-a", metav1.GetOptions{})

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -106,7 +106,7 @@ with open('/etc/ceph/ceph.conf', 'w') as configfile:
 "
 
 # create new keyring
-ceph -n client.admin auth get-or-create osd."$OSD_ID" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring
+ceph -n client.rookoperator auth get-or-create osd."$OSD_ID" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring
 
 # active the osd with ceph-volume
 if [[ "$CV_MODE" == "lvm" ]]; then

--- a/pkg/operator/ceph/cluster/rbd/controller_test.go
+++ b/pkg/operator/ceph/cluster/rbd/controller_test.go
@@ -164,9 +164,10 @@ func TestCephRBDMirrorController(t *testing.T) {
 	t.Run("error - wrong peers configuration", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -143,7 +143,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	// state we are in and if we should upgrade or not
 
 	// Try to load clusterInfo so we can compare the running version with the one from the spec image
-	clusterInfo, _, _, err := controller.LoadClusterInfo(c.context, c.ClusterInfo.Context, c.Namespace)
+	clusterInfo, _, _, err := controller.LoadClusterInfoAnyUser(c.context, c.ClusterInfo.Context, c.Namespace)
 	if err == nil {
 		clusterInfo.Context = c.ClusterInfo.Context
 		// Write connection info (ceph config file and keyring) for ceph commands

--- a/pkg/operator/ceph/config/keyring/admin.go
+++ b/pkg/operator/ceph/config/keyring/admin.go
@@ -53,8 +53,8 @@ func (s *SecretStore) Admin() *AdminStore {
 
 // CreateOrUpdate creates or updates the admin keyring secret with cluster information.
 func (a *AdminStore) CreateOrUpdate(c *cephclient.ClusterInfo, context *clusterd.Context, annotation v1.AnnotationsSpec) error {
-	keyring := fmt.Sprintf(adminKeyringTemplate, c.CephCred.Secret)
-	err := a.secretStore.CreateOrUpdate(adminKeyringResourceName, keyring)
+	operatorKeyring := fmt.Sprintf(adminKeyringTemplate, c.CephCred.Secret)
+	err := a.secretStore.CreateOrUpdate(adminKeyringResourceName, operatorKeyring)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/config/keyring/admin.go
+++ b/pkg/operator/ceph/config/keyring/admin.go
@@ -30,8 +30,8 @@ const (
 	adminKeyringResourceName          = "rook-ceph-admin"
 	crashCollectorKeyringResourceName = "rook-ceph-crash-collector"
 
-	adminKeyringTemplate = `
-[client.admin]
+	operatorAdminKeyringTemplate = `
+[%s]
 	key = %s
 	caps mds = "allow *"
 	caps mon = "allow *"
@@ -53,7 +53,7 @@ func (s *SecretStore) Admin() *AdminStore {
 
 // CreateOrUpdate creates or updates the admin keyring secret with cluster information.
 func (a *AdminStore) CreateOrUpdate(c *cephclient.ClusterInfo, context *clusterd.Context, annotation v1.AnnotationsSpec) error {
-	operatorKeyring := fmt.Sprintf(adminKeyringTemplate, c.CephCred.Secret)
+	operatorKeyring := fmt.Sprintf(operatorAdminKeyringTemplate, c.CephCred.Username, c.CephCred.Secret)
 	err := a.secretStore.CreateOrUpdate(adminKeyringResourceName, operatorKeyring)
 	if err != nil {
 		return err

--- a/pkg/operator/ceph/config/keyring/admin_test.go
+++ b/pkg/operator/ceph/config/keyring/admin_test.go
@@ -54,6 +54,7 @@ func TestAdminKeyringStore(t *testing.T) {
 
 	// create key
 	clusterInfo.CephCred.Secret = "adminsecretkey"
+
 	err := k.Admin().CreateOrUpdate(clusterInfo, ctx, v1.AnnotationsSpec{v1.KeyClusterMetadata: v1.Annotations{"key": "value"}})
 	assert.NoError(t, err)
 	assertKeyringData(fmt.Sprintf(adminKeyringTemplate, "adminsecretkey"))

--- a/pkg/operator/ceph/config/keyring/admin_test.go
+++ b/pkg/operator/ceph/config/keyring/admin_test.go
@@ -53,11 +53,12 @@ func TestAdminKeyringStore(t *testing.T) {
 	}
 
 	// create key
+	clusterInfo.CephCred.Username = "admin"
 	clusterInfo.CephCred.Secret = "adminsecretkey"
 
 	err := k.Admin().CreateOrUpdate(clusterInfo, ctx, v1.AnnotationsSpec{v1.KeyClusterMetadata: v1.Annotations{"key": "value"}})
 	assert.NoError(t, err)
-	assertKeyringData(fmt.Sprintf(adminKeyringTemplate, "adminsecretkey"))
+	assertKeyringData(fmt.Sprintf(operatorAdminKeyringTemplate, clusterInfo.CephCred.Username, "adminsecretkey"))
 
 	// test annotation
 	secret, err := ctx.Clientset.CoreV1().Secrets(clusterInfo.Namespace).Get(clusterInfo.Context, keyringSecretName(adminKeyringResourceName), metav1.GetOptions{})
@@ -68,7 +69,7 @@ func TestAdminKeyringStore(t *testing.T) {
 	clusterInfo.CephCred.Secret = "differentsecretkey"
 	err = k.Admin().CreateOrUpdate(clusterInfo, ctx, v1.AnnotationsSpec{})
 	assert.NoError(t, err)
-	assertKeyringData(fmt.Sprintf(adminKeyringTemplate, "differentsecretkey"))
+	assertKeyringData(fmt.Sprintf(operatorAdminKeyringTemplate, clusterInfo.CephCred.Username, "differentsecretkey"))
 }
 
 func TestAdminVolumeAndMount(t *testing.T) {

--- a/pkg/operator/ceph/controller/cluster_info_test.go
+++ b/pkg/operator/ceph/controller/cluster_info_test.go
@@ -46,9 +46,6 @@ func TestCreateClusterSecrets(t *testing.T) {
 			if command == "ceph-authtool" && args[0] == "--create-keyring" {
 				filename := args[1]
 				assert.NoError(t, ioutil.WriteFile(filename, []byte(fmt.Sprintf("key = %s", adminSecret)), 0600))
-			} else if command == "ceph" && args[0] == "auth" && args[1] == "get-or-create-key" {
-				return `{"key":"AQDkLIBd9vLGJxAAnXsIKPrwvUXAmY+D1g0X1Q=="}`, nil
-
 			}
 			return "", nil
 		},
@@ -63,7 +60,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, -1, maxID)
 	require.NotNil(t, info)
-	assert.Equal(t, "client.rookoperator", info.CephCred.Username)
+	assert.Equal(t, "client.admin", info.CephCred.Username)
 	assert.Equal(t, adminSecret, info.CephCred.Secret)
 	assert.NotEqual(t, "", info.FSID)
 	assert.NotNil(t, mapping)
@@ -84,7 +81,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	// Check that the cluster info can now be loaded
 	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "client.rookoperator", info.CephCred.Username)
+	assert.Equal(t, "client.admin", info.CephCred.Username)
 	assert.Equal(t, adminSecret, info.CephCred.Secret)
 
 	// Fail to load the external cluster if the admin placeholder is specified
@@ -94,7 +91,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	_, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, false)
 	assert.Error(t, err)
 
-	// Load the external cluster with the new creds
+	// Load the external cluster with the legacy external creds
 	secret.Name = OperatorCreds
 	secret.Data = map[string][]byte{
 		"userID":  []byte("testid"),
@@ -106,18 +103,4 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "testid", info.CephCred.Username)
 	assert.Equal(t, "testkey", info.CephCred.Secret)
-
-	// err = clientset.CoreV1().Secrets(namespace).Delete(ctx, AppName, metav1.DeleteOptions{})
-	// assert.NoError(t, err)
-	secret.Name = AppName
-	secret.Data = map[string][]byte{
-		string(CephNonOperatorUsernameKey):   []byte("client.admin"),
-		string(CephNonOperatorUserSecretKey): []byte("key"),
-	}
-	_, err = clientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
-	assert.NoError(t, err)
-	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, false)
-	assert.NoError(t, err)
-	assert.Equal(t, "client.rookoperator", info.CephCred.Username)
-	assert.Equal(t, adminSecret, info.CephCred.Secret)
 }

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -193,7 +193,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 		// If so deploy the plugin holder with the fsid attached
 		if holderEnabled {
 			// Load cluster info for later use in updating the ceph-csi configmap
-			clusterInfo, _, _, err := opcontroller.LoadClusterInfo(r.context, r.opManagerContext, cluster.Namespace)
+			clusterInfo, _, _, err := opcontroller.LoadClusterInfoAnyUser(r.context, r.opManagerContext, cluster.Namespace)
 			if err != nil {
 				// This avoids a requeue with exponential backoff and allows the controller to reconcile
 				// more quickly when the cluster is ready.

--- a/pkg/operator/ceph/csi/controller_test.go
+++ b/pkg/operator/ceph/csi/controller_test.go
@@ -190,9 +190,10 @@ func TestCephCSIController(t *testing.T) {
 		}
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -209,7 +209,7 @@ func (c *ClusterMap) GetClusterInfo(namespace string) *cephClient.ClusterInfo {
 	}
 
 	clusterInfo := cephClient.NewClusterInfo(namespace, cluster.ObjectMeta.GetName())
-	clusterInfo.CephCred.Username = cephClient.AdminUsername
+	clusterInfo.CephCred.Username = cephClient.OperatorAdminUsername
 	return clusterInfo
 }
 

--- a/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
@@ -135,7 +135,6 @@ func (r *MachineDisruptionReconciler) reconcile(request reconcile.Request) (reco
 	}
 	// Check if the cluster is clean or not
 	clusterInfo := cephClient.AdminClusterInfo(r.context.OpManagerContext, request.NamespacedName.Namespace, request.NamespacedName.Name)
-	clusterInfo.CephCred.Username = cephClient.OperatorAdminUsername
 	_, isClean, err := cephClient.IsClusterClean(r.context.ClusterdContext, clusterInfo)
 	if err != nil {
 		maxUnavailable := int32(0)

--- a/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
@@ -135,6 +135,7 @@ func (r *MachineDisruptionReconciler) reconcile(request reconcile.Request) (reco
 	}
 	// Check if the cluster is clean or not
 	clusterInfo := cephClient.AdminClusterInfo(r.context.OpManagerContext, request.NamespacedName.Namespace, request.NamespacedName.Name)
+	clusterInfo.CephCred.Username = cephClient.OperatorAdminUsername
 	_, isClean, err := cephClient.IsClusterClean(r.context.ClusterdContext, clusterInfo)
 	if err != nil {
 		maxUnavailable := int32(0)

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -242,7 +242,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, *cephFilesystem, errors.Wrap(err, "failed to populate cluster info")
 	}
 	r.clusterInfo = clusterInfo
-
+	logger.Info("PRINTING CLUSTER INFO. %v", r.clusterInfo)
 	// DELETE: the CR was deleted
 	if !cephFilesystem.GetDeletionTimestamp().IsZero() {
 		deps, err := CephFilesystemDependents(r.context, r.clusterInfo, cephFilesystem)

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -237,7 +237,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 
 	// Populate clusterInfo
 	// Always populate it during each reconcile
-	clusterInfo, _, _, err := opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	clusterInfo, _, _, err := opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, r.cephClusterSpec.External.Enable)
 	if err != nil {
 		return reconcile.Result{}, *cephFilesystem, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -265,9 +265,10 @@ func TestCephFilesystemController(t *testing.T) {
 	t.Run("success - ceph cluster ready and mds are running", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -334,9 +335,10 @@ func TestCephFilesystemController(t *testing.T) {
 
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -177,9 +177,13 @@ func (r *ReconcileFilesystemMirror) reconcile(request reconcile.Request) (reconc
 	r.cephClusterSpec = &cephCluster.Spec
 
 	// Populate clusterInfo
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return opcontroller.ImmediateRetryResult, *filesystemMirror, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, *filesystemMirror, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// Detect desired CephCluster version

--- a/pkg/operator/ceph/file/mirror/controller_test.go
+++ b/pkg/operator/ceph/file/mirror/controller_test.go
@@ -174,9 +174,10 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 	t.Run("error - ceph cluster ready but version is too old", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -168,9 +168,10 @@ func TestCephClientController(t *testing.T) {
 	t.Run("success - ceph cluster ready, mds are running and subvolumegroup created", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -196,9 +196,13 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 
 	// Populate clusterInfo
 	// Always populate it during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, r.cephClusterSpec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, *cephNFS, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, *cephNFS, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// DELETE: the CR was deleted

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -103,8 +103,8 @@ func TestCephNFSController(t *testing.T) {
 			MockExecuteCommand: func(command string, args ...string) error {
 				logger.Infof("mock execute: %s %v", command, args)
 				if command == "rados" {
-					assert.Equal(t, "stat", args[6])
-					assert.Contains(t, []string{"conf-nfs.my-nfs", "conf-nfs.nfs2"}, args[7])
+					assert.Equal(t, "stat", args[8])
+					assert.Contains(t, []string{"conf-nfs.my-nfs", "conf-nfs.nfs2"}, args[9])
 					return nil
 				}
 				panic(fmt.Sprintf("unhandled command %s %v", command, args))
@@ -112,11 +112,11 @@ func TestCephNFSController(t *testing.T) {
 			MockExecuteCommandWithEnv: func(env []string, command string, args ...string) error {
 				logger.Infof("mock execute: %s %v", command, args)
 				if command == "ganesha-rados-grace" {
-					if args[4] == "add" {
+					if args[8] == "add" {
 						assert.Len(t, env, 1)
 						return nil
 					}
-					if args[4] == "remove" {
+					if args[8] == "remove" {
 						assert.Len(t, env, 1)
 						return nil
 					}

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -176,9 +176,10 @@ func TestCephNFSController(t *testing.T) {
 
 		// Create mock clusterInfo secret
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -19,6 +19,7 @@ package nfs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
@@ -140,6 +141,7 @@ func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS, name string) er
 		"--pool", n.Spec.RADOS.Pool,
 		"--namespace", n.Spec.RADOS.Namespace,
 		"--conf", cephclient.CephConfFilePath(r.context.ConfigDir, n.Namespace),
+		"--name", r.clusterInfo.CephCred.Username,
 	}
 	err := r.context.Executor.ExecuteCommand(cmd, append(args, "stat", config)...)
 	if err == nil {
@@ -172,7 +174,11 @@ func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, name st
 func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, action string) error {
 	nodeID := getNFSNodeID(nfs, name)
 	cmd := ganeshaRadosGraceCmd
-	args := []string{"--pool", nfs.Spec.RADOS.Pool, "--ns", nfs.Spec.RADOS.Namespace, action, nodeID}
+	args := []string{
+		"--cephconf", cephclient.CephConfFilePath(r.context.ConfigDir, nfs.Namespace),
+		"--userid", strings.TrimPrefix(r.clusterInfo.CephCred.Username, "client."), "--pool", nfs.Spec.RADOS.Pool,
+		"--ns", nfs.Spec.RADOS.Namespace, action, nodeID,
+	}
 	env := []string{fmt.Sprintf("CEPH_CONF=%s", cephclient.CephConfFilePath(r.context.ConfigDir, nfs.Namespace))}
 
 	return r.context.Executor.ExecuteCommandWithEnv(env, cmd, args...)

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -245,9 +245,8 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 	// When connecting to an external cluster, the Ceph user is different than client.rookoperator
 	// This is not perfect though since "client.rookoperator" is somehow supported...
 
-	c.clusterInfo.CephCred.Username = cephclient.NonOperatorAdminUsername
 	logger.Info("PRINTING CLUSTER INFO in admin. %v", c.clusterInfo)
-	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.NonOperatorAdminUsername {
+	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.OperatorAdminUsername {
 		options := []string{
 			fmt.Sprintf("--rgw-realm=%s", c.Realm),
 			fmt.Sprintf("--rgw-zonegroup=%s", c.ZoneGroup),

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -245,8 +245,12 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 	// When connecting to an external cluster, the Ceph user is different than client.rookoperator
 	// This is not perfect though since "client.rookoperator" is somehow supported...
 
+	if c.clusterInfo.CephCred.Username == cephclient.CephAdminUsername {
+		logger.Info("FOUND client.admin, changing to client.rookoperator")
+		c.clusterInfo.CephCred.Username = cephclient.OperatorAdminUsername
+	}
 	logger.Info("PRINTING CLUSTER INFO in admin. %v", c.clusterInfo)
-	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.OperatorAdminUsername {
+	if c.Name != "" && (c.clusterInfo.CephCred.Username == cephclient.OperatorAdminUsername || c.clusterInfo.CephCred.Username == cephclient.CephAdminUsername) {
 		options := []string{
 			fmt.Sprintf("--rgw-realm=%s", c.Realm),
 			fmt.Sprintf("--rgw-zonegroup=%s", c.ZoneGroup),

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -242,9 +242,9 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 	// simply because the external cluster mode does not support that yet
 	//
 	// The following conditions tries to determine if the cluster is external
-	// When connecting to an external cluster, the Ceph user is different than client.admin
-	// This is not perfect though since "client.admin" is somehow supported...
-	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.AdminUsername {
+	// When connecting to an external cluster, the Ceph user is different than client.rookoperator
+	// This is not perfect though since "client.rookoperator" is somehow supported...
+	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.OperatorAdminUsername {
 		options := []string{
 			fmt.Sprintf("--rgw-realm=%s", c.Realm),
 			fmt.Sprintf("--rgw-zonegroup=%s", c.ZoneGroup),

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -244,7 +244,10 @@ func runAdminCommand(c *Context, expectJSON bool, args ...string) (string, error
 	// The following conditions tries to determine if the cluster is external
 	// When connecting to an external cluster, the Ceph user is different than client.rookoperator
 	// This is not perfect though since "client.rookoperator" is somehow supported...
-	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.OperatorAdminUsername {
+
+	c.clusterInfo.CephCred.Username = cephclient.NonOperatorAdminUsername
+	logger.Info("PRINTING CLUSTER INFO in admin. %v", c.clusterInfo)
+	if c.Name != "" && c.clusterInfo.CephCred.Username == cephclient.NonOperatorAdminUsername {
 		options := []string{
 			fmt.Sprintf("--rgw-realm=%s", c.Realm),
 			fmt.Sprintf("--rgw-zonegroup=%s", c.ZoneGroup),

--- a/pkg/operator/ceph/object/bucket/controller_test.go
+++ b/pkg/operator/ceph/object/bucket/controller_test.go
@@ -155,9 +155,10 @@ func TestCephBucketController(t *testing.T) {
 
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -456,9 +456,10 @@ func TestCephObjectStoreController(t *testing.T) {
 		r := setupNewEnvironment(cephCluster)
 
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -590,9 +591,10 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 	}
 
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -819,9 +821,10 @@ func TestCephObjectExternalStoreController(t *testing.T) {
 	}
 
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -245,7 +245,7 @@ func getReadyCluster(client client.Client, opManagerContext context.Context, con
 		logger.Debug("Ceph cluster not yet present.")
 		return nil, nil, nil
 	}
-	clusterInfo, _, _, err := opcontroller.LoadClusterInfo(&context, opManagerContext, cephCluster.Namespace)
+	clusterInfo, _, _, err := opcontroller.LoadClusterInfo(&context, opManagerContext, cephCluster.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to populate cluster info")
 	}

--- a/pkg/operator/ceph/object/notification/controller_test.go
+++ b/pkg/operator/ceph/object/notification/controller_test.go
@@ -116,9 +116,10 @@ func mockSetup(t *testing.T) {
 
 	// create secrets
 	secrets := map[string][]byte{
-		"fsid":         []byte("name"),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte("name"),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -148,7 +148,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectRealm.GetDeletionTimestamp().IsZero() && !cephClusterExists {
@@ -168,9 +168,13 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, *cephObjectRealm, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, *cephObjectRealm, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// validate the realm settings

--- a/pkg/operator/ceph/object/realm/controller_test.go
+++ b/pkg/operator/ceph/object/realm/controller_test.go
@@ -112,9 +112,10 @@ func TestCephObjectRealmController(t *testing.T) {
 
 	// Mock clusterInfo
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -281,7 +281,7 @@ func TestValidateSpec(t *testing.T) {
 		},
 		clusterInfo: &client.ClusterInfo{
 			CephCred: client.CephCred{
-				Username: "client.admin",
+				Username: "client.rookoperator",
 			},
 		},
 	}

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -187,9 +187,10 @@ func TestCephBucketTopicController(t *testing.T) {
 		}
 
 		secrets := map[string][]byte{
-			"fsid":         []byte("name"),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte("name"),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -86,7 +86,7 @@ func TestCephBucketTopicController(t *testing.T) {
 			},
 		},
 	}
-	clusterInfo := cephclient.AdminClusterInfo(ctx, namespace, "rook")
+	clusterInfo := cephclient.AdminTestClusterInfo(namespace)
 	clusterSpec := cephv1.ClusterSpec{}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -187,9 +187,13 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	r.cephClusterSpec = &cephCluster.Spec
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, *cephObjectStoreUser, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, *cephObjectStoreUser, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// Validate the object store has been initialized

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -195,9 +195,10 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	t.Run("failure CephCluster is ready but NO rgw object", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -168,9 +168,13 @@ func (r *ReconcileObjectZone) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, *cephObjectZone, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, *cephObjectZone, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// validate the zone settings

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -241,9 +241,10 @@ func TestCephObjectZoneController(t *testing.T) {
 
 	// Mock clusterInfo
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -142,7 +142,7 @@ func (r *ReconcileObjectZoneGroup) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectZoneGroup.GetDeletionTimestamp().IsZero() && !cephClusterExists {
@@ -161,9 +161,13 @@ func (r *ReconcileObjectZoneGroup) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, errors.Wrap(err, "failed to populate cluster info")
 	}
 
 	// validate the zone group settings

--- a/pkg/operator/ceph/object/zonegroup/controller_test.go
+++ b/pkg/operator/ceph/object/zonegroup/controller_test.go
@@ -233,9 +233,10 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 
 	// Mock clusterInfo
 	secrets := map[string][]byte{
-		"fsid":         []byte(name),
-		"mon-secret":   []byte("monsecret"),
-		"admin-secret": []byte("adminsecret"),
+		"fsid":                   []byte(name),
+		"mon-secret":             []byte("monsecret"),
+		"admin-secret":           []byte("adminsecret"),
+		"ceph-operator-username": []byte("client.rookoperator"),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -358,9 +358,10 @@ func TestCephBlockPoolController(t *testing.T) {
 
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -168,9 +168,13 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 	}
 
 	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace)
+	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, cephCluster.Spec.External.Enable)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
+		result := opcontroller.ImmediateRetryResult
+		if errors.Is(err, opcontroller.ClusterInfoNoOperatorKeyring) {
+			result = opcontroller.WaitForRequeueIfOperatorNotInitialized
+		}
+		return result, errors.Wrap(err, "failed to populate cluster info")
 	}
 	r.clusterInfo.Context = r.opManagerContext
 

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -167,9 +167,10 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 	t.Run("success - ceph cluster ready, block pool rados namespace created", func(t *testing.T) {
 		// Mock clusterInfo
 		secrets := map[string][]byte{
-			"fsid":         []byte(name),
-			"mon-secret":   []byte("monsecret"),
-			"admin-secret": []byte("adminsecret"),
+			"fsid":                   []byte(name),
+			"mon-secret":             []byte("monsecret"),
+			"admin-secret":           []byte("adminsecret"),
+			"ceph-operator-username": []byte("client.rookoperator"),
 		}
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -135,6 +135,7 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 
 	s.verifyOperatorImage(installer.LocalBuildTag)
 	s.verifyRookUpgrade(numOSDs)
+
 	err := s.installer.WaitForToolbox(s.namespace)
 	assert.NoError(s.T(), err)
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -111,9 +111,9 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	preFilename := "pre-upgrade-file"
 	numOSDs, rbdFilesToRead, cephfsFilesToRead := s.deployClusterforUpgrade(objectUserID, preFilename)
 
-	clusterInfo := client.AdminTestClusterInfo(s.namespace)
 	requireBlockImagesRemoved := false
 	defer func() {
+		clusterInfo := client.AdminTestClusterInfo(s.namespace)
 		blockTestDataCleanUp(s.helper, s.k8sh, &s.Suite, clusterInfo, installer.BlockPoolName, installer.BlockPoolSCName, blockName, rbdPodName, requireBlockImagesRemoved)
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
@@ -179,9 +179,9 @@ func (s *UpgradeSuite) TestUpgradeCephToQuincyDevel() {
 	preFilename := "pre-upgrade-file"
 	s.settings.CephVersion = installer.QuincyVersion
 	numOSDs, rbdFilesToRead, cephfsFilesToRead := s.deployClusterforUpgrade(objectUserID, preFilename)
-	clusterInfo := client.AdminTestClusterInfo(s.namespace)
 	requireBlockImagesRemoved := false
 	defer func() {
+		clusterInfo := client.AdminTestClusterInfo(s.namespace)
 		blockTestDataCleanUp(s.helper, s.k8sh, &s.Suite, clusterInfo, installer.BlockPoolName, installer.BlockPoolSCName, blockName, rbdPodName, requireBlockImagesRemoved)
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
@@ -212,9 +212,9 @@ func (s *UpgradeSuite) TestUpgradeCephToPacificDevel() {
 	preFilename := "pre-upgrade-file"
 	s.settings.CephVersion = installer.PacificVersion
 	numOSDs, rbdFilesToRead, cephfsFilesToRead := s.deployClusterforUpgrade(objectUserID, preFilename)
-	clusterInfo := client.AdminTestClusterInfo(s.namespace)
 	requireBlockImagesRemoved := false
 	defer func() {
+		clusterInfo := client.AdminTestClusterInfo(s.namespace)
 		blockTestDataCleanUp(s.helper, s.k8sh, &s.Suite, clusterInfo, installer.BlockPoolName, installer.BlockPoolSCName, blockName, rbdPodName, requireBlockImagesRemoved)
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
@@ -244,6 +244,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(objectUserID, preFilename string)
 	// The helm chart already created these though.
 	//
 	clusterInfo := client.AdminTestClusterInfo(s.namespace)
+	clusterInfo.CephCred.Username = client.CephAdminUsername
 	if !s.settings.UseHelm {
 		logger.Infof("Initializing block before the upgrade")
 		setupBlockLite(s.helper, s.k8sh, &s.Suite, clusterInfo, installer.BlockPoolName, installer.BlockPoolSCName, blockName)


### PR DESCRIPTION
**Description of your changes:**

using client.rookoperator instead of client.admin for
running ceph commands will help debug ceph logs in
finding the source of ceph commands.

Closes: #10169
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #10169 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
