### PR TITLE
osd: close the encrypted disk after cleanup is done

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -207,6 +207,17 @@ jobs:
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences
 
+    - name: teardown cluster with cleanup policy
+      run: |
+        kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
+        kubectl -n rook-ceph delete cephcluster rook-ceph
+        kubectl -n rook-ceph logs deploy/rook-ceph-operator
+        tests/scripts/github-action-helper.sh wait_for_cleanup_pod
+        lsblk
+        BLOCK=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo head --bytes=60 ${BLOCK}1
+        sudo head --bytes=60 ${BLOCK}2
+
     - name: collect common logs
       if: always()
       uses: ./.github/workflows/collect-logs
@@ -362,6 +373,17 @@ jobs:
       run: |
         kubectl -n rook-ceph delete deploy/rook-ceph-osd-0
         tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+
+    - name: teardown cluster with cleanup policy
+      run: |
+        kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
+        kubectl -n rook-ceph delete cephcluster rook-ceph
+        kubectl -n rook-ceph logs deploy/rook-ceph-operator
+        tests/scripts/github-action-helper.sh wait_for_cleanup_pod
+        BLOCK=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo head --bytes=60 ${BLOCK}1
+        sudo head --bytes=60 ${BLOCK}2
+        sudo lsblk
 
     - name: collect common logs
       if: always()

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -39,7 +39,7 @@ var (
 	luksLabelCephFSID = regexp.MustCompile("ceph_fsid=(.*)")
 )
 
-func closeEncryptedDevice(context *clusterd.Context, dmName string) error {
+func CloseEncryptedDevice(context *clusterd.Context, dmName string) error {
 	args := []string{"--verbose", "luksClose", dmName}
 	cryptsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(cryptsetupBinary, args...)
 	if err != nil {

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -79,7 +79,7 @@ func TestCloseEncryptedDevice(t *testing.T) {
 	}
 
 	context := &clusterd.Context{Executor: executor}
-	err := closeEncryptedDevice(context, "/dev/mapper/ceph-43e9efed-0676-4731-b75a-a4c42ece1bb1-xvdbr-block-dmcrypt")
+	err := CloseEncryptedDevice(context, "/dev/mapper/ceph-43e9efed-0676-4731-b75a-a4c42ece1bb1-xvdbr-block-dmcrypt")
 	assert.NoError(t, err)
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -108,6 +108,7 @@ type OSDInfo struct {
 	Store         string `json:"store"`
 	// Ensure the OSD daemon has affinity with the same topology from the OSD prepare pod
 	TopologyAffinity string `json:"topologyAffinity"`
+	Encrypted        bool   `json:"encrypted"`
 }
 
 // OrchestrationStatus represents the status of an OSD orchestration

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -250,6 +250,16 @@ function wait_for_prepare_pod() {
   kubectl -n rook-ceph describe deployment/rook-ceph-osd-0 || true
 }
 
+function wait_for_cleanup_pod() {
+  timeout 180 bash <<EOF
+until kubectl --namespace rook-ceph logs job/cluster-cleanup-job-$(uname -n); do
+  echo "waiting for cleanup up pod to be present"
+  sleep 1
+done
+EOF
+  kubectl --namespace rook-ceph logs --follow job/cluster-cleanup-job-"$(uname -n)"
+}
+
 function wait_for_ceph_to_be_ready() {
   DAEMONS=$1
   OSD_COUNT=$2


### PR DESCRIPTION
**Description of your changes:**

Once we are done cleaning up the content of the encrypted osd, let's
close the main LUKS device.
This avoids having dm devices on the system after the cleanup.

Closes: https://github.com/rook/rook/issues/10181
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/10181

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
