### PR TITLE
operator: Increase memory limit of operator

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -646,7 +646,7 @@ spec:
           #resources:
           #  limits:
           #    cpu: 500m
-          #    memory: 256Mi
+          #    memory: 512Mi
           #  requests:
           #    cpu: 100m
           #    memory: 128Mi

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -581,7 +581,7 @@ spec:
           #resources:
           #  limits:
           #    cpu: 500m
-          #    memory: 256Mi
+          #    memory: 512Mi
           #  requests:
           #    cpu: 100m
           #    memory: 128Mi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator is very bursty and when starting up may need more memory to reconcile all the CRs initially before it calms down. The default of 256Mi was not sufficient for many clusters, so now we bump up the limit to 512Mi.

This is a follow-up from the same change to the helm chart in https://github.com/rook/rook/pull/10195.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
