### PR TITLE
pool: Built-in pools require flag to force creation

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -447,6 +447,9 @@ func createReplicatedPoolForApp(context *clusterd.Context, clusterInfo *ClusterI
 		// Create the pool since it doesn't exist yet
 		// If there was some error other than ENOENT (not exists), go ahead and ensure the pool is created anyway
 		args := []string{"osd", "pool", "create", pool.Name, pgCount, "replicated", crushRuleName, "--size", strconv.FormatUint(uint64(pool.Replicated.Size), 10)}
+		if strings.HasPrefix(pool.Name, ".") && clusterInfo.CephVersion.IsAtLeastReef() {
+			args = append(args, "--yes-i-really-mean-it")
+		}
 		output, err := NewCephCommand(context, clusterInfo, args).Run()
 		if err != nil {
 			return errors.Wrapf(err, "failed to create replicated pool %s. %s", pool.Name, string(output))

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -304,6 +304,9 @@ func (r *ReconcileCephNFS) configureNFSPool(n *cephv1.CephNFS) error {
 	logger.Infof("configuring pool %q for nfs", poolName)
 
 	args := []string{"osd", "pool", "create", poolName}
+	if r.clusterInfo.CephVersion.IsAtLeastReef() {
+		args = append(args, "--yes-i-really-mean-it")
+	}
 	output, err := cephclient.NewCephCommand(r.context, r.clusterInfo, args).Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create default NFS pool %q. %s", poolName, string(output))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Ceph added a check recently that prevents creation of the built-in pools that start with a dot, such as .nfs, .mgr, and .rgw.root. These pools require a --yes-i-really-mean-it flag to be passed to force the creation now.

This has been causing the daily tests to fail on the latest master builds.
The change in ceph requiring the flag to force creation for built-in pools is seen here: https://github.com/ceph/ceph/pull/44911

**Which issue is resolved by this Pull Request:**
Resolves #10013 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
