### PR TITLE
osd: fix disk uuid management

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -128,10 +128,12 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 
 	// get the UUID for disks
 	var diskUUID string
-	if diskType != sys.PartType {
-		diskUUID, err = sys.GetDiskUUID(d, executor)
+	if diskType == sys.DiskType {
+		uuid, err := sys.GetDiskUUID(d, executor)
 		if err != nil {
-			return nil, err
+			logger.Warning(err)
+		} else {
+			diskUUID = uuid
 		}
 	}
 

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -245,7 +245,7 @@ func checkMatchingDevice(checkDev sys.LocalDisk, devices []sys.LocalDisk) *sys.L
 		// check if devices should be considered the same. the uuid can be
 		// unstable, so we also use the reported serial and device name, which
 		// appear to be more stable.
-		if checkDev.UUID == dev.UUID {
+		if checkDev.UUID != "" && dev.UUID != "" && checkDev.UUID == dev.UUID {
 			return &devices[i]
 		}
 


### PR DESCRIPTION
**Description of your changes:**

- disk UUID should only be got for "disk" type device.
- It's not necessary to fail prepare job when failing to get disk UUID
- We should consider that `sgdisk` reports UUID even if there is no GPT.

**Which issue is resolved by this Pull Request:**
Resolves #9948

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
