### PR TITLE
core: Add reef version info

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -47,6 +47,8 @@ var (
 	Pacific = CephVersion{16, 0, 0, 0, ""}
 	// Quincy Ceph version
 	Quincy = CephVersion{17, 0, 0, 0, ""}
+	// Reef Ceph version
+	Reef = CephVersion{18, 0, 0, 0, ""}
 
 	// supportedVersions are production-ready versions that rook supports
 	supportedVersions = []CephVersion{Octopus, Pacific, Quincy}
@@ -89,6 +91,8 @@ func (v *CephVersion) ReleaseName() string {
 		return "pacific"
 	case Quincy.Major:
 		return "quincy"
+	case Reef.Major:
+		return "reef"
 	default:
 		return unknownVersionString
 	}
@@ -179,6 +183,11 @@ func (v *CephVersion) IsQuincy() bool {
 	return v.isRelease(Quincy)
 }
 
+// IsReef checks if the Ceph version is Reef
+func (v *CephVersion) IsReef() bool {
+	return v.isRelease(Reef)
+}
+
 // IsAtLeast checks a given Ceph version is at least a given one
 func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	if v.Major > other.Major {
@@ -200,6 +209,11 @@ func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	}
 	// If we arrive here then both versions are identical
 	return true
+}
+
+// IsAtLeastReef check that the Ceph version is at least Reef
+func (v *CephVersion) IsAtLeastReef() bool {
+	return v.IsAtLeast(Reef)
 }
 
 // IsAtLeastQuincy check that the Ceph version is at least Quincy

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -101,14 +101,17 @@ func TestSupported(t *testing.T) {
 	for _, v := range supportedVersions {
 		assert.True(t, v.Supported())
 	}
+	assert.False(t, Reef.Supported())
 }
 
 func TestIsRelease(t *testing.T) {
 	assert.True(t, Octopus.isRelease(Octopus))
 	assert.True(t, Pacific.isRelease(Pacific))
 	assert.True(t, Quincy.isRelease(Quincy))
+	assert.True(t, Reef.isRelease(Reef))
 
 	assert.False(t, Pacific.isRelease(Octopus))
+	assert.False(t, Reef.isRelease(Quincy))
 
 	OctopusUpdate := Octopus
 	OctopusUpdate.Minor = 33
@@ -206,10 +209,11 @@ func TestCephVersion_Unsupported(t *testing.T) {
 		fields fields
 		want   bool
 	}{
-		{"supported", fields{Major: 16, Minor: 2, Extra: 1, Build: 0}, false},
-		{"supported", fields{Major: 15, Minor: 2, Extra: 1, Build: 0}, false},
-		{"supported", fields{Major: 15, Minor: 2, Extra: 6, Build: 0}, false},
-		{"unsupported", fields{Major: 17, Minor: 2, Extra: 0, Build: 0}, false},
+		{"octopus", fields{Major: 15, Minor: 2, Extra: 1, Build: 0}, false},
+		{"octopus", fields{Major: 15, Minor: 2, Extra: 6, Build: 0}, false},
+		{"pacific", fields{Major: 16, Minor: 2, Extra: 1, Build: 0}, false},
+		{"quincy", fields{Major: 17, Minor: 2, Extra: 0, Build: 0}, false},
+		{"reef", fields{Major: 18, Minor: 2, Extra: 0, Build: 0}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Since Quincy is released, Ceph master builds will soon be tagged with the reef v18 version. This adds the capability for rook to check for the reef version of Ceph.

Needed for #10208.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
