### PR TITLE
docs: Add prometheus doc link to pick up rook service monitor

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -14,6 +14,10 @@ contains a Prometheus instance, it will automatically discover Rook's scrape end
 `prometheus.io/scrape` and `prometheus.io/port` annotations.
 
 > **NOTE**: This assumes that the Prometheus instances is searching all your Kubernetes namespaces for Pods with these annotations.
+> If prometheus is already installed in a cluster, it may not be configured to watch for third-party service monitors such as for Rook.
+> Normally you should be able to add the prometheus annotations "prometheus.io/scrape=true" and prometheus.io/port={port} and
+> prometheus would automatically configure the scrape points and start gathering metrics. If prometheus isn't configured to do this, see the
+> [prometheus operator docs](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#prometheusioscrape).
 
 ## Prometheus Operator
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If prometheus is already installed in a cluster, it may not be configured to watch for third-party service monitors such as for Rook. To help with this configuration, a link is added to the doc for enabling the third-party service monitors.

@Daxcor69 Does this help clarify? Suggestions welcome on the wording to help with the prometheus config.

**Which issue is resolved by this Pull Request:**
Resolves #10207 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
