### PR TITLE
webhook: update the check-in cluster spec validation

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -31,7 +31,8 @@
         "security",
         "subvolumegroup",
         "namespace",
-        "test"
+        "test",
+        "webhook"
       ]
     ],
     "body-leading-blank": [

--- a/pkg/apis/ceph.rook.io/v1/cluster.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster.go
@@ -81,9 +81,11 @@ func validateUpdatedCephCluster(updatedCephCluster *CephCluster, found *CephClus
 		return errors.Errorf("invalid update: Provider change from %q to %q is not allowed", found.Spec.Network.Provider, updatedCephCluster.Spec.Network.Provider)
 	}
 
-	for i, storageClassDeviceSet := range updatedCephCluster.Spec.Storage.StorageClassDeviceSets {
-		if storageClassDeviceSet.Encrypted != found.Spec.Storage.StorageClassDeviceSets[i].Encrypted {
-			return errors.Errorf("invalid update: StorageClassDeviceSet %q encryption change from %t to %t is not allowed", storageClassDeviceSet.Name, found.Spec.Storage.StorageClassDeviceSets[i].Encrypted, storageClassDeviceSet.Encrypted)
+	if len(updatedCephCluster.Spec.Storage.StorageClassDeviceSets) == len(found.Spec.Storage.StorageClassDeviceSets) {
+		for i, storageClassDeviceSet := range found.Spec.Storage.StorageClassDeviceSets {
+			if storageClassDeviceSet.Encrypted != updatedCephCluster.Spec.Storage.StorageClassDeviceSets[i].Encrypted {
+				return errors.Errorf("invalid update: StorageClassDeviceSet %q encryption change from %t to %t is not allowed", storageClassDeviceSet.Name, found.Spec.Storage.StorageClassDeviceSets[i].Encrypted, storageClassDeviceSet.Encrypted)
+			}
 		}
 	}
 

--- a/pkg/apis/ceph.rook.io/v1/cluster_test.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster_test.go
@@ -76,6 +76,14 @@ func TestCephClusterValidateUpdate(t *testing.T) {
 		},
 		Spec: ClusterSpec{
 			DataDirHostPath: "/var/lib/rook",
+			Storage: StorageScopeSpec{
+				StorageClassDeviceSets: []StorageClassDeviceSet{
+					{
+						Name:      "sc1",
+						Encrypted: true,
+					},
+				},
+			},
 		},
 	}
 	err := c.ValidateCreate()
@@ -84,6 +92,22 @@ func TestCephClusterValidateUpdate(t *testing.T) {
 	// Updating the CRD specs with invalid values
 	uc := c.DeepCopy()
 	uc.Spec.DataDirHostPath = "var/rook"
+	uc.Spec.Storage.StorageClassDeviceSets[0].Encrypted = false
 	err = uc.ValidateUpdate(c)
 	assert.Error(t, err)
+
+	// reverting the to older hostPath
+	uc.Spec.DataDirHostPath = "/var/lib/rook"
+	uc.Spec.Storage.StorageClassDeviceSets = []StorageClassDeviceSet{
+		{
+			Name:      "sc1",
+			Encrypted: true,
+		},
+		{
+			Name: "sc2",
+		},
+	}
+
+	err = uc.ValidateUpdate(c)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

we should iterate older clusters spec instead of
new cluster spec since in case of new storageClassdeviceset
added in spec. The total count of the new clusters and older
spec cluster is will not be the same and we'll get panic.

Closes: https://github.com/rook/rook/issues/10222
Signed-off-by: subhamkrai <srai@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #10222 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
