### PR TITLE
core: append filesystem property on disk

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -166,6 +166,9 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 	if val, ok := diskProps["KNAME"]; ok {
 		disk.KernelName = path.Base(val)
 	}
+	if val, ok := diskProps["FSTYPE"]; ok && val != "" {
+		disk.Filesystem = path.Base(val)
+	}
 
 	return disk, nil
 }

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -169,6 +169,9 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 	if val, ok := diskProps["FSTYPE"]; ok && val != "" {
 		disk.Filesystem = path.Base(val)
 	}
+	if val, ok := diskProps["MOUNTPOINT"]; ok && val != "" {
+		disk.Mountpoint = path.Base(val)
+	}
 
 	return disk, nil
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -296,6 +296,12 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 			continue
 		}
 
+		// Add detection for mounted device and skip if mounted
+		if device.Mountpoint != "" {
+			logger.Infof("skipping device %q with mountpoint %q", device.Name, device.Mountpoint)
+			continue
+		}
+
 		// Ignore device with filesystem signature since c-v inventory
 		// cannot detect that correctly
 		// see: https://tracker.ceph.com/issues/43585

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -95,6 +95,8 @@ type LocalDisk struct {
 	Partitions []Partition
 	// Filesystem is the filesystem currently on the device
 	Filesystem string `json:"filesystem"`
+	// Mountpoint is the mountpoint of the filesystem's on the device
+	Mountpoint string `json:"mountpoint"`
 	// Vendor is the device vendor
 	Vendor string `json:"vendor"`
 	// Model is the device model

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -206,11 +206,12 @@ func GetDeviceProperties(device string, executor exec.Executor) (map[string]stri
 // GetDevicePropertiesFromPath gets a device property from a path
 func GetDevicePropertiesFromPath(devicePath string, executor exec.Executor) (map[string]string, error) {
 	output, err := executor.ExecuteCommandWithOutput("lsblk", devicePath,
-		"--bytes", "--nodeps", "--pairs", "--paths", "--output", "SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME")
+		"--bytes", "--nodeps", "--pairs", "--paths", "--output", "SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE")
 	if err != nil {
 		logger.Errorf("failed to execute lsblk. output: %s", output)
 		return nil, err
 	}
+	logger.Debugf("lsblk output: %q", output)
 
 	return parseKeyValuePairString(output), nil
 }
@@ -234,6 +235,7 @@ func GetUdevInfo(device string, executor exec.Executor) (map[string]string, erro
 	if err != nil {
 		return nil, err
 	}
+	logger.Debugf("udevadm info output: %q", output)
 
 	return parseUdevInfo(output), nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

hen detecting the device property the filesystem was not passed but
used later to validate if the device should be taken or not. Now we read
the filesystem info from "lsblk" and populate it in the device type.

**Which issue is resolved by this Pull Request:**
Resolves #9470

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
