### PR TITLE
core: treat cluster as not existing if it is allowed to uninstall with volumes

### DIFF
--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -137,8 +137,10 @@ func IsReadyToReconcile(ctx context.Context, c client.Client, namespacedName typ
 	}
 	cephCluster = clusterList.Items[0]
 
-	// If the cluster has a cleanup policy to destroy the cluster and it has been marked for deletion, treat it as if it does not exist
-	if cephCluster.Spec.CleanupPolicy.HasDataDirCleanPolicy() && !cephCluster.DeletionTimestamp.IsZero() {
+	// If the cluster has a cleanup policy to destroy the cluster, it has been marked for deletion and it is allowed to uninstall
+	// with volumes, treat it as if it does not exist
+	if cephCluster.Spec.CleanupPolicy.HasDataDirCleanPolicy() && !cephCluster.DeletionTimestamp.IsZero() &&
+		cephCluster.Spec.CleanupPolicy.AllowUninstallWithVolumes {
 		logger.Infof("%q: CephCluster has a destructive cleanup policy, allowing %q to be deleted", controllerName, namespacedName)
 		return cephCluster, false, cephClusterExists, WaitForRequeueIfCephClusterNotReady
 	}

--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -173,6 +173,27 @@ func TestIsReadyToReconcile(t *testing.T) {
 		c, ready, clusterExists, _ := IsReadyToReconcile(ctx.TODO(), client, clusterName, controllerName)
 		assert.NotNil(t, c)
 		assert.False(t, ready)
+		assert.True(t, clusterExists)
+	})
+
+	t.Run("cephcluster with cleanup policy when deleted and allowed to uninstall with volumes", func(t *testing.T) {
+		cephCluster := &cephv1.CephCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              clusterName.Name,
+				Namespace:         clusterName.Namespace,
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			},
+			Spec: cephv1.ClusterSpec{
+				CleanupPolicy: cephv1.CleanupPolicySpec{
+					Confirmation:              cephv1.DeleteDataDirOnHostsConfirmation,
+					AllowUninstallWithVolumes: true,
+				},
+			}}
+		objects := []runtime.Object{cephCluster}
+		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+		c, ready, clusterExists, _ := IsReadyToReconcile(ctx.TODO(), client, clusterName, controllerName)
+		assert.NotNil(t, c)
+		assert.False(t, ready)
 		assert.False(t, clusterExists)
 	})
 }


### PR DESCRIPTION

**Description of your changes:**


IsReadyToReconcile() used to return cluster as not existing
if cleanup policy was set to destroy and cluster marked for
deletion.
However, to allow proper deletion of corresponding PVCs,
deletion of blockpool, filesystem CRs need to wait for
rbd images and subvolumes to be deleted.
Hence, consider cluster as not existing only when
`AllowUninstallWithVolumes` is also set to true.

Signed-off-by: Rakshith R <rar@redhat.com>


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
