### PR TITLE
rgw: support FQDN for RGW endpoint

### DIFF
--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -163,7 +163,7 @@ class TestRadosJSON(unittest.TestCase):
             self.fail("An Exception was expected to be thrown")
         except ext.ExecutionFailureException as err:
             print("Successfully thrown error: {}".format(err))
-        # mal formatted IP
+        # malformatted IP
         try:
             self.rjObj._invalid_endpoint("10.103..212.133:8000")
             self.fail("An Exception was expected to be thrown")
@@ -179,7 +179,14 @@ class TestRadosJSON(unittest.TestCase):
             self.fail("An Exception was expected to be thrown")
         except ext.ExecutionFailureException as err:
             print("Successfully thrown error: {}".format(err))
-
+            
+    def test_convert_fqdn_rgw_endpoint_to_ip(self):
+        try:
+            rgw_endpoint_ip = self.rjObj.convert_fqdn_rgw_endpoint_to_ip("www.redhat.com:80")
+            print("Successfully Converted www.redhat.com to it's IP {}".format(rgw_endpoint_ip))
+        except  ext.ExecutionFailureException as err:
+            print("Successfully thrown error: {}".format(err))   
+        
     def test_upgrade_user_permissions(self):
         self.rjObj = ext.RadosJSON(
             ['--upgrade', '--run-as-user=client.csi-cephfs-provisioner', '--format=json'])


### PR DESCRIPTION
Now rgw can be pass by FQDN too,
to avoid problems where it is required
The format should be similar to
Ip(<IP>:<PORT> format), <FQDN>:<PORT> format

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
