### PR TITLE
namespace: adding radosnamespace in canary CI

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -83,9 +83,6 @@ jobs:
     - name: run external script create-external-cluster-resources.py unit tests
       run: |
         kubectl -n rook-ceph exec $(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[0].metadata.name}') -- python3 -m unittest /etc/ceph/create-external-cluster-resources-tests.py
-        # write a test file
-        # copy the test file
-        # execute the test file
 
     - name: wait for the subvolumegroup to be created
       run: |
@@ -105,6 +102,16 @@ jobs:
         # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
         kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace1
         kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosNamespace1 --cluster-name rookStorage --restricted-auth-permission true
+        # test the CRD created rados namespace `namespace-a` using external script
+        kubectl create -f deploy/examples/radosnamespace.yaml
+        timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace namespace-a --cluster-name rookStorage --restricted-auth-permission true
+        # test the rados namespace which not exit for replicapool(false testing)
+        if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace false-test-namespace --cluster-name rookStorage --restricted-auth-permission true); then
+          echo $output
+        else
+          echo "script failed because wrong rados namespace was passed"
+        fi  
 
     - name: test external script with restricted_auth_permission flag
       run: |


### PR DESCRIPTION
THe radosnamespace CRD is already added by
https://github.com/rook/rook/pull/9733,
Checking the external script with the namespace created by
the CRD

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
