### PR TITLE
docs: update tolerations name from controlplane to control-plane

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -215,7 +215,7 @@ data:
   # CSI provisioner would be best to start on the same nodes as other ceph daemons.
   # CSI_PROVISIONER_TOLERATIONS: |
   #   - effect: NoSchedule
-  #     key: node-role.kubernetes.io/controlplane
+  #     key: node-role.kubernetes.io/control-plane
   #     operator: Exists
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd
@@ -227,7 +227,7 @@ data:
   # CSI plugins need to be started on all the nodes where the clients need to mount the storage.
   # CSI_PLUGIN_TOLERATIONS: |
   #   - effect: NoSchedule
-  #     key: node-role.kubernetes.io/controlplane
+  #     key: node-role.kubernetes.io/control-plane
   #     operator: Exists
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -130,7 +130,7 @@ data:
   # CSI provisioner would be best to start on the same nodes as other ceph daemons.
   # CSI_PROVISIONER_TOLERATIONS: |
   #   - effect: NoSchedule
-  #     key: node-role.kubernetes.io/controlplane
+  #     key: node-role.kubernetes.io/control-plane
   #     operator: Exists
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd
@@ -142,7 +142,7 @@ data:
   # CSI plugins need to be started on all the nodes where the clients need to mount the storage.
   # CSI_PLUGIN_TOLERATIONS: |
   #   - effect: NoSchedule
-  #     key: node-role.kubernetes.io/controlplane
+  #     key: node-role.kubernetes.io/control-plane
   #     operator: Exists
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd
@@ -497,7 +497,7 @@ spec:
             # - name: DISCOVER_TOLERATIONS
             #   value: |
             #     - effect: NoSchedule
-            #       key: node-role.kubernetes.io/controlplane
+            #       key: node-role.kubernetes.io/control-plane
             #       operator: Exists
             #     - effect: NoExecute
             #       key: node-role.kubernetes.io/etcd


### PR DESCRIPTION
In the `deploy/examples/operator.yaml` file, the correct name for the control plane toleration key is `node-role.kubernetes.io/control-plane` instead of `node-role.kubernetes.io/controlplane`.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
