### PR TITLE
build: add psp for missing roles

### DIFF
--- a/deploy/charts/library/templates/_cluster-psp.tpl
+++ b/deploy/charts/library/templates/_cluster-psp.tpl
@@ -37,6 +37,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: rook-ceph-rgw-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-rgw
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: rook-ceph-mgr-psp
   namespace: {{ .Release.Namespace }} # namespace:cluster
 roleRef:
@@ -60,5 +74,19 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-purge-osd-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
     namespace: {{ .Release.Namespace }} # namespace:cluster
 {{- end }}

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -1267,6 +1267,20 @@ subjects:
     name: rook-ceph-purge-osd
     namespace: rook-ceph # namespace:cluster
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-purge-osd-psp
+  namespace: rook-ceph # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: rook-ceph # namespace:cluster
+---
 # Allow the rgw pods in this namespace to work with configmaps
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1277,6 +1291,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rook-ceph-rgw
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-rgw
+    namespace: rook-ceph # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-rgw-psp
+  namespace: rook-ceph # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-rgw


### PR DESCRIPTION
**Description of your changes:**
This commit adds psp RoleBindings to rook-ceph-rgw role and
rook-ceph-purge-osd role. Without this commit, I cannot perform
rook-ceph-purge-osd job on PSP-enabled cluster.

Signed-off-by: Yuichiro Ueno <ueno@preferred.jp>

**Which issue is resolved by this Pull Request:**
Resolves #10243 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
