### PR TITLE
ci: Run tests against k8s 1.24

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -14,7 +14,7 @@ runs:
         go-version: 1.17
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.4.2
+      uses: manusa/actions-setup-minikube@v2.6.0
       with:
         minikube version: "v1.24.0"
         kubernetes version: "v1.23.0"

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -101,7 +101,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -135,7 +135,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -203,7 +203,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephObjectSuite
         run: |
@@ -237,7 +237,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephObjectSuite
         run: |
@@ -271,7 +271,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -305,7 +305,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.23.0"
+          kubernetes-version: "1.24.1"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-config/action.yaml
+++ b/.github/workflows/integration-test-config/action.yaml
@@ -17,9 +17,9 @@ runs:
       go-version: 1.17
 
   - name: setup minikube
-    uses: manusa/actions-setup-minikube@v2.4.2
+    uses: manusa/actions-setup-minikube@v2.6.0
     with:
-      minikube version: "v1.24.0"
+      minikube version: "v1.26.0"
       kubernetes version: ${{ inputs.kubernetes-version }}
       start args: --memory 6g --cpus=2 --addons ingress
       github token: ${{ inputs.github-token }}

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17', 'v1.23.0']
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.23.0']
+        kubernetes-versions : ['v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.23.0']
+        kubernetes-versions : ['v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17', 'v1.23.0']
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17', 'v1.23.0']
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17', 'v1.23.0']
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.19.16', 'v1.23.0']
+        kubernetes-versions : ['v1.19.16', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.23.0']
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.23.0']
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.23.0']
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.23.0']
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.19.16','v1.21.7', 'v1.23.0']
+        kubernetes-versions : ['v1.19.16','v1.21.7', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.17.17', 'v1.23.0']
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Since K8s 1.24.0 was released we need to run rook CI against the latest Kubernetes. At the same time, we update minikube in the CI to 1.25.2.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
