### PR TITLE
osd: Allow the osd to take a long time to start

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -48,14 +48,19 @@ const (
 	volumeMountSubPath                      = "data"
 	crashVolumeName                         = "rook-ceph-crash"
 	daemonSocketDir                         = "/run/ceph"
-	livenessProbeInitialDelaySeconds  int32 = 10
-	startupProbeFailuresDaemonDefault int32 = 6 // multiply by 10 = effective startup timeout
-	startupProbeFailuresDaemonOSD     int32 = 9 // multiply by 10 = effective startup timeout
 	logCollector                            = "log-collector"
 	DaemonIDLabel                           = "ceph_daemon_id"
 	daemonTypeLabel                         = "ceph_daemon_type"
 	ExternalMgrAppName                      = "rook-ceph-mgr-external"
 	ServiceExternalMetricName               = "http-external-metrics"
+	livenessProbeInitialDelaySeconds  int32 = 10
+	startupProbeFailuresDaemonDefault int32 = 6 // multiply by 10 = effective startup timeout
+	// The OSD requires a long timeout in case the OSD is taking extra time to
+	// scrub data during startup. We don't want the probe to disrupt the OSD update
+	// and restart the OSD prematurely. So we set a really long timeout to avoid
+	// disabling the startup and liveness probes completely.
+	// The default is two hours after multiplying by the 10s retry interval.
+	startupProbeFailuresDaemonOSD int32 = 12 * 60
 )
 
 type daemonConfig struct {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The startup probe for the OSD has been too aggressive to kill the OSD in case the OSD is taking some time to start. The OSD may be self-optimizing, scrubbing, or some other internal operation before it is ready to start. Rather than disable the startup probe completely, the default is now to retry for two hours in case the OSD is performing those operations.

**Which issue is resolved by this Pull Request:**
Resolves #10196 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
