### PR TITLE
helm: Only copy relevant monitoring settings

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ default .Release.Namespace .Values.clusterName }}
 spec:
   monitoring:
-{{ toYaml .Values.monitoring | indent 4 }}
+    enabled: {{ .Values.monitoring.enabled | default false }}
+{{- if .Values.monitoring.externalMgrEndpoints }}
+    externalMgrEndpoints:
+{{ toYaml .Values.monitoring.externalMgrEndpoints | indent 6 }}
+{{- end }}
+{{- if .Values.monitoring.externalMgrPrometheusPort }}
+    externalMgrPrometheusPort: {{ toYaml .Values.monitoring.externalMgrPrometheusPort }}
+{{- end }}
 
 {{ toYaml .Values.cephClusterSpec | indent 2 }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -4,6 +4,7 @@ kind: CephCluster
 metadata:
   name: {{ default .Release.Namespace .Values.clusterName }}
 spec:
+{{- if .Values.monitoring }}
   monitoring:
     enabled: {{ .Values.monitoring.enabled | default false }}
 {{- if .Values.monitoring.externalMgrEndpoints }}
@@ -12,6 +13,7 @@ spec:
 {{- end }}
 {{- if .Values.monitoring.externalMgrPrometheusPort }}
     externalMgrPrometheusPort: {{ toYaml .Values.monitoring.externalMgrPrometheusPort }}
+{{- end }}
 {{- end }}
 
 {{ toYaml .Values.cephClusterSpec | indent 2 }}

--- a/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring }}
 {{- if .Values.monitoring.createPrometheusRules }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -27,5 +28,6 @@ spec:
   {{- range $path, $bytes := .Files.Glob "prometheus/localrules.yaml" }}
   {{ $root.Files.Get $path | indent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -44,6 +44,9 @@ monitoring:
   # If you have multiple rook-ceph clusters in the same k8s cluster, choose the same namespace (ideally, namespace with prometheus
   # deployed) to set rulesNamespace for all the clusters. Otherwise, you will get duplicate alerts with multiple alert definitions.
   rulesNamespaceOverride:
+  # Monitoring settings for external clusters:
+  # externalMgrEndpoints: <list of endpoints>
+  # externalMgrPrometheusPort: <port>
 
 # If true, create & use PSP resources. Set this to the same value as the rook-ceph chart.
 pspEnable: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The cephcluster CR monitoring schema should be honored. The helm chart was creating extra values that didn't match the schema by copying the values such as createPrometheusRules that are only used for template evaluation. Now only the monitoring values from the schema will be added to the template.

**Which issue is resolved by this Pull Request:**
Resolves #10267 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
