### PR TITLE
operator: rename telemetry rook-version to rook/version

### DIFF
--- a/pkg/operator/ceph/cluster/telemetry/telemetry.go
+++ b/pkg/operator/ceph/cluster/telemetry/telemetry.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package telemetry codifes the Rook telemetry spec used to record Rook information for Ceph
+// telemetry. See: https://docs.ceph.com/en/latest/mgr/telemetry/
+package telemetry
+
+import (
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	rookversion "github.com/rook/rook/pkg/version"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "telemetry")
+
+const (
+	RookVersionKey = `rook/version`
+)
+
+// SetRookVersion sets the Rook version in Ceph's config-key store to allow Rook clusters that
+// enable Ceph telemetry to be identified easily as Rook clusters while additionally providing
+// useful information about the version of Rook that is managing the cluster.
+// e.g., rook/version=v1.8.7
+func SetRookVersion(context *clusterd.Context, clusterInfo *client.ClusterInfo) {
+	ms := config.GetMonStore(context, clusterInfo)
+	if err := ms.SetKeyValue(RookVersionKey, rookversion.Version); err != nil {
+		logger.Warningf("failed to set telemetry key; this cluster may not be identifiable by ceph telemetry as a Rook cluster. %v", err)
+	}
+}


### PR DESCRIPTION
The Rook and Ceph teams settled on using slashes to separate Rook
telemetry items into a hierarchy in https://github.com/rook/rook/pull/10254.
Rename the config-key used to `rook/version`, and create a `telemetry`
package to define the telemetry key constants.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Note: was originally added here: #10161

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
