### PR TITLE
docs: use absolute path for latest-release

### DIFF
--- a/.docs/overrides/main.html
+++ b/.docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block outdated %}
   This document is for a development version of Rook.
-  <a href="{{ '../' ~ base_url }}"> 
+  <a href="{{ '../' ~ base_url }}/latest-release/">
     <strong>Click here to go to latest release documentation.</strong>
   </a>
 {% endblock %}

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -50,9 +50,9 @@ DOCS_WORK_DIR := $(WORK_DIR)/rook.github.io
 DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/docs/rook/$(DOCS_VERSION)
 
 ifdef GIT_API_TOKEN
-DOCS_GIT_REPO := https://$(GIT_API_TOKEN)@github.com/koor-tech/rook.github.io.git
+DOCS_GIT_REPO := https://$(GIT_API_TOKEN)@github.com/rook/rook.github.io.git
 else
-DOCS_GIT_REPO := git@github.com:koor-tech/rook.github.io.git
+DOCS_GIT_REPO := git@github.com:rook/rook.github.io.git
 endif
 
 ifeq ($(origin BRANCH_NAME), undefined)


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Description of your changes:**

This should fix the banner url when on the `latest` or old doc versions, to correctly point to the latest release ("alias").

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.