### PR TITLE
build: Correct architecture for the release build

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   push-image-to-container-registry:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     if: github.repository == 'rook/rook'
     steps:
       - name: checkout
@@ -50,11 +50,6 @@ jobs:
         run: |
           echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
           echo "GITHUB_REF"=${GITHUB_REF} >> $GITHUB_ENV
-
-      - name: pip install
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install python3-pip
 
       - name: build and release
         env:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The push image build CI action is mistakenly running on arm64 instead of amd64, which is failing the build since it only expects amd64. The ubuntu 20.04 runner always seems to use arm instead of amd with 18.04, so let's try reverting to 18.04 for now.

This partially reverts #10289.

**Which issue is resolved by this Pull Request:**
Resolves #10282 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
