### PR TITLE
build: disable docs build in 1.8 branch

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -59,7 +59,7 @@ REMOTE_NAME ?= origin
 PLATFORMS ?= $(ALL_PLATFORMS)
 
 ifneq ($(filter master release-%,$(BRANCH_NAME)),)
-FLAVORS ?= output images docs helm
+FLAVORS ?= output images helm
 else
 FLAVORS ?= output
 override BRANCH_NAME := pr/$(BRANCH_NAME)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the full rework of the docs framework, we cannot support automated updating of docs from branches where the doc framework has not been backported. We are largely done with the 1.8 releases, so we can just disable publishing the docs for the 1.8 branch. If further updates are required in the docs, we can update the legacy docs directly in the rook.github.io repo.

**Which issue is resolved by this Pull Request:**
Resolves #10282 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
