### PR TITLE
build: Add setup tools package for docs publish

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -51,6 +51,16 @@ jobs:
           echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
           echo "GITHUB_REF"=${GITHUB_REF} >> $GITHUB_ENV
 
+      - name: install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.1.tar.gz -O libgit2-1.3.1.tar.gz
+          tar xzf libgit2-1.3.1.tar.gz
+          cd libgit2-1.3.1/
+          cmake .
+          make
+          sudo make install
+
       - name: build and release
         env:
           GIT_API_TOKEN: ${{ secrets.GIT_API_TOKEN }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The setup tools package is required on ubuntu 18.04 in order to install the mkdocs framework and publish the docs.

**Which issue is resolved by this Pull Request:**
Resolves #10282 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
