### PR TITLE
docs: add missing spec in ceph-fs-mirror example

### DIFF
--- a/Documentation/CRDs/Shared-Filesystem/ceph-fs-mirror-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-fs-mirror-crd.md
@@ -19,6 +19,7 @@ kind: CephFilesystemMirror
 metadata:
   name: my-fs-mirror
   namespace: rook-ceph
+spec: {}
 ```
 
 ## Settings


### PR DESCRIPTION
`spec` is a required field for the CephFilesystemMirror CRD

Signed-off-by: Benjamin Gentil <benjamin.gentil@infomaniak.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/v1.9/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/v1.9/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/v1.9/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

