### PR TITLE
rgw: make fqdn rgw converted to ip everywhere

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -929,7 +929,7 @@ class RadosJSON:
         pools_to_validate = [self._arg_parser.rbd_data_pool_name]
         # if rgw_endpoint is provided, validate it
         if self._arg_parser.rgw_endpoint:
-            rgw_endpoint = self.convert_fqdn_rgw_endpoint_to_ip(self._arg_parser.rgw_endpoint)
+            rgw_endpoint = self._arg_parser.rgw_endpoint
             self._invalid_endpoint(rgw_endpoint)
             self.endpoint_dial(rgw_endpoint,
                                cert=self.validate_rgw_endpoint_tls_cert())
@@ -1000,6 +1000,8 @@ class RadosJSON:
     def _gen_output_map(self):
         if self.out_map:
             return
+        if self._arg_parser.rgw_endpoint:
+            self._arg_parser.rgw_endpoint = self.convert_fqdn_rgw_endpoint_to_ip(self._arg_parser.rgw_endpoint)
         self.validate_pool()
         self.validate_rados_namespace()
         self._excluded_keys.add('CLUSTER_NAME')


### PR DESCRIPTION
During the recent additions of rgw validation
changes there are too many places where we use
rgw endpoint, so making fqdn to ip conversion globally

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
