### PR TITLE
csi: update cephfs osd caps

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -662,7 +662,7 @@ class RadosJSON:
             else:
                 entity = "{}-{}-{}".format(entity,
                                            cluster_name, cephfs_filesystem)
-                caps["osd"] = "allow rw tag cephfs data={}".format(
+                caps["osd"] = "allow rw tag cephfs *={}".format(
                     cephfs_filesystem)
 
         return caps, entity


### PR DESCRIPTION
Currently cephfs caps are data=filesystemname,
which only have write access, but not the read access
changing it to *=filesystemname so we can read data also

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
