### PR TITLE
test: Fix encrypted OSDs on latest Ceph releases and add canary test for encrypted osd in host-based cluster

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -338,7 +338,6 @@ jobs:
 
     - name: use local disk as OSD
       run: |
-
         BLOCK=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)
         tests/scripts/github-action-helper.sh use_local_disk
         tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
@@ -351,6 +350,52 @@ jobs:
 
     - name: deploy cluster
       run: tests/scripts/github-action-helper.sh deploy_cluster osd_with_metadata_device
+
+    - name: wait for prepare pod
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+
+    - name: wait for ceph to be ready
+      run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
+
+    - name: check-ownerreferences
+      run: tests/scripts/github-action-helper.sh check_ownerreferences
+
+    - name: collect common logs
+      if: always()
+      uses: ./.github/workflows/collect-logs
+      with:
+        name: canary
+
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+
+  encryption:
+    runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: setup cluster resources
+      uses: ./.github/workflows/canary-test-config
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: validate-yaml
+      run: tests/scripts/github-action-helper.sh validate_yaml
+
+    - name: use local disk as OSD
+      run: |
+        BLOCK=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        tests/scripts/github-action-helper.sh use_local_disk
+        tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
+
+    - name: deploy cluster
+      run: tests/scripts/github-action-helper.sh deploy_cluster encryptiton
 
     - name: wait for prepare pod
       run: tests/scripts/github-action-helper.sh wait_for_prepare_pod

--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -50,7 +50,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7
 Ceph OSDs have a dependency on LVM in the following scenarios:
 
 * OSDs are created on raw devices or partitions
-* If encryption is enabled (`encryptedDevice: true` in the cluster CR)
+* If encryption is enabled (`encryptedDevice: "true"` in the cluster CR)
 * A `metadata` device is specified
 
 LVM is not required for OSDs in these scenarios:

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -64,6 +64,7 @@ const (
 	bluestoreBlockName    = "block"
 	bluestoreMetadataName = "block.db"
 	bluestoreWalName      = "block.wal"
+	tempEtcCephDir        = "/etc/temp-ceph"
 )
 
 const (
@@ -74,11 +75,35 @@ set -o nounset # fail if variables are unset
 set -o xtrace
 
 OSD_ID="$ROOK_OSD_ID"
+CEPH_FSID=%s
 OSD_UUID=%s
 OSD_STORE_FLAG="%s"
 OSD_DATA_DIR=/var/lib/ceph/osd/ceph-"$OSD_ID"
 CV_MODE=%s
 DEVICE="$%s"
+
+# "ceph.conf" must have the "fsid" global configuration to activate encrypted OSDs
+# after the following Ceph's PR is merged.
+# https://github.com/ceph/ceph/commit/25655e5a8829e001adf467511a6bde8142b0a575
+# This limitation will be removed later. After that, we can remove this
+# fsid injection code. Probably a good time is when to remove Quincy support.
+# https://github.com/rook/rook/pull/10333#discussion_r892817877
+cp --no-preserve=mode /etc/temp-ceph/ceph.conf /etc/ceph/ceph.conf
+python3 -c "
+import configparser
+
+config = configparser.ConfigParser()
+config.read('/etc/ceph/ceph.conf')
+
+if not config.has_section('global'):
+    config['global'] = {}
+
+if not config.has_option('global','fsid'):
+    config['global']['fsid'] = '$CEPH_FSID'
+
+with open('/etc/ceph/ceph.conf', 'w') as configfile:
+    config.write(configfile)
+"
 
 # create new keyring
 ceph -n client.admin auth get-or-create osd."$OSD_ID" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring
@@ -750,7 +775,7 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 	volMounts := []v1.VolumeMount{
 		{Name: activateOSDVolumeName, MountPath: activateOSDMountPathID},
 		{Name: "devices", MountPath: "/dev"},
-		{Name: k8sutil.ConfigOverrideName, ReadOnly: true, MountPath: opconfig.EtcCephDir},
+		{Name: k8sutil.ConfigOverrideName, ReadOnly: true, MountPath: tempEtcCephDir},
 	}
 	volMounts = append(volMounts, adminKeyringVolMount)
 
@@ -762,7 +787,7 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			fmt.Sprintf(activateOSDOnNodeCode, osdInfo.UUID, osdStore, osdInfo.CVMode, blockPathVarName),
+			fmt.Sprintf(activateOSDOnNodeCode, c.clusterInfo.FSID, osdInfo.UUID, osdStore, osdInfo.CVMode, blockPathVarName),
 		},
 		Name:            "activate",
 		Image:           c.spec.CephVersion.Image,

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -214,6 +214,8 @@ function deploy_cluster() {
     sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\/}\n    config:\n      osdsPerDevice: \"2\"|g" cluster-test.yaml
   elif [ "$1" = "osd_with_metadata_device" ] ; then
     sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\/}\n    config:\n      metadataDevice: /dev/test-rook-vg/test-rook-lv|g" cluster-test.yaml
+  elif [ "$1" = "encryption" ] ; then
+    sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\/}\n    config:\n      encryptedDevice: \"true\"|g" cluster-test.yaml
   fi
   kubectl create -f cluster-test.yaml
   kubectl create -f object-test.yaml


### PR DESCRIPTION
**Description of your changes:**


- encrypted OSD on device don't startup a if Ceph applied [this change](https://github.com/ceph/ceph/commit/25655e5a8829e001adf467511a6bde8142b0a575).
- It's better to test the creation of encrypted devices in host-based clusters. This test will reduce the potential risks of regression
when modifying the osd-creation code.

Resolves: #10375

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
