### PR TITLE
core: Report basic cluster and version telemetry

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strconv"
+	"sync"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -40,6 +42,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	rookversion "github.com/rook/rook/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +52,8 @@ import (
 const (
 	detectVersionName = "rook-ceph-detect-version"
 )
+
+var telemetryMutex sync.Mutex
 
 type cluster struct {
 	ClusterInfo        *client.ClusterInfo
@@ -217,6 +222,10 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 
 	// Start the monitoring if not already started
 	c.configureCephMonitoring(cluster, cluster.ClusterInfo)
+
+	// Asynchronously report the telemetry to allow another reconcile to proceed if needed
+	go cluster.reportTelemetry()
+
 	return nil
 }
 
@@ -486,9 +495,6 @@ func (c *cluster) skipMDSSanityChecks(skip bool) error {
 // It gets executed right after the main mon Start() method
 // Basically, it is executed between the monitors and the manager sequence
 func (c *cluster) postMonStartupActions() error {
-	// Identify this as a rook cluster for Ceph telemetry by setting the Rook version.
-	telemetry.SetRookVersion(c.context, c.ClusterInfo)
-
 	// Create CSI Kubernetes Secrets
 	err := csi.CreateCSISecrets(c.context, c.ClusterInfo)
 	if err != nil {
@@ -531,6 +537,62 @@ func (c *cluster) postMonStartupActions() error {
 	}
 
 	return nil
+}
+
+func (c *cluster) reportTelemetry() {
+	// In the corner case that reconciles are started in quick succession and the telemetry
+	// hasn't had a chance to complete yet from a previous reconcile, simply allow
+	// a single goroutine to report telemetry at a time.
+	telemetryMutex.Lock()
+	defer telemetryMutex.Unlock()
+
+	// Identify this as a rook cluster for Ceph telemetry by setting the Rook version.
+	logger.Info("reporting cluster telemetry")
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.RookVersionKey, rookversion.Version)
+
+	// Report the K8s version
+	serverVersion, err := c.context.Clientset.Discovery().ServerVersion()
+	if err != nil {
+		logger.Warningf("failed to report the K8s server version. %v", err)
+	} else {
+		telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.K8sVersionKey, serverVersion.String())
+	}
+
+	// Report the CSI version if it has been detected
+	if telemetry.CSIVersion != "" {
+		telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.CSIVersionKey, telemetry.CSIVersion)
+	}
+
+	// Report the max mon id
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.MonMaxIDKey, strconv.Itoa(c.mons.MaxMonID()))
+
+	// Report the telemetry for mon settings
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.MonCountKey, strconv.Itoa(c.Spec.Mon.Count))
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.MonAllowMultiplePerNodeKey, strconv.FormatBool(c.Spec.Mon.AllowMultiplePerNode))
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.MonPVCEnabledKey, strconv.FormatBool(c.Spec.Mon.VolumeClaimTemplate != nil))
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.MonStretchEnabledKey, strconv.FormatBool(c.Spec.IsStretchCluster()))
+
+	// Set the telemetry for device sets
+	deviceSets := 0
+	portableDeviceSets := 0
+	nonportableDeviceSets := 0
+	for _, deviceSet := range c.Spec.Storage.StorageClassDeviceSets {
+		deviceSets++
+		if deviceSet.Portable {
+			portableDeviceSets++
+		} else {
+			nonportableDeviceSets++
+		}
+	}
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.DeviceSetTotalKey, strconv.Itoa(deviceSets))
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.DeviceSetPortableKey, strconv.Itoa(portableDeviceSets))
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.DeviceSetNonPortableKey, strconv.Itoa(nonportableDeviceSets))
+
+	// Set the telemetry for network settings
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.NetworkProviderKey, c.Spec.Network.Provider)
+
+	// Set the telemetry for external cluster settings
+	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.ExternalModeEnabledKey, strconv.FormatBool(c.Spec.External.Enable))
 }
 
 func (c *cluster) configureMsgr2() error {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -156,6 +156,10 @@ func New(ctx context.Context, clusterdContext *clusterd.Context, namespace strin
 	}
 }
 
+func (c *Cluster) MaxMonID() int {
+	return c.maxMonID
+}
+
 // Start begins the process of running a cluster of Ceph mons.
 func (c *Cluster) Start(clusterInfo *cephclient.ClusterInfo, rookVersion string, cephVersion cephver.CephVersion, spec cephv1.ClusterSpec) (*cephclient.ClusterInfo, error) {
 	// Only one goroutine can orchestrate the mons at a time

--- a/pkg/operator/ceph/cluster/telemetry/telemetry.go
+++ b/pkg/operator/ceph/cluster/telemetry/telemetry.go
@@ -23,22 +23,33 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	rookversion "github.com/rook/rook/pkg/version"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "telemetry")
 
 const (
-	RookVersionKey = `rook/version`
+	RookVersionKey             = "rook/version"
+	K8sVersionKey              = "rook/kubernetes/version"
+	CSIVersionKey              = "rook/csi/version"
+	MonMaxIDKey                = "rook/cluster/mon/max-id"
+	MonCountKey                = "rook/cluster/mon/count"
+	MonAllowMultiplePerNodeKey = "rook/cluster/mon/allow-multiple-per-node"
+	MonPVCEnabledKey           = "rook/cluster/mon/pvc/enabled"
+	MonStretchEnabledKey       = "rook/cluster/mon/stretch/enabled"
+	DeviceSetTotalKey          = "rook/cluster/storage/device-set/count/total"
+	DeviceSetPortableKey       = "rook/cluster/storage/device-set/count/portable"
+	DeviceSetNonPortableKey    = "rook/cluster/storage/device-set/count/non-portable"
+	NetworkProviderKey         = "rook/cluster/network/provider"
+	ExternalModeEnabledKey     = "rook/cluster/external-mode"
 )
 
-// SetRookVersion sets the Rook version in Ceph's config-key store to allow Rook clusters that
-// enable Ceph telemetry to be identified easily as Rook clusters while additionally providing
-// useful information about the version of Rook that is managing the cluster.
-// e.g., rook/version=v1.8.7
-func SetRookVersion(context *clusterd.Context, clusterInfo *client.ClusterInfo) {
+var CSIVersion string
+
+func ReportKeyValue(context *clusterd.Context, clusterInfo *client.ClusterInfo, key, value string) {
 	ms := config.GetMonStore(context, clusterInfo)
-	if err := ms.SetKeyValue(RookVersionKey, rookversion.Version); err != nil {
-		logger.Warningf("failed to set telemetry key; this cluster may not be identifiable by ceph telemetry as a Rook cluster. %v", err)
+	if err := ms.SetKeyValue(key, value); err != nil {
+		logger.Warningf("failed to set telemetry key %q. %v", key, err)
+		return
 	}
+	logger.Debugf("set telemetry key: %s=%s", key, value)
 }

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rook/rook/pkg/operator/ceph/cluster/telemetry"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/k8sutil/cmdreporter"
@@ -739,6 +740,10 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 		return nil, errors.Wrap(err, "failed to extract ceph CSI version")
 	}
 	logger.Infof("Detected ceph CSI image version: %q", version)
+
+	// Set the CSI version on a package variable so that each cluster reporting the
+	// telemetry can report the same CSI version
+	telemetry.CSIVersion = version.String()
 
 	if !version.Supported() {
 		return nil, errors.Errorf("ceph CSI image needs to be at least version %q", minimum.String())


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
For the ceph telemetry report the csi version, k8s version, and metrics from the desired state in the cephcluster CR such as mon count, stretch cluster, number of device sets, and so on.

This is the next round of rook telemetry reported as defined in the [telemetry design doc](https://github.com/rook/rook/blob/master/design/ceph/ceph-telemetry.md).

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
