### PR TITLE
ceph: Add holder pod if csi host networking is disabled

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1191,7 +1191,7 @@ jobs:
       run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
 
     - name: wait for ceph to be ready
-      run: IS_MULTUS=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd_multus 2
+      run: IS_POD_NETWORK=true IS_MULTUS=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd_multus 2
 
     - name: wait for ceph-csi configmap to be updated with network namespace
       run: tests/scripts/github-action-helper.sh wait_for_ceph_csi_configmap_to_be_updated
@@ -1207,6 +1207,55 @@ jobs:
       uses: ./.github/workflows/collect-logs
       with:
         name: canary-multus
+
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+
+  csi-hostnetwork-disabled:
+    runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: setup cluster resources
+      uses: ./.github/workflows/canary-test-config
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+
+    - name: use local disk and create partitions for osds
+      run: |
+        tests/scripts/github-action-helper.sh use_local_disk
+        tests/scripts/github-action-helper.sh create_partitions_for_osds
+
+    - name: deploy CSI hostNetworking disabled cluster
+      run: tests/scripts/github-action-helper.sh deploy_csi_hostnetwork_disabled_cluster
+
+    - name: wait for prepare pod
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+
+    - name: wait for ceph to be ready
+      run: IS_POD_NETWORK=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+
+    - name: wait for ceph-csi configmap to be updated with network namespace
+      run: tests/scripts/github-action-helper.sh wait_for_ceph_csi_configmap_to_be_updated
+
+    - name: test ceph-csi-rbd plugin restart
+      run: tests/scripts/github-action-helper.sh test_csi_rbd_workload
+
+    - name: test ceph-csi-cephfs plugin restart
+      run: tests/scripts/github-action-helper.sh test_csi_cephfs_workload
+
+    - name: collect common logs
+      if: always()
+      uses: ./.github/workflows/collect-logs
+      with:
+        name: csi-hostnetwork-disabled
 
     - name: setup tmate session for debugging when event is PR
       if: failure() && github.event_name == 'pull_request'

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -42,9 +42,9 @@ func TestReconcileCSI_configureHolders(t *testing.T) {
 			Clientset:     testop.New(t, 1),
 			RookClientset: rookclient.NewSimpleClientset(),
 		},
-		opManagerContext: context.TODO(),
-		opConfig:         opcontroller.OperatorConfig{},
-		multusClusters:   []ClusterDetail{},
+		opManagerContext:   context.TODO(),
+		opConfig:           opcontroller.OperatorConfig{},
+		clustersWithHolder: []ClusterDetail{},
 	}
 
 	t.Run("no clusters, noop", func(t *testing.T) {
@@ -68,7 +68,7 @@ func TestReconcileCSI_configureHolders(t *testing.T) {
 			Namespace: r.opConfig.OperatorNamespace,
 		}
 
-		r.multusClusters = []ClusterDetail{
+		r.clustersWithHolder = []ClusterDetail{
 			{
 				cluster: &cephv1.CephCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph", Name: "my-cluster"},

--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-holder.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-holder.yaml
@@ -1,9 +1,9 @@
-# This DaemonSet is only active when the cluster is deployed with Multus enabled. Hopefully in the
-# future it will be part of every Ceph-CSI deployment. Its role is to "hold" the Ceph Filesystem
-# mounts that are created by the CSI driver. Essentially, it exposes its network namespace into the
-# Kubelet plugin directly and Ceph-CSI picks it up. When mounting, the Ceph-CSI driver will use the
-# network namespace of the DaemonSet instead of its own (the plugin pod). This pod is not expected
-# to be updated nor restarted unless the node reboots.
+# This DaemonSet is only active when the cluster is deployed with Multus enabled or EnableCSIHostNetwork
+# is set to false. Hopefully in the future it will be part of every Ceph-CSI deployment. Its role is to
+# "hold" the Ceph Filesystem mounts that are created by the CSI driver. Essentially, it exposes its
+# network namespace into the Kubelet plugin directly and Ceph-CSI picks it up. When mounting, the Ceph-CSI
+# driver will use the network namespace of the DaemonSet instead of its own (the plugin pod). This pod
+# is not expected to be updated nor restarted unless the node reboots.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-holder.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-holder.yaml
@@ -1,9 +1,9 @@
-# This DaemonSet is only active when the cluster is deployed with Multus enabled. Hopefully in the
-# future it will be part of every Ceph-CSI deployment. Its role is to "hold" the network RBD block
-# mapping that are created by the CSI driver. Essentially, it exposes its network namespace into the
-# Kubelet plugin directly and Ceph-CSI picks it up. When mapping an RBD image, the Ceph-CSI driver
-# will use the network namespace of the DaemonSet instead of its own (the plugin pod). This pod is
-# not expected to be updated nor restarted unless the node reboots.
+# This DaemonSet is only active when the cluster is deployed with Multus enabled or EnableCSIHostNetwork
+# is set to false. Hopefully in the future it will be part of every Ceph-CSI deployment. Its role is
+# to "hold" the network RBD block mapping that are created by the CSI driver. Essentially, it exposes
+# its network namespace into the Kubelet plugin directly and Ceph-CSI picks it up. When mapping an RBD
+# image, the Ceph-CSI driver will use the network namespace of the DaemonSet instead of its own (the plugin pod).
+# This pod is not expected to be updated nor restarted unless the node reboots.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -40,8 +40,8 @@ var (
 	// custom ceph.conf is supported in v3.5.0+
 	cephConfSupportedVersion = CephCSIVersion{3, 5, 0}
 
-	// multus fix with the extra holder pod is supported with at least v3.6.1
-	multusSupportedVersion = CephCSIVersion{3, 6, 1}
+	// pod networking fix with the extra holder pod is supported with at least v3.6.1
+	nsenterSupportedVersion = CephCSIVersion{3, 6, 1}
 
 	// for parsing the output of `cephcsi`
 	versionCSIPattern = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
@@ -131,13 +131,13 @@ func (v *CephCSIVersion) SupportsCustomCephConf() bool {
 	return v.isAtLeast(&cephConfSupportedVersion)
 }
 
-// SupportsMultus checks if the csi image has support for calling "nsenter" while executing
+// SupportsNsenter checks if the csi image has support for calling "nsenter" while executing
 // mount/map commands. This is needed for Multus scenarios.
-func (v *CephCSIVersion) SupportsMultus() bool {
+func (v *CephCSIVersion) SupportsNsenter() bool {
 	// if AllowUnsupported is set also a csi-image greater than the supported ones are allowed
 	if AllowUnsupported {
 		return true
 	}
 
-	return v.isAtLeast(&multusSupportedVersion)
+	return v.isAtLeast(&nsenterSupportedVersion)
 }

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -114,22 +114,22 @@ func TestSupportsCustomCephConf(t *testing.T) {
 	assert.True(t, ret)
 }
 
-func TestSupportsMultus(t *testing.T) {
+func TestSupportsNsenter(t *testing.T) {
 	t.Run("AllowUnsupported=true regardless of the version", func(t *testing.T) {
 		AllowUnsupported = true
-		ret := testMinVersion.SupportsMultus()
+		ret := testMinVersion.SupportsNsenter()
 		assert.True(t, ret)
 	})
 
 	t.Run("AllowUnsupported=false and version 3.5 is too old", func(t *testing.T) {
 		AllowUnsupported = false
-		ret := testMinVersion.SupportsMultus()
+		ret := testMinVersion.SupportsNsenter()
 		assert.False(t, ret)
 	})
 
 	t.Run("AllowUnsupported=false and version 3.6.1 is fine", func(t *testing.T) {
 		AllowUnsupported = false
-		ret := testReleaseV361.SupportsMultus()
+		ret := testReleaseV361.SupportsNsenter()
 		assert.True(t, ret)
 	})
 }

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -89,17 +89,20 @@ function test_demo_pool {
 
 function test_csi {
   timeout 360 bash -x <<-'EOF'
+    echo $IS_POD_NETWORK
     echo $IS_MULTUS
-    if [ -z $IS_MULTUS ]; then
+    if [ -z "$IS_POD_NETWORK" ]; then
       until [[ "$(kubectl -n rook-ceph get pods --field-selector=status.phase=Running|grep -c ^csi-)" -eq 4 ]]; do
         echo "waiting for csi pods to be ready"
         sleep 5
       done
     else
       until [[ "$(kubectl -n rook-ceph get pods --field-selector=status.phase=Running|grep -c ^csi-)" -eq 6 ]]; do
-        echo "waiting for csi pods to be ready with multus"
+        echo "waiting for csi pods to be ready with multus or pod networking"
         sleep 5
       done
+    fi
+    if [ -n "$IS_MULTUS" ]; then
       echo "verifying csi holder interfaces (multus ones must be present)"
       kubectl -n rook-ceph exec -t ds/csi-rbdplugin-holder-my-cluster -- grep net /proc/net/dev
       kubectl -n rook-ceph exec -t ds/csi-cephfsplugin-holder-my-cluster -- grep net /proc/net/dev


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

If csi is configured not the use the hostnetworking, deploy the holder pod for executing the commands with nsenter.
The implementation is the same as multus.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


Note:
```
Added DNM label as testing is still pending
```