### PR TITLE
csi: add volumeattachment list rbac

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -493,7 +493,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -99,7 +99,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

rbd node plugin needs volumeattachment RBAC to remount, the volume in case of the nbd driver is used to mount the volume.
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

```
E0531 04:50:56.553128     589 rbd_healer.go:141] list volumeAttachments failed, err: volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
E0531 04:50:56.553147     589 driver.go:198] healer had failures, err volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
```

Found this in CI run [here](https://github.com/rook/rook/runs/6664462968?check_suite_focus=true)

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
