### PR TITLE
pool: Delete ceph pool when blockpool cr is deleted

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/pool_test.go
+++ b/pkg/apis/ceph.rook.io/v1/pool_test.go
@@ -37,11 +37,11 @@ func TestValidatePoolSpec(t *testing.T) {
 			},
 		},
 	}
-	err := validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err := validatePoolSpec(p.ToNamedPoolSpec())
 	assert.NoError(t, err)
 
 	p.Spec.ErasureCoded.DataChunks = 1
-	err = validatePoolSpec(p.Spec.ToNamedPoolSpec())
+	err = validatePoolSpec(p.ToNamedPoolSpec())
 	assert.Error(t, err)
 }
 

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -123,22 +123,27 @@ func TestCreatePool(t *testing.T) {
 func TestCephPoolName(t *testing.T) {
 	t.Run("spec not set", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "metapool"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "metapool", name)
 	})
 	t.Run("same name already set", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "metapool"}, Spec: cephv1.NamedBlockPoolSpec{Name: "metapool"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "metapool", name)
 	})
 	t.Run("override device metrics", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "device-metrics"}, Spec: cephv1.NamedBlockPoolSpec{Name: "device_health_metrics"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "device_health_metrics", name)
+	})
+	t.Run("override mgr", func(t *testing.T) {
+		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "default-mgr"}, Spec: cephv1.NamedBlockPoolSpec{Name: ".mgr"}}
+		name := p.ToNamedPoolSpec().Name
+		assert.Equal(t, ".mgr", name)
 	})
 	t.Run("override nfs", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "default-nfs"}, Spec: cephv1.NamedBlockPoolSpec{Name: ".nfs"}}
-		name := getCephName(p)
+		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, ".nfs", name)
 	})
 }

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -33,7 +33,7 @@ func validatePool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo
 		return errors.New("missing namespace")
 	}
 
-	if err := cephv1.ValidateCephBlockPool(&p.Spec); err != nil {
+	if err := cephv1.ValidateCephBlockPool(p); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
During deletion of a CephBlockPool CR, the underlying ceph pool was not being deleted. During the deletion sequence this is due to the spec being refreshed upon a call to check for dependents in ReportDeletionNotBlockedDueToDependents(). The pool name was then coming up blank during the deletion request and rook of course then wasn't finding the pool to delete.

Now Rook properly sets the pool name in the named spec every time it is converted internally from a CephBlockPool type to a NamedPoolSpec.

This does not repro in v1.8.9, it seems to be a regression in v1.9.

**Which issue is resolved by this Pull Request:**
Resolves #10360 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
