### PR TITLE
build: Flannel flag to minikube is causing test failures

### DIFF
--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         minikube version: "v1.24.0"
         kubernetes version: "v1.23.0"
-        start args: --memory 6g --cpus=2 --addons ingress --cni=flannel
+        start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 
     - name: install deps


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The minikube node is staying in NotReady state and preventing the operator from even starting in the canary and other suites that use the setup-cluster-resources action.

The failing tests are all waiting for the osd prepare pods to start, but the cluster doesn't get near that far since the operator is stuck pending for the node to get to Ready state.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
