### PR TITLE
osd: ignore the region label when it is the same as zone label in topology

### DIFF
--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -93,6 +93,11 @@ func extractTopologyFromLabels(labels map[string]string) (map[string]string, str
 		topologyAffinity = formatTopologyAffinity(corev1.LabelZoneFailureDomainStable, zone)
 	}
 
+	// ignore the region k8s topology label when it has the same value as the k8s zone label
+	if topology[regionLabel] == topology[zoneLabel] {
+		delete(topology, regionLabel)
+	}
+
 	// get host
 	host, ok := labels[corev1.LabelHostname]
 	if ok {

--- a/pkg/operator/ceph/cluster/osd/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology_test.go
@@ -134,4 +134,14 @@ func TestTopologyLabels(t *testing.T) {
 	topology, affinity = extractTopologyFromLabels(nodeLabels)
 	assert.Equal(t, 0, len(topology))
 	assert.Equal(t, "", affinity)
+
+	// ignore the region k8s topology label when it has the same value as the k8s zone label
+	nodeLabels = map[string]string{
+		corev1.LabelZoneRegionStable:        "zone",
+		corev1.LabelZoneFailureDomainStable: "zone",
+	}
+	topology, affinity = extractTopologyFromLabels(nodeLabels)
+	assert.Equal(t, 1, len(topology))
+	assert.Equal(t, "zone", topology["zone"])
+	assert.Equal(t, "topology.kubernetes.io/zone=zone", affinity)
 }


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Ceph requires all topology label being unique. And it is quite common to
have topology.kubernetes.io/region and topology.kubernetes.io/zone being set
to the same value. In this case, let's just ignore the region label.

See https://github.com/rook/rook/issues/9419#issuecomment-1144311818

**Which issue is resolved by this Pull Request:**

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
