### PR TITLE
external: format python files using tool black

### DIFF
--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -1,4 +1,4 @@
-'''
+"""
 Copyright 2022 The Rook Authors. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,9 +9,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-'''
+"""
 
 import unittest
+
 # This package is available since python 3.x and this is the unit test so backward compatibility will not be an issue.
 import importlib
 import sys
@@ -34,7 +35,13 @@ ext = importlib.import_module("create-external-cluster-resources")
 class TestRadosJSON(unittest.TestCase):
     def setUp(self):
         print("\nI am in setup")
-        self.rjObj = ext.RadosJSON(['--rbd-data-pool-name=abc', '--rgw-endpoint=10.10.212.122:9000', '--format=json'])
+        self.rjObj = ext.RadosJSON(
+            [
+                "--rbd-data-pool-name=abc",
+                "--rgw-endpoint=10.10.212.122:9000",
+                "--format=json",
+            ]
+        )
         # for testing, we are using 'DummyRados' object
         self.rjObj.cluster = ext.DummyRados.Rados()
 
@@ -51,7 +58,7 @@ class TestRadosJSON(unittest.TestCase):
         self.rjObj.main()
         print("\n\nNon compatible output (--abcd)")
         try:
-            self.rjObj._arg_parser.format = 'abcd'
+            self.rjObj._arg_parser.format = "abcd"
             self.rjObj.main()
             self.fail("Function should have thrown an Exception")
         except ext.ExecutionFailureException as err:
@@ -59,36 +66,44 @@ class TestRadosJSON(unittest.TestCase):
 
     def test_method_create_cephCSIKeyring_cephFSProvisioner(self):
         csiKeyring = self.rjObj.create_cephCSIKeyring_user(
-            "client.csi-cephfs-provisioner")
-        print("cephCSIKeyring without restricting it to a metadata pool. {}".format(
-            csiKeyring))
+            "client.csi-cephfs-provisioner"
+        )
+        print(
+            "cephCSIKeyring without restricting it to a metadata pool. {}".format(
+                csiKeyring
+            )
+        )
         self.rjObj._arg_parser.restricted_auth_permission = True
         self.rjObj._arg_parser.cluster_name = "openshift-storage"
         csiKeyring = self.rjObj.create_cephCSIKeyring_user(
-            "client.csi-cephfs-provisioner")
+            "client.csi-cephfs-provisioner"
+        )
         print("cephCSIKeyring for a specific cluster. {}".format(csiKeyring))
         self.rjObj._arg_parser.cephfs_filesystem_name = "myfs"
         csiKeyring = self.rjObj.create_cephCSIKeyring_user(
-            "client.csi-cephfs-provisioner")
-        print("cephCSIKeyring for a specific metadata pool and cluster. {}".format(
-            csiKeyring))
+            "client.csi-cephfs-provisioner"
+        )
+        print(
+            "cephCSIKeyring for a specific metadata pool and cluster. {}".format(
+                csiKeyring
+            )
+        )
 
     def test_non_zero_return_and_error(self):
         self.rjObj.cluster.return_val = 1
         self.rjObj.cluster.err_message = "Dummy Error"
         try:
             self.rjObj.create_checkerKey()
-            self.fail(
-                "Failed to raise an exception, 'ext.ExecutionFailureException'")
+            self.fail("Failed to raise an exception, 'ext.ExecutionFailureException'")
         except ext.ExecutionFailureException as err:
             print("Successfully thrown error.\nError: {}".format(err))
 
     def test_multi_filesystem_scenario(self):
-        cmd_key = self.rjObj.cluster.cmd_names['fs ls']
+        cmd_key = self.rjObj.cluster.cmd_names["fs ls"]
         cmd_out = self.rjObj.cluster.cmd_output_map[cmd_key]
         cmd_json_out = json.loads(cmd_out)
         second_fs_details = dict(cmd_json_out[0])
-        second_fs_details['name'] += '-2'
+        second_fs_details["name"] += "-2"
         cmd_json_out.append(second_fs_details)
         self.rjObj.cluster.cmd_output_map[cmd_key] = json.dumps(cmd_json_out)
         # multiple filesystem present,
@@ -98,10 +113,13 @@ class TestRadosJSON(unittest.TestCase):
             print("As we are returning silently, no error thrown as expected")
         except ext.ExecutionFailureException as err:
             self.fail(
-                "Supposed to get returned silently, but instead error thrown: {}".format(err))
+                "Supposed to get returned silently, but instead error thrown: {}".format(
+                    err
+                )
+            )
         # pass an existing filesystem name
         try:
-            self.rjObj._arg_parser.cephfs_filesystem_name = second_fs_details['name']
+            self.rjObj._arg_parser.cephfs_filesystem_name = second_fs_details["name"]
             self.rjObj.get_cephfs_data_pool_details()
         except ext.ExecutionFailureException as err:
             self.fail("Should not have thrown error: {}".format(err))
@@ -121,18 +139,18 @@ class TestRadosJSON(unittest.TestCase):
             print("Successfully thrown error: {}".format(err))
 
     def test_multi_data_pool_scenario(self):
-        cmd_key = self.rjObj.cluster.cmd_names['fs ls']
+        cmd_key = self.rjObj.cluster.cmd_names["fs ls"]
         cmd_out = self.rjObj.cluster.cmd_output_map[cmd_key]
         cmd_json_out = json.loads(cmd_out)
         first_fs_details = cmd_json_out[0]
-        new_data_pool_name = 'myfs-data1'
-        first_fs_details['data_pools'].append(new_data_pool_name)
+        new_data_pool_name = "myfs-data1"
+        first_fs_details["data_pools"].append(new_data_pool_name)
         print("Modified JSON Cmd Out: {}".format(cmd_json_out))
         self.rjObj._arg_parser.cephfs_data_pool_name = new_data_pool_name
         self.rjObj.cluster.cmd_output_map[cmd_key] = json.dumps(cmd_json_out)
         self.rjObj.get_cephfs_data_pool_details()
         # use a non-existing data-pool-name
-        bad_data_pool_name = 'myfs-data3'
+        bad_data_pool_name = "myfs-data3"
         self.rjObj._arg_parser.cephfs_data_pool_name = bad_data_pool_name
         try:
             self.rjObj.get_cephfs_data_pool_details()
@@ -140,7 +158,7 @@ class TestRadosJSON(unittest.TestCase):
         except ext.ExecutionFailureException as err:
             print("Successfully thrown error: {}".format(err))
         # empty data-pool scenario
-        first_fs_details['data_pools'] = []
+        first_fs_details["data_pools"] = []
         self.rjObj.cluster.cmd_output_map[cmd_key] = json.dumps(cmd_json_out)
         try:
             self.rjObj.get_cephfs_data_pool_details()
@@ -178,35 +196,50 @@ class TestRadosJSON(unittest.TestCase):
             self.fail("An Exception was expected to be thrown")
         except ext.ExecutionFailureException as err:
             print("Successfully thrown error: {}".format(err))
-            
+
     def test_convert_fqdn_rgw_endpoint_to_ip(self):
         try:
-            rgw_endpoint_ip = self.rjObj.convert_fqdn_rgw_endpoint_to_ip("www.redhat.com:80")
-            print("Successfully Converted www.redhat.com to it's IP {}".format(rgw_endpoint_ip))
-        except  ext.ExecutionFailureException as err:
-            print("Successfully thrown error: {}".format(err))   
-        
+            rgw_endpoint_ip = self.rjObj.convert_fqdn_rgw_endpoint_to_ip(
+                "www.redhat.com:80"
+            )
+            print(
+                "Successfully Converted www.redhat.com to it's IP {}".format(
+                    rgw_endpoint_ip
+                )
+            )
+        except ext.ExecutionFailureException as err:
+            print("Successfully thrown error: {}".format(err))
+
     def test_upgrade_user_permissions(self):
         self.rjObj = ext.RadosJSON(
-            ['--upgrade', '--run-as-user=client.csi-cephfs-provisioner', '--format=json'])
+            [
+                "--upgrade",
+                "--run-as-user=client.csi-cephfs-provisioner",
+                "--format=json",
+            ]
+        )
         # for testing, we are using 'DummyRados' object
         self.rjObj.cluster = ext.DummyRados.Rados()
         self.rjObj.main()
 
     def test_monitoring_endpoint_validation(self):
-        self.rjObj = ext.RadosJSON(
-            ['--rbd-data-pool-name=abc', '--format=json'])
+        self.rjObj = ext.RadosJSON(["--rbd-data-pool-name=abc", "--format=json"])
         self.rjObj.cluster = ext.DummyRados.Rados()
 
-        valid_ip_ports = [("10.22.31.131", "3534"),
-                          ("10.177.3.81", ""), ("", ""), ("", "9092")]
+        valid_ip_ports = [
+            ("10.22.31.131", "3534"),
+            ("10.177.3.81", ""),
+            ("", ""),
+            ("", "9092"),
+        ]
         for each_ip_port_pair in valid_ip_ports:
             # reset monitoring ip and port
-            self.rjObj._arg_parser.monitoring_endpoint = ''
-            self.rjObj._arg_parser.monitoring_endpoint_port = ''
+            self.rjObj._arg_parser.monitoring_endpoint = ""
+            self.rjObj._arg_parser.monitoring_endpoint_port = ""
             new_mon_ip, new_mon_port = each_ip_port_pair
             check_ip_val = self.rjObj.cluster.dummy_host_ip_map.get(
-                new_mon_ip, new_mon_ip)
+                new_mon_ip, new_mon_ip
+            )
             check_port_val = ext.RadosJSON.DEFAULT_MONITORING_ENDPOINT_PORT
             if new_mon_ip:
                 self.rjObj._arg_parser.monitoring_endpoint = new_mon_ip
@@ -217,19 +250,28 @@ class TestRadosJSON(unittest.TestCase):
             mon_ips, mon_port = self.rjObj.get_active_and_standby_mgrs()
             mon_ip = mon_ips.split(",")[0]
             if check_ip_val and check_ip_val != mon_ip:
-                self.fail("Expected IP: {}, Returned IP: {}".format(
-                    check_ip_val, mon_ip))
+                self.fail(
+                    "Expected IP: {}, Returned IP: {}".format(check_ip_val, mon_ip)
+                )
             if check_port_val and check_port_val != mon_port:
-                self.fail("Expected Port: '{}', Returned Port: '{}'".format(
-                    check_port_val, mon_port))
+                self.fail(
+                    "Expected Port: '{}', Returned Port: '{}'".format(
+                        check_port_val, mon_port
+                    )
+                )
             print("MonIP: {}, MonPort: {}".format(mon_ip, mon_port))
 
-        invalid_ip_ports = [("10.22.31.131.43", "5334"), ("", "91943"),
-                            ("10.177.3.81", "90320"), ("", "73422"), ("10.232.12.8", "90922")]
+        invalid_ip_ports = [
+            ("10.22.31.131.43", "5334"),
+            ("", "91943"),
+            ("10.177.3.81", "90320"),
+            ("", "73422"),
+            ("10.232.12.8", "90922"),
+        ]
         for each_ip_port_pair in invalid_ip_ports:
             # reset the command-line monitoring args
-            self.rjObj._arg_parser.monitoring_endpoint = ''
-            self.rjObj._arg_parser.monitoring_endpoint_port = ''
+            self.rjObj._arg_parser.monitoring_endpoint = ""
+            self.rjObj._arg_parser.monitoring_endpoint_port = ""
             new_mon_ip, new_mon_port = each_ip_port_pair
             if new_mon_ip:
                 self.rjObj._arg_parser.monitoring_endpoint = new_mon_ip

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1,4 +1,4 @@
-'''
+"""
 Copyright 2020 The Rook Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-'''
+"""
 
 import errno
 import sys
@@ -67,8 +67,10 @@ except:
     from urllib.parse import urlparse, unquote
     from base64 import encodebytes as encodestring
 
+
 class ExecutionFailureException(Exception):
     pass
+
 
 ################################################
 ################## DummyRados ##################
@@ -79,54 +81,100 @@ class ExecutionFailureException(Exception):
 class DummyRados(object):
     def __init__(self):
         self.return_val = 0
-        self.err_message = ''
-        self.state = 'connected'
+        self.err_message = ""
+        self.state = "connected"
         self.cmd_output_map = {}
         self.cmd_names = {}
         self._init_cmd_output_map()
         self.dummy_host_ip_map = {}
 
     def _init_cmd_output_map(self):
-        json_file_name = 'test-data/ceph-status-out'
+        json_file_name = "test-data/ceph-status-out"
         script_dir = path.abspath(path.dirname(__file__))
         ceph_status_str = ""
-        with open(path.join(script_dir, json_file_name), 'r') as json_file:
+        with open(path.join(script_dir, json_file_name), "r") as json_file:
             ceph_status_str = json_file.read()
-        self.cmd_names['fs ls'] = '''{"format": "json", "prefix": "fs ls"}'''
-        self.cmd_names['quorum_status'] = '''{"format": "json", "prefix": "quorum_status"}'''
-        self.cmd_names['mgr services'] = '''{"format": "json", "prefix": "mgr services"}'''
+        self.cmd_names["fs ls"] = """{"format": "json", "prefix": "fs ls"}"""
+        self.cmd_names[
+            "quorum_status"
+        ] = """{"format": "json", "prefix": "quorum_status"}"""
+        self.cmd_names[
+            "mgr services"
+        ] = """{"format": "json", "prefix": "mgr services"}"""
         # all the commands and their output
-        self.cmd_output_map[self.cmd_names['fs ls']
-                            ] = '''[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":2,"data_pool_ids":[3],"data_pools":["myfs-replicated"]}]'''
-        self.cmd_output_map[self.cmd_names['quorum_status']] = '''{"election_epoch":3,"quorum":[0],"quorum_names":["a"],"quorum_leader_name":"a","quorum_age":14385,"features":{"quorum_con":"4540138292836696063","quorum_mon":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"]},"monmap":{"epoch":1,"fsid":"af4e1673-0b72-402d-990a-22d2919d0f1c","modified":"2020-05-07T03:36:39.918035Z","created":"2020-05-07T03:36:39.918035Z","min_mon_release":15,"min_mon_release_name":"octopus","features":{"persistent":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"],"optional":[]},"mons":[{"rank":0,"name":"a","public_addrs":{"addrvec":[{"type":"v2","addr":"10.110.205.174:3300","nonce":0},{"type":"v1","addr":"10.110.205.174:6789","nonce":0}]},"addr":"10.110.205.174:6789/0","public_addr":"10.110.205.174:6789/0","priority":0,"weight":0}]}}'''
-        self.cmd_output_map[self.cmd_names['mgr services']
-                            ] = '''{"dashboard":"https://ceph-dashboard:8443/","prometheus":"http://ceph-dashboard-db:9283/"}'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command quorum_status", "osd", "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r, allow command quorum_status","osd":"allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "profile rbd, allow command 'osd blocklist'", "osd", "profile rbd"], "entity": "client.csi-rbd-node", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-rbd-node","key":"AQBOgrNeHbK1AxAAubYBeV8S1U/GPzq5SVeq6g==","caps":{"mon":"profile rbd, allow command 'osd blocklist'","osd":"profile rbd"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "profile rbd, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "profile rbd"], "entity": "client.csi-rbd-provisioner", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-rbd-provisioner","key":"AQBNgrNe1geyKxAA8ekViRdE+hss5OweYBkwNg==","caps":{"mgr":"allow rw","mon":"profile rbd, allow command 'osd blocklist'","osd":"profile rbd"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs *=*", "mds", "allow rw"], "entity": "client.csi-cephfs-node", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-node","key":"AQBOgrNeENunKxAAPCmgE7R6G8DcXnaJ1F32qg==","caps":{"mds":"allow rw","mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs *=*"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner","key":"AQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=*"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner-openshift-storage", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner-openshift-storage","key":"BQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=*"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=myfs"], "entity": "client.csi-cephfs-provisioner-openshift-storage-myfs", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner-openshift-storage-myfs","key":"CQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=myfs"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command quorum_status, allow command version", "mgr", "allow command config", "osd", "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]'''
-        self.cmd_output_map['''{"format": "json", "prefix": "mgr services"}'''] = '''{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}'''
-        self.cmd_output_map['''{"entity": "client.healthchecker", "format": "json", "prefix": "auth get"}'''] = '''{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}'''
-        self.cmd_output_map['''{"entity": "client.healthchecker", "format": "json", "prefix": "auth get"}'''] = '''[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]'''
-        self.cmd_output_map['''{"entity": "client.csi-cephfs-node", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-rbd-node", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-rbd-provisioner", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-cephfs-provisioner-openshift-storage", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-cephfs-provisioner-openshift-storage-myfs", "format": "json", "prefix": "auth get"}'''] = '''[]'''
-        self.cmd_output_map['''{"entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get"}'''] = '''[{"entity":"client.csi-cephfs-provisioner","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r", "mgr":"allow rw", "osd":"allow rw tag cephfs metadata=*"}}]'''
-        self.cmd_output_map['''{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth caps"}'''] = '''[{"entity":"client.csi-cephfs-provisioner","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r,  allow command 'osd blocklist'", "mgr":"allow rw", "osd":"allow rw tag cephfs metadata=*"}}]'''
+        self.cmd_output_map[
+            self.cmd_names["fs ls"]
+        ] = """[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":2,"data_pool_ids":[3],"data_pools":["myfs-replicated"]}]"""
+        self.cmd_output_map[
+            self.cmd_names["quorum_status"]
+        ] = """{"election_epoch":3,"quorum":[0],"quorum_names":["a"],"quorum_leader_name":"a","quorum_age":14385,"features":{"quorum_con":"4540138292836696063","quorum_mon":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"]},"monmap":{"epoch":1,"fsid":"af4e1673-0b72-402d-990a-22d2919d0f1c","modified":"2020-05-07T03:36:39.918035Z","created":"2020-05-07T03:36:39.918035Z","min_mon_release":15,"min_mon_release_name":"octopus","features":{"persistent":["kraken","luminous","mimic","osdmap-prune","nautilus","octopus"],"optional":[]},"mons":[{"rank":0,"name":"a","public_addrs":{"addrvec":[{"type":"v2","addr":"10.110.205.174:3300","nonce":0},{"type":"v1","addr":"10.110.205.174:6789","nonce":0}]},"addr":"10.110.205.174:6789/0","public_addr":"10.110.205.174:6789/0","priority":0,"weight":0}]}}"""
+        self.cmd_output_map[
+            self.cmd_names["mgr services"]
+        ] = """{"dashboard":"https://ceph-dashboard:8443/","prometheus":"http://ceph-dashboard-db:9283/"}"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command quorum_status", "osd", "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r, allow command quorum_status","osd":"allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow x pool=default.rgw.buckets.index"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "profile rbd, allow command 'osd blocklist'", "osd", "profile rbd"], "entity": "client.csi-rbd-node", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-rbd-node","key":"AQBOgrNeHbK1AxAAubYBeV8S1U/GPzq5SVeq6g==","caps":{"mon":"profile rbd, allow command 'osd blocklist'","osd":"profile rbd"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "profile rbd, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "profile rbd"], "entity": "client.csi-rbd-provisioner", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-rbd-provisioner","key":"AQBNgrNe1geyKxAA8ekViRdE+hss5OweYBkwNg==","caps":{"mgr":"allow rw","mon":"profile rbd, allow command 'osd blocklist'","osd":"profile rbd"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs *=*", "mds", "allow rw"], "entity": "client.csi-cephfs-node", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-cephfs-node","key":"AQBOgrNeENunKxAAPCmgE7R6G8DcXnaJ1F32qg==","caps":{"mds":"allow rw","mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs *=*"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-cephfs-provisioner","key":"AQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=*"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner-openshift-storage", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-cephfs-provisioner-openshift-storage","key":"BQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=*"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=myfs"], "entity": "client.csi-cephfs-provisioner-openshift-storage-myfs", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.csi-cephfs-provisioner-openshift-storage-myfs","key":"CQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r, allow command 'osd blocklist'","osd":"allow rw tag cephfs metadata=myfs"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command quorum_status, allow command version", "mgr", "allow command config", "osd", "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}"""
+        ] = """[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]"""
+        self.cmd_output_map[
+            """{"format": "json", "prefix": "mgr services"}"""
+        ] = """{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}"""
+        self.cmd_output_map[
+            """{"entity": "client.healthchecker", "format": "json", "prefix": "auth get"}"""
+        ] = """{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}"""
+        self.cmd_output_map[
+            """{"entity": "client.healthchecker", "format": "json", "prefix": "auth get"}"""
+        ] = """[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-cephfs-node", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-rbd-node", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-rbd-provisioner", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-cephfs-provisioner-openshift-storage", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-cephfs-provisioner-openshift-storage-myfs", "format": "json", "prefix": "auth get"}"""
+        ] = """[]"""
+        self.cmd_output_map[
+            """{"entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get"}"""
+        ] = """[{"entity":"client.csi-cephfs-provisioner","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r", "mgr":"allow rw", "osd":"allow rw tag cephfs metadata=*"}}]"""
+        self.cmd_output_map[
+            """{"caps": ["mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth caps"}"""
+        ] = """[{"entity":"client.csi-cephfs-provisioner","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon":"allow r,  allow command 'osd blocklist'", "mgr":"allow rw", "osd":"allow rw tag cephfs metadata=*"}}]"""
         self.cmd_output_map['{"format": "json", "prefix": "status"}'] = ceph_status_str
 
     def shutdown(self):
         pass
 
     def get_fsid(self):
-        return 'af4e1673-0b72-402d-990a-22d2919d0f1c'
+        return "af4e1673-0b72-402d-990a-22d2919d0f1c"
 
     def conf_read_file(self):
         pass
@@ -141,20 +189,24 @@ class DummyRados(object):
         json_cmd = json.loads(cmd)
         json_cmd_str = json.dumps(json_cmd, sort_keys=True)
         cmd_output = self.cmd_output_map[json_cmd_str]
-        return self.return_val, \
-            cmd_output, \
-            "{}".format(self.err_message).encode('utf-8')
+        return (
+            self.return_val,
+            cmd_output,
+            "{}".format(self.err_message).encode("utf-8"),
+        )
 
     def _convert_hostname_to_ip(self, host_name):
-        ip_reg_x = re.compile(r'\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}')
+        ip_reg_x = re.compile(r"\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}")
         # if provided host is directly an IP address, return the same
         if ip_reg_x.match(host_name):
             return host_name
         import random
+
         host_ip = self.dummy_host_ip_map.get(host_name, "")
         if not host_ip:
             host_ip = "172.9.{}.{}".format(
-                random.randint(0, 254), random.randint(0, 254))
+                random.randint(0, 254), random.randint(0, 254)
+            )
             self.dummy_host_ip_map[host_name] = host_ip
         del random
         return host_ip
@@ -163,10 +215,12 @@ class DummyRados(object):
     def Rados(conffile=None):
         return DummyRados()
 
+
 class S3Auth(AuthBase):
 
     """Attaches AWS Authentication to the given Request object."""
-    service_base_url = 's3.amazonaws.com'
+
+    service_base_url = "s3.amazonaws.com"
 
     def __init__(self, access_key, secret_key, service_url=None):
         if service_url:
@@ -176,23 +230,19 @@ class S3Auth(AuthBase):
 
     def __call__(self, r):
         # Create date header if it is not created yet.
-        if 'date' not in r.headers and 'x-amz-date' not in r.headers:
-            r.headers['date'] = formatdate(
-                timeval=None,
-                localtime=False,
-                usegmt=True)
+        if "date" not in r.headers and "x-amz-date" not in r.headers:
+            r.headers["date"] = formatdate(timeval=None, localtime=False, usegmt=True)
         signature = self.get_signature(r)
         if py3k:
-            signature = signature.decode('utf-8')
-        r.headers['Authorization'] = 'AWS %s:%s' % (self.access_key, signature)
+            signature = signature.decode("utf-8")
+        r.headers["Authorization"] = "AWS %s:%s" % (self.access_key, signature)
         return r
 
     def get_signature(self, r):
-        canonical_string = self.get_canonical_string(
-            r.url, r.headers, r.method)
+        canonical_string = self.get_canonical_string(r.url, r.headers, r.method)
         if py3k:
-            key = self.secret_key.encode('utf-8')
-            msg = canonical_string.encode('utf-8')
+            key = self.secret_key.encode("utf-8")
+            msg = canonical_string.encode("utf-8")
         else:
             key = self.secret_key
             msg = canonical_string
@@ -203,49 +253,48 @@ class S3Auth(AuthBase):
         parsedurl = urlparse(url)
         objectkey = parsedurl.path[1:]
 
-        bucket = parsedurl.netloc[:-len(self.service_base_url)]
+        bucket = parsedurl.netloc[: -len(self.service_base_url)]
         if len(bucket) > 1:
             # remove last dot
             bucket = bucket[:-1]
 
-        interesting_headers = {
-            'content-md5': '',
-            'content-type': '',
-            'date': ''}
+        interesting_headers = {"content-md5": "", "content-type": "", "date": ""}
         for key in headers:
             lk = key.lower()
             try:
-                lk = lk.decode('utf-8')
+                lk = lk.decode("utf-8")
             except:
                 pass
-            if headers[key] and (lk in interesting_headers.keys()
-                                 or lk.startswith('x-amz-')):
+            if headers[key] and (
+                lk in interesting_headers.keys() or lk.startswith("x-amz-")
+            ):
                 interesting_headers[lk] = headers[key].strip()
 
         # If x-amz-date is used it supersedes the date header.
         if not py3k:
-            if 'x-amz-date' in interesting_headers:
-                interesting_headers['date'] = ''
+            if "x-amz-date" in interesting_headers:
+                interesting_headers["date"] = ""
         else:
-            if 'x-amz-date' in interesting_headers:
-                interesting_headers['date'] = ''
+            if "x-amz-date" in interesting_headers:
+                interesting_headers["date"] = ""
 
-        buf = '%s\n' % method
+        buf = "%s\n" % method
         for key in sorted(interesting_headers.keys()):
             val = interesting_headers[key]
-            if key.startswith('x-amz-'):
-                buf += '%s:%s\n' % (key, val)
+            if key.startswith("x-amz-"):
+                buf += "%s:%s\n" % (key, val)
             else:
-                buf += '%s\n' % val
+                buf += "%s\n" % val
 
         # append the bucket if it exists
-        if bucket != '':
-            buf += '/%s' % bucket
+        if bucket != "":
+            buf += "/%s" % bucket
 
         # add the objectkey. even if it doesn't exist, add the slash
-        buf += '/%s' % objectkey
+        buf += "/%s" % objectkey
 
         return buf
+
 
 class RadosJSON:
     EXTERNAL_USER_NAME = "client.healthchecker"
@@ -258,70 +307,140 @@ class RadosJSON:
     def gen_arg_parser(cls, args_to_parse=None):
         argP = argparse.ArgumentParser()
 
-        common_group = argP.add_argument_group('common')
-        common_group.add_argument("--verbose", "-v",
-                                  action='store_true', default=False)
-        common_group.add_argument("--ceph-conf", "-c",
-                                  help="Provide a ceph conf file.", type=str)
-        common_group.add_argument("--run-as-user", "-u", default="", type=str,
-                                  help="Provides a user name to check the cluster's health status, must be prefixed by 'client.'")
-        common_group.add_argument("--cluster-name", default="",
-                                  help="Ceph cluster name")
-        common_group.add_argument("--namespace", default="",
-                                  help="Namespace where CephCluster is running")
-        common_group.add_argument("--rgw-pool-prefix", default="",
-                                  help="RGW Pool prefix")
-        common_group.add_argument("--restricted-auth-permission", default=False,
-                                  help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster and pool namespaces." +
-                                  "Mandatory flags that need to be set are --rbd-data-pool-name, --rados-namespace and --cluster-name." +
-                                  "--cephfs-filesystem-name flag can also be passed in case of cephfs user restriction, so it can restrict user to particular cephfs filesystem" +
-                                  "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true`" +
-                                  "Note: Restricting the users per pool, per cluster and per pool namespace will require to create new users and new secrets for that users.")
+        common_group = argP.add_argument_group("common")
+        common_group.add_argument("--verbose", "-v", action="store_true", default=False)
+        common_group.add_argument(
+            "--ceph-conf", "-c", help="Provide a ceph conf file.", type=str
+        )
+        common_group.add_argument(
+            "--run-as-user",
+            "-u",
+            default="",
+            type=str,
+            help="Provides a user name to check the cluster's health status, must be prefixed by 'client.'",
+        )
+        common_group.add_argument(
+            "--cluster-name", default="", help="Ceph cluster name"
+        )
+        common_group.add_argument(
+            "--namespace", default="", help="Namespace where CephCluster is running"
+        )
+        common_group.add_argument(
+            "--rgw-pool-prefix", default="", help="RGW Pool prefix"
+        )
+        common_group.add_argument(
+            "--restricted-auth-permission",
+            default=False,
+            help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster and pool namespaces."
+            + "Mandatory flags that need to be set are --rbd-data-pool-name, --rados-namespace and --cluster-name."
+            + "--cephfs-filesystem-name flag can also be passed in case of cephfs user restriction, so it can restrict user to particular cephfs filesystem"
+            + "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true`"
+            + "Note: Restricting the users per pool, per cluster and per pool namespace will require to create new users and new secrets for that users.",
+        )
 
-        output_group = argP.add_argument_group('output')
-        output_group.add_argument("--format", "-t", choices=["json", "bash"],
-                                  default='json', help="Provides the output format (json | bash)")
-        output_group.add_argument("--output", "-o", default="",
-                                  help="Output will be stored into the provided file")
-        output_group.add_argument("--cephfs-filesystem-name", default="",
-                                  help="Provides the name of the Ceph filesystem")
-        output_group.add_argument("--cephfs-metadata-pool-name", default="",
-                                  help="Provides the name of the cephfs metadata pool")
-        output_group.add_argument("--cephfs-data-pool-name", default="",
-                                  help="Provides the name of the cephfs data pool")
-        output_group.add_argument("--rbd-data-pool-name", default="", required=False,
-                                  help="Provides the name of the RBD datapool")
-        output_group.add_argument("--rgw-endpoint", default="", required=False,
-                                  help="RADOS Gateway endpoint (in <IP>:<PORT> format). Note: FQDN is also supported(in <FQDN>:<PORT> format)")
-        output_group.add_argument("--rgw-tls-cert-path", default="", required=False,
-                                  help="RADOS Gateway endpoint TLS certificate")
-        output_group.add_argument("--rgw-skip-tls", required=False, default=False,
-                                  help="Ignore TLS certification validation when a self-signed certificate is provided (NOT RECOMMENDED")
-        output_group.add_argument("--monitoring-endpoint", default="", required=False,
-                                  help="Ceph Manager prometheus exporter endpoints (comma separated list of <IP> entries of active and standby mgrs)")
-        output_group.add_argument("--monitoring-endpoint-port", default="", required=False,
-                                  help="Ceph Manager prometheus exporter port")
-        output_group.add_argument("--rbd-metadata-ec-pool-name", default="", required=False,
-                                  help="Provides the name of erasure coded RBD metadata pool")
-        output_group.add_argument("--dry-run", default=False, action='store_true',
-                                  help="Dry run prints the executed commands without running them")
-        output_group.add_argument("--rados-namespace", default="", required=False,
-                                  help="divides a pool into separate logical namespaces")
+        output_group = argP.add_argument_group("output")
+        output_group.add_argument(
+            "--format",
+            "-t",
+            choices=["json", "bash"],
+            default="json",
+            help="Provides the output format (json | bash)",
+        )
+        output_group.add_argument(
+            "--output",
+            "-o",
+            default="",
+            help="Output will be stored into the provided file",
+        )
+        output_group.add_argument(
+            "--cephfs-filesystem-name",
+            default="",
+            help="Provides the name of the Ceph filesystem",
+        )
+        output_group.add_argument(
+            "--cephfs-metadata-pool-name",
+            default="",
+            help="Provides the name of the cephfs metadata pool",
+        )
+        output_group.add_argument(
+            "--cephfs-data-pool-name",
+            default="",
+            help="Provides the name of the cephfs data pool",
+        )
+        output_group.add_argument(
+            "--rbd-data-pool-name",
+            default="",
+            required=False,
+            help="Provides the name of the RBD datapool",
+        )
+        output_group.add_argument(
+            "--rgw-endpoint",
+            default="",
+            required=False,
+            help="RADOS Gateway endpoint (in <IP>:<PORT> format). Note: FQDN is also supported(in <FQDN>:<PORT> format)",
+        )
+        output_group.add_argument(
+            "--rgw-tls-cert-path",
+            default="",
+            required=False,
+            help="RADOS Gateway endpoint TLS certificate",
+        )
+        output_group.add_argument(
+            "--rgw-skip-tls",
+            required=False,
+            default=False,
+            help="Ignore TLS certification validation when a self-signed certificate is provided (NOT RECOMMENDED",
+        )
+        output_group.add_argument(
+            "--monitoring-endpoint",
+            default="",
+            required=False,
+            help="Ceph Manager prometheus exporter endpoints (comma separated list of <IP> entries of active and standby mgrs)",
+        )
+        output_group.add_argument(
+            "--monitoring-endpoint-port",
+            default="",
+            required=False,
+            help="Ceph Manager prometheus exporter port",
+        )
+        output_group.add_argument(
+            "--rbd-metadata-ec-pool-name",
+            default="",
+            required=False,
+            help="Provides the name of erasure coded RBD metadata pool",
+        )
+        output_group.add_argument(
+            "--dry-run",
+            default=False,
+            action="store_true",
+            help="Dry run prints the executed commands without running them",
+        )
+        output_group.add_argument(
+            "--rados-namespace",
+            default="",
+            required=False,
+            help="divides a pool into separate logical namespaces",
+        )
 
-        upgrade_group = argP.add_argument_group('upgrade')
-        upgrade_group.add_argument("--upgrade", action='store_true', default=False,
-                                   help="Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied." +
-                                   "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade`, this will upgrade all the default csi users(non-restricted)" +
-                                   "For restricted users(For example: client.csi-cephfs-provisioner-openshift-storage-myfs), users created using --restricted-auth-permission flag need to pass mandatory flags" +
-                                   "mandatory flags: '--rbd-data-pool-name, --rados-namespace, --cluster-name and --run-as-user' flags while upgrading" +
-                                   "in case of cephfs users if you have passed --cephfs-filesystem-name flag while creating user then while upgrading it will be mandatory too" +
-                                   "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage  --run-as-user client.csi-rbd-node-rookStorage-replicapool-radosNamespace`" +
-                                   "PS: An existing non-restricted user cannot be downgraded to a restricted user by upgrading. Admin need to create a new restricted user for this by re-running the script." +
-                                   "Upgrade flag should only be used to append new permissions to users, it shouldn't be used for changing user already applied permission, for example you shouldn't change in which pool user has access")
+        upgrade_group = argP.add_argument_group("upgrade")
+        upgrade_group.add_argument(
+            "--upgrade",
+            action="store_true",
+            default=False,
+            help="Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied."
+            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade`, this will upgrade all the default csi users(non-restricted)"
+            + "For restricted users(For example: client.csi-cephfs-provisioner-openshift-storage-myfs), users created using --restricted-auth-permission flag need to pass mandatory flags"
+            + "mandatory flags: '--rbd-data-pool-name, --rados-namespace, --cluster-name and --run-as-user' flags while upgrading"
+            + "in case of cephfs users if you have passed --cephfs-filesystem-name flag while creating user then while upgrading it will be mandatory too"
+            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage  --run-as-user client.csi-rbd-node-rookStorage-replicapool-radosNamespace`"
+            + "PS: An existing non-restricted user cannot be downgraded to a restricted user by upgrading. Admin need to create a new restricted user for this by re-running the script."
+            + "Upgrade flag should only be used to append new permissions to users, it shouldn't be used for changing user already applied permission, for example you shouldn't change in which pool user has access",
+        )
 
         if args_to_parse:
-            assert type(args_to_parse) == list, \
-                "Argument to 'gen_arg_parser' should be a list"
+            assert (
+                type(args_to_parse) == list
+            ), "Argument to 'gen_arg_parser' should be a list"
         else:
             args_to_parse = sys.argv[1:]
         return argP.parse_args(args_to_parse)
@@ -341,32 +460,41 @@ class RadosJSON:
                     "Flag '--rbd-metadata-ec-pool-name' should not be empty"
                 )
 
-            cmd_json = {
-                "prefix": "osd dump", "format": "json"
-            }
+            cmd_json = {"prefix": "osd dump", "format": "json"}
             ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
             if ret_val != 0 or len(json_out) == 0:
                 raise ExecutionFailureException(
-                    "{}".format(cmd_json['prefix']) + " command failed.\n" +
-                    "Error: {}".format(err_msg if ret_val !=
-                                       0 else self.EMPTY_OUTPUT_LIST)
+                    "{}".format(cmd_json["prefix"])
+                    + " command failed.\n"
+                    + "Error: {}".format(
+                        err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST
+                    )
                 )
             metadata_pool_exist, pool_exist = False, False
 
-            for key in json_out['pools']:
+            for key in json_out["pools"]:
                 # if erasure_code_profile is empty and pool name exists then it replica pool
-                if key['erasure_code_profile'] == "" and key['pool_name'] == rbd_metadata_ec_pool_name:
+                if (
+                    key["erasure_code_profile"] == ""
+                    and key["pool_name"] == rbd_metadata_ec_pool_name
+                ):
                     metadata_pool_exist = True
                 # if erasure_code_profile is not empty and pool name exists then it is ec pool
-                if key['erasure_code_profile'] and key['pool_name'] == rbd_pool_name:
+                if key["erasure_code_profile"] and key["pool_name"] == rbd_pool_name:
                     pool_exist = True
 
             if not metadata_pool_exist:
                 raise ExecutionFailureException(
-                    "Provided rbd_ec_metadata_pool name, {}, does not exist".format(rbd_metadata_ec_pool_name))
+                    "Provided rbd_ec_metadata_pool name, {}, does not exist".format(
+                        rbd_metadata_ec_pool_name
+                    )
+                )
             if not pool_exist:
                 raise ExecutionFailureException(
-                    "Provided rbd_data_pool name, {}, does not exist".format(rbd_pool_name))
+                    "Provided rbd_data_pool name, {}, does not exist".format(
+                        rbd_pool_name
+                    )
+                )
             return rbd_metadata_ec_pool_name
 
     def dry_run(self, msg):
@@ -375,39 +503,43 @@ class RadosJSON:
 
     def validate_rgw_endpoint_tls_cert(self):
         if self._arg_parser.rgw_tls_cert_path:
-            with open(self._arg_parser.rgw_tls_cert_path, encoding='utf8') as f:
+            with open(self._arg_parser.rgw_tls_cert_path, encoding="utf8") as f:
                 contents = f.read()
                 return contents.rstrip()
 
     def _check_conflicting_options(self):
         if not self._arg_parser.upgrade and not self._arg_parser.rbd_data_pool_name:
             raise ExecutionFailureException(
-                "Either '--upgrade' or '--rbd-data-pool-name <pool_name>' should be specified")
+                "Either '--upgrade' or '--rbd-data-pool-name <pool_name>' should be specified"
+            )
 
     def _invalid_endpoint(self, endpoint_str):
         try:
-            ipv4, port = endpoint_str.split(':')
+            ipv4, port = endpoint_str.split(":")
         except ValueError:
             raise ExecutionFailureException(
-                "Not a proper endpoint: {}, <IPv4>:<PORT>, format is expected".format(endpoint_str))
-        ipParts = ipv4.split('.')
+                "Not a proper endpoint: {}, <IPv4>:<PORT>, format is expected".format(
+                    endpoint_str
+                )
+            )
+        ipParts = ipv4.split(".")
         if len(ipParts) != 4:
-            raise ExecutionFailureException(
-                "Not a valid IP address: {}".format(ipv4))
+            raise ExecutionFailureException("Not a valid IP address: {}".format(ipv4))
         for eachPart in ipParts:
             if not eachPart.isdigit():
                 raise ExecutionFailureException(
-                    "IP address parts should be numbers: {}".format(ipv4))
+                    "IP address parts should be numbers: {}".format(ipv4)
+                )
             intPart = int(eachPart)
             if intPart < 0 or intPart > 254:
                 raise ExecutionFailureException(
-                    "Out of range IP addresses: {}".format(ipv4))
+                    "Out of range IP addresses: {}".format(ipv4)
+                )
         if not port.isdigit():
             raise ExecutionFailureException("Port not valid: {}".format(port))
         intPort = int(port)
-        if intPort < 1 or intPort > 2**16-1:
-            raise ExecutionFailureException(
-                "Out of range port number: {}".format(port))
+        if intPort < 1 or intPort > 2**16 - 1:
+            raise ExecutionFailureException("Out of range port number: {}".format(port))
         return False
 
     def endpoint_dial(self, endpoint_str, timeout=3, cert=None):
@@ -432,7 +564,8 @@ class RadosJSON:
             except:
                 continue
         raise ExecutionFailureException(
-            "unable to connect to endpoint: {}".format(endpoint_str))
+            "unable to connect to endpoint: {}".format(endpoint_str)
+        )
 
     def __init__(self, arg_list=None):
         self.out_map = {}
@@ -443,13 +576,13 @@ class RadosJSON:
         self.output_file = self._arg_parser.output
         self.ceph_conf = self._arg_parser.ceph_conf
         self.MIN_USER_CAP_PERMISSIONS = {
-            'mgr': 'allow command config',
-            'mon': 'allow r, allow command quorum_status, allow command version',
-            'osd': "allow rwx pool={0}.rgw.meta, " +
-            "allow r pool=.rgw.root, " +
-            "allow rw pool={0}.rgw.control, " +
-            "allow rx pool={0}.rgw.log, " +
-            "allow x pool={0}.rgw.buckets.index"
+            "mgr": "allow command config",
+            "mon": "allow r, allow command quorum_status, allow command version",
+            "osd": "allow rwx pool={0}.rgw.meta, "
+            + "allow r pool=.rgw.root, "
+            + "allow rw pool={0}.rgw.control, "
+            + "allow rx pool={0}.rgw.log, "
+            + "allow x pool={0}.rgw.buckets.index",
         }
         # if user not provided, give a default user
         if not self.run_as_user and not self._arg_parser.upgrade:
@@ -474,11 +607,14 @@ class RadosJSON:
 
     def _common_cmd_json_gen(self, cmd_json):
         cmd = json.dumps(cmd_json, sort_keys=True)
-        ret_val, cmd_out, err_msg = self.cluster.mon_command(cmd, b'')
+        ret_val, cmd_out, err_msg = self.cluster.mon_command(cmd, b"")
         if self._arg_parser.verbose:
             print("Command Input: {}".format(cmd))
-            print("Return Val: {}\nCommand Output: {}\nError Message: {}\n----------\n".format(
-                  ret_val, cmd_out, err_msg))
+            print(
+                "Return Val: {}\nCommand Output: {}\nError Message: {}\n----------\n".format(
+                    ret_val, cmd_out, err_msg
+                )
+            )
         json_out = {}
         # if there is no error (i.e; ret_val is ZERO) and 'cmd_out' is not empty
         # then convert 'cmd_out' to a json output
@@ -489,43 +625,47 @@ class RadosJSON:
     def get_ceph_external_mon_data(self):
         cmd_json = {"prefix": "quorum_status", "format": "json"}
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + cmd_json['prefix'])
+            return self.dry_run("ceph " + cmd_json["prefix"])
         ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
         # if there is an unsuccessful attempt,
         if ret_val != 0 or len(json_out) == 0:
             raise ExecutionFailureException(
-                "'quorum_status' command failed.\n" +
-                "Error: {}".format(err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST))
-        q_leader_name = json_out['quorum_leader_name']
+                "'quorum_status' command failed.\n"
+                + "Error: {}".format(
+                    err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST
+                )
+            )
+        q_leader_name = json_out["quorum_leader_name"]
         q_leader_details = {}
-        q_leader_matching_list = [l for l in json_out['monmap']['mons']
-                                  if l['name'] == q_leader_name]
+        q_leader_matching_list = [
+            l for l in json_out["monmap"]["mons"] if l["name"] == q_leader_name
+        ]
         if len(q_leader_matching_list) == 0:
             raise ExecutionFailureException("No matching 'mon' details found")
         q_leader_details = q_leader_matching_list[0]
         # get the address vector of the quorum-leader
-        q_leader_addrvec = q_leader_details.get(
-            'public_addrs', {}).get('addrvec', [])
+        q_leader_addrvec = q_leader_details.get("public_addrs", {}).get("addrvec", [])
         # if the quorum-leader has only one address in the address-vector
         # and it is of type 'v2' (ie; with <IP>:3300),
         # raise an exception to make user aware that
         # they have to enable 'v1' (ie; with <IP>:6789) type as well
-        if len(q_leader_addrvec) == 1 and q_leader_addrvec[0]['type'] == 'v2':
+        if len(q_leader_addrvec) == 1 and q_leader_addrvec[0]["type"] == "v2":
             raise ExecutionFailureException(
-                "Only 'v2' address type is enabled, user should also enable 'v1' type as well")
-        ip_port = str(q_leader_details['public_addr'].split('/')[0])
+                "Only 'v2' address type is enabled, user should also enable 'v1' type as well"
+            )
+        ip_port = str(q_leader_details["public_addr"].split("/")[0])
         return "{}={}".format(str(q_leader_name), ip_port)
 
     def _join_host_port(self, endpoint, port):
         port = "{}".format(port)
         # regex to check the given endpoint is enclosed in square brackets
-        ipv6_regx = re.compile(r'^\[[^]]*\]$')
+        ipv6_regx = re.compile(r"^\[[^]]*\]$")
         # endpoint has ':' in it and if not (already) enclosed in square brackets
-        if endpoint.count(':') and not ipv6_regx.match(endpoint):
-            endpoint = '[{}]'.format(endpoint)
+        if endpoint.count(":") and not ipv6_regx.match(endpoint):
+            endpoint = "[{}]".format(endpoint)
         if not port:
             return endpoint
-        return ':'.join([endpoint, port])
+        return ":".join([endpoint, port])
 
     def _convert_hostname_to_ip(self, host_name):
         # if 'cluster' instance is a dummy type,
@@ -535,6 +675,7 @@ class RadosJSON:
         if isinstance(self.cluster, DummyRados):
             return self.cluster._convert_hostname_to_ip(host_name)
         import socket
+
         ip = socket.gethostbyname(host_name)
         del socket
         return ip
@@ -551,23 +692,29 @@ class RadosJSON:
             # if there is an unsuccessful attempt,
             if ret_val != 0 or len(json_out) == 0:
                 raise ExecutionFailureException(
-                    "'mgr services' command failed.\n" +
-                    "Error: {}".format(err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST))
-            monitoring_endpoint = json_out.get('mgrmap', {}).get(
-                'services', {}).get('prometheus', '')
+                    "'mgr services' command failed.\n"
+                    + "Error: {}".format(
+                        err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST
+                    )
+                )
+            monitoring_endpoint = (
+                json_out.get("mgrmap", {}).get("services", {}).get("prometheus", "")
+            )
             if not monitoring_endpoint:
                 raise ExecutionFailureException(
-                    "'prometheus' service not found, is the exporter enabled?'.\n")
+                    "'prometheus' service not found, is the exporter enabled?'.\n"
+                )
             # now check the stand-by mgr-s
-            standby_arr = json_out.get('mgrmap', {}).get('standbys', [])
+            standby_arr = json_out.get("mgrmap", {}).get("standbys", [])
             for each_standby in standby_arr:
-                if 'name' in each_standby.keys():
-                    standby_mgrs.append(each_standby['name'])
+                if "name" in each_standby.keys():
+                    standby_mgrs.append(each_standby["name"])
             try:
                 parsed_endpoint = urlparse(monitoring_endpoint)
             except ValueError:
                 raise ExecutionFailureException(
-                    "invalid endpoint: {}".format(monitoring_endpoint))
+                    "invalid endpoint: {}".format(monitoring_endpoint)
+                )
             monitoring_endpoint_ip_list = parsed_endpoint.hostname
             if not monitoring_endpoint_port:
                 monitoring_endpoint_port = "{}".format(parsed_endpoint.port)
@@ -577,8 +724,7 @@ class RadosJSON:
             monitoring_endpoint_port = self.DEFAULT_MONITORING_ENDPOINT_PORT
 
         # user could give comma and space separated inputs (like --monitoring-endpoint="<ip1>, <ip2>")
-        monitoring_endpoint_ip_list = monitoring_endpoint_ip_list.replace(
-            ",", " ")
+        monitoring_endpoint_ip_list = monitoring_endpoint_ip_list.replace(",", " ")
         monitoring_endpoint_ip_list_split = monitoring_endpoint_ip_list.split()
         # if monitoring-endpoint could not be found, raise an error
         if len(monitoring_endpoint_ip_list_split) == 0:
@@ -591,19 +737,23 @@ class RadosJSON:
 
         try:
             monitoring_endpoint_ip = self._convert_hostname_to_ip(
-                monitoring_endpoint_ip)
+                monitoring_endpoint_ip
+            )
             # collect all the 'stand-by' mgr ips
             mgr_ips = []
             for each_standby_mgr in standby_mgrs:
                 failed_ip = each_standby_mgr
-                mgr_ips.append(
-                    self._convert_hostname_to_ip(each_standby_mgr))
+                mgr_ips.append(self._convert_hostname_to_ip(each_standby_mgr))
         except:
             raise ExecutionFailureException(
                 "Conversion of host: {} to IP failed. "
-                "Please enter the IP addresses of all the ceph-mgrs with the '--monitoring-endpoint' flag".format(failed_ip))
+                "Please enter the IP addresses of all the ceph-mgrs with the '--monitoring-endpoint' flag".format(
+                    failed_ip
+                )
+            )
         monitoring_endpoint = self._join_host_port(
-            monitoring_endpoint_ip, monitoring_endpoint_port)
+            monitoring_endpoint_ip, monitoring_endpoint_port
+        )
         self._invalid_endpoint(monitoring_endpoint)
         self.endpoint_dial(monitoring_endpoint)
 
@@ -613,87 +763,98 @@ class RadosJSON:
         return all_mgr_ips_str, monitoring_endpoint_port
 
     def check_user_exist(self, user):
-        cmd_json = {"prefix": "auth get", "entity": "{}".format(
-            user), "format": "json"}
+        cmd_json = {"prefix": "auth get", "entity": "{}".format(user), "format": "json"}
         ret_val, json_out, _ = self._common_cmd_json_gen(cmd_json)
         if ret_val != 0 or len(json_out) == 0:
             return ""
-        return str(json_out[0]['key'])
+        return str(json_out[0]["key"])
 
     def get_cephfs_provisioner_caps_and_entity(self):
         entity = "client.csi-cephfs-provisioner"
-        caps = {"mon": "allow r, allow command 'osd blocklist'",
-                "mgr": "allow rw",
-                "osd": "allow rw tag cephfs metadata=*"}
+        caps = {
+            "mon": "allow r, allow command 'osd blocklist'",
+            "mgr": "allow rw",
+            "osd": "allow rw tag cephfs metadata=*",
+        }
         if self._arg_parser.restricted_auth_permission:
             cluster_name = self._arg_parser.cluster_name
             if cluster_name == "":
                 raise ExecutionFailureException(
-                    "cluster_name not found, please set the '--cluster-name' flag")
+                    "cluster_name not found, please set the '--cluster-name' flag"
+                )
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
             if cephfs_filesystem == "":
                 entity = "{}-{}".format(entity, cluster_name)
             else:
-                entity = "{}-{}-{}".format(entity,
-                                           cluster_name, cephfs_filesystem)
+                entity = "{}-{}-{}".format(entity, cluster_name, cephfs_filesystem)
                 caps["osd"] = "allow rw tag cephfs metadata={}".format(
-                    cephfs_filesystem)
+                    cephfs_filesystem
+                )
 
         return caps, entity
 
     def get_cephfs_node_caps_and_entity(self):
         entity = "client.csi-cephfs-node"
-        caps = {"mon": "allow r, allow command 'osd blocklist'",
-                "mgr": "allow rw",
-                "osd": "allow rw tag cephfs *=*",
-                "mds": "allow rw"}
+        caps = {
+            "mon": "allow r, allow command 'osd blocklist'",
+            "mgr": "allow rw",
+            "osd": "allow rw tag cephfs *=*",
+            "mds": "allow rw",
+        }
         if self._arg_parser.restricted_auth_permission:
             cluster_name = self._arg_parser.cluster_name
             if cluster_name == "":
                 raise ExecutionFailureException(
-                    "cluster_name not found, please set the '--cluster-name' flag")
+                    "cluster_name not found, please set the '--cluster-name' flag"
+                )
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
             if cephfs_filesystem == "":
                 entity = "{}-{}".format(entity, cluster_name)
             else:
-                entity = "{}-{}-{}".format(entity,
-                                           cluster_name, cephfs_filesystem)
-                caps["osd"] = "allow rw tag cephfs *={}".format(
-                    cephfs_filesystem)
+                entity = "{}-{}-{}".format(entity, cluster_name, cephfs_filesystem)
+                caps["osd"] = "allow rw tag cephfs *={}".format(cephfs_filesystem)
 
         return caps, entity
 
     def get_rbd_provisioner_caps_and_entity(self):
         entity = "client.csi-rbd-provisioner"
-        caps = {"mon": "profile rbd, allow command 'osd blocklist'",
-                "mgr": "allow rw",
-                "osd": "profile rbd"}
+        caps = {
+            "mon": "profile rbd, allow command 'osd blocklist'",
+            "mgr": "allow rw",
+            "osd": "profile rbd",
+        }
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
             rados_namespace = self._arg_parser.rados_namespace
             if rbd_pool_name == "" or cluster_name == "" or rados_namespace == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags")
-            entity = "{}-{}-{}-{}".format(entity, cluster_name,
-                                          rbd_pool_name, rados_namespace)
+                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags"
+                )
+            entity = "{}-{}-{}-{}".format(
+                entity, cluster_name, rbd_pool_name, rados_namespace
+            )
             caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
 
         return caps, entity
 
     def get_rbd_node_caps_and_entity(self):
         entity = "client.csi-rbd-node"
-        caps = {"mon": "profile rbd, allow command 'osd blocklist'",
-                "osd": "profile rbd"}
+        caps = {
+            "mon": "profile rbd, allow command 'osd blocklist'",
+            "osd": "profile rbd",
+        }
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
             rados_namespace = self._arg_parser.rados_namespace
             if rbd_pool_name == "" or cluster_name == "" or rados_namespace == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags")
-            entity = "{}-{}-{}-{}".format(entity, cluster_name,
-                                          rbd_pool_name, rados_namespace)
+                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags"
+                )
+            entity = "{}-{}-{}-{}".format(
+                entity, cluster_name, rbd_pool_name, rados_namespace
+            )
             caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
 
         return caps, entity
@@ -718,20 +879,30 @@ class RadosJSON:
 
         raise ExecutionFailureException(
             "no user found with user_name: {} ,".format(user_name)
-            + "get_caps_and_entity command failed.\n")
+            + "get_caps_and_entity command failed.\n"
+        )
 
     def create_cephCSIKeyring_user(self, user):
-        '''
+        """
         command: ceph auth get-or-create client.csi-cephfs-provisioner mon 'allow r' mgr 'allow rw' osd 'allow rw tag cephfs metadata=*'
-        '''
+        """
         caps, entity = self.get_caps_and_entity(user)
-        cmd_json = {"prefix": "auth get-or-create",
-                    "entity": entity,
-                    "caps": [cap for cap_list in list(caps.items()) for cap in cap_list],
-                    "format": "json"}
+        cmd_json = {
+            "prefix": "auth get-or-create",
+            "entity": entity,
+            "caps": [cap for cap_list in list(caps.items()) for cap in cap_list],
+            "format": "json",
+        }
 
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + cmd_json['prefix'] + " " + cmd_json['entity'] + " " + " ".join(cmd_json['caps']))
+            return self.dry_run(
+                "ceph "
+                + cmd_json["prefix"]
+                + " "
+                + cmd_json["entity"]
+                + " "
+                + " ".join(cmd_json["caps"])
+            )
         # check if user already exist
         user_key = self.check_user_exist(entity)
         if user_key != "":
@@ -741,40 +912,54 @@ class RadosJSON:
         # if there is an unsuccessful attempt,
         if ret_val != 0 or len(json_out) == 0:
             raise ExecutionFailureException(
-                "'auth get-or-create {}' command failed.\n".format(user) +
-                "Error: {}".format(err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST))
-        return str(json_out[0]['key'])
+                "'auth get-or-create {}' command failed.\n".format(user)
+                + "Error: {}".format(
+                    err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST
+                )
+            )
+        return str(json_out[0]["key"])
 
     def get_cephfs_data_pool_details(self):
         cmd_json = {"prefix": "fs ls", "format": "json"}
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + cmd_json['prefix'])
+            return self.dry_run("ceph " + cmd_json["prefix"])
         ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
         # if there is an unsuccessful attempt, report an error
         if ret_val != 0:
             # if fs and data_pool arguments are not set, silently return
-            if self._arg_parser.cephfs_filesystem_name == "" and self._arg_parser.cephfs_data_pool_name == "":
+            if (
+                self._arg_parser.cephfs_filesystem_name == ""
+                and self._arg_parser.cephfs_data_pool_name == ""
+            ):
                 return
             # if user has provided any of the
             # '--cephfs-filesystem-name' or '--cephfs-data-pool-name' arguments,
             # raise an exception as we are unable to verify the args
             raise ExecutionFailureException(
-                "'fs ls' ceph call failed with error: {}".format(err_msg))
+                "'fs ls' ceph call failed with error: {}".format(err_msg)
+            )
 
         matching_json_out = {}
         # if '--cephfs-filesystem-name' argument is provided,
         # check whether the provided filesystem-name exists or not
         if self._arg_parser.cephfs_filesystem_name:
             # get the matching list
-            matching_json_out_list = [matched for matched in json_out
-                                      if str(matched['name']) == self._arg_parser.cephfs_filesystem_name]
+            matching_json_out_list = [
+                matched
+                for matched in json_out
+                if str(matched["name"]) == self._arg_parser.cephfs_filesystem_name
+            ]
             # unable to find a matching fs-name, raise an error
             if len(matching_json_out_list) == 0:
                 raise ExecutionFailureException(
-                    ("Filesystem provided, '{}', " +
-                     "is not found in the fs-list: '{}'").format(
+                    (
+                        "Filesystem provided, '{}', "
+                        + "is not found in the fs-list: '{}'"
+                    ).format(
                         self._arg_parser.cephfs_filesystem_name,
-                        [str(x['name']) for x in json_out]))
+                        [str(x["name"]) for x in json_out],
+                    )
+                )
             matching_json_out = matching_json_out_list[0]
         # if cephfs filesystem name is not provided,
         # try to get a default fs name by doing the following
@@ -786,139 +971,201 @@ class RadosJSON:
             elif self._arg_parser.cephfs_data_pool_name:
                 # and if present, check whether there exists a fs which has the data_pool
                 for eachJ in json_out:
-                    if self._arg_parser.cephfs_data_pool_name in eachJ['data_pools']:
+                    if self._arg_parser.cephfs_data_pool_name in eachJ["data_pools"]:
                         matching_json_out = eachJ
                         break
                 # if there is no matching fs exists, that means provided data_pool name is invalid
                 if not matching_json_out:
                     raise ExecutionFailureException(
                         "Provided data_pool name, {}, does not exists".format(
-                            self._arg_parser.cephfs_data_pool_name))
+                            self._arg_parser.cephfs_data_pool_name
+                        )
+                    )
             # c. if nothing is set and couldn't find a default,
             else:
                 # just return silently
                 return
 
         if matching_json_out:
-            self._arg_parser.cephfs_filesystem_name = str(
-                matching_json_out['name'])
+            self._arg_parser.cephfs_filesystem_name = str(matching_json_out["name"])
             self._arg_parser.cephfs_metadata_pool_name = str(
-                matching_json_out['metadata_pool'])
+                matching_json_out["metadata_pool"]
+            )
 
-        if type(matching_json_out['data_pools']) == list:
+        if type(matching_json_out["data_pools"]) == list:
             # if the user has already provided data-pool-name,
             # through --cephfs-data-pool-name
             if self._arg_parser.cephfs_data_pool_name:
                 # if the provided name is not matching with the one in the list
-                if self._arg_parser.cephfs_data_pool_name not in matching_json_out['data_pools']:
+                if (
+                    self._arg_parser.cephfs_data_pool_name
+                    not in matching_json_out["data_pools"]
+                ):
                     raise ExecutionFailureException(
                         "{}: '{}', {}: {}".format(
                             "Provided data-pool-name",
                             self._arg_parser.cephfs_data_pool_name,
                             "doesn't match from the data-pools' list",
-                            [str(x) for x in matching_json_out['data_pools']]))
+                            [str(x) for x in matching_json_out["data_pools"]],
+                        )
+                    )
             # if data_pool name is not provided,
             # then try to find a default data pool name
             else:
                 # if no data_pools exist, silently return
-                if len(matching_json_out['data_pools']) == 0:
+                if len(matching_json_out["data_pools"]) == 0:
                     return
                 self._arg_parser.cephfs_data_pool_name = str(
-                    matching_json_out['data_pools'][0])
+                    matching_json_out["data_pools"][0]
+                )
             # if there are more than one 'data_pools' exist,
             # then warn the user that we are using the selected name
-            if len(matching_json_out['data_pools']) > 1:
-                print("{}: {}\n{}: '{}'\n".format(
-                    "WARNING: Multiple data pools detected",
-                    [str(x) for x in matching_json_out['data_pools']],
-                    "Using the data-pool",
-                    self._arg_parser.cephfs_data_pool_name))
+            if len(matching_json_out["data_pools"]) > 1:
+                print(
+                    "{}: {}\n{}: '{}'\n".format(
+                        "WARNING: Multiple data pools detected",
+                        [str(x) for x in matching_json_out["data_pools"]],
+                        "Using the data-pool",
+                        self._arg_parser.cephfs_data_pool_name,
+                    )
+                )
 
     def create_checkerKey(self):
-        cmd_json = {"prefix": "auth get-or-create",
-                    "entity": self.run_as_user,
-                    "caps": ["mon", self.MIN_USER_CAP_PERMISSIONS['mon'],
-                             "mgr", self.MIN_USER_CAP_PERMISSIONS['mgr'],
-                             "osd", self.MIN_USER_CAP_PERMISSIONS['osd'].format(self._arg_parser.rgw_pool_prefix)],
-                    "format": "json"}
+        cmd_json = {
+            "prefix": "auth get-or-create",
+            "entity": self.run_as_user,
+            "caps": [
+                "mon",
+                self.MIN_USER_CAP_PERMISSIONS["mon"],
+                "mgr",
+                self.MIN_USER_CAP_PERMISSIONS["mgr"],
+                "osd",
+                self.MIN_USER_CAP_PERMISSIONS["osd"].format(
+                    self._arg_parser.rgw_pool_prefix
+                ),
+            ],
+            "format": "json",
+        }
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + cmd_json['prefix'] + " " + cmd_json['entity'] + " " + " ".join(cmd_json['caps']))
+            return self.dry_run(
+                "ceph "
+                + cmd_json["prefix"]
+                + " "
+                + cmd_json["entity"]
+                + " "
+                + " ".join(cmd_json["caps"])
+            )
         ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
         # if there is an unsuccessful attempt,
         if ret_val != 0 or len(json_out) == 0:
             raise ExecutionFailureException(
-                "'auth get-or-create {}' command failed\n".format(self.run_as_user) +
-                "Error: {}".format(err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST))
-        return str(json_out[0]['key'])
+                "'auth get-or-create {}' command failed\n".format(self.run_as_user)
+                + "Error: {}".format(
+                    err_msg if ret_val != 0 else self.EMPTY_OUTPUT_LIST
+                )
+            )
+        return str(json_out[0]["key"])
 
     def get_ceph_dashboard_link(self):
         cmd_json = {"prefix": "mgr services", "format": "json"}
         if self._arg_parser.dry_run:
-            return self.dry_run("ceph " + cmd_json['prefix'])
+            return self.dry_run("ceph " + cmd_json["prefix"])
         ret_val, json_out, _ = self._common_cmd_json_gen(cmd_json)
         # if there is an unsuccessful attempt,
         if ret_val != 0 or len(json_out) == 0:
             return None
-        if not 'dashboard' in json_out:
+        if not "dashboard" in json_out:
             return None
-        return json_out['dashboard']
+        return json_out["dashboard"]
 
     def create_rgw_admin_ops_user(self):
-        cmd = ['radosgw-admin', 'user', 'create', '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME, '--display-name',
-               'Rook RGW Admin Ops user', '--caps', 'info=read;buckets=*;users=*;usage=read;metadata=read;zone=read']
+        cmd = [
+            "radosgw-admin",
+            "user",
+            "create",
+            "--uid",
+            self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
+            "--display-name",
+            "Rook RGW Admin Ops user",
+            "--caps",
+            "info=read;buckets=*;users=*;usage=read;metadata=read;zone=read",
+        ]
         if self._arg_parser.dry_run:
             return self.dry_run("ceph " + " ".join(cmd))
         try:
-            output = subprocess.check_output(cmd,
-                                             stderr=subprocess.PIPE)
+            output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as execErr:
             # if the user already exists, we just query it
             if execErr.returncode == errno.EEXIST:
-                cmd = ['radosgw-admin', 'user', 'info',
-                       '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME
-                       ]
+                cmd = [
+                    "radosgw-admin",
+                    "user",
+                    "info",
+                    "--uid",
+                    self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
+                ]
                 try:
-                    output = subprocess.check_output(cmd,
-                                                     stderr=subprocess.PIPE)
+                    output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
                 except subprocess.CalledProcessError as execErr:
-                    err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
-                        cmd, execErr.output, execErr.returncode, execErr.stderr)
+                    err_msg = (
+                        "failed to execute command %s. Output: %s. Code: %s. Error: %s"
+                        % (cmd, execErr.output, execErr.returncode, execErr.stderr)
+                    )
                     raise Exception(err_msg)
             else:
-                err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
-                    cmd, execErr.output, execErr.returncode, execErr.stderr)
+                err_msg = (
+                    "failed to execute command %s. Output: %s. Code: %s. Error: %s"
+                    % (cmd, execErr.output, execErr.returncode, execErr.stderr)
+                )
                 raise Exception(err_msg)
-
 
         # separately add info=read caps, because sometimes users already exited and the cap doesn't update
         info_cap_supported = True
-        cmd = ['radosgw-admin', 'caps', 'add', '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
-            '--caps', 'info=read']
+        cmd = [
+            "radosgw-admin",
+            "caps",
+            "add",
+            "--uid",
+            self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME,
+            "--caps",
+            "info=read",
+        ]
         try:
-            output = subprocess.check_output(cmd,
-                                            stderr=subprocess.PIPE)
+            output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as execErr:
             # if the ceph version not supported for adding `info=read` cap(rgw_validation)
-            if 'could not add caps: unable to add caps: info=read\n' in execErr.stderr.decode("utf-8") and execErr.returncode == 244:
+            if (
+                "could not add caps: unable to add caps: info=read\n"
+                in execErr.stderr.decode("utf-8")
+                and execErr.returncode == 244
+            ):
                 info_cap_supported = False
             else:
-                err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
-                        cmd, execErr.output, execErr.returncode, execErr.stderr)
+                err_msg = (
+                    "failed to execute command %s. Output: %s. Code: %s. Error: %s"
+                    % (cmd, execErr.output, execErr.returncode, execErr.stderr)
+                )
                 raise Exception(err_msg)
 
         jsonoutput = json.loads(output)
-        return jsonoutput["keys"][0]['access_key'], jsonoutput["keys"][0]['secret_key'], info_cap_supported
+        return (
+            jsonoutput["keys"][0]["access_key"],
+            jsonoutput["keys"][0]["secret_key"],
+            info_cap_supported,
+        )
 
-    def convert_fqdn_rgw_endpoint_to_ip(self,fqdn_rgw_endpoint):
+    def convert_fqdn_rgw_endpoint_to_ip(self, fqdn_rgw_endpoint):
         try:
-            fqdn, port = fqdn_rgw_endpoint.split(':')
+            fqdn, port = fqdn_rgw_endpoint.split(":")
         except ValueError:
             raise ExecutionFailureException(
-            "Not a proper endpoint: {}, <FQDN>:<PORT>, format is expected".format(fqdn_rgw_endpoint))
+                "Not a proper endpoint: {}, <FQDN>:<PORT>, format is expected".format(
+                    fqdn_rgw_endpoint
+                )
+            )
         rgw_endpoint_ip = self._convert_hostname_to_ip(fqdn)
         rgw_endpoint_port = port
-        rgw_endpoint = self._join_host_port(
-        rgw_endpoint_ip, rgw_endpoint_port)
+        rgw_endpoint = self._join_host_port(rgw_endpoint_ip, rgw_endpoint_port)
         return rgw_endpoint
 
     def validate_pool(self):
@@ -927,20 +1174,22 @@ class RadosJSON:
         if self._arg_parser.rgw_endpoint:
             rgw_endpoint = self._arg_parser.rgw_endpoint
             self._invalid_endpoint(rgw_endpoint)
-            self.endpoint_dial(rgw_endpoint,
-                               cert=self.validate_rgw_endpoint_tls_cert())
+            self.endpoint_dial(rgw_endpoint, cert=self.validate_rgw_endpoint_tls_cert())
             # only validate if rgw_pool_prefix is passed else it will take default value and we don't create these default pools
             if self._arg_parser.rgw_pool_prefix != "default":
-                rgw_pool_to_validate = ["{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
-                                        ".rgw.root",
-                                        "{0}.rgw.control".format(self._arg_parser.rgw_pool_prefix),
-                                        "{0}.rgw.log".format(self._arg_parser.rgw_pool_prefix)]
+                rgw_pool_to_validate = [
+                    "{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
+                    ".rgw.root",
+                    "{0}.rgw.control".format(self._arg_parser.rgw_pool_prefix),
+                    "{0}.rgw.log".format(self._arg_parser.rgw_pool_prefix),
+                ]
                 pools_to_validate.extend(rgw_pool_to_validate)
 
         for pool in pools_to_validate:
             if not self.cluster.pool_exists(pool):
                 raise ExecutionFailureException(
-                    "The provided pool, '{}', does not exist".format(pool))
+                    "The provided pool, '{}', does not exist".format(pool)
+                )
 
     def validate_rados_namespace(self):
         rbd_pool_name = self._arg_parser.rbd_data_pool_name
@@ -951,12 +1200,14 @@ class RadosJSON:
         ioctx = self.cluster.open_ioctx(rbd_pool_name)
         if rbd_inst.namespace_exists(ioctx, rados_namespace) == False:
             raise ExecutionFailureException(
-                ("The provided rados Namespace, '{}', is not found in the pool '{}'").format(
-                    rados_namespace, rbd_pool_name))
+                (
+                    "The provided rados Namespace, '{}', is not found in the pool '{}'"
+                ).format(rados_namespace, rbd_pool_name)
+            )
 
     def get_rgw_fsid(self):
-        access_key = self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY']
-        secret_key = self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY']
+        access_key = self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"]
+        secret_key = self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"]
         rgw_endpoint = self._arg_parser.rgw_endpoint
         cert = None
         verify = None
@@ -965,21 +1216,29 @@ class RadosJSON:
             verify = True
         if self._arg_parser.rgw_skip_tls:
             verify = False
-        base_url =  self.endpoint_dial(rgw_endpoint,cert=cert) + "://"
+        base_url = self.endpoint_dial(rgw_endpoint, cert=cert) + "://"
         base_url = base_url + rgw_endpoint + "/admin/info?"
-        params = {'format': 'json'}
+        params = {"format": "json"}
         request_url = base_url + urllib.parse.urlencode(params)
 
         try:
-            r = requests.get(request_url, auth=S3Auth(access_key, secret_key,rgw_endpoint), cert=cert, verify=verify)
+            r = requests.get(
+                request_url,
+                auth=S3Auth(access_key, secret_key, rgw_endpoint),
+                cert=cert,
+                verify=verify,
+            )
         except requests.exceptions.Timeout:
             raise ExecutionFailureException(
-                    "invalid endpoint:, not able to call admin-ops api{}".format(rgw_endpoint))
+                "invalid endpoint:, not able to call admin-ops api{}".format(
+                    rgw_endpoint
+                )
+            )
         r1 = r.json()
-        if r1 is None or r1.get('info') is None:
+        if r1 is None or r1.get("info") is None:
             return ""  # Invalid rgw-endpoint exception will returned by validate_rgw_endpoint()
 
-        return r1['info']['storage_backends'][0]['cluster_id']
+        return r1["info"]["storage_backends"][0]["cluster_id"]
 
     def validate_rgw_endpoint(self):
         # if the 'cluster' instance is a dummy one,
@@ -990,65 +1249,85 @@ class RadosJSON:
         rgw_fsid = self.get_rgw_fsid()
         if fsid != rgw_fsid:
             raise ExecutionFailureException(
-                ("The provided rgw Endpoint, '{}', is invalid. We are validating by calling the adminops api through rgw-endpoint and validating the cluster_id '{}' is equal to the ceph cluster fsid '{}'").format(
-                    self._arg_parser.rgw_endpoint,rgw_fsid,fsid))
+                (
+                    "The provided rgw Endpoint, '{}', is invalid. We are validating by calling the adminops api through rgw-endpoint and validating the cluster_id '{}' is equal to the ceph cluster fsid '{}'"
+                ).format(self._arg_parser.rgw_endpoint, rgw_fsid, fsid)
+            )
 
     def _gen_output_map(self):
         if self.out_map:
             return
         if self._arg_parser.rgw_endpoint:
-            self._arg_parser.rgw_endpoint = self.convert_fqdn_rgw_endpoint_to_ip(self._arg_parser.rgw_endpoint)
+            self._arg_parser.rgw_endpoint = self.convert_fqdn_rgw_endpoint_to_ip(
+                self._arg_parser.rgw_endpoint
+            )
         self.validate_pool()
         self.validate_rados_namespace()
-        self._excluded_keys.add('CLUSTER_NAME')
+        self._excluded_keys.add("CLUSTER_NAME")
         self.get_cephfs_data_pool_details()
-        self.out_map['NAMESPACE'] = self._arg_parser.namespace
-        self.out_map['CLUSTER_NAME'] = self._arg_parser.cluster_name
-        self.out_map['ROOK_EXTERNAL_FSID'] = self.get_fsid()
-        self.out_map['ROOK_EXTERNAL_USERNAME'] = self.run_as_user
-        self.out_map['ROOK_EXTERNAL_CEPH_MON_DATA'] = self.get_ceph_external_mon_data()
-        self.out_map['ROOK_EXTERNAL_USER_SECRET'] = self.create_checkerKey()
-        self.out_map['ROOK_EXTERNAL_DASHBOARD_LINK'] = self.get_ceph_dashboard_link()
-        self.out_map['CSI_RBD_NODE_SECRET'] = self.create_cephCSIKeyring_user(
-            "client.csi-rbd-node")
-        self.out_map['CSI_RBD_PROVISIONER_SECRET'] = self.create_cephCSIKeyring_user(
-            "client.csi-rbd-provisioner")
-        self.out_map['CEPHFS_POOL_NAME'] = self._arg_parser.cephfs_data_pool_name
-        self.out_map['CEPHFS_METADATA_POOL_NAME'] = self._arg_parser.cephfs_metadata_pool_name
-        self.out_map['CEPHFS_FS_NAME'] = self._arg_parser.cephfs_filesystem_name
-        self.out_map['RESTRICTED_AUTH_PERMISSION'] = self._arg_parser.restricted_auth_permission
-        self.out_map['RADOS_NAMESPACE'] = self._arg_parser.rados_namespace
-        self.out_map['CSI_CEPHFS_NODE_SECRET'] = ''
-        self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] = ''
+        self.out_map["NAMESPACE"] = self._arg_parser.namespace
+        self.out_map["CLUSTER_NAME"] = self._arg_parser.cluster_name
+        self.out_map["ROOK_EXTERNAL_FSID"] = self.get_fsid()
+        self.out_map["ROOK_EXTERNAL_USERNAME"] = self.run_as_user
+        self.out_map["ROOK_EXTERNAL_CEPH_MON_DATA"] = self.get_ceph_external_mon_data()
+        self.out_map["ROOK_EXTERNAL_USER_SECRET"] = self.create_checkerKey()
+        self.out_map["ROOK_EXTERNAL_DASHBOARD_LINK"] = self.get_ceph_dashboard_link()
+        self.out_map["CSI_RBD_NODE_SECRET"] = self.create_cephCSIKeyring_user(
+            "client.csi-rbd-node"
+        )
+        self.out_map["CSI_RBD_PROVISIONER_SECRET"] = self.create_cephCSIKeyring_user(
+            "client.csi-rbd-provisioner"
+        )
+        self.out_map["CEPHFS_POOL_NAME"] = self._arg_parser.cephfs_data_pool_name
+        self.out_map[
+            "CEPHFS_METADATA_POOL_NAME"
+        ] = self._arg_parser.cephfs_metadata_pool_name
+        self.out_map["CEPHFS_FS_NAME"] = self._arg_parser.cephfs_filesystem_name
+        self.out_map[
+            "RESTRICTED_AUTH_PERMISSION"
+        ] = self._arg_parser.restricted_auth_permission
+        self.out_map["RADOS_NAMESPACE"] = self._arg_parser.rados_namespace
+        self.out_map["CSI_CEPHFS_NODE_SECRET"] = ""
+        self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"] = ""
         # create CephFS node and provisioner keyring only when MDS exists
-        if self.out_map['CEPHFS_FS_NAME'] and self.out_map['CEPHFS_POOL_NAME']:
-            self.out_map['CSI_CEPHFS_NODE_SECRET'] = self.create_cephCSIKeyring_user(
-                "client.csi-cephfs-node")
-            self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] = self.create_cephCSIKeyring_user(
-                "client.csi-cephfs-provisioner")
-        self.out_map['RGW_ENDPOINT'] = self._arg_parser.rgw_endpoint
-        self.out_map['RGW_TLS_CERT'] = ''
-        self.out_map['MONITORING_ENDPOINT'], \
-            self.out_map['MONITORING_ENDPOINT_PORT'] = self.get_active_and_standby_mgrs()
-        self.out_map['RBD_POOL_NAME'] = self._arg_parser.rbd_data_pool_name
-        self.out_map['RBD_METADATA_EC_POOL_NAME'] = self.validate_rgw_metadata_ec_pool_name()
-        self.out_map['RGW_POOL_PREFIX'] = self._arg_parser.rgw_pool_prefix
+        if self.out_map["CEPHFS_FS_NAME"] and self.out_map["CEPHFS_POOL_NAME"]:
+            self.out_map["CSI_CEPHFS_NODE_SECRET"] = self.create_cephCSIKeyring_user(
+                "client.csi-cephfs-node"
+            )
+            self.out_map[
+                "CSI_CEPHFS_PROVISIONER_SECRET"
+            ] = self.create_cephCSIKeyring_user("client.csi-cephfs-provisioner")
+        self.out_map["RGW_ENDPOINT"] = self._arg_parser.rgw_endpoint
+        self.out_map["RGW_TLS_CERT"] = ""
+        (
+            self.out_map["MONITORING_ENDPOINT"],
+            self.out_map["MONITORING_ENDPOINT_PORT"],
+        ) = self.get_active_and_standby_mgrs()
+        self.out_map["RBD_POOL_NAME"] = self._arg_parser.rbd_data_pool_name
+        self.out_map[
+            "RBD_METADATA_EC_POOL_NAME"
+        ] = self.validate_rgw_metadata_ec_pool_name()
+        self.out_map["RGW_POOL_PREFIX"] = self._arg_parser.rgw_pool_prefix
         if self._arg_parser.rgw_endpoint:
             if self._arg_parser.dry_run:
                 self.create_rgw_admin_ops_user()
             else:
-                self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY'], self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY'], info_cap_supported = self.create_rgw_admin_ops_user()
+                (
+                    self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"],
+                    self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"],
+                    info_cap_supported,
+                ) = self.create_rgw_admin_ops_user()
                 if info_cap_supported:
                     self.validate_rgw_endpoint()
             if self._arg_parser.rgw_tls_cert_path:
-                self.out_map['RGW_TLS_CERT'] = self.validate_rgw_endpoint_tls_cert()
+                self.out_map["RGW_TLS_CERT"] = self.validate_rgw_endpoint_tls_cert()
 
     def gen_shell_out(self):
         self._gen_output_map()
         shOutIO = StringIO()
         for k, v in self.out_map.items():
             if v and k not in self._excluded_keys:
-                shOutIO.write('export {}={}{}'.format(k, v, LINESEP))
+                shOutIO.write("export {}={}{}".format(k, v, LINESEP))
         shOut = shOutIO.getvalue()
         shOutIO.close()
         return shOut
@@ -1062,210 +1341,267 @@ class RadosJSON:
                 "name": "rook-ceph-mon-endpoints",
                 "kind": "ConfigMap",
                 "data": {
-                    "data": self.out_map['ROOK_EXTERNAL_CEPH_MON_DATA'],
+                    "data": self.out_map["ROOK_EXTERNAL_CEPH_MON_DATA"],
                     "maxMonId": "0",
-                    "mapping": "{}"
-                }
+                    "mapping": "{}",
+                },
             },
             {
                 "name": "rook-ceph-mon",
                 "kind": "Secret",
                 "data": {
                     "admin-secret": "admin-secret",
-                    "fsid": self.out_map['ROOK_EXTERNAL_FSID'],
-                    "mon-secret": "mon-secret"
+                    "fsid": self.out_map["ROOK_EXTERNAL_FSID"],
+                    "mon-secret": "mon-secret",
                 },
             },
             {
                 "name": "rook-ceph-operator-creds",
                 "kind": "Secret",
                 "data": {
-                    "userID": self.out_map['ROOK_EXTERNAL_USERNAME'],
-                    "userKey": self.out_map['ROOK_EXTERNAL_USER_SECRET']
-                }
+                    "userID": self.out_map["ROOK_EXTERNAL_USERNAME"],
+                    "userKey": self.out_map["ROOK_EXTERNAL_USER_SECRET"],
+                },
             },
             {
                 "name": "monitoring-endpoint",
                 "kind": "CephCluster",
                 "data": {
-                    "MonitoringEndpoint": self.out_map['MONITORING_ENDPOINT'],
-                    "MonitoringPort": self.out_map['MONITORING_ENDPOINT_PORT']
-                }
-            }
+                    "MonitoringEndpoint": self.out_map["MONITORING_ENDPOINT"],
+                    "MonitoringPort": self.out_map["MONITORING_ENDPOINT_PORT"],
+                },
+            },
         ]
 
-        if self.out_map['RBD_METADATA_EC_POOL_NAME']:
-            json_out.append({
-                "name": "ceph-rbd",
-                "kind": "StorageClass",
-                "data": {
-                    "dataPool": self.out_map['RBD_POOL_NAME'],
-                    "pool": self.out_map['RBD_METADATA_EC_POOL_NAME']
-                },
-            })
+        if self.out_map["RBD_METADATA_EC_POOL_NAME"]:
+            json_out.append(
+                {
+                    "name": "ceph-rbd",
+                    "kind": "StorageClass",
+                    "data": {
+                        "dataPool": self.out_map["RBD_POOL_NAME"],
+                        "pool": self.out_map["RBD_METADATA_EC_POOL_NAME"],
+                    },
+                }
+            )
         else:
-            json_out.append({
-                "name": "ceph-rbd",
-                "kind": "StorageClass",
-                "data": {
-                    "pool": self.out_map['RBD_POOL_NAME']
-                },
-            })
+            json_out.append(
+                {
+                    "name": "ceph-rbd",
+                    "kind": "StorageClass",
+                    "data": {"pool": self.out_map["RBD_POOL_NAME"]},
+                }
+            )
 
         if self._arg_parser.restricted_auth_permission:
             cluster_name = self._arg_parser.cluster_name
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
             rados_namespace = self._arg_parser.rados_namespace
-            json_out.append({
-                "name": "rook-csi-rbd-node-{}-{}-{}".format(cluster_name, rbd_pool_name, rados_namespace),
-                "kind": "Secret",
-                "data": {
-                    "userID": 'csi-rbd-node-{}-{}-{}'.format(cluster_name, rbd_pool_name, rados_namespace),
-                    "userKey": self.out_map['CSI_RBD_NODE_SECRET']
+            json_out.append(
+                {
+                    "name": "rook-csi-rbd-node-{}-{}-{}".format(
+                        cluster_name, rbd_pool_name, rados_namespace
+                    ),
+                    "kind": "Secret",
+                    "data": {
+                        "userID": "csi-rbd-node-{}-{}-{}".format(
+                            cluster_name, rbd_pool_name, rados_namespace
+                        ),
+                        "userKey": self.out_map["CSI_RBD_NODE_SECRET"],
+                    },
                 }
-            })
+            )
             # if 'CSI_RBD_PROVISIONER_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
-            if self.out_map['CSI_RBD_PROVISIONER_SECRET']:
-                json_out.append({
-                    "name": "rook-csi-rbd-provisioner-{}-{}-{}".format(cluster_name, rbd_pool_name, rados_namespace),
-                    "kind": "Secret",
-                    "data": {
-                        "userID": 'csi-rbd-provisioner-{}-{}-{}'.format(cluster_name, rbd_pool_name, rados_namespace),
-                        "userKey": self.out_map['CSI_RBD_PROVISIONER_SECRET']
-                    },
-                })
+            if self.out_map["CSI_RBD_PROVISIONER_SECRET"]:
+                json_out.append(
+                    {
+                        "name": "rook-csi-rbd-provisioner-{}-{}-{}".format(
+                            cluster_name, rbd_pool_name, rados_namespace
+                        ),
+                        "kind": "Secret",
+                        "data": {
+                            "userID": "csi-rbd-provisioner-{}-{}-{}".format(
+                                cluster_name, rbd_pool_name, rados_namespace
+                            ),
+                            "userKey": self.out_map["CSI_RBD_PROVISIONER_SECRET"],
+                        },
+                    }
+                )
             # if 'CSI_CEPHFS_PROVISIONER_SECRET' exists, then only add 'rook-csi-cephfs-provisioner' Secret
-            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] and cephfs_filesystem != "":
-                json_out.append({
-                    "name": "rook-csi-cephfs-provisioner-{}-{}".format(cluster_name, cephfs_filesystem),
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-provisioner-{}-{}'.format(cluster_name, cephfs_filesystem),
-                        "adminKey": self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']
-                    },
-                })
-            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] and cephfs_filesystem == "":
-                json_out.append({
-                    "name": "rook-csi-cephfs-provisioner-{}".format(cluster_name),
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-provisioner-{}'.format(cluster_name),
-                        "adminKey": self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']
-                    },
-                })
+            if (
+                self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"]
+                and cephfs_filesystem != ""
+            ):
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-provisioner-{}-{}".format(
+                            cluster_name, cephfs_filesystem
+                        ),
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-provisioner-{}-{}".format(
+                                cluster_name, cephfs_filesystem
+                            ),
+                            "adminKey": self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"],
+                        },
+                    }
+                )
+            if (
+                self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"]
+                and cephfs_filesystem == ""
+            ):
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-provisioner-{}".format(cluster_name),
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-provisioner-{}".format(cluster_name),
+                            "adminKey": self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"],
+                        },
+                    }
+                )
             # if 'CSI_CEPHFS_NODE_SECRET' exists, then only add 'rook-csi-cephfs-node' Secret
-            if self.out_map['CSI_CEPHFS_NODE_SECRET'] and cephfs_filesystem != "":
-                json_out.append({
-                    "name": "rook-csi-cephfs-node-{}-{}".format(cluster_name, cephfs_filesystem),
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-node-{}-{}'.format(cluster_name, cephfs_filesystem),
-                        "adminKey": self.out_map['CSI_CEPHFS_NODE_SECRET']
+            if self.out_map["CSI_CEPHFS_NODE_SECRET"] and cephfs_filesystem != "":
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-node-{}-{}".format(
+                            cluster_name, cephfs_filesystem
+                        ),
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-node-{}-{}".format(
+                                cluster_name, cephfs_filesystem
+                            ),
+                            "adminKey": self.out_map["CSI_CEPHFS_NODE_SECRET"],
+                        },
                     }
-                })
-            if self.out_map['CSI_CEPHFS_NODE_SECRET'] and cephfs_filesystem == "":
-                json_out.append({
-                    "name": "rook-csi-cephfs-node-{}".format(cluster_name),
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-node-{}'.format(cluster_name),
-                        "adminKey": self.out_map['CSI_CEPHFS_NODE_SECRET']
+                )
+            if self.out_map["CSI_CEPHFS_NODE_SECRET"] and cephfs_filesystem == "":
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-node-{}".format(cluster_name),
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-node-{}".format(cluster_name),
+                            "adminKey": self.out_map["CSI_CEPHFS_NODE_SECRET"],
+                        },
                     }
-                })
+                )
         else:
-            json_out.append({
-                "name": "rook-csi-rbd-node",
-                "kind": "Secret",
-                "data": {
-                    "userID": 'csi-rbd-node',
-                    "userKey": self.out_map['CSI_RBD_NODE_SECRET']
+            json_out.append(
+                {
+                    "name": "rook-csi-rbd-node",
+                    "kind": "Secret",
+                    "data": {
+                        "userID": "csi-rbd-node",
+                        "userKey": self.out_map["CSI_RBD_NODE_SECRET"],
+                    },
                 }
-            })
+            )
             # if 'CSI_RBD_PROVISIONER_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
-            if self.out_map['CSI_RBD_PROVISIONER_SECRET']:
-                json_out.append({
-                    "name": "rook-csi-rbd-provisioner",
-                    "kind": "Secret",
-                    "data": {
-                        "userID": 'csi-rbd-provisioner',
-                        "userKey": self.out_map['CSI_RBD_PROVISIONER_SECRET']
-                    },
-                })
-            # if 'CSI_CEPHFS_PROVISIONER_SECRET' exists, then only add 'rook-csi-cephfs-provisioner' Secret
-            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']:
-                json_out.append({
-                    "name": "rook-csi-cephfs-provisioner",
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-provisioner',
-                        "adminKey": self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']
-                    },
-                })
-            # if 'CSI_CEPHFS_NODE_SECRET' exists, then only add 'rook-csi-cephfs-node' Secret
-            if self.out_map['CSI_CEPHFS_NODE_SECRET']:
-                json_out.append({
-                    "name": "rook-csi-cephfs-node",
-                    "kind": "Secret",
-                    "data": {
-                        "adminID": 'csi-cephfs-node',
-                        "adminKey": self.out_map['CSI_CEPHFS_NODE_SECRET']
+            if self.out_map["CSI_RBD_PROVISIONER_SECRET"]:
+                json_out.append(
+                    {
+                        "name": "rook-csi-rbd-provisioner",
+                        "kind": "Secret",
+                        "data": {
+                            "userID": "csi-rbd-provisioner",
+                            "userKey": self.out_map["CSI_RBD_PROVISIONER_SECRET"],
+                        },
                     }
-                })
+                )
+            # if 'CSI_CEPHFS_PROVISIONER_SECRET' exists, then only add 'rook-csi-cephfs-provisioner' Secret
+            if self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"]:
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-provisioner",
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-provisioner",
+                            "adminKey": self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"],
+                        },
+                    }
+                )
+            # if 'CSI_CEPHFS_NODE_SECRET' exists, then only add 'rook-csi-cephfs-node' Secret
+            if self.out_map["CSI_CEPHFS_NODE_SECRET"]:
+                json_out.append(
+                    {
+                        "name": "rook-csi-cephfs-node",
+                        "kind": "Secret",
+                        "data": {
+                            "adminID": "csi-cephfs-node",
+                            "adminKey": self.out_map["CSI_CEPHFS_NODE_SECRET"],
+                        },
+                    }
+                )
         # if 'ROOK_EXTERNAL_DASHBOARD_LINK' exists, then only add 'rook-ceph-dashboard-link' Secret
-        if self.out_map['ROOK_EXTERNAL_DASHBOARD_LINK']:
-            json_out.append({
-                "name": "rook-ceph-dashboard-link",
-                "kind": "Secret",
-                "data": {
-                    "userID": 'ceph-dashboard-link',
-                    "userKey": self.out_map['ROOK_EXTERNAL_DASHBOARD_LINK']
+        if self.out_map["ROOK_EXTERNAL_DASHBOARD_LINK"]:
+            json_out.append(
+                {
+                    "name": "rook-ceph-dashboard-link",
+                    "kind": "Secret",
+                    "data": {
+                        "userID": "ceph-dashboard-link",
+                        "userKey": self.out_map["ROOK_EXTERNAL_DASHBOARD_LINK"],
+                    },
                 }
-            })
+            )
         # if 'CEPHFS_FS_NAME' exists, then only add 'cephfs' StorageClass
-        if self.out_map['CEPHFS_FS_NAME']:
-            json_out.append({
-                "name": "cephfs",
-                "kind": "StorageClass",
-                "data": {
-                    "fsName": self.out_map['CEPHFS_FS_NAME'],
-                    "pool": self.out_map['CEPHFS_POOL_NAME']
+        if self.out_map["CEPHFS_FS_NAME"]:
+            json_out.append(
+                {
+                    "name": "cephfs",
+                    "kind": "StorageClass",
+                    "data": {
+                        "fsName": self.out_map["CEPHFS_FS_NAME"],
+                        "pool": self.out_map["CEPHFS_POOL_NAME"],
+                    },
                 }
-            })
+            )
         # if 'RGW_ENDPOINT' exists, then only add 'ceph-rgw' StorageClass
-        if self.out_map['RGW_ENDPOINT']:
-            json_out.append({
-                "name": "ceph-rgw",
-                "kind": "StorageClass",
-                "data": {
-                    "endpoint": self.out_map['RGW_ENDPOINT'],
-                    "poolPrefix": self.out_map['RGW_POOL_PREFIX']
+        if self.out_map["RGW_ENDPOINT"]:
+            json_out.append(
+                {
+                    "name": "ceph-rgw",
+                    "kind": "StorageClass",
+                    "data": {
+                        "endpoint": self.out_map["RGW_ENDPOINT"],
+                        "poolPrefix": self.out_map["RGW_POOL_PREFIX"],
+                    },
                 }
-            })
+            )
             json_out.append(
                 {
                     "name": "rgw-admin-ops-user",
                     "kind": "Secret",
                     "data": {
-                        "accessKey": self.out_map['RGW_ADMIN_OPS_USER_ACCESS_KEY'],
-                        "secretKey": self.out_map['RGW_ADMIN_OPS_USER_SECRET_KEY']
-                    }
-                })
-        # if 'RGW_TLS_CERT' exists, then only add the "ceph-rgw-tls-cert" secret
-        if self.out_map['RGW_TLS_CERT']:
-            json_out.append({
-                "name": "ceph-rgw-tls-cert",
-                "kind": "Secret",
-                "data": {
-                    "cert": self.out_map['RGW_TLS_CERT'],
+                        "accessKey": self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"],
+                        "secretKey": self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"],
+                    },
                 }
-            })
+            )
+        # if 'RGW_TLS_CERT' exists, then only add the "ceph-rgw-tls-cert" secret
+        if self.out_map["RGW_TLS_CERT"]:
+            json_out.append(
+                {
+                    "name": "ceph-rgw-tls-cert",
+                    "kind": "Secret",
+                    "data": {
+                        "cert": self.out_map["RGW_TLS_CERT"],
+                    },
+                }
+            )
 
-        return json.dumps(json_out)+LINESEP
+        return json.dumps(json_out) + LINESEP
 
     def upgrade_users_permissions(self):
-        users = ["client.csi-cephfs-node", "client.csi-cephfs-provisioner",
-                 "client.csi-rbd-node", "client.csi-rbd-provisioner"]
+        users = [
+            "client.csi-cephfs-node",
+            "client.csi-cephfs-provisioner",
+            "client.csi-rbd-node",
+            "client.csi-rbd-provisioner",
+        ]
         if self.run_as_user != "" and self.run_as_user not in users:
             users.append(self.run_as_user)
         for user in users:
@@ -1273,58 +1609,63 @@ class RadosJSON:
 
     def upgrade_user_permissions(self, user):
         # check whether the given user exists or not
-        cmd_json = {"prefix": "auth get", "entity": "{}".format(
-            user), "format": "json"}
+        cmd_json = {"prefix": "auth get", "entity": "{}".format(user), "format": "json"}
         ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
         if ret_val != 0 or len(json_out) == 0:
             print("user {} not found for upgrading.".format(user))
             return
-        existing_caps = json_out[0]['caps']
+        existing_caps = json_out[0]["caps"]
         new_cap, _ = self.get_caps_and_entity(user)
         cap_keys = ["mon", "mgr", "osd", "mds"]
         caps = []
         for eachCap in cap_keys:
-            cur_cap_values = existing_caps.get(eachCap, '')
-            new_cap_values = new_cap.get(eachCap, '')
-            cur_cap_perm_list = [x.strip()
-                                 for x in cur_cap_values.split(',') if x.strip()]
-            new_cap_perm_list = [x.strip()
-                                 for x in new_cap_values.split(',') if x.strip()]
+            cur_cap_values = existing_caps.get(eachCap, "")
+            new_cap_values = new_cap.get(eachCap, "")
+            cur_cap_perm_list = [
+                x.strip() for x in cur_cap_values.split(",") if x.strip()
+            ]
+            new_cap_perm_list = [
+                x.strip() for x in new_cap_values.split(",") if x.strip()
+            ]
             # append new_cap_list to cur_cap_list to maintain the order of caps
             cur_cap_perm_list.extend(new_cap_perm_list)
             # eliminate duplicates without using 'set'
             # set re-orders items in the list and we have to keep the order
             new_cap_list = []
-            [new_cap_list.append(
-                x) for x in cur_cap_perm_list if x not in new_cap_list]
+            [new_cap_list.append(x) for x in cur_cap_perm_list if x not in new_cap_list]
             existing_caps[eachCap] = ", ".join(new_cap_list)
             if existing_caps[eachCap]:
                 caps.append(eachCap)
                 caps.append(existing_caps[eachCap])
-        cmd_json = {"prefix": "auth caps",
-                    "entity": user,
-                    "caps": caps,
-                    "format": "json"}
+        cmd_json = {
+            "prefix": "auth caps",
+            "entity": user,
+            "caps": caps,
+            "format": "json",
+        }
         ret_val, json_out, err_msg = self._common_cmd_json_gen(cmd_json)
         if ret_val != 0:
-            raise ExecutionFailureException("'auth caps {}' command failed.\n".format(user) +
-                                            "Error: {}".format(err_msg))
+            raise ExecutionFailureException(
+                "'auth caps {}' command failed.\n".format(user)
+                + "Error: {}".format(err_msg)
+            )
         print("Updated user, {}, successfully.".format(user))
 
     def main(self):
-        generated_output = ''
+        generated_output = ""
         if self._arg_parser.upgrade:
             self.upgrade_users_permissions()
-        elif self._arg_parser.format == 'json':
+        elif self._arg_parser.format == "json":
             generated_output = self.gen_json_out()
-        elif self._arg_parser.format == 'bash':
+        elif self._arg_parser.format == "bash":
             generated_output = self.gen_shell_out()
         else:
-            raise ExecutionFailureException("Unsupported format: {}".format(
-                self._arg_parser.format))
-        print('{}'.format(generated_output))
+            raise ExecutionFailureException(
+                "Unsupported format: {}".format(self._arg_parser.format)
+            )
+        print("{}".format(generated_output))
         if self.output_file and generated_output:
-            fOut = open(self.output_file, 'w')
+            fOut = open(self.output_file, "w")
             fOut.write(generated_output)
             fOut.close()
 
@@ -1332,7 +1673,7 @@ class RadosJSON:
 ################################################
 ##################### MAIN #####################
 ################################################
-if __name__ == '__main__':
+if __name__ == "__main__":
     rjObj = RadosJSON()
     try:
         rjObj.main()


### PR DESCRIPTION
`black` is python formatter tool which
automatically formats python files without
manual changing. just run `black <python-file>`
and done.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
