### PR TITLE
mon: update node labels as per new key value

### DIFF
--- a/deploy/examples/cluster-stretched-aws.yaml
+++ b/deploy/examples/cluster-stretched-aws.yaml
@@ -126,10 +126,13 @@ spec:
   placement:
     # The arbiter mon can have its own placement settings that will be different from the mons.
     # If the arbiter section is not included in the placement, the arbiter will use the same placement
-    # settings as other mons. In this example, the arbiter has a toleration to run on a master node.
+    # settings as other mons. In this example, the arbiter has a toleration to run on a control-plane node.
     arbiter:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        # kubernetes v1.24 clusters would need the taint `node-role.kubernetes.io/control-plane`
+        # configuration. For earlier versions you may use `node-role.kubernetes.io/master` if
+        # available in your cluster.
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
   priorityClassNames:

--- a/deploy/examples/cluster-stretched.yaml
+++ b/deploy/examples/cluster-stretched.yaml
@@ -54,10 +54,13 @@ spec:
   placement:
     # The arbiter mon can have its own placement settings that will be different from the mons.
     # If the arbiter section is not included in the placement, the arbiter will use the same placement
-    # settings as other mons. In this example, the arbiter has a toleration to run on a master node.
+    # settings as other mons. In this example, the arbiter has a toleration to run on a control-plane node.
     arbiter:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        # kubernetes v1.24 clusters would need the taint `node-role.kubernetes.io/control-plane`
+        # configuration. For earlier versions you may use `node-role.kubernetes.io/master` if
+        # available in your cluster.
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
     osd:


### PR DESCRIPTION
From kube v1.24 onwards, Kubeadm applies a "node-role" label to its
control plane Nodes.Currently this label key is node-role.kubernetes.io/master
and it will be renamed to node-role.kubernetes.io/control-plane. Kubeadm
also uses the same "node-role" as key for a taint it applies on control
plane Nodes. This taint key should also be renamed to
"node-role.kubernetes.io/control-plane".

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/rook/rook/issues/10398

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
