### PR TITLE
object: add the external rgw server check properly

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -874,11 +874,9 @@ func getDashboardUser(context *Context) (ObjectUser, error) {
 		SystemUser:  true,
 	}
 
-	if !context.CephClusterSpec.External.Enable {
-		// Retrieve RGW Dashboard credentials if some are already set
-		if err := retrieveDashboardAPICredentials(context, &user); err != nil {
-			return user, errors.Wrapf(err, "failed to retrieve RGW Dashboard credentials for %q user", DashboardUser)
-		}
+	// Retrieve RGW Dashboard credentials if some are already set
+	if err := retrieveDashboardAPICredentials(context, &user); err != nil {
+		return user, errors.Wrapf(err, "failed to retrieve RGW Dashboard credentials for %q user", DashboardUser)
 	}
 
 	return user, nil

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -226,7 +226,7 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 func (c *clusterConfig) deleteStore() {
 	logger.Infof("deleting object store %q from namespace %q", c.store.Name, c.store.Namespace)
 
-	if !c.clusterSpec.External.Enable {
+	if !c.store.Spec.IsExternal() {
 		// Delete rgw CephX keys and configuration in centralized mon database
 		for i := 0; i < int(c.store.Spec.Gateway.Instances); i++ {
 			daemonLetterID := k8sutil.IndexToName(i)

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -478,15 +478,15 @@ func (r *ReconcileObjectStoreUser) reconcileCephUserSecret(cephObjectStoreUser *
 }
 
 func (r *ReconcileObjectStoreUser) objectStoreInitialized(cephObjectStoreUser *cephv1.CephObjectStoreUser) error {
-	_, err := r.getObjectStore(cephObjectStoreUser.Spec.Store)
+	cephObjectStore, err := r.getObjectStore(cephObjectStoreUser.Spec.Store)
 	if err != nil {
 		return err
 	}
 	logger.Debug("CephObjectStore exists")
 
-	// If the cluster is external just return
+	// If the rgw is external just return
 	// since there are no pods running
-	if r.cephClusterSpec.External.Enable {
+	if cephObjectStore.Spec.IsExternal() {
 		return nil
 	}
 
@@ -571,10 +571,8 @@ func (r *ReconcileObjectStoreUser) validateUser(u *cephv1.CephObjectStoreUser) e
 	if u.Namespace == "" {
 		return errors.New("missing namespace")
 	}
-	if !r.cephClusterSpec.External.Enable {
-		if u.Spec.Store == "" {
-			return errors.New("missing store")
-		}
+	if u.Spec.Store == "" {
+		return errors.New("missing store")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In object package code, external rgw server checks whether ceph cluster
is external instead of rgw. Correcting such scenarios in the code base.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
