### PR TITLE
csi: make storage class updated with csi-users in external cluster (backport #10278)

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -102,16 +102,12 @@ jobs:
     - name: test external script with restricted_auth_permission flag and without having cephfs_filesystem flag
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
-        kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace1
-        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosNamespace1 --cluster-name rookStorage --restricted-auth-permission true
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
 
     - name: test external script with restricted_auth_permission flag
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        # create `radosNamespace` rados-namespace for `replicapool` rbd data-pool
-        kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace
-        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
 
     - name: test the upgrade flag
       run: |
@@ -127,12 +123,12 @@ jobs:
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         # print existing client auth
-        kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookStorage-replicapool-radosNamespace
-        # restricted auth user need to provide --rbd-data-pool-name, --rados-namespace,
+        kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
+        # restricted auth user need to provide --rbd-data-pool-name,
         #  --cluster-name and --run-as-user flag while upgrading
-        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage  --run-as-user client.csi-rbd-node-rookStorage-replicapool-radosNamespace
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
         # print ugraded client auth
-        kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookStorage-replicapool-radosNamespace
+        kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -331,11 +331,11 @@ class RadosJSON:
         common_group.add_argument(
             "--restricted-auth-permission",
             default=False,
-            help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster and pool namespaces."
-            + "Mandatory flags that need to be set are --rbd-data-pool-name, --rados-namespace and --cluster-name."
+            help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster."
+            + "Mandatory flags that need to be set are --rbd-data-pool-name, and --cluster-name."
             + "--cephfs-filesystem-name flag can also be passed in case of cephfs user restriction, so it can restrict user to particular cephfs filesystem"
-            + "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true`"
-            + "Note: Restricting the users per pool, per cluster and per pool namespace will require to create new users and new secrets for that users.",
+            + "sample run: `python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --cluster-name rookStorage --restricted-auth-permission true`"
+            + "Note: Restricting the users per pool, and per cluster will require to create new users and new secrets for that users.",
         )
 
         output_group = argP.add_argument_group("output")
@@ -430,9 +430,9 @@ class RadosJSON:
             help="Upgrades the cephCSIKeyrings(For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied."
             + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade`, this will upgrade all the default csi users(non-restricted)"
             + "For restricted users(For example: client.csi-cephfs-provisioner-openshift-storage-myfs), users created using --restricted-auth-permission flag need to pass mandatory flags"
-            + "mandatory flags: '--rbd-data-pool-name, --rados-namespace, --cluster-name and --run-as-user' flags while upgrading"
+            + "mandatory flags: '--rbd-data-pool-name, --cluster-name and --run-as-user' flags while upgrading"
             + "in case of cephfs users if you have passed --cephfs-filesystem-name flag while creating user then while upgrading it will be mandatory too"
-            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage  --run-as-user client.csi-rbd-node-rookStorage-replicapool-radosNamespace`"
+            + "Sample run: `python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --cluster-name rookStorage  --run-as-user client.csi-rbd-node-rookStorage-replicapool`"
             + "PS: An existing non-restricted user cannot be downgraded to a restricted user by upgrading. Admin need to create a new restricted user for this by re-running the script."
             + "Upgrade flag should only be used to append new permissions to users, it shouldn't be used for changing user already applied permission, for example you shouldn't change in which pool user has access",
         )
@@ -826,13 +826,12 @@ class RadosJSON:
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
-            rados_namespace = self._arg_parser.rados_namespace
-            if rbd_pool_name == "" or cluster_name == "" or rados_namespace == "":
+            if rbd_pool_name == "" or cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags"
+                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' flags"
                 )
-            entity = "{}-{}-{}-{}".format(
-                entity, cluster_name, rbd_pool_name, rados_namespace
+            entity = "{}-{}-{}".format(
+                entity, cluster_name, rbd_pool_name
             )
             caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
 
@@ -847,13 +846,12 @@ class RadosJSON:
         if self._arg_parser.restricted_auth_permission:
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cluster_name = self._arg_parser.cluster_name
-            rados_namespace = self._arg_parser.rados_namespace
-            if rbd_pool_name == "" or cluster_name == "" or rados_namespace == "":
+            if rbd_pool_name == "" or cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' and --rados-namespace flags"
+                    "mandatory flags not found, please set the '--rbd-data-pool-name', '--cluster-name' flags"
                 )
-            entity = "{}-{}-{}-{}".format(
-                entity, cluster_name, rbd_pool_name, rados_namespace
+            entity = "{}-{}-{}".format(
+                entity, cluster_name, rbd_pool_name
             )
             caps["osd"] = "profile rbd pool={}".format(rbd_pool_name)
 
@@ -1397,16 +1395,15 @@ class RadosJSON:
             cluster_name = self._arg_parser.cluster_name
             rbd_pool_name = self._arg_parser.rbd_data_pool_name
             cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
-            rados_namespace = self._arg_parser.rados_namespace
             json_out.append(
                 {
-                    "name": "rook-csi-rbd-node-{}-{}-{}".format(
-                        cluster_name, rbd_pool_name, rados_namespace
+                    "name": "rook-csi-rbd-node-{}-{}".format(
+                        cluster_name, rbd_pool_name
                     ),
                     "kind": "Secret",
                     "data": {
-                        "userID": "csi-rbd-node-{}-{}-{}".format(
-                            cluster_name, rbd_pool_name, rados_namespace
+                        "userID": "csi-rbd-node-{}-{}".format(
+                            cluster_name, rbd_pool_name
                         ),
                         "userKey": self.out_map["CSI_RBD_NODE_SECRET"],
                     },
@@ -1416,13 +1413,13 @@ class RadosJSON:
             if self.out_map["CSI_RBD_PROVISIONER_SECRET"]:
                 json_out.append(
                     {
-                        "name": "rook-csi-rbd-provisioner-{}-{}-{}".format(
-                            cluster_name, rbd_pool_name, rados_namespace
+                        "name": "rook-csi-rbd-provisioner-{}-{}".format(
+                            cluster_name, rbd_pool_name
                         ),
                         "kind": "Secret",
                         "data": {
-                            "userID": "csi-rbd-provisioner-{}-{}-{}".format(
-                                cluster_name, rbd_pool_name, rados_namespace
+                            "userID": 'csi-rbd-provisioner-{}-{}'.format(
+                                cluster_name, rbd_pool_name
                             ),
                             "userKey": self.out_map["CSI_RBD_PROVISIONER_SECRET"],
                         },


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
 For using restricted auth users we need to update the
    restricted users in the Storage class, so updating
    it in the json output for external cluster
    
    Signed-off-by: parth-gr <paarora@redhat.com>
    (cherry picked from commit b7c165b41103b3d98731f6c31f5ad4dde1b9054d)
    Signed-off-by: parth-gr <paarora@redhat.com>

Original PR: https://github.com/rook/rook/pull/10278

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
