### PR TITLE
osd: add lvm flag for lvm osd activate

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -71,7 +71,6 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 		// It's fine to continue if deactivate fails since we will return error if activate fails
 		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-an", "-vv", volumeGroupName); err != nil {
 			logger.Errorf("failed to deactivate volume group for lv %q. output: %s. %v", lvPath, op, err)
-			return nil
 		}
 
 		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-ay", "-vv", volumeGroupName); err != nil {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -372,6 +372,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			"--setgroup", "ceph",
 			fmt.Sprintf("--crush-location=%s", osd.Location),
 		}
+		osd.LVBackedPV = true
 	} else if osdProps.onPVC() && osd.CVMode == "raw" {
 		doBinaryCopyInit = false
 		doConfigInit = false


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Ancient OSDs based on LVM and activated by the Rook binary are still in
production. They fail on the deactivation of the VolumeGroup due to
incorrect filter. Setting the OSD as LVM adjusts the filter and make the
deactivate call working.

Repro without and with the correct filter:

```
[root@ca862389706c /]# vgchange -an -vv ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  global/use_lvmpolld not found in config: defaulting to 1
  devices/sysfs_scan not found in config: defaulting to 1
  devices/scan_lvs not found in config: defaulting to 0
  devices/multipath_component_detection not found in config: defaulting to 1
  devices/md_component_detection not found in config: defaulting to 1
  devices/fw_raid_component_detection not found in config: defaulting to 0
  devices/ignore_suspended_devices not found in config: defaulting to 0
  devices/ignore_lvm_mirrors not found in config: defaulting to 1
  devices/scan_lvs not found in config: defaulting to 0
  devices/allow_mixed_block_sizes not found in config: defaulting to 0
  devices/hints not found in config: defaulting to "all"
  activation/activation_mode not found in config: defaulting to "degraded"
  metadata/record_lvs_history not found in config: defaulting to 0
  devices/search_for_devnames not found in config: defaulting to "auto"
  activation/monitoring not found in config: defaulting to 1
  global/locking_type not found in config: defaulting to 1
  global/wait_for_locks not found in config: defaulting to 1
  global/prioritise_write_locks not found in config: defaulting to 1
  global/locking_dir not found in config: defaulting to "/run/lock/lvm"
  devices/md_component_detection not found in config: defaulting to 1
  devices/md_component_checks not found in config: defaulting to "auto"
  devices/multipath_wwids_file not found in config: defaulting to "/etc/multipath/wwids"
  global/use_lvmlockd not found in config: defaulting to 0
  report/output_format not found in config: defaulting to "basic"
  log/report_command_log not found in config: defaulting to 0
  devices/use_devicesfile not found in config: defaulting to 0
  /dev/log: stat failed: No such file or directory
  devices/global_filter not found in config: defaulting to global_filter = [ "a|.*|" ]
  Setting devices/filter to filter = [ "a|^/mnt/.*|", "r|.*|" ]
  devices/global_filter not found in config: defaulting to global_filter = [ "a|.*|" ]
  Setting devices/filter to filter = [ "a|^/mnt/.*|", "r|.*|" ]
  devices/devicesfile not found in config: defaulting to "system.devices"
  Obtaining the complete list of VGs to process
  VG name on command line not found in list of VGs: ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  Processing VG ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  Locking /run/lock/lvm/V_ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d WB
  Unlocking /run/lock/lvm/V_ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  Volume group "ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d" not found
  Cannot process volume group ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  global/notify_dbus not found in config: defaulting to 1
[root@ca862389706c /]# echo $?
5
[root@ca862389706c /]# vi /etc/lvm/lvm.conf
[root@ca862389706c /]# vgchange -an -vv ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  global/use_lvmpolld not found in config: defaulting to 1
  devices/sysfs_scan not found in config: defaulting to 1
  devices/scan_lvs not found in config: defaulting to 0
  devices/multipath_component_detection not found in config: defaulting to 1
  devices/md_component_detection not found in config: defaulting to 1
  devices/fw_raid_component_detection not found in config: defaulting to 0
  devices/ignore_suspended_devices not found in config: defaulting to 0
  devices/ignore_lvm_mirrors not found in config: defaulting to 1
  devices/scan_lvs not found in config: defaulting to 0
  devices/allow_mixed_block_sizes not found in config: defaulting to 0
  devices/hints not found in config: defaulting to "all"
  activation/activation_mode not found in config: defaulting to "degraded"
  metadata/record_lvs_history not found in config: defaulting to 0
  devices/search_for_devnames not found in config: defaulting to "auto"
  activation/monitoring not found in config: defaulting to 1
  global/locking_type not found in config: defaulting to 1
  global/wait_for_locks not found in config: defaulting to 1
  global/prioritise_write_locks not found in config: defaulting to 1
  global/locking_dir not found in config: defaulting to "/run/lock/lvm"
  devices/md_component_detection not found in config: defaulting to 1
  devices/md_component_checks not found in config: defaulting to "auto"
  devices/multipath_wwids_file not found in config: defaulting to "/etc/multipath/wwids"
  global/use_lvmlockd not found in config: defaulting to 0
  report/output_format not found in config: defaulting to "basic"
  log/report_command_log not found in config: defaulting to 0
  devices/use_devicesfile not found in config: defaulting to 0
  /dev/log: stat failed: No such file or directory
  /dev/block/7:0: size is 2097152 sectors
  /dev/nbd0: size is 0 sectors
  /dev/nbd8: size is 0 sectors
  /dev/vda: size is 83886080 sectors
  /dev/block/7:1: size is 0 sectors
  /dev/vda1: size is 83883999 sectors
  /dev/block/7:2: size is 0 sectors
  /dev/block/7:3: size is 0 sectors
  /dev/block/7:4: size is 0 sectors
  /dev/block/7:5: size is 0 sectors
  /dev/block/7:6: size is 0 sectors
  /dev/block/7:7: size is 0 sectors
  /dev/vdb: size is 83886080 sectors
  /dev/nbd1: size is 0 sectors
  /dev/nbd9: size is 0 sectors
  /dev/vdc: size is 83886080 sectors
  /dev/vdd: size is 83886080 sectors
  /dev/nbd2: size is 0 sectors
  /dev/nbd10: size is 0 sectors
  /dev/nbd3: size is 0 sectors
  /dev/nbd11: size is 0 sectors
  /dev/nbd4: size is 0 sectors
  /dev/nbd12: size is 0 sectors
  /dev/nbd5: size is 0 sectors
  /dev/nbd13: size is 0 sectors
  /dev/nbd6: size is 0 sectors
  /dev/nbd14: size is 0 sectors
  /dev/nbd7: size is 0 sectors
  /dev/nbd15: size is 0 sectors
  devices/global_filter not found in config: defaulting to global_filter = [ "a|.*|" ]
  Setting devices/filter to filter = [ "a|^/mnt/.*|", "r|^/dev/loop.*|", "a|^/dev/.*|", "r|.*|" ]
  /dev/block/7:0: using cached size 2097152 sectors
  /dev/block/7:0: using cached size 2097152 sectors
  /dev/block/7:0: No lvm label detected
  /dev/vda: using cached size 83886080 sectors
  /dev/vda1: using cached size 83883999 sectors
  /dev/vda1: using cached size 83883999 sectors
  /dev/vda1: No lvm label detected
  /dev/vdb: using cached size 83886080 sectors
  /dev/vdb: using cached size 83886080 sectors
  /dev/vdc: using cached size 83886080 sectors
  /dev/vdc: using cached size 83886080 sectors
  /dev/vdd: using cached size 83886080 sectors
  /dev/vdd: using cached size 83886080 sectors
  devices/global_filter not found in config: defaulting to global_filter = [ "a|.*|" ]
  Setting devices/filter to filter = [ "a|^/mnt/.*|", "r|^/dev/loop.*|", "a|^/dev/.*|", "r|.*|" ]
  devices/devicesfile not found in config: defaulting to "system.devices"
  /dev/block/7:0: using cached size 2097152 sectors
  /dev/nbd0: using cached size 0 sectors
  /dev/nbd8: using cached size 0 sectors
  /dev/vda: using cached size 83886080 sectors
  /dev/block/7:1: using cached size 0 sectors
  /dev/vda1: using cached size 83883999 sectors
  /dev/block/7:2: using cached size 0 sectors
  /dev/block/7:3: using cached size 0 sectors
  /dev/block/7:4: using cached size 0 sectors
  /dev/block/7:5: using cached size 0 sectors
  /dev/block/7:6: using cached size 0 sectors
  /dev/block/7:7: using cached size 0 sectors
  /dev/vdb: using cached size 83886080 sectors
  /dev/nbd1: using cached size 0 sectors
  /dev/nbd9: using cached size 0 sectors
  /dev/vdc: using cached size 83886080 sectors
  /dev/vdd: using cached size 83886080 sectors
  /dev/nbd2: using cached size 0 sectors
  /dev/nbd10: using cached size 0 sectors
  /dev/nbd3: using cached size 0 sectors
  /dev/nbd11: using cached size 0 sectors
  /dev/nbd4: using cached size 0 sectors
  /dev/nbd12: using cached size 0 sectors
  /dev/nbd5: using cached size 0 sectors
  /dev/nbd13: using cached size 0 sectors
  /dev/nbd6: using cached size 0 sectors
  /dev/nbd14: using cached size 0 sectors
  /dev/nbd7: using cached size 0 sectors
  /dev/nbd15: using cached size 0 sectors
  Obtaining the complete list of VGs to process
  Processing VG ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d VxbTWs-fMrC-KErD-Pc2l-NBs6-xffp-7n1qab
  Locking /run/lock/lvm/V_ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d WB
  metadata/lvs_history_retention_time not found in config: defaulting to 0
  /dev/vdd: using cached size 83886080 sectors
  Running command for VG ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d VxbTWs-fMrC-KErD-Pc2l-NBs6-xffp-7n1qab
  Deactivating logical volume ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d/osd-block-058f4926-6ee7-4165-9a55-db5a1fd22d2f.
  activation/verify_udev_operations not found in config: defaulting to 0
  Getting driver version
  Removing ceph--a8ae9f01--a440--4a0e--8e4d--592d3bce3a9d-osd--block--058f4926--6ee7--4165--9a55--db5a1fd22d2f (252:2)
  Deactivated 1 logical volumes in volume group ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d.
  0 logical volume(s) in volume group "ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d" now active
  Unlocking /run/lock/lvm/V_ceph-a8ae9f01-a440-4a0e-8e4d-592d3bce3a9d
  global/notify_dbus not found in config: defaulting to 1
[root@ca862389706c /]# echo $?
0
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
