### PR TITLE
docs: Remove obsolete limitation from multus docs

### DIFF
--- a/Documentation/CRDs/ceph-cluster-crd.md
+++ b/Documentation/CRDs/ceph-cluster-crd.md
@@ -419,11 +419,6 @@ allowing the daemon to communicate with the rest of the cluster. There is work i
 this issue in the [multus-service](https://github.com/k8snetworkplumbingwg/multus-service)
 repository. At the time of writing it's unclear when this will be supported.
 
-#### Known issues with Multus
-
-When a CephFS/RBD volume is mounted in a Pod using cephcsi and then the CSI CephFS/RBD plugin is restarted or terminated (e.g. by restarting or deleting its DaemonSet), all operations on the volume become blocked, even after restarting the CSI pods. The only workaround is to restart the node where the cephcsi plugin pod was restarted.
-This issue is tracked [here](https://github.com/rook/rook/issues/8085).
-
 #### IPFamily
 
 Provide single-stack IPv4 or IPv6 protocol to assign corresponding addresses to pods and services. This field is optional. Possible inputs are IPv6 and IPv4. Empty value will be treated as IPv4. Kubernetes version should be at least v1.13 to run IPv6. Dual-stack is supported as of ceph Pacific.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the new holder pod that was implemented for the csi driver to maintain a consistent network endpoint across csi plugin restarts, there is no longer a limitation that needs to be documented.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
