### PR TITLE
csi: fix stagingpath

### DIFF
--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -67,7 +67,7 @@ spec:
             - "--metricsport={{ .RBDGRPCMetricsPort }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
-            - "--stagingpath={{ .KubeletDirPath }}/plugins/kubernetes.io/csi/pv/"
+            - "--stagingpath={{ .KubeletDirPath }}/plugins/kubernetes.io/csi/"
             {{ if .EnableCSIAddonsSideCar }}
             - "--csi-addons-endpoint=$(CSIADDONS_ENDPOINT)"
             {{ end }}


### PR DESCRIPTION
**Description of your changes:**

Kubernetes 1.24 and newer use a different path for staging the volume.
That means the CSI-driver is requested to mount the volume at an other
location, compared to previous versions of Kubernetes.

The backward compatibility should be taken care by the CSI driver.

See-also: kubernetes/kubernetes#107065
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>