### PR TITLE
object: network mode can be set separately for cephcluster and rgw

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -104,6 +104,7 @@ The gateway settings correspond to the RGW daemon settings.
 * `caBundleRef`: If specified, this is the name of the Kubernetes secret (type `opaque`) that
   contains additional custom ca-bundle to use. The secret must be in the same namespace as the Rook
   cluster. Rook will look in the secret provided at the `cabundle` key name.
+* `hostNetwork`: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
 * `port`: The port on which the Object service will be reachable. If host networking is enabled, the RGW daemons will also listen on that port. If running on SDN, the RGW daemon listening port will be 8080 internally.
 * `securePort`: The secure port on which RGW pods will be listening. A TLS certificate must be specified either via `sslCerticateRef` or `service.annotations`
 * `instances`: The number of pods that will be started to load balance this object store.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -8569,6 +8569,11 @@ spec:
                           type: object
                       type: object
                   type: object
+                hostNetwork:
+                  description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                  nullable: true
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
                 metadataPool:
                   description: The metadata pool settings
                   nullable: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -8561,6 +8561,11 @@ spec:
                           type: object
                       type: object
                   type: object
+                hostNetwork:
+                  description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                  nullable: true
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
                 metadataPool:
                   description: The metadata pool settings
                   nullable: true

--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -49,6 +49,13 @@ func (s *ObjectStoreSpec) IsExternal() bool {
 	return len(s.Gateway.ExternalRgwEndpoints) != 0
 }
 
+func (s *ObjectStoreSpec) IsHostNetwork(c *ClusterSpec) bool {
+	if s.HostNetwork != nil {
+		return *s.HostNetwork
+	}
+	return c.Network.IsHost()
+}
+
 func (s *ObjectRealmSpec) IsPullRealm() bool {
 	return s.Pull.Endpoint != ""
 }

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1321,6 +1321,12 @@ type ObjectStoreSpec struct {
 	// +optional
 	// +nullable
 	Security *SecuritySpec `json:"security,omitempty"`
+
+	// Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +nullable
+	// +optional
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // BucketHealthCheckSpec represents the health check of an object store

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2988,6 +2988,11 @@ func (in *ObjectStoreSpec) DeepCopyInto(out *ObjectStoreSpec) {
 		*out = new(SecuritySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -65,7 +65,7 @@ func (c *clusterConfig) portString() string {
 
 	port := c.store.Spec.Gateway.Port
 	if port != 0 {
-		if !c.clusterSpec.Network.IsHost() {
+		if !c.store.Spec.IsHostNetwork(c.clusterSpec) {
 			port = rgwPortInternalPort
 		}
 		portString = fmt.Sprintf("port=%s", strconv.Itoa(int(port)))

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -103,6 +103,8 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 	if reflect.DeepEqual(rgwDaemonContainer, v1.Container{}) {
 		return v1.PodTemplateSpec{}, errors.New("got empty container for RGW daemon")
 	}
+
+	hostNetwork := c.store.Spec.IsHostNetwork(c.clusterSpec)
 	podSpec := v1.PodSpec{
 		InitContainers: []v1.Container{
 			c.makeChownInitContainer(rgwConfig),
@@ -113,7 +115,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 			controller.DaemonVolumes(c.DataPathMap, rgwConfig.ResourceName),
 			c.mimeTypesVolume(),
 		),
-		HostNetwork:        c.clusterSpec.Network.IsHost(),
+		HostNetwork:        hostNetwork,
 		PriorityClassName:  c.store.Spec.Gateway.PriorityClassName,
 		ServiceAccountName: serviceAccountName,
 	}
@@ -198,7 +200,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 	c.store.Spec.Gateway.Annotations.ApplyToObjectMeta(&podTemplateSpec.ObjectMeta)
 	c.store.Spec.Gateway.Labels.ApplyToObjectMeta(&podTemplateSpec.ObjectMeta)
 
-	if c.clusterSpec.Network.IsHost() {
+	if hostNetwork {
 		podTemplateSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	} else if c.clusterSpec.Network.IsMultus() {
 		if err := k8sutil.ApplyMultus(c.clusterSpec.Network, &podTemplateSpec.ObjectMeta); err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Network mode can be set separately for cephcluster and rgw

**Which issue is resolved by this Pull Request:**
Resolves #10451 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
