### PR TITLE
ci: use ceph v17.2.0 for testing

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -47,7 +47,7 @@ const (
 	// test with the latest pacific build
 	pacificTestImage = "quay.io/ceph/ceph:v16"
 	// test with the latest pacific build
-	quincyTestImage = "quay.io/ceph/ceph:v17"
+	quincyTestImage = "quay.io/ceph/ceph:v17.2.0"
 	// test with the current development version of Pacific
 	octopusDevelTestImage = "quay.io/ceph/daemon-base:latest-octopus-devel"
 	pacificDevelTestImage = "quay.io/ceph/daemon-base:latest-pacific-devel"


### PR DESCRIPTION
The CI smoke suite for CephFilesystem has been flaky since the quay
image for Ceph v17.2.1 was released. Revert to using v17.2.0.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
