### PR TITLE
ci: be selective about when to offer tmate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,16 @@ jobs:
       working-directory: /Users/runner/go/src/github.com/rook/rook
       run: tests/scripts/validate_modified_files.sh gen-rbac
 
-    - name: setup tmate session for debugging
+    - name: consider debugging
       if: failure()
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -100,7 +108,15 @@ jobs:
       run: |
         tests/scripts/github-action-helper.sh build_rook_all
 
-    - name: setup tmate session for debugging
+    - name: consider debugging
       if: failure()
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -174,8 +174,16 @@ jobs:
       with:
         name: canary
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -220,8 +228,16 @@ jobs:
       with:
         name: canary
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -266,8 +282,16 @@ jobs:
       with:
         name: canary
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -318,8 +342,16 @@ jobs:
       with:
         name: canary
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -364,8 +396,16 @@ jobs:
       with:
         name: canary
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -429,8 +469,16 @@ jobs:
       with:
         name: pvc
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -477,8 +525,16 @@ jobs:
       with:
         name: pvc-db
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -528,8 +584,16 @@ jobs:
       with:
         name: pvc-db-wal
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -596,8 +660,16 @@ jobs:
       with:
         name: encryption-pvc
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -646,8 +718,16 @@ jobs:
       with:
         name: encryption-pvc-db
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -697,8 +777,16 @@ jobs:
       with:
         name: encryption-pvc-db-wal
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -775,8 +863,16 @@ jobs:
       with:
         name: encryption-pvc-kms-vault-token-auth
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -836,8 +932,16 @@ jobs:
       with:
         name: encryption-pvc-kms-vault-k8s-auth
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -889,8 +993,16 @@ jobs:
       with:
         name: lvm-pvc
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -1080,8 +1192,16 @@ jobs:
       with:
         name: multi-cluster-mirroring
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -1107,8 +1227,16 @@ jobs:
         name: rgw-multisite-testing
         path: test
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -1137,8 +1265,16 @@ jobs:
         name: encryption-pvc-kms-ibm-kp
         path: test
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -1191,8 +1327,16 @@ jobs:
       with:
         name: canary-multus
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -1240,7 +1384,15 @@ jobs:
       with:
         name: csi-hostnetwork-disabled
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -61,7 +61,15 @@ jobs:
         name: ceph-helm-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -55,7 +55,15 @@ jobs:
         name: ceph-mgr-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -57,7 +57,15 @@ jobs:
         name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -56,7 +56,15 @@ jobs:
         name: ceph-object-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -56,7 +56,15 @@ jobs:
         name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -104,7 +104,15 @@ jobs:
         name: ceph-upgrade-helm-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging when event is PR
+    - name: consider debugging
       if: failure() && github.event_name == 'pull_request'
+      run: |
+        # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+        if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+          echo USE_TMATE=1 >> $GITHUB_ENV
+        fi
+
+    - name: set up tmate session for debugging
+      if: failure() && env.USE_TMATE
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -73,7 +73,15 @@ jobs:
         run: |
           tests/scripts/build-release.sh
 
-      - name: setup tmate session for debugging
+      - name: consider debugging
         if: failure()
+        run: |
+          # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+          if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo USE_TMATE=1 >> $GITHUB_ENV
+          fi
+
+      - name: set up tmate session for debugging
+        if: failure() && env.USE_TMATE
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 60


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Be selective about when to offer tmate
* Unconditionally offer it when running from the rook org
* Offer it if the current repository has a `USE_TMATE` secret
* Offer it if the workflow is being re-run

w/o this change, tmate is run on all forks when builds fail.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
