### PR TITLE
mon: Disable insecure global ids for new deployments

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -166,12 +166,7 @@ func (c *cephStatusChecker) configureHealthSettings(status cephclient.CephStatus
 	if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED"]; ok {
 		if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]; !ok {
 			logger.Info("Disabling the insecure global ID as no legacy clients are currently connected. If you still require the insecure connections, see the CVE to suppress the health warning and re-enable the insecure connections. https://docs.ceph.com/en/latest/security/CVE-2021-20288/")
-			monStore := config.GetMonStore(c.context, c.clusterInfo)
-			if err := monStore.Set("mon", "auth_allow_insecure_global_id_reclaim", "false"); err != nil {
-				logger.Warningf("failed to disable the insecure global ID. %v", err)
-			} else {
-				logger.Info("insecure global ID is now disabled")
-			}
+			config.DisableInsecureGlobalID(c.context, c.clusterInfo)
 		} else {
 			logger.Warning("insecure clients are connected to the cluster, to resolve the AUTH_INSECURE_GLOBAL_ID_RECLAIM health warning please refer to the upgrade guide to ensure all Ceph daemons are updated.")
 		}

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -29,6 +29,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	optest "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -161,6 +162,7 @@ func TestConfigureHealthSettings(t *testing.T) {
 		context:     &clusterd.Context{},
 		clusterInfo: cephclient.AdminTestClusterInfo("ns"),
 	}
+	c.clusterInfo.CephVersion = version.Quincy
 	setGlobalIDReclaim := false
 	c.context.Executor = &exectest.MockExecutor{
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -517,7 +517,7 @@ func (c *cluster) postMonStartupActions() error {
 	}
 
 	if err := c.configureMsgr2(); err != nil {
-		return errors.Wrap(err, "failed to configured msgr2")
+		return errors.Wrap(err, "failed to configure msgr2")
 	}
 
 	crushRoot := client.GetCrushRootFromSpec(c.Spec)

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -160,6 +160,12 @@ func (c *Cluster) Start() error {
 		}
 	}
 
+	// Insecure global IDs should be disabled for new clusters immediately.
+	// If we're waiting for the mgr deployments to start, it is a clean deployment
+	if len(deploymentsToWaitFor) > 0 {
+		config.DisableInsecureGlobalID(c.context, c.clusterInfo)
+	}
+
 	// If the mgr is newly created, wait for it to start before continuing with the service and
 	// module configuration
 	for _, d := range deploymentsToWaitFor {

--- a/pkg/operator/ceph/config/config_test.go
+++ b/pkg/operator/ceph/config/config_test.go
@@ -19,6 +19,8 @@ package config
 import (
 	"testing"
 
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,4 +30,17 @@ func TestNewFlag(t *testing.T) {
 	assert.Equal(t, NewFlag("b_key", "b"), "--b-key=b")
 	assert.Equal(t, NewFlag("c key", "c"), "--c-key=c")
 	assert.Equal(t, NewFlag("quotes", "\"quoted\""), "--quotes=\"quoted\"")
+}
+
+func TestInsecureGlobalIDVersion(t *testing.T) {
+	c := &client.ClusterInfo{CephVersion: version.CephVersion{Major: 17, Minor: 2, Extra: 0}}
+	assert.True(t, canDisableInsecureGlobalID(c))
+	c = &client.ClusterInfo{CephVersion: version.CephVersion{Major: 16, Minor: 2, Extra: 0}}
+	assert.False(t, canDisableInsecureGlobalID(c))
+	c = &client.ClusterInfo{CephVersion: version.CephVersion{Major: 16, Minor: 2, Extra: 1}}
+	assert.True(t, canDisableInsecureGlobalID(c))
+	c = &client.ClusterInfo{CephVersion: version.CephVersion{Major: 15, Minor: 2, Extra: 10}}
+	assert.False(t, canDisableInsecureGlobalID(c))
+	c = &client.ClusterInfo{CephVersion: version.CephVersion{Major: 15, Minor: 2, Extra: 11}}
+	assert.True(t, canDisableInsecureGlobalID(c))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In new deployments we always want to disable the insecure global id in versions of ceph where it is supported. If the mgr deployment is newly created, we know it's a new cluster and the mons are in quorum, so we can go ahead and disable the insecure global IDs.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
