### PR TITLE
ci: enable and fixes for nfs ci

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -153,8 +153,6 @@ spec:
     modules:
     - name: pg_autoscaler
       enabled: true
-    - name: rook
-      enabled: true
   dashboard:
     enabled: true
   network:
@@ -503,7 +501,7 @@ spec:
     user: ` + usercaps
 }
 
-//GetBucketStorageClass returns the manifest to create object bucket
+// GetBucketStorageClass returns the manifest to create object bucket
 func (m *CephManifestsMaster) GetBucketStorageClass(storeName, storageClassName, reclaimPolicy string) string {
 	return `apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -516,7 +514,7 @@ parameters:
     objectStoreNamespace: ` + m.settings.Namespace
 }
 
-//GetOBC returns the manifest to create object bucket claim
+// GetOBC returns the manifest to create object bucket claim
 func (m *CephManifestsMaster) GetOBC(claimName string, storageClassName string, objectBucketName string, maxObject string, varBucketName bool) string {
 	bucketParameter := "generateBucketName"
 	if varBucketName {
@@ -533,7 +531,7 @@ spec:
     maxObjects: "` + maxObject + `"`
 }
 
-//GetOBCNotification returns the manifest to create object bucket claim
+// GetOBCNotification returns the manifest to create object bucket claim
 func (m *CephManifestsMaster) GetOBCNotification(claimName string, storageClassName string, objectBucketName string, notificationName string, varBucketName bool) string {
 	bucketParameter := "generateBucketName"
 	if varBucketName {
@@ -550,7 +548,7 @@ spec:
   storageClassName: ` + storageClassName
 }
 
-//GetBucketNotification returns the manifest to create ceph bucket notification
+// GetBucketNotification returns the manifest to create ceph bucket notification
 func (m *CephManifestsMaster) GetBucketNotification(notificationName string, topicName string) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephBucketNotification
@@ -564,7 +562,7 @@ spec:
 `
 }
 
-//GetBucketTopic returns the manifest to create ceph bucket topic
+// GetBucketTopic returns the manifest to create ceph bucket topic
 func (m *CephManifestsMaster) GetBucketTopic(topicName string, storeName string, httpEndpointService string) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephBucketTopic

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -439,6 +439,10 @@ func cleanupFilesystemConsumer(helper *clients.TestClient, k8sh *utils.K8sHelper
 	if !isdeleted {
 		assert.Fail(s.T(), fmt.Sprintf("Failed to delete PVC %q", podName))
 	}
+	isPVListZero := k8sh.WaitUntilZeroPVs()
+	if !isPVListZero {
+		assert.Fail(s.T(), fmt.Sprintf("PV list is not zero"))
+	}
 	logger.Infof("File system consumer deleted")
 }
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -94,11 +94,10 @@ func (s *SmokeSuite) SetupSuite() {
 		ConnectionsCompressed:     true,
 		UseCrashPruner:            true,
 		EnableVolumeReplication:   true,
-		// TODO: uncomment once issue https://github.com/rook/rook/issues/10518 is resolved.
-		// TestNFSCSI:                true,
-		ChangeHostName: true,
-		RookVersion:    installer.LocalBuildTag,
-		CephVersion:    installer.ReturnCephVersion(),
+		TestNFSCSI:                true,
+		ChangeHostName:            true,
+		RookVersion:               installer.LocalBuildTag,
+		CephVersion:               installer.ReturnCephVersion(),
 	}
 	s.settings.ApplyEnvVars()
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
@@ -113,6 +112,10 @@ func (s *SmokeSuite) TearDownSuite() {
 	s.installer.UninstallRook()
 }
 
+func (s *SmokeSuite) TestCephNFS_SmokeTest() {
+	runNFSFileE2ETest(s.helper, s.k8sh, &s.Suite, s.settings, "smoke-test-nfs")
+}
+
 func (s *SmokeSuite) TestBlockStorage_SmokeTest() {
 	runBlockCSITest(s.helper, s.k8sh, &s.Suite, s.settings.Namespace)
 }
@@ -120,10 +123,6 @@ func (s *SmokeSuite) TestBlockStorage_SmokeTest() {
 func (s *SmokeSuite) TestFileStorage_SmokeTest() {
 	preserveFilesystemOnDelete := true
 	runFileE2ETest(s.helper, s.k8sh, &s.Suite, s.settings, "smoke-test-fs", preserveFilesystemOnDelete)
-}
-
-func (s *SmokeSuite) TestNetworkFileStorage_SmokeTest() {
-	runNFSFileE2ETest(s.helper, s.k8sh, &s.Suite, s.settings, "smoke-test-nfs")
 }
 
 func (s *SmokeSuite) TestObjectStorage_SmokeTest() {


### PR DESCRIPTION
This commit anabled nfs csi ci and
add fixes/improvements to it like the
following:
- verify deletion of cephnfs and .nfs pool before proceeding
- verify pv deletion
- do not enable rook module
- reduce activeCount to 1 to save resources
- run cephnfs ci before cephfs ci since it cephfs
  ci is more resource intensive.

Signed-off-by: Rakshith R <rar@redhat.com>

Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
