### PR TITLE
ci: add ci bot for auto assign issue

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,0 +1,17 @@
+name: Assign issue to contributor
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  assign:
+    name: Run self assign job
+    runs-on: ubuntu-latest
+    steps:
+      - name: take the issue
+        uses: bdougie/take-action@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          message: Thanks for taking this issue! Let us know if you have any questions!
+          trigger: /assign

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -77,6 +77,11 @@ git remote -v
 
 Now you should have at least `origin` and `upstream` remotes. You can also add other remotes to collaborate with other contributors.
 
+### Self assign Issue
+
+You can self-assign any issue that is open and not assigned to anyone in Rook upstream repo, by adding
+an issue comment with `/assign` in the body.
+
 ## Layout
 
 A source code layout is shown below, annotated with comments about the use of each important directory:


### PR DESCRIPTION
ci: add ci bot for auto assign issue

Now users can auto-assign issues by commenting
/assign on the issue topic

Closes: https://github.com/rook/rook/issues/10492
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
