### PR TITLE
build: fix working dir for docs building

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -137,7 +137,7 @@ deps.docs:
 
 build.docs: deps.docs
 	# Build the docs once before they are published to ensure they are correctly building
-	mkdocs build --strict
+	cd $(ROOT_DIR) && mkdocs build --strict
 
 publish.docs:
 	if ! git remote show docs > /dev/null 2>&1; then git remote add docs $(DOCS_GIT_REPO); fi


### PR DESCRIPTION
**Description of your changes:**

The `mkdocs build` needs to be run in the root of the repo to work.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
