### PR TITLE
core: fix stuck reconciler (more checkpoints for cancelled context)

### DIFF
--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -99,8 +99,8 @@ func TestGenerateConfigFile(t *testing.T) {
 		Context:     ctx,
 	}
 
-	isInitialized := clusterInfo.IsInitialized(true)
-	assert.True(t, isInitialized)
+	isInitialized := clusterInfo.IsInitialized()
+	assert.NoError(t, isInitialized)
 
 	// generate the config file to disk now
 	configFilePath, err := generateConfigFile(context, clusterInfo, configDir, filepath.Join(configDir, "mykeyring"), nil, nil)

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -112,42 +113,30 @@ func AdminTestClusterInfo(namespace string) *ClusterInfo {
 // in. This method exists less out of necessity than the desire to be explicit about the lifecycle
 // of the ClusterInfo struct during startup, specifically that it is expected to exist after the
 // Rook operator has started up or connected to the first components of the Ceph cluster.
-func (c *ClusterInfo) IsInitialized(logError bool) bool {
-	var isInitialized bool
-
+func (c *ClusterInfo) IsInitialized() error {
 	if c == nil {
-		if logError {
-			logger.Error("clusterInfo is nil")
-		}
-	} else if c.FSID == "" {
-		if logError {
-			logger.Error("cluster fsid is empty")
-		}
-	} else if c.MonitorSecret == "" {
-		if logError {
-			logger.Error("monitor secret is empty")
-		}
-	} else if c.CephCred.Username == "" {
-		if logError {
-			logger.Error("ceph username is empty")
-		}
-	} else if c.CephCred.Secret == "" {
-		if logError {
-			logger.Error("ceph secret is empty")
-		}
-	} else if c.Context == nil {
-		if logError {
-			logger.Error("nil context")
-		}
-	} else if c.Context.Err() != nil {
-		if logError {
-			logger.Errorf("%v", c.Context.Err())
-		}
-	} else {
-		isInitialized = true
+		return errors.New("clusterInfo is nil")
+	}
+	if c.FSID == "" {
+		return errors.New("cluster fsid is empty")
+	}
+	if c.MonitorSecret == "" {
+		return errors.New("monitor secret is empty")
+	}
+	if c.CephCred.Username == "" {
+		return errors.New("ceph username is empty")
+	}
+	if c.CephCred.Secret == "" {
+		return errors.New("ceph secret is empty")
+	}
+	if c.Context == nil {
+		return errors.New("context is nil")
+	}
+	if c.Context.Err() != nil {
+		return c.Context.Err()
 	}
 
-	return isInitialized
+	return nil
 }
 
 // NewMonInfo returns a new Ceph mon info struct from the given inputs.

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -118,8 +118,8 @@ func (c *cluster) reconcileCephDaemons(rookImage string, cephVersion cephver.Cep
 	c.ClusterInfo.NetworkSpec = c.Spec.Network
 
 	// The cluster Identity must be established at this point
-	if !c.ClusterInfo.IsInitialized(true) {
-		return errors.New("the cluster identity was not established")
+	if err := c.ClusterInfo.IsInitialized(); err != nil {
+		return errors.Wrap(err, "the cluster identity was not established")
 	}
 
 	if c.ClusterInfo.Context.Err() != nil {

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -94,8 +94,8 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 
 	// The cluster Identity must be established at this point
-	if !cluster.ClusterInfo.IsInitialized(true) {
-		return errors.New("the cluster identity was not established")
+	if err := cluster.ClusterInfo.IsInitialized(); err != nil {
+		return errors.Wrap(err, "the cluster identity was not established")
 	}
 	logger.Info("external cluster identity established")
 

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -133,6 +133,12 @@ func (hc *HealthChecker) Check(monitoringRoutines map[string]*controller.Cluster
 			delete(monitoringRoutines, daemon)
 			return
 
+		// Since c.ClusterInfo.IsInitialized() below uses a different context, we need to check if the context is done
+		case <-hc.monCluster.ClusterInfo.Context.Done():
+			logger.Infof("stopping monitoring of mons in namespace %q", hc.monCluster.Namespace)
+			delete(monitoringRoutines, daemon)
+			return
+
 		case <-time.After(hc.interval):
 			logger.Debugf("checking health of mons")
 			err := hc.monCluster.checkHealth(monitoringRoutines[daemon].InternalCtx)

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -148,8 +148,8 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 	defer c.releaseOrchestrationLock()
 
 	// If cluster details are not initialized
-	if !c.ClusterInfo.IsInitialized(true) {
-		return errors.New("skipping mon health check since cluster details are not initialized")
+	if err := c.ClusterInfo.IsInitialized(); err != nil {
+		return errors.Wrap(err, "skipping mon health check since cluster details are not initialized")
 	}
 
 	// If the cluster is converged and no mons were specified

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1320,6 +1320,11 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterInfo *cephclient.Cl
 	retryCount := 0
 	retryMax := 30
 	for {
+		// Return immediately if the context has been canceled
+		if clusterInfo.Context.Err() != nil {
+			return clusterInfo.Context.Err()
+		}
+
 		retryCount++
 		if retryCount > retryMax {
 			return errors.New("exceeded max retry count waiting for monitors to reach quorum")

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -213,7 +213,7 @@ func TestOperatorRestart(t *testing.T) {
 	// start a basic cluster
 	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Quincy, c.spec)
 	assert.NoError(t, err)
-	assert.True(t, info.IsInitialized(true))
+	assert.NoError(t, info.IsInitialized())
 
 	validateStart(t, c)
 
@@ -223,7 +223,7 @@ func TestOperatorRestart(t *testing.T) {
 	// starting again should be a no-op, but will not result in an error
 	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Quincy, c.spec)
 	assert.NoError(t, err)
-	assert.True(t, info.IsInitialized(true))
+	assert.NoError(t, info.IsInitialized())
 
 	validateStart(t, c)
 }
@@ -241,7 +241,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	// start a basic cluster
 	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Quincy, c.spec)
 	assert.NoError(t, err)
-	assert.True(t, info.IsInitialized(true))
+	assert.NoError(t, info.IsInitialized())
 
 	validateStart(t, c)
 
@@ -253,7 +253,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	// starting again should be a no-op, but still results in an error
 	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Quincy, c.spec)
 	assert.NoError(t, err)
-	assert.True(t, info.IsInitialized(true), info)
+	assert.NoError(t, info.IsInitialized(), info)
 
 	validateStart(t, c)
 }

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -268,13 +268,14 @@ func (c *Cluster) updateAndCreateOSDsLoop(
 			updateConfig.updateExistingOSDs(errs)
 
 		case <-minuteTicker.C:
-			if c.clusterInfo.Context.Err() != nil {
-				return false, c.clusterInfo.Context.Err()
-			}
 			// Log progress
 			c, cExp := createConfig.progress()
 			u, uExp := updateConfig.progress()
 			logger.Infof("waiting... %d of %d OSD prepare jobs have finished processing and %d of %d OSDs have been updated", c, cExp, u, uExp)
+
+		case <-c.clusterInfo.Context.Done():
+			logger.Infof("context cancelled, exiting OSD update and create loop")
+			return false, c.clusterInfo.Context.Err()
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -153,9 +153,9 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 		}
 	}
 
-	if !clusterInfo.IsInitialized(false) {
+	if err := clusterInfo.IsInitialized(); err != nil {
 		// If not initialized, this is likely a new cluster so there is nothing to do
-		logger.Debug("cluster not initialized, nothing to validate")
+		logger.Debugf("cluster not initialized, nothing to validate. %v", err)
 		return nil
 	}
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -400,6 +400,9 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 
 	err = r.client.Update(clusterInfo.Context, pdbStateMap)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, errors.Wrapf(err, "failed to update configMap %q in cluster %q", pdbStateMapName, request)
 	}
 


### PR DESCRIPTION
Some context canceled were missed and not reported correctly. We had
multiple reconcilers running in //. Since they all run in goroutine then
will continue to run until they timeout (if the timeout is available,
    otherwise would run forever until the op is restarted).

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
