### PR TITLE
test: Upgrade test to use correct manifests for uninstall

### DIFF
--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -87,6 +87,7 @@ func (s *UpgradeSuite) baseSetup(useHelm bool, initialCephVersion v1.CephVersion
 		UsePVC:                      false,
 		Mons:                        1,
 		EnableDiscovery:             true,
+		SkipClusterCleanup:          true,
 		RookVersion:                 installer.Version1_8,
 		CephVersion:                 initialCephVersion,
 	}

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -447,6 +447,7 @@ func (s *UpgradeSuite) verifyFilesAfterUpgrade(newFileToWrite string, rbdFilesTo
 func (s *UpgradeSuite) upgradeToMaster() {
 	// Apply the CRDs for the latest master
 	s.settings.RookVersion = installer.LocalBuildTag
+	s.installer.Manifests = installer.NewCephManifests(s.settings)
 
 	if s.settings.UseHelm {
 		// Upgrade the operator chart
@@ -458,13 +459,12 @@ func (s *UpgradeSuite) upgradeToMaster() {
 		return
 	}
 
-	m := installer.NewCephManifests(s.settings)
-	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetCRDs(s.k8sh)))
+	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", s.installer.Manifests.GetCRDs(s.k8sh)))
 
-	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetCommon()))
+	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", s.installer.Manifests.GetCommon()))
 
 	require.NoError(s.T(),
 		s.k8sh.SetDeploymentVersion(s.settings.OperatorNamespace, operatorContainer, operatorContainer, installer.LocalBuildTag))
 
-	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetToolbox()))
+	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", s.installer.Manifests.GetToolbox()))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The uninstall after the upgrade test was attempting to read the crds from github, instead of the local repo as expected. Now the correct manifests interface is updated during the upgrade so it will be used during the uninstall.

**Which issue is resolved by this Pull Request:**
Resolves #10516

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
