### PR TITLE
ci: skip nfs e2e to avoid flaky e2e

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1171,7 +1171,7 @@ func (k8sh *K8sHelper) WaitUntilPVCIsDeleted(namespace string, pvcname string) b
 	ctx := context.TODO()
 	for i := 0; i < RetryLoop; i++ {
 		_, err := k8sh.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcname, getOpts)
-		if err != nil {
+		if err != nil && kerrors.IsNotFound(err) {
 			return true
 		}
 		logger.Infof("waiting for PVC %s to be deleted.", pvcname)

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -435,6 +435,10 @@ func cleanupFilesystemConsumer(helper *clients.TestClient, k8sh *utils.K8sHelper
 	}
 	err = helper.FSClient.DeletePVC(namespace, podName)
 	assertNoErrorUnlessNotFound(s, err)
+	isdeleted := k8sh.WaitUntilPVCIsDeleted(namespace, podName)
+	if !isdeleted {
+		assert.Fail(s.T(), fmt.Sprintf("Failed to delete PVC %q", podName))
+	}
 	logger.Infof("File system consumer deleted")
 }
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -94,10 +94,11 @@ func (s *SmokeSuite) SetupSuite() {
 		ConnectionsCompressed:     true,
 		UseCrashPruner:            true,
 		EnableVolumeReplication:   true,
-		TestNFSCSI:                true,
-		ChangeHostName:            true,
-		RookVersion:               installer.LocalBuildTag,
-		CephVersion:               installer.ReturnCephVersion(),
+		// TODO: uncomment once issue https://github.com/rook/rook/issues/10518 is resolved.
+		// TestNFSCSI:                true,
+		ChangeHostName: true,
+		RookVersion:    installer.LocalBuildTag,
+		CephVersion:    installer.ReturnCephVersion(),
 	}
 	s.settings.ApplyEnvVars()
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)


### PR DESCRIPTION
Skip nfs e2e until https://github.com/rook/rook/issues/10518
is resolved to avoid flakiness.

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
