### PR TITLE
manifest: use `Recreate` strategy for operator upgrade

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       app: rook-ceph-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -534,6 +534,8 @@ spec:
   selector:
     matchLabels:
       app: rook-ceph-operator
+  strategy:
+    type: Recreate
   replicas: 1
   template:
     metadata:

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -455,6 +455,8 @@ spec:
   selector:
     matchLabels:
       app: rook-ceph-operator
+  strategy:
+    type: Recreate
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Use `Recreate` strategy instead of `RollingUpdate` for
rook-ceph-operator deployement upgrade

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #10237 

Testing:
- Strategy: RollingUpdate
Operator deployment replica is still 1 and new operator pod is started. 
```
oc get pods -n rook-ceph 
NAME                                                 READY   STATUS              RESTARTS      AGE
csi-cephfsplugin-provisioner-84b87c9778-49glw        6/6     Running             0             11m
csi-cephfsplugin-zjx5p                               3/3     Running             0             11m
csi-rbdplugin-provisioner-74c78559f6-szwt5           6/6     Running             2 (11m ago)   11m
csi-rbdplugin-vpq6r                                  3/3     Running             0             11m
rook-ceph-crashcollector-minikube-584d846954-8jh79   1/1     Running             0             8m41s
rook-ceph-mgr-a-795f8c448c-hzdxj                     2/2     Running             0             9m12s
rook-ceph-mgr-b-5bddc8fcdc-7tqqr                     2/2     Running             0             9m12s
rook-ceph-mon-a-5d9cf4b868-5jzh4                     1/1     Running             0             10m
rook-ceph-mon-b-6596d46d6-zcqlt                      1/1     Running             0             9m40s
rook-ceph-mon-c-7685544768-rvlw9                     1/1     Running             0             9m29s
rook-ceph-operator-6cc669bd6b-4rq7f                  0/1     ContainerCreating   0             55s
rook-ceph-operator-9dffdd495-vr69b                   1/1     Running             0             12m
rook-ceph-osd-0-9bd5f5585-78fgh                      1/1     Running             0             8m41s
rook-ceph-osd-prepare-minikube--1-mw96d              0/1     Completed           0             8m12s
rook-ceph-tools-78f6fdf966-qzzdk                     1/1     Running             0             12m
```

- Strategy: Recreate
Operator deployment replica is set to 0 and then new operator pod was started.
```
$ oc get pods  -n rook-ceph      
NAME                                                 READY   STATUS              RESTARTS        AGE
csi-cephfsplugin-lvxvf                               3/3     Running             0               13m
csi-cephfsplugin-provisioner-84b87c9778-chkm8        6/6     Running             0               13m
csi-rbdplugin-m9mlg                                  3/3     Running             0               13m
csi-rbdplugin-provisioner-74c78559f6-jps6n           6/6     Running             0               13m
rook-ceph-crashcollector-minikube-56fc799bcd-cvlqq   1/1     Running             0               74s
rook-ceph-mgr-a-5cfdc94c7-c282x                      2/2     Running             1 (7m49s ago)   12m
rook-ceph-mgr-b-db96f7b6f-v7g64                      2/2     Running             0               12m
rook-ceph-mon-a-846bb6f5f6-d6jsg                     1/1     Running             0               74s
rook-ceph-mon-b-65f654574b-n4k64                     1/1     Running             0               12m
rook-ceph-mon-c-5cb99bbb88-z9z9g                     1/1     Running             0               12m
rook-ceph-operator-7c89b8d585-cnq2c                  0/1     ContainerCreating   0               7s
rook-ceph-osd-0-6bcc6c697d-m87r9                     1/1     Running             0               11m
rook-ceph-osd-prepare-minikube--1-9nb49              0/1     Completed           0               6m54s
rook-ceph-tools-78f6fdf966-p9wt9                     1/1     Running             0               13m
```
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
