### PR TITLE
external: add support for subvolumegroup and rados namespace (backport #10459)

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -92,12 +92,39 @@ jobs:
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
 
-    - name: test rados namespace
+    - name: test subvolumegroup validation
+      run: |
+        toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+        # pass the correct subvolumegroup and cephfs_filesystem flag name
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group group-a --cephfs-filesystem-name myfs
+        # pass the wrong subvolumegroup name
+        if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group false-test-subvolume-group); then
+          echo "unexpectedly succeeded after passing the wrong subvolumegroup name: $output"
+          exit 1
+        else
+          echo "script failed because wrong subvolumegroup name was passed"
+        fi
+
+    - name: test of rados namespace
       run: |
         kubectl create -f deploy/examples/radosnamespace.yaml
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
         kubectl delete -f deploy/examples/radosnamespace.yaml
+
+    - name: test rados namespace validation
+      run: |
+        toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+        # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
+        kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace1
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosNamespace1
+         # test the rados namespace which not exit for replicapool(false testing)
+        if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace false-test-namespace); then
+          echo "unexpectedly succeeded after passing the wrong rados namespace: $output"
+          exit 1
+        else
+          echo "script failed because wrong rados namespace was passed"
+        fi
 
     - name: test external script with restricted_auth_permission flag and without having cephfs_filesystem flag
       run: |

--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -37,15 +37,11 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
 - `--namespace`: Namespace where CephCluster will run, for example `rook-ceph-external`
 - `--format bash`: The format of the output
 - `--rbd-data-pool-name`: The name of the RBD data pool
-- `--rbd-metadata-ec-pool-name`: (optional) Provides the name of erasure coded RBD metadata pool
-- `--rados-namespace`: (optional) Divides a pool into separate logical namespaces
-- `--cephfs-filesystem-name`: (optional) The name of the filesystem
-- `--cephfs-metadata-pool-name`: (optional) Provides the name of the cephfs metadata pool
-- `--cephfs-data-pool-name`: (optional) Provides the name of the CephFS data pool
 - `--rgw-endpoint`: (optional) The RADOS Gateway endpoint in the format `<IP>:<PORT>`
 - `--rgw-pool-prefix`: (optional) The prefix of the RGW pools. If not specified, the default prefix is `default`
 - `--rgw-tls-cert-path`: (optional) RADOS Gateway endpoint TLS certificate file path
 - `--rgw-skip-tls`: (optional) Ignore TLS certification validation when a self-signed certificate is provided (NOT RECOMMENDED)
+- `--rbd-metadata-ec-pool-name`: (optional) Provides the name of erasure coded RBD metadata pool, used for creating ECRBDStorageClass.
 - `--monitoring-endpoint`: (optional) Ceph Manager prometheus exporter endpoints (comma separated list of <IP> entries of active and standby mgrs)
 - `--monitoring-endpoint-port`: (optional) Ceph Manager prometheus exporter port
 - `--ceph-conf`: (optional) Provide a Ceph conf file
@@ -53,6 +49,11 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
 - `--output`: (optional) Output will be stored into the provided file
 - `--dry-run`: (optional) Prints the executed commands without running them
 - `--run-as-user`: (optional) Provides a user name to check the cluster's health status, must be prefixed by `client`.
+- `--cephfs-metadata-pool-name`: (optional) Provides the name of the cephfs metadata pool
+- `--cephfs-filesystem-name`: (optional) The name of the filesystem, used for creating CephFS StorageClass
+- `--cephfs-data-pool-name`: (optional) Provides the name of the CephFS data pool, used for creating CephFS StorageClass
+- `--rados-namespace`: (optional) Divides a pool into separate logical namespaces, used for creating RBD PVC in a RadosNamespaces
+- `--subvolume-group`: (optional) Provides the name of the subvolume group, used for creating CephFS PVC in a subvolumeGroup
 - `--restricted-auth-permission`: (optional) Restrict cephCSIKeyrings auth permissions to specific pools, and cluster. Mandatory flags that need to be set are `--rbd-data-pool-name`, and `--cluster-name`. `--cephfs-filesystem-name` flag can also be passed in case of CephFS user restriction, so it can restrict users to particular CephFS filesystem.
 
 !!! note
@@ -125,9 +126,6 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
     ```console
     kubectl -n rook-ceph-external get sc
     ```
-
-    !!! note
-        For CephFS StorageClass you also need to export `CEPHFS_FS_NAME`, `CEPHFS_POOL_NAME` or you can pass these parameters with a CLI flag (--cephfs-data-pool-name,--cephfs-filesystem-name) while running the python script. For creating ECRBDStorageClass you need to pass --rbd-metadata-ec-pool-name CLI flag or export `RBD_METADATA_EC_POOL_NAME`.
 
 7. Then you can now create a [persistent volume](/deploy/examples/csi) based on these StorageClass.
 

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -421,6 +421,12 @@ class RadosJSON:
             required=False,
             help="divides a pool into separate logical namespaces",
         )
+        output_group.add_argument(
+            "--subvolume-group",
+            default="",
+            required=False,
+            help="provides the name of the subvolume group",
+        )
 
         upgrade_group = argP.add_argument_group("upgrade")
         upgrade_group.add_argument(
@@ -1203,6 +1209,31 @@ class RadosJSON:
                 ).format(rados_namespace, rbd_pool_name)
             )
 
+    def validate_subvolume_group(self):
+        cephfs_filesystem_name = self._arg_parser.cephfs_filesystem_name
+        subvolume_group = self._arg_parser.subvolume_group
+        if subvolume_group == "":
+            return
+        if cephfs_filesystem_name == "":
+            raise ExecutionFailureException(
+                "if subvolume group is passed cephfs filesystem name is mandatory to pass"
+            )
+
+        cmd = [
+            "ceph",
+            "fs",
+            "subvolumegroup",
+            "getpath",
+            cephfs_filesystem_name,
+            subvolume_group,
+        ]
+        try:
+            _ = subprocess.check_output(cmd, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as execErr:
+            raise ExecutionFailureException(
+                "subvolume group {} passed doesn't exist".format(subvolume_group)
+            )
+
     def get_rgw_fsid(self):
         access_key = self.out_map["RGW_ADMIN_OPS_USER_ACCESS_KEY"]
         secret_key = self.out_map["RGW_ADMIN_OPS_USER_SECRET_KEY"]
@@ -1262,6 +1293,7 @@ class RadosJSON:
             )
         self.validate_pool()
         self.validate_rados_namespace()
+        self.validate_subvolume_group()
         self._excluded_keys.add("CLUSTER_NAME")
         self.get_cephfs_data_pool_details()
         self.out_map["NAMESPACE"] = self._arg_parser.namespace
@@ -1286,6 +1318,7 @@ class RadosJSON:
             "RESTRICTED_AUTH_PERMISSION"
         ] = self._arg_parser.restricted_auth_permission
         self.out_map["RADOS_NAMESPACE"] = self._arg_parser.rados_namespace
+        self.out_map["SUBVOLUME_GROUP"] = self._arg_parser.subvolume_group
         self.out_map["CSI_CEPHFS_NODE_SECRET"] = ""
         self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"] = ""
         # create CephFS node and provisioner keyring only when MDS exists


### PR DESCRIPTION
Using subvolume group and rados namespace for external deployment
was complicated and not documented,
Automating the process for the users, so they just need to pass
the respective names by cli flag for creation

Closes: rook#10427

Signed-off-by: parth-gr <paarora@redhat.com>
(cherry picked from commit c9a864ccdb683f45e231e10250e2b72eef44a654)
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
