### PR TITLE
docs: Correct multiple 404 page not found error

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -28,7 +28,7 @@ The features available from the external cluster will vary depending on the vers
 
 In order to configure an external Ceph cluster with Rook, we need to extract some information in order to connect to that cluster.
 
-1. Run the python script [create-external-cluster-resources.py](/deploy/examples/create-external-cluster-resources.py) for creating all users and keys.
+1. Run the python script [create-external-cluster-resources.py](https://github.com/rook/rook/blob/master/deploy/examples/create-external-cluster-resources.py) for creating all users and keys.
 
    ```console
    python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --cephfs-filesystem-name <filesystem-name> --rgw-endpoint  <rgw-endpoint> --namespace <namespace> --format bash
@@ -102,13 +102,13 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
 
 ## Commands on the K8s consumer cluster
 
-1. Deploy Rook, create [common.yaml](/deploy/examples/common.yaml), [crds.yaml](/deploy/examples/crds.yaml) and [operator.yaml](/deploy/examples/operator.yaml) manifests.
+1. Deploy Rook, create [common.yaml](https://github.com/rook/rook/blob/master/deploy/examples/common.yaml), [crds.yaml](https://github.com/rook/rook/blob/master/deploy/examples/crds.yaml) and [operator.yaml](https://github.com/rook/rook/blob/master/deploy/examples/operator.yaml) manifests.
 
-2. Create [common-external.yaml](/deploy/examples/common-external.yaml) and [cluster-external.yaml](/deploy/examples/cluster-external.yaml)
+2. Create [common-external.yaml](https://github.com/rook/rook/blob/master/deploy/examples/common-external.yaml) and [cluster-external.yaml](https://github.com/rook/rook/blob/master/deploy/examples/cluster-external.yaml)
 
 3. Paste the above output from `create-external-cluster-resources.py` into your current shell to allow importing the source data.
 
-4. Run the [import](/deploy/examples/import-external-cluster.sh) script.
+4. Run the [import](https://github.com/rook/rook/blob/master/deploy/examples/import-external-cluster.sh) script.
 
     ```console
     . import-external-cluster.sh
@@ -127,7 +127,7 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
     kubectl -n rook-ceph-external get sc
     ```
 
-7. Then you can now create a [persistent volume](/deploy/examples/csi) based on these StorageClass.
+7. Then you can now create a [persistent volume](https://github.com/rook/rook/tree/master/deploy/examples/csi) based on these StorageClass.
 
 ### CephCluster example (management)
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,3 +1,3 @@
 # Rook Feature Proposal
 
-Please follow the [design section guideline](https://rook.io/docs/rook/latest/development-flow.html#design-document).
+Please follow the [design section guideline](https://rook.io/docs/rook/v1.9/Contributing/development-flow/#design-document).


### PR DESCRIPTION
**Description of your changes:**
Multiple links are broken in docs

**Which issue is resolved by this Pull Request:**
Fixes: #10482
Signed-off-by: Sheetal Pamecha <spamecha@redhat.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
