### PR TITLE
helm: use recommended value for helm managed-by label

### DIFF
--- a/deploy/charts/library/templates/_recommended-labels.tpl
+++ b/deploy/charts/library/templates/_recommended-labels.tpl
@@ -3,7 +3,7 @@ Common labels
 */}}
 {{- define "library.rook-ceph.labels" -}}
 app.kubernetes.io/part-of: rook-ceph-operator
-app.kubernetes.io/managed-by: helm
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/created-by: helm
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end }}


### PR DESCRIPTION
**Description of your changes:**

This changes the `app.kubernetes.io/managed-by` label to use the helm
`{{ .Release.Service }}` for it's value.
This is recommended by the Helm labels and annotations standard labels
doc page, see https://helm.sh/docs/chart_best_practices/labels/#standard-labels

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #10473 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
