### PR TITLE
csi: default values of leader election not enough

### DIFF
--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -30,6 +30,9 @@ spec:
             - "--leader-election=true"
             - "--timeout={{ .GRPCTimeout }}"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
           env:
             - name: ADDRESS
               value: /csi/csi-provisioner.sock
@@ -46,6 +49,9 @@ spec:
             - "--timeout={{ .GRPCTimeout }}"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
@@ -61,8 +67,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--v={{ .LogLevel }}"
             - "--timeout={{ .GRPCTimeout }}"
-            - "--leader-election"
+            - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--handle-volume-inuse-error=false"
           env:
             - name: ADDRESS
@@ -80,6 +89,9 @@ spec:
             - "--retry-interval-start=500ms"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--extra-create-metadata=true"
           env:
             - name: ADDRESS

--- a/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
@@ -30,6 +30,9 @@ spec:
             - "--retry-interval-start=500ms"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -31,6 +31,9 @@ spec:
             - "--retry-interval-start=500ms"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--default-fstype=ext4"
             - "--extra-create-metadata=true"
           env:
@@ -46,8 +49,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--v={{ .LogLevel }}"
             - "--timeout={{ .GRPCTimeout }}"
-            - "--leader-election"
+            - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--handle-volume-inuse-error=false"
           env:
             - name: ADDRESS
@@ -64,6 +70,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
           env:
             - name: ADDRESS
               value: /csi/csi-provisioner.sock
@@ -80,6 +89,9 @@ spec:
             - "--timeout={{ .GRPCTimeout }}"
             - "--leader-election=true"
             - "--leader-election-namespace={{ .Namespace }}"
+            - "--leader-election-lease-duration=137s"
+            - "--leader-election-renew-deadline=107s"
+            - "--leader-election-retry-period=26s"
             - "--extra-create-metadata=true"
           env:
             - name: ADDRESS


### PR DESCRIPTION
**Description of your changes:**

CSI pods use leader election and they were using
default values but seems like the default values of the leader
elections are not working for some specific clusters.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
