### PR TITLE
helm: add labels and annotations to PrometheusRule

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -52,22 +52,24 @@ helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter                          | Description                                                                                | Default         |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ | --------------- |
-| `operatorNamespace`                | Namespace of the Rook Operator                                                             | `rook-ceph`     |
-| `kubeVersion`                      | Optional override of the target kubernetes version                                         | ``              |
-| `configOverride`                   | Cluster ceph.conf override                                                                 | `<none>`        |
-| `toolbox.enabled`                  | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md) | `false`         |
-| `toolbox.tolerations`              | Toolbox tolerations                                                                        | `[]`            |
-| `toolbox.affinity`                 | Toolbox affinity                                                                           | `{}`            |
-| `toolbox.resources`                | Toolbox resources                                                                          | see values.yaml |
-| `monitoring.enabled`               | Enable Prometheus integration, will also create necessary RBAC rules                       | `false`         |
-| `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts                                     | `false`         |
-| `cephClusterSpec.*`                | Cluster configuration, see below                                                           | See below       |
-| `ingress.dashboard`                | Enable an ingress for the ceph-dashboard                                                   | `{}`            |
-| `cephBlockPools.[*]`               | A list of CephBlockPool configurations to deploy                                           | See below       |
-| `cephFileSystems.[*]`              | A list of CephFileSystem configurations to deploy                                          | See below       |
-| `cephObjectStores.[*]`             | A list of CephObjectStore configurations to deploy                                         | See below       |
+| Parameter                               | Description                                                                                | Default         |
+| --------------------------------------- | ------------------------------------------------------------------------------------------ | --------------- |
+| `operatorNamespace`                     | Namespace of the Rook Operator                                                             | `rook-ceph`     |
+| `kubeVersion`                           | Optional override of the target kubernetes version                                         | ``              |
+| `configOverride`                        | Cluster ceph.conf override                                                                 | `<none>`        |
+| `toolbox.enabled`                       | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md)    | `false`         |
+| `toolbox.tolerations`                   | Toolbox tolerations                                                                        | `[]`            |
+| `toolbox.affinity`                      | Toolbox affinity                                                                           | `{}`            |
+| `toolbox.resources`                     | Toolbox resources                                                                          | see values.yaml |
+| `monitoring.enabled`                    | Enable Prometheus integration, will also create necessary RBAC rules                       | `false`         |
+| `monitoring.createPrometheusRules`      | Whether to create the Prometheus rules for Ceph alerts                                     | `false`         |
+| `monitoring.prometheusRule.labels`      | Labels applied to PrometheusRule                                                           | `false`         |
+| `monitoring.prometheusRule.annotations` | Annotations applied to PrometheusRule                                                      | `false`         |
+| `cephClusterSpec.*`                     | Cluster configuration, see below                                                           | See below       |
+| `ingress.dashboard`                     | Enable an ingress for the ceph-dashboard                                                   | `{}`            |
+| `cephBlockPools.[*]`                    | A list of CephBlockPool configurations to deploy                                           | See below       |
+| `cephFileSystems.[*]`                   | A list of CephFileSystem configurations to deploy                                          | See below       |
+| `cephObjectStores.[*]`                  | A list of CephObjectStore configurations to deploy                                         | See below       |
 
 ### **Ceph Cluster Spec**
 

--- a/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/prometheusrules.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     prometheus: rook-prometheus
     role: alert-rules
+{{- if  .Values.monitoring.prometheusRule.labels }}
+{{ toYaml .Values.monitoring.prometheusRule.labels | indent 4 }}
+{{- end }}
+{{- if .Values.monitoring.prometheusRule.annotations }}
+  annotations:
+{{ toYaml .Values.monitoring.prometheusRule.annotations | indent 4 }}
+{{- end }}
   name: prometheus-ceph-rules
   namespace: {{ default .Release.Namespace .Values.monitoring.rulesNamespaceOverride }}
 spec:

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -47,6 +47,10 @@ monitoring:
   # Monitoring settings for external clusters:
   # externalMgrEndpoints: <list of endpoints>
   # externalMgrPrometheusPort: <port>
+  # allow adding custom labels and annotations to the prometheus rule
+  prometheusRule:
+    labels: {}
+    annotations: {}
 
 # If true, create & use PSP resources. Set this to the same value as the rook-ceph chart.
 pspEnable: true


### PR DESCRIPTION
**Description of your changes:**

To install rook-ceph using ArgoCD while Prometheus is not yet installed, I need to add the [following annotation](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types): 

```yaml
metadata:
  annotations:
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
