### PR TITLE
examples: fix secrets naming import-external-cluster.sh script

### DIFF
--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -197,11 +197,11 @@ parameters:
   dataPool: $RBD_METADATA_EC_POOL_NAME
   imageFormat: "2"
   imageFeatures: layering
-  csi.storage.k8s.io/provisioner-secret-name: $CSI_RBD_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/provisioner-secret-name: "rook-$CSI_RBD_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/provisioner-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/controller-expand-secret-name:  $CSI_RBD_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/controller-expand-secret-name:  "rook-$CSI_RBD_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/controller-expand-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/node-stage-secret-name: $CSI_RBD_NODE_SECRET_NAME
+  csi.storage.k8s.io/node-stage-secret-name: "rook-$CSI_RBD_NODE_SECRET_NAME"
   csi.storage.k8s.io/node-stage-secret-namespace: $NAMESPACE
   csi.storage.k8s.io/fstype: ext4
 allowVolumeExpansion: true
@@ -221,11 +221,11 @@ parameters:
   pool: $RBD_POOL_NAME
   imageFormat: "2"
   imageFeatures: layering
-  csi.storage.k8s.io/provisioner-secret-name: $CSI_RBD_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/provisioner-secret-name: "rook-$CSI_RBD_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/provisioner-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/controller-expand-secret-name:  $CSI_RBD_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/controller-expand-secret-name:  "rook-$CSI_RBD_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/controller-expand-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/node-stage-secret-name: $CSI_RBD_NODE_SECRET_NAME
+  csi.storage.k8s.io/node-stage-secret-name: "rook-$CSI_RBD_NODE_SECRET_NAME"
   csi.storage.k8s.io/node-stage-secret-namespace: $NAMESPACE
   csi.storage.k8s.io/fstype: ext4
 allowVolumeExpansion: true
@@ -244,11 +244,11 @@ parameters:
   clusterID: $CLUSTER_ID_CEPHFS
   fsName: $CEPHFS_FS_NAME
   pool: $CEPHFS_POOL_NAME
-  csi.storage.k8s.io/provisioner-secret-name: $CSI_CEPHFS_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/provisioner-secret-name: "rook-$CSI_CEPHFS_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/provisioner-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/controller-expand-secret-name: $CSI_CEPHFS_PROVISIONER_SECRET_NAME
+  csi.storage.k8s.io/controller-expand-secret-name: "rook-$CSI_CEPHFS_PROVISIONER_SECRET_NAME"
   csi.storage.k8s.io/controller-expand-secret-namespace: $NAMESPACE
-  csi.storage.k8s.io/node-stage-secret-name: $CSI_CEPHFS_NODE_SECRET_NAME
+  csi.storage.k8s.io/node-stage-secret-name: "rook-$CSI_CEPHFS_NODE_SECRET_NAME"
   csi.storage.k8s.io/node-stage-secret-namespace: $NAMESPACE
 allowVolumeExpansion: true
 reclaimPolicy: Delete


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The secrets in import-external-cluster.sh are being created with "rook-" prefix, but used without when creating the Storage Clasees

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
