### PR TITLE
docs: Add telemetry section to quickstart guide

### DIFF
--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -164,6 +164,19 @@ Create a toolbox pod for full access to a ceph admin client for debugging and tr
 Each Rook cluster has some built in metrics collectors/exporters for monitoring with [Prometheus](https://prometheus.io/).
 To learn how to set up monitoring for your Rook cluster, you can follow the steps in the [monitoring guide](../Storage-Configuration/Monitoring/ceph-monitoring.md).
 
+## Telemetry
+
+To allow us to understand usage, the maintainers for Rook and Ceph would like to receive telemetry reports for Rook clusters.
+The data is anonymous and does not include any identifying information.
+We invite you to enable the telemetry reporting feature with the following command in the toolbox:
+
+```
+ceph telemetry on
+```
+
+The telemetry is disabled by default. For more details on what is reported and how your privacy is protected,
+see the [Ceph Telemetry Documentation](https://docs.ceph.com/en/latest/mgr/telemetry/).
+
 ## Teardown
 
 When you are done with the test cluster, see [these instructions](../Storage-Configuration/ceph-teardown.md) to clean up the cluster.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
To start collecting telemetry on upstream clusters, we add a new section to the quickstart guide that requests users to enable the telemetry.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
