### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kms
 
 import (
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -83,20 +82,15 @@ func TestConfigEnvsToMapString(t *testing.T) {
 	assert.Equal(t, 0, len(envs))
 
 	// Single KMS value
-	os.Setenv("KMS_PROVIDER", "vault")
-	defer os.Unsetenv("KMS_PROVIDER")
+	t.Setenv("KMS_PROVIDER", "vault")
 	envs = ConfigEnvsToMapString()
 	assert.Equal(t, 1, len(envs))
 
 	// Some more Vault KMS with one intruder
-	os.Setenv("KMS_PROVIDER", "vault")
-	defer os.Unsetenv("KMS_PROVIDER")
-	os.Setenv("VAULT_ADDR", "1.1.1.1")
-	defer os.Unsetenv("VAULT_ADDR")
-	os.Setenv("VAULT_SKIP_VERIFY", "true")
-	defer os.Unsetenv("VAULT_SKIP_VERIFY")
-	os.Setenv("foo", "bar")
-	defer os.Unsetenv("foo")
+	t.Setenv("KMS_PROVIDER", "vault")
+	t.Setenv("VAULT_ADDR", "1.1.1.1")
+	t.Setenv("VAULT_SKIP_VERIFY", "true")
+	t.Setenv("foo", "bar")
 	envs = ConfigEnvsToMapString()
 	assert.Equal(t, 3, len(envs))
 	assert.True(t, envs["KMS_PROVIDER"] == "vault")

--- a/pkg/daemon/ceph/osd/kms/vault_test.go
+++ b/pkg/daemon/ceph/osd/kms/vault_test.go
@@ -233,7 +233,7 @@ func Test_configTLS(t *testing.T) {
 					}
 				}
 			}
-			os.Setenv("ROOK_TMP_FILE", ff.Name())
+			t.Setenv("ROOK_TMP_FILE", ff.Name())
 
 			return ff, errors.New("error creating tmp file")
 		}
@@ -250,7 +250,6 @@ func Test_configTLS(t *testing.T) {
 		assert.Error(t, err)
 		assert.EqualError(t, err, "failed to generate temp file for k8s secret \"vault-ca-cert\" content: error creating tmp file")
 		assert.NoFileExists(t, os.Getenv("ROOK_TMP_FILE"))
-		os.Unsetenv("ROOK_TMP_FILE")
 	})
 }
 

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1155,8 +1155,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
 	// Test with flag --crush-device-class.
-	os.Setenv(oposd.CrushDeviceClassVarName, "foo")
-	defer os.Unsetenv(oposd.CrushDeviceClassVarName)
+	t.Setenv(oposd.CrushDeviceClassVarName, "foo")
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
 	}
@@ -1230,8 +1229,7 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 	}
 
 	// Test with flag --block.db and --crush-device-class flag.
-	os.Setenv(oposd.CrushDeviceClassVarName, "foo")
-	defer os.Unsetenv(oposd.CrushDeviceClassVarName)
+	t.Setenv(oposd.CrushDeviceClassVarName, "foo")
 	context = &clusterd.Context{Executor: executor}
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},

--- a/pkg/daemon/util/copybins_test.go
+++ b/pkg/daemon/util/copybins_test.go
@@ -62,10 +62,7 @@ func TestCopyBinary(t *testing.T) {
 	// create a test PATH="testRootDir/bin"
 	envPath := path.Join(testRootDir, "bin")
 	mkdir(envPath)
-	oPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oPath)
-	err := os.Setenv("PATH", envPath)
-	assert.NoError(t, err)
+	t.Setenv("PATH", envPath)
 	// create initial copy-to-dir
 	copyToDir := path.Join(testRootDir, "copy-to-dir")
 	mkdir(copyToDir)
@@ -82,7 +79,7 @@ func TestCopyBinary(t *testing.T) {
 	createTestBinary(path.Join(envPath, "rook"))
 	cleanDir(copyToDir)
 
-	err = CopyBinaries(copyToDir)
+	err := CopyBinaries(copyToDir)
 	assert.NoError(t, err)
 	r := fileText(path.Join(copyToDir, "rook"))
 	assert.Contains(t, r, path.Join(testRootDir, "bin/rook"))

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -19,7 +19,6 @@ package mon
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -509,8 +508,7 @@ func TestUpdateMonTimeout(t *testing.T) {
 		assert.Equal(t, time.Minute*10, MonOutTimeout)
 	})
 	t.Run("using env var mon timeout", func(t *testing.T) {
-		os.Setenv("ROOK_MON_OUT_TIMEOUT", "10s")
-		defer os.Unsetenv("ROOK_MON_OUT_TIMEOUT")
+		t.Setenv("ROOK_MON_OUT_TIMEOUT", "10s")
 		m := &Cluster{}
 		updateMonTimeout(m)
 		assert.Equal(t, time.Second*10, MonOutTimeout)
@@ -530,8 +528,7 @@ func TestUpdateMonInterval(t *testing.T) {
 		assert.Equal(t, time.Second*45, HealthCheckInterval)
 	})
 	t.Run("using env var mon timeout", func(t *testing.T) {
-		os.Setenv("ROOK_MON_HEALTHCHECK_INTERVAL", "10s")
-		defer os.Unsetenv("ROOK_MON_HEALTHCHECK_INTERVAL")
+		t.Setenv("ROOK_MON_HEALTHCHECK_INTERVAL", "10s")
 		m := &Cluster{}
 		h := &HealthChecker{m, HealthCheckInterval}
 		updateMonInterval(m, h)

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -120,8 +119,7 @@ func testOSDIntegration(t *testing.T) {
 	test.PrependComplexJobReactor(t, clientset, assignPodToNode)
 	test.SetFakeKubernetesVersion(clientset, "v1.13.2") // v1.13 or higher is required for OSDs on PVC
 
-	os.Setenv(k8sutil.PodNamespaceEnvVar, namespace)
-	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, namespace)
 
 	statusMapWatcher := watch.NewRaceFreeFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(statusMapWatcher, nil))

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -18,7 +18,6 @@ package osd
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -138,8 +137,7 @@ func TestAddRemoveNode(t *testing.T) {
 
 	// set up a fake k8s client set and watcher to generate events that the operator will listen to
 	clientset := fake.NewSimpleClientset()
-	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
-	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
 
 	test.AddReadyNode(t, clientset, nodeName, "23.23.23.23")
 	cmErr := createDiscoverConfigmap(nodeName, "rook-system", clientset)
@@ -315,8 +313,7 @@ func TestAddNodeFailure(t *testing.T) {
 	nodeErr := createNode(nodeName, corev1.NodeReady, clientset)
 	assert.Nil(t, nodeErr)
 
-	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
-	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
 
 	cmErr := createDiscoverConfigmap(nodeName, "rook-system", clientset)
 	assert.Nil(t, cmErr)

--- a/pkg/operator/ceph/controller_test.go
+++ b/pkg/operator/ceph/controller_test.go
@@ -110,8 +110,7 @@ func TestOperatorController(t *testing.T) {
 				ServiceAccount:    "foo",
 			},
 		}
-		os.Setenv("ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS", "10")
-		defer os.Unsetenv("ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS")
+		t.Setenv("ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS", "10")
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.False(t, res.Requeue)
@@ -189,8 +188,7 @@ func TestOperatorController(t *testing.T) {
 				ServiceAccount:    "foo",
 			},
 		}
-		os.Setenv("ROOK_ENABLE_DISCOVERY_DAEMON", "true")
-		defer os.Unsetenv("ROOK_ENABLE_DISCOVERY_DAEMON")
+		t.Setenv("ROOK_ENABLE_DISCOVERY_DAEMON", "true")
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.False(t, res.Requeue)

--- a/pkg/operator/ceph/csi/controller_test.go
+++ b/pkg/operator/ceph/csi/controller_test.go
@@ -47,10 +47,10 @@ func TestCephCSIController(t *testing.T) {
 	// Set DEBUG logging
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
 	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
-	os.Setenv(k8sutil.PodNameEnvVar, "rook-ceph-operator")
-	os.Setenv(k8sutil.PodNamespaceEnvVar, namespace)
+	t.Setenv(k8sutil.PodNameEnvVar, "rook-ceph-operator")
+	t.Setenv(k8sutil.PodNamespaceEnvVar, namespace)
 
-	os.Setenv("ROOK_CSI_ALLOW_UNSUPPORTED_VERSION", "true")
+	t.Setenv("ROOK_CSI_ALLOW_UNSUPPORTED_VERSION", "true")
 	CSIParam = Param{
 		CSIPluginImage:   "image",
 		RegistrarImage:   "image",

--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -18,12 +18,10 @@ package peermap
 
 import (
 	"context"
-	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
-
-	"strings"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
@@ -363,10 +361,8 @@ func TestDecodePeerToken(t *testing.T) {
 }
 
 func TestCreateOrUpdateConfig(t *testing.T) {
-	os.Setenv("POD_NAME", "rook-ceph-operator")
-	defer os.Setenv("POD_NAME", "")
-	os.Setenv("POD_NAMESPACE", ns)
-	defer os.Setenv("POD_NAMESPACE", "")
+	t.Setenv("POD_NAME", "rook-ceph-operator")
+	t.Setenv("POD_NAMESPACE", ns)
 
 	scheme := scheme.Scheme
 	err := cephv1.AddToScheme(scheme)

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"context"
 	_ "embed"
-	"os"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -78,7 +77,7 @@ func TestReconcileCSI_configureHolders(t *testing.T) {
 			},
 		}
 
-		os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-ceph")
+		t.Setenv(k8sutil.PodNamespaceEnvVar, "rook-ceph")
 		_, err := r.context.Clientset.CoreV1().ConfigMaps("rook-ceph").Create(r.opManagerContext, &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ConfigName, Namespace: "rook-ceph"}, Data: map[string]string{}}, metav1.CreateOptions{})
 		assert.NoError(t, err)
 

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -54,26 +54,19 @@ func TestGetPortFromConfig(t *testing.T) {
 	assert.Equal(t, port, defaultPort)
 
 	// valid port is set in env
-	err = os.Setenv(key, "9000")
-	assert.Nil(t, err)
+	t.Setenv(key, "9000")
 	port, err = getPortFromConfig(data, key, defaultPort)
 	assert.Nil(t, err)
 	assert.Equal(t, port, uint16(9000))
 
-	err = os.Unsetenv(key)
-	assert.Nil(t, err)
 	// higher port value is set in env
-	err = os.Setenv(key, "65536")
-	assert.Nil(t, err)
+	t.Setenv(key, "65536")
 	port, err = getPortFromConfig(data, key, defaultPort)
 	assert.Error(t, err)
 	assert.Equal(t, port, defaultPort)
 
-	err = os.Unsetenv(key)
-	assert.Nil(t, err)
 	// negative port is set in env
-	err = os.Setenv(key, "-1")
-	assert.Nil(t, err)
+	t.Setenv(key, "-1")
 	port, err = getPortFromConfig(data, key, defaultPort)
 	assert.Error(t, err)
 	assert.Equal(t, port, defaultPort)

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -213,7 +213,7 @@ func TestCephClientController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
+		t.Setenv("POD_NAMESPACE", namespace)
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
@@ -260,7 +260,7 @@ func TestCephClientController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
+		t.Setenv("POD_NAMESPACE", namespace)
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
@@ -309,7 +309,7 @@ func TestCephClientController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
+		t.Setenv("POD_NAMESPACE", namespace)
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -19,7 +19,6 @@ package object
 import (
 	"context"
 	"fmt"
-	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -223,7 +222,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 
 func TestGetObjectBucketProvisioner(t *testing.T) {
 	testNamespace := "test-namespace"
-	os.Setenv(k8sutil.PodNamespaceEnvVar, testNamespace)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, testNamespace)
 
 	t.Run("watch single namespace", func(t *testing.T) {
 		data := map[string]string{"ROOK_OBC_WATCH_OPERATOR_NAMESPACE": "true"}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -401,10 +401,8 @@ func TestCephBlockPoolController(t *testing.T) {
 		assert.True(t, res.Requeue)
 	})
 
-	os.Setenv("POD_NAME", "test")
-	defer os.Setenv("POD_NAME", "")
-	os.Setenv("POD_NAMESPACE", namespace)
-	defer os.Setenv("POD_NAMESPACE", "")
+	t.Setenv("POD_NAME", "test")
+	t.Setenv("POD_NAMESPACE", namespace)
 	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -212,7 +212,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
+		t.Setenv("POD_NAMESPACE", namespace)
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")
@@ -258,7 +258,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 
 		// Enable CSI
 		csi.EnableRBD = true
-		os.Setenv("POD_NAMESPACE", namespace)
+		t.Setenv("POD_NAMESPACE", namespace)
 		// Create CSI config map
 		ownerRef := &metav1.OwnerReference{}
 		ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, "")

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -19,7 +19,6 @@ package discover
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -38,14 +37,9 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 3)
 
-	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
-	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
-
-	os.Setenv(k8sutil.PodNameEnvVar, "rook-operator")
-	defer os.Unsetenv(k8sutil.PodNameEnvVar)
-
-	os.Setenv(discoverDaemonsetPriorityClassNameEnv, "my-priority-class")
-	defer os.Unsetenv(discoverDaemonsetPriorityClassNameEnv)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	t.Setenv(k8sutil.PodNameEnvVar, "rook-operator")
+	t.Setenv(discoverDaemonsetPriorityClassNameEnv, "my-priority-class")
 
 	namespace := "ns"
 	a := New(clientset)
@@ -97,11 +91,8 @@ func TestGetAvailableDevices(t *testing.T) {
 	pvcBackedOSD := false
 	ns := "rook-system"
 	nodeName := "node123"
-	os.Setenv(k8sutil.PodNamespaceEnvVar, ns)
-	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
-
-	os.Setenv(k8sutil.PodNameEnvVar, "rook-operator")
-	defer os.Unsetenv(k8sutil.PodNameEnvVar)
+	t.Setenv(k8sutil.PodNamespaceEnvVar, ns)
+	t.Setenv(k8sutil.PodNameEnvVar, "rook-operator")
 
 	data := make(map[string]string, 1)
 	data[discoverDaemon.LocalDiskCMData] = `[{"name":"sdd","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/scsi-36001405f826bd553d8c4dbf9f41c18be    /dev/disk/by-id/wwn-0x6001405f826bd553d8c4dbf9f41c18be /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-1","size":10737418240,"uuid":"","serial":"36001405f826bd553d8c4dbf9f41c18be","type":"disk","rotational":true,"readOnly":false,"ownPartition":true,"filesystem":"","vendor":"LIO-ORG","model":"disk02","wwn":"0x6001405f826bd553","wwnVendorExtension":"0x6001405f826bd553d8c4dbf9f41c18be","empty":true},{"name":"sdb","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/scsi-3600140577f462d9908b409d94114e042   /dev/disk/by-id/wwn-0x600140577f462d9908b409d94114e042 /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-3","size":5368709120,"uuid":"","serial":"3600140577f462d9908b409d94114e042","type":"disk","rotational":true,"readOnly":false,"ownPartition":false,"filesystem":"","vendor":"LIO-ORG","model":"disk04","wwn":"0x600140577f462d99","wwnVendorExtension":"0x600140577f462d9908b409d94114e042","empty":true},{"name":"sdc","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/scsi-3600140568c0bd28d4ee43769387c9f02    /dev/disk/by-id/wwn-0x600140568c0bd28d4ee43769387c9f02 /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-2","size":5368709120,"uuid":"","serial":"3600140568c0bd28d4ee43769387c9f02","type":"disk","rotational":true,"readOnly":false,"ownPartition":true,"filesystem":"","vendor":"LIO-ORG","model":"disk03","wwn":"0x600140568c0bd28d","wwnVendorExtension":"0x600140568c0bd28d4ee43769387c9f02","empty":true},{"name":"sda","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/scsi-36001405fc00c75fb4c243aa9d61987bd    /dev/disk/by-id/wwn-0x6001405fc00c75fb4c243aa9d61987bd /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-0","size":10737418240,"uuid":"","serial":"36001405fc00c75fb4c243aa9d61987bd","type":"disk","rotational":true,"readOnly":false,"ownPartition":false,"filesystem":"","vendor":"LIO-ORG","model":"disk01","wwn":"0x6001405fc00c75fb","wwnVendorExtension":"0x6001405fc00c75fb4c243aa9d61987bd","empty":true},{"name":"nvme0n1","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/nvme-eui.002538c5710091a7","size":512110190592,"uuid":"","serial":"","type":"disk","rotational":false,"readOnly":false,"ownPartition":false,"filesystem":"","vendor":"","model":"","wwn":"","wwnVendorExtension":"","empty":true}]`

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -88,14 +88,13 @@ func TestGetOperatorSetting(t *testing.T) {
 	// Env Var doesn't exist
 	assert.Equal(t, defaultValue, setting)
 	// Env Var exists
-	err = os.Setenv(nodeAffinity, envSettingValue)
-	assert.NoError(t, err)
+	t.Setenv(nodeAffinity, envSettingValue)
 	setting, err = GetOperatorSetting(ctx, k8s, operatorSettingConfigMapName, nodeAffinity, defaultValue)
 	assert.NoError(t, err)
 	assert.Equal(t, envSettingValue, setting)
 
 	// ConfigMap is found
-	os.Setenv("POD_NAMESPACE", testNamespace)
+	t.Setenv("POD_NAMESPACE", testNamespace)
 	_, err = k8s.CoreV1().ConfigMaps(testNamespace).Create(ctx, cm, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -115,8 +114,7 @@ func TestGetOperatorSetting(t *testing.T) {
 	// Env Var doesn't exist
 	assert.Equal(t, defaultValue, setting)
 	// Env Var exists
-	err = os.Setenv(podAffinity, envSettingValue)
-	assert.NoError(t, err)
+	t.Setenv(podAffinity, envSettingValue)
 	setting, err = GetOperatorSetting(ctx, k8s, operatorSettingConfigMapName, podAffinity, defaultValue)
 	assert.NoError(t, err)
 	assert.Equal(t, envSettingValue, setting)

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -18,7 +18,6 @@ package k8sutil
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -96,7 +95,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration := newToleration(5, "node.kubernetes.io/unreachable")
 
 	// Change the UR toleration in the pod using env var and the tested function
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "5")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "5")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 1, len(podSpec.Tolerations))
@@ -108,7 +107,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration = newToleration(6, "node.kubernetes.io/unreachable")
 
 	// Change the UR toleration in the pod using env var and the tested function
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "6")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "6")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 1, len(podSpec.Tolerations))
@@ -125,7 +124,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration = newToleration(7, "node.kubernetes.io/unreachable")
 
 	// Change the Unreachable node toleration
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "7")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "7")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 2, len(podSpec.Tolerations))
@@ -139,7 +138,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration = newToleration(8, "node.kubernetes.io/unreachable")
 
 	// Change the Unreachable node toleration
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "8")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "8")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 3, len(podSpec.Tolerations))
@@ -153,7 +152,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration = newToleration(9, "node.kubernetes.io/unreachable")
 
 	// Change the Unreachable node toleration
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "9")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "9")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 2, len(podSpec.Tolerations))
@@ -166,7 +165,7 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	expectedURToleration = newToleration(5, "node.kubernetes.io/unreachable")
 
 	// Change the Unreachable node toleration using wrong format
-	os.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "9s")
+	t.Setenv("ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS", "9s")
 	AddUnreachableNodeToleration(&podSpec)
 
 	assert.Equal(t, 1, len(podSpec.Tolerations))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv


**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
