### PR TITLE
core: use "rockylinux:9" as base image

### DIFF
--- a/images/image.mk
+++ b/images/image.mk
@@ -32,7 +32,7 @@ include $(SELF_DIR)/../build/makelib/common.mk
 CACHE_REGISTRY := cache
 
 # the base image to use
-OSBASE ?= centos:7
+OSBASE ?= rockylinux:9
 
 ifeq ($(GOARCH),amd64)
 PLATFORM_ARCH = x86_64


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Migrating to "rockylinux:9" as the base image because:

1. "centos" project declared End-Of-Life(EOL) of Centos at 

     https://blog.centos.org/2020/12/future-is-centos-stream/
     https://www.redhat.com/en/blog/transforming-development-experience-within-centos

2. Rook-ceph v1.9.x install failing on latest kernels as older version "modprobe" 
in csi-plugin image is failing to load kernel modules compressed with "zstd" compression
which resulted in kernel modules to be "*.ko.zst" format instead of "*.ko"

Further, rocky linux is proposed because it is based on the same "yum", "rpm" and "dnf" 
based package management system and it is free and compatible with Red Hat Enterprise Linux®.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>


**Which issue is resolved by this Pull Request:**
Resolves #10615 

**Checklist:**

- [*] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [*] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [*] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [*] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [*] Documentation has been updated, if necessary.
- [*] Unit tests have been added, if necessary.
- [*] Integration tests have been added, if necessary.
