### PR TITLE
test: fix minor code unreachability error in test

### DIFF
--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -216,7 +216,7 @@ func TestCommitConfigChanges(t *testing.T) {
 					}
 				}
 
-				t.Fatalf("unhandled command: %s %v", command, args)
+				t.Errorf("unhandled command: %s %v", command, args)
 				panic("unhandled command")
 			},
 		}

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -509,7 +509,7 @@ func Test_createMultisite(t *testing.T) {
 						}
 					}
 				}
-				t.Fatalf("unhandled command: %s %v", command, arg)
+				t.Errorf("unhandled command: %s %v", command, arg)
 				panic("unhandled command")
 			},
 		}


### PR DESCRIPTION
t.Error* will report test failures but continue executing the test. t.Fatal* will report test failures and stop the test immediately. So if the code is after t.Fatal, it is actually unreachable

Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
