### PR TITLE
rgw: remove .rgw.root pool creation for cephobjectstore CR

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -446,8 +446,9 @@ func createReplicatedPoolForApp(context *clusterd.Context, clusterInfo *ClusterI
 	if err != nil {
 		// Create the pool since it doesn't exist yet
 		// If there was some error other than ENOENT (not exists), go ahead and ensure the pool is created anyway
+
 		args := []string{"osd", "pool", "create", pool.Name, pgCount, "replicated", crushRuleName, "--size", strconv.FormatUint(uint64(pool.Replicated.Size), 10)}
-		if strings.HasPrefix(pool.Name, ".") && clusterInfo.CephVersion.IsAtLeastReef() {
+		if strings.HasPrefix(pool.Name, ".") && clusterInfo.CephVersion.IsAtLeastQuincy() {
 			args = append(args, "--yes-i-really-mean-it")
 		}
 		output, err := NewCephCommand(context, clusterInfo, args).Run()

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -785,6 +785,7 @@ func createRGWPool(ctx *Context, clusterSpec *cephv1.ClusterSpec, poolSpec cephv
 		Name:     poolName(ctx.Name, requestedName),
 		PoolSpec: poolSpec,
 	}
+
 	if err := cephclient.CreatePoolWithPGs(ctx.Context, ctx.clusterInfo, clusterSpec, pool, AppName, pgCount); err != nil {
 		return errors.Wrapf(err, "failed to create pool %q", pool.Name)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The `.rgw.root` is automatically created when first radosgw-admin is
executed, its more needed for cli than rgw server itself. And in current
ceph master is not allowing to create pools starting with `.`, hence
removing its creation. But this pool will still removed when last
cephobjectstore CR is deleted.

**Which issue is resolved by this Pull Request:**
Resolves #10631
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
