### PR TITLE
build: Remove obsolete OSBASE image var

### DIFF
--- a/images/image.mk
+++ b/images/image.mk
@@ -31,15 +31,10 @@ include $(SELF_DIR)/../build/makelib/common.mk
 # the registry used for cached images
 CACHE_REGISTRY := cache
 
-# the base image to use
-OSBASE ?= centos:7
-
 ifeq ($(GOARCH),amd64)
 PLATFORM_ARCH = x86_64
-OSBASEIMAGE = $(OSBASE)
 else ifeq ($(GOARCH),arm64)
 PLATFORM_ARCH = aarch64
-OSBASEIMAGE = arm64v8/$(OSBASE)
 else
 $(error Unknown go architecture $(GOARCH))
 endif


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSBASE and OSBASEIMAGE are obsolete from an older version of rook where Ceph was not the base image. Now that Ceph provides the base image, there is no need for these vars in the makefile.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
