### PR TITLE
docs: add section to update GOPROXY

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -38,11 +38,13 @@ cd rook
 Building Rook-Ceph is simple.
 
 ```console
-make
+make build
 ```
 
 If you want to use `podman` instead of `docker` then uninstall `docker` packages from your machine, make will automatically pick up `podman`.
 
+!!! tip
+    If you are in linux environment and `make build` command throws an error like `unknown revision` for some imports, try adding `export GOPROXY=https://proxy.golang.org,direct` to `~/.bashrc` and then run `source ~/.bashrc` or to a similar file to update your environment and confirm with `go env` that `GOPROXY` is updated.
 ### Development Settings
 
 To provide consistent whitespace and other formatting in your `go` and other source files (e.g., Markdown), it is recommended you apply


### PR DESCRIPTION
In linux environment, when go is installed using
`dnf/yum/apt` or other pacakge installer. In this case we
get error when we do `make build` because of GOPROXY.
So, we need to update the GOPROXY with `export GOPROXY=https://proxy.golang.org,direct`
in `.bashrc` file

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
