### PR TITLE
Revert "ci: use ceph v17.2.1 instead of latest v17"

### DIFF
--- a/deploy/examples/cluster-multus-test.yaml
+++ b/deploy/examples/cluster-multus-test.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v17.2.1
+    image: quay.io/ceph/ceph:v17
     allowUnsupported: true
   mon:
     count: 1

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v17.2.1
+    image: quay.io/ceph/ceph:v17
     allowUnsupported: true
   mon:
     count: 1

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -45,7 +45,7 @@ const (
 	// test with the latest pacific build
 	pacificTestImage = "quay.io/ceph/ceph:v16"
 	// test with the latest pacific build
-	quincyTestImage = "quay.io/ceph/ceph:v17.2.1"
+	quincyTestImage = "quay.io/ceph/ceph:v17"
 	// test with the current development version of Pacific
 	pacificDevelTestImage = "quay.io/ceph/daemon-base:latest-pacific-devel"
 	quincyDevelTestImage  = "quay.io/ceph/daemon-base:latest-quincy-devel"


### PR DESCRIPTION
This reverts commit 3279cb91870e59eccabb9b5eff903d71beb31594.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
