### PR TITLE
monitoring: fix pool growth warning grouping

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -727,7 +727,7 @@ groups:
     rules:
       - alert: CephPoolGrowthWarning
         expr: |
-          (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
+          (predict_linear((max(ceph_pool_percent_used) without (pod, instance))[2d:1h], 3600 * 24 * 5) * on(pool_id)
               group_right ceph_pool_metadata) >= 95
         labels:
           severity: warning

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -735,7 +735,7 @@ spec:
       rules:
         - alert: CephPoolGrowthWarning
           expr: |
-            (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
+            (predict_linear((max(ceph_pool_percent_used) without (pod, instance))[2d:1h], 3600 * 24 * 5) * on(pool_id)
                 group_right ceph_pool_metadata) >= 95
           labels:
             severity: warning


### PR DESCRIPTION
Predict linear will continue to predict on exporter data from old pods.
We can take the max value for every hour in the 2 day window before we
linearly predict to get the most conservative estimate. This will only
affect the hour in which a new mgr pod is started.

Fixes #10691

Signed-off-by: Jamison Lofthouse <jamison.lofthouse@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #10691 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
