### PR TITLE
test: fix test pod log collector

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1385,7 +1385,7 @@ func (k8sh *K8sHelper) createTestLogFile(platformName, name, namespace, testName
 		}
 	}
 	fileName := fmt.Sprintf("%s_%s_%s_%s%s_%d.log", testName, platformName, namespace, name, suffix, time.Now().Unix())
-	filePath := path.Join(logDir, fileName)
+	filePath := path.Join(logDir, strings.ReplaceAll(fileName, "/", "_"))
 	file, err := os.Create(filePath)
 	if err != nil {
 		logger.Errorf("Cannot create file %s. %v", filePath, err)


### PR DESCRIPTION
**Description of your changes:**

When a test has a slash in it's name the log collection can fail due to
the "directory" not existing, this makes sure the full path exists.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

In our fork, in which we have enabled all CI workflows, when a test, e.g., CephUpgradeSuite/TestUpgradeHelm, failed the log collection wants to write the logs to a file placed _output/tests/TestCephUpgradeSuite/TestUpgradeHelm_localhost_upgrade-system_rook-ceph-operator-67c5cbc94c-drf7g_1660327489.log but only the directories up to _output/tests is created in the k8s_helper.go logic (around line 1378). I haven't checked rook's failed CI logs but this should also be an issue that can occur here.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.