### PR TITLE
mon: Improve mon failover reliability to better handle failure and topology

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -127,6 +127,8 @@ type monConfig struct {
 	Port int32
 	// The zone used for a stretch cluster
 	Zone string
+	// The node where the mon is assigned
+	NodeName string
 	// DataPathMap is the mapping relationship between mon data stored on the host and mon data
 	// stored in containers.
 	DataPathMap *config.DataPathMap
@@ -515,7 +517,7 @@ func (c *Cluster) initClusterInfo(cephVersion cephver.CephVersion, clusterName s
 func (c *Cluster) initMonConfig(size int) (int, []*monConfig, error) {
 
 	// initialize the mon pod info for mons that have been previously created
-	mons := c.clusterInfoToMonConfig("")
+	mons := c.clusterInfoToMonConfig()
 
 	// initialize mon info if we don't have enough mons (at first startup)
 	existingCount := len(c.ClusterInfo.Monitors)
@@ -531,7 +533,11 @@ func (c *Cluster) initMonConfig(size int) (int, []*monConfig, error) {
 	return existingCount, mons, nil
 }
 
-func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
+func (c *Cluster) clusterInfoToMonConfig() []*monConfig {
+	return c.clusterInfoToMonConfigWithExclude("")
+}
+
+func (c *Cluster) clusterInfoToMonConfigWithExclude(excludedMon string) []*monConfig {
 	mons := []*monConfig{}
 	for _, monitor := range c.ClusterInfo.Monitors {
 		if monitor.Name == excludedMon {
@@ -539,9 +545,11 @@ func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
 			continue
 		}
 		var zone string
+		var nodeName string
 		schedule := c.mapping.Schedule[monitor.Name]
 		if schedule != nil {
 			zone = schedule.Zone
+			nodeName = schedule.Name
 		}
 		mons = append(mons, &monConfig{
 			ResourceName: resourceName(monitor.Name),
@@ -549,6 +557,7 @@ func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
 			Port:         cephutil.GetPortFromEndpoint(monitor.Endpoint),
 			PublicIP:     cephutil.GetIPFromEndpoint(monitor.Endpoint),
 			Zone:         zone,
+			NodeName:     nodeName,
 			DataPathMap:  config.NewStatefulDaemonDataPathMap(c.spec.DataDirHostPath, dataDirRelativeHostPath(monitor.Name), config.MonType, monitor.Name, c.Namespace),
 		})
 	}
@@ -1125,6 +1134,10 @@ func (c *Cluster) commitMaxMonID(monName string) error {
 		return errors.Wrapf(err, "invalid mon name %q", monName)
 	}
 
+	return c.commitMaxMonIDRequireIncrementing(committedMonID, true)
+}
+
+func (c *Cluster) commitMaxMonIDRequireIncrementing(desiredMaxMonID int, requireIncrementing bool) error {
 	configmap, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(c.ClusterInfo.Context, EndpointConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to find existing mon endpoint config map")
@@ -1136,13 +1149,13 @@ func (c *Cluster) commitMaxMonID(monName string) error {
 		return errors.Wrap(err, "failed to read existing maxMonId")
 	}
 
-	if existingMax >= committedMonID {
-		logger.Infof("no need to commit maxMonID %d since it is not greater than existing maxMonID %d", committedMonID, existingMax)
+	if requireIncrementing && existingMax >= desiredMaxMonID {
+		logger.Infof("no need to commit maxMonID %d since it is not greater than existing maxMonID %d", desiredMaxMonID, existingMax)
 		return nil
 	}
 
-	logger.Infof("updating maxMonID from %d to %d after committing mon %q", existingMax, committedMonID, monName)
-	configmap.Data[controller.MaxMonIDKey] = strconv.Itoa(committedMonID)
+	logger.Infof("updating maxMonID from %d to %d", existingMax, desiredMaxMonID)
+	configmap.Data[controller.MaxMonIDKey] = strconv.Itoa(desiredMaxMonID)
 
 	if _, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(c.ClusterInfo.Context, configmap, metav1.UpdateOptions{}); err != nil {
 		return errors.Wrap(err, "failed to update mon endpoint config map for the maxMonID")
@@ -1327,7 +1340,7 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterInfo *cephclient.Cl
 
 	// wait for monitors to establish quorum
 	retryCount := 0
-	retryMax := 30
+	retryMax := 60
 	for {
 		// Return immediately if the context has been canceled
 		if clusterInfo.Context.Err() != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Mon failover reliability is improved in two scenarios with these changes. 
1. If the failover is aborted because of failing to start the new mon and wait for it to join quorum, the new mon will be fully removed and the failover rolled back. Previously, the operator would leave the new mon pod running even if it never joined quorum. Now the timeout for the failover is increased to wait longer for the new mon, but if it times out, there are no leftovers from the cancelled failover.
2. If the operator is failed in the middle of a failover before the old mon is removed, the operator needs to remove an extra
mon. The operator was only selecting a random mon for removal instead of honoring the stretch cluster topology or looking for mons on the same node that could be removed to restore the correct desired number of mons.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
