### PR TITLE
core: no need to delete v1beta cronJob during v1 deletion

### DIFF
--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -299,9 +299,6 @@ func (r *ReconcileNode) reconcileCrashRetention(namespace string, cephCluster ce
 		var cronJob client.Object
 		// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
 		if useCronJobV1 {
-			if err := r.deletev1betaJob(objectMeta); err != nil {
-				return err
-			}
 			cronJob = &v1.CronJob{ObjectMeta: objectMeta}
 		} else {
 			cronJob = &v1beta1.CronJob{ObjectMeta: objectMeta}


### PR DESCRIPTION
we are already deleting v1beta1 cronJob while creating v1 cronJob,
so no need to delete v1beta while v1 cronJob deltion.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
