### PR TITLE
ci: update codespell config

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -30,7 +30,11 @@ jobs:
       - name: codespell
         uses: codespell-project/actions-codespell@master
         with:
-          skip: .git,*.png,*.jpg,*.svg,*.sum
+          # LICENSE: skip file because codespell wants to flag complies, which we may want to flag
+          # in other places, so ignore the file itself assuming it is correct
+          # crds.yaml, resources.yaml: CRD files are fully generated from content we control (should
+          # be flagged elsewhere) and content we don't control (can't fix easily), so ignore
+          skip: .git,*.png,*.jpg,*.svg,*.sum,./LICENSE,./deploy/examples/crds.yaml,./deploy/charts/rook-ceph/templates/resources.yaml
           # aks: Amazon Kubernetes Service
           # keyserver: flag to apt-key
           # atleast: codespell wants to flag any 'AtLeast' method
@@ -40,6 +44,7 @@ jobs:
           # te: udev persistent naming test in pkg/daemon/ceph/osd/daemon_test.go
           # parm: modinfo parameter
           # assigment: inherited from K8s TopologySpreadConstraints dependency
-          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment
+          # ro, RO: means read-only
+          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,ro,RO
           check_filenames: true
           check_hidden: true

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -910,7 +910,7 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list contains muliple different endpoints from existing list containing single zone",
+		{"new endpoint list contains multiple different endpoints from existing list containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-3", "http://rgw-endpoint-4"},


### PR DESCRIPTION
Codespell had its first release in a year yesterday and added some
dictionary rules that are now being flagged in our code. None of the
issues require changes to our code, so modify the codespell config to
allow the words we want to allow.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
