### PR TITLE
build: Update mergify for the release-1.10 branch and remove 1.6 automatic backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,39 +15,6 @@ pull_request_rules:
       comment:
         message: Hi @{{author}}, this pull request was opened against a release branch, is it expected? Normally patches should go in the master branch first and then be backported to release branches.
 
-  # release-1.6 branch
-  - name: automerge backport release-1.6
-    conditions:
-      - author=mergify[bot]
-      - base=release-1.6
-      - label!=do-not-merge
-      - "status-success=DCO"
-      - "check-success=canary"
-      - "check-success=unittests"
-      - "check-success=golangci-lint"
-      - "check-success=codegen"
-      - "check-success=lint"
-      - "check-success=modcheck"
-      - "check-success=pvc"
-      - "check-success=pvc-db"
-      - "check-success=pvc-db-wal"
-      - "check-success=encryption-pvc"
-      - "check-success=encryption-pvc-db"
-      - "check-success=encryption-pvc-db-wal"
-      - "check-success=encryption-pvc-kms-vault-token-auth"
-      - "check-success=TestCephSmokeSuite (v1.16.15)"
-      - "check-success=TestCephSmokeSuite (v1.21.0)"
-      - "check-success=TestCephHelmSuite (v1.16.15)"
-      - "check-success=TestCephHelmSuite (v1.22.0)"
-      - "check-success=TestCephMultiClusterDeploySuite (v1.21.0)"
-      - "check-success=TestCephUpgradeSuite (v1.16.15)"
-      - "check-success=TestCephUpgradeSuite (v1.21.0)"
-    actions:
-      merge:
-        method: merge
-      dismiss_reviews: {}
-      delete_head_branch: {}
-
   # release-1.7 branch
   - name: automerge backport release-1.7
     conditions:
@@ -161,14 +128,48 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
-  # release-1.6 branch
-  - actions:
-      backport:
-        branches:
-          - release-1.6
+  # release-1.10 branch
+  - name: automerge backport release-1.10
     conditions:
-      - label=backport-release-1.6
-    name: backport release-1.6
+      - author=mergify[bot]
+      - base=release-1.10
+      - label!=do-not-merge
+      - "status-success=DCO"
+      - "check-success=canary"
+      - "check-success=unittests"
+      - "check-success=golangci-lint"
+      - "check-success=codegen"
+      - "check-success=codespell"
+      - "check-success=lint"
+      - "check-success=modcheck"
+      - "check-success=Shellcheck"
+      - "check-success=yaml-linter"
+      - "check-success=lint-test"
+      - "check-success=gen-rbac"
+      - "check-success=crds-gen"
+      - "check-success=pvc"
+      - "check-success=pvc-db"
+      - "check-success=pvc-db-wal"
+      - "check-success=encryption-pvc"
+      - "check-success=encryption-pvc-db"
+      - "check-success=encryption-pvc-db-wal"
+      - "check-success=encryption-pvc-kms-vault-token-auth"
+      - "check-success=encryption-pvc-kms-vault-k8s-auth"
+      - "check-success=lvm-pvc"
+      - "check-success=multi-cluster-mirroring"
+      - "check-success=rgw-multisite-testing"
+      - "check-success=TestCephSmokeSuite (v1.17.17)"
+      - "check-success=TestCephSmokeSuite (v1.24.1)"
+      - "check-success=TestCephHelmSuite (v1.17.17)"
+      - "check-success=TestCephHelmSuite (v1.24.1)"
+      - "check-success=TestCephMultiClusterDeploySuite (v1.24.1)"
+      - "check-success=TestCephUpgradeSuite (v1.17.17)"
+      - "check-success=TestCephUpgradeSuite (v1.24.1)"
+    actions:
+      merge:
+        method: merge
+      dismiss_reviews: {}
+      delete_head_branch: {}
 
   # release-1.7 branch
   - actions:
@@ -196,3 +197,12 @@ pull_request_rules:
     conditions:
       - label=backport-release-1.9
     name: backport release-1.9
+
+  # release-1.10 branch
+  - actions:
+      backport:
+        branches:
+          - release-1.10
+    conditions:
+      - label=backport-release-1.10
+    name: backport release-1.10


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Configure the mergify bot to open backport PRs for the 1.10 release branch if PRs are labeled as such.
- Remove configuration for the bot to backport to release-1.6 since we haven't backported to that release for so long.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
