### PR TITLE
object: hostNetwork setting should be under spec.gateway instead of spec in the ObjectStore CRD

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -8632,6 +8632,11 @@ spec:
                         type: object
                       nullable: true
                       type: array
+                    hostNetwork:
+                      description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                      nullable: true
+                      type: boolean
+                      x-kubernetes-preserve-unknown-fields: true
                     instances:
                       description: The number of pods in the rgw replicaset.
                       format: int32
@@ -9581,11 +9586,6 @@ spec:
                           type: object
                       type: object
                   type: object
-                hostNetwork:
-                  description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
-                  nullable: true
-                  type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 metadataPool:
                   description: The metadata pool settings
                   nullable: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -8624,6 +8624,11 @@ spec:
                         type: object
                       nullable: true
                       type: array
+                    hostNetwork:
+                      description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                      nullable: true
+                      type: boolean
+                      x-kubernetes-preserve-unknown-fields: true
                     instances:
                       description: The number of pods in the rgw replicaset.
                       format: int32
@@ -9573,11 +9578,6 @@ spec:
                           type: object
                       type: object
                   type: object
-                hostNetwork:
-                  description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
-                  nullable: true
-                  type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 metadataPool:
                   description: The metadata pool settings
                   nullable: true

--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -50,8 +50,8 @@ func (s *ObjectStoreSpec) IsExternal() bool {
 }
 
 func (s *ObjectStoreSpec) IsHostNetwork(c *ClusterSpec) bool {
-	if s.HostNetwork != nil {
-		return *s.HostNetwork
+	if s.Gateway.HostNetwork != nil {
+		return *s.Gateway.HostNetwork
 	}
 	return c.Network.IsHost()
 }

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1337,12 +1337,6 @@ type ObjectStoreSpec struct {
 	// +optional
 	// +nullable
 	Security *ObjectStoreSecuritySpec `json:"security,omitempty"`
-
-	// Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
-	// +kubebuilder:pruning:PreserveUnknownFields
-	// +nullable
-	// +optional
-	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // BucketHealthCheckSpec represents the health check of an object store
@@ -1433,6 +1427,12 @@ type GatewaySpec struct {
 	// +optional
 	// +nullable
 	Service *RGWServiceSpec `json:"service,omitempty"`
+
+	// Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +nullable
+	// +optional
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // ZoneSpec represents a Ceph Object Store Gateway Zone specification

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2363,6 +2363,11 @@ func (in *GatewaySpec) DeepCopyInto(out *GatewaySpec) {
 		*out = new(RGWServiceSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -3036,11 +3041,6 @@ func (in *ObjectStoreSpec) DeepCopyInto(out *ObjectStoreSpec) {
 		in, out := &in.Security, &out.Security
 		*out = new(ObjectStoreSecuritySpec)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.HostNetwork != nil {
-		in, out := &in.HostNetwork, &out.HostNetwork
-		*out = new(bool)
-		**out = **in
 	}
 	return
 }

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -753,15 +753,15 @@ func TestMakeRGWPodSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.isSet {
 				if tt.enabled {
-					c.store.Spec.HostNetwork = func(hostNetwork bool) *bool { return &hostNetwork }(true)
+					c.store.Spec.Gateway.HostNetwork = func(hostNetwork bool) *bool { return &hostNetwork }(true)
 				} else {
-					c.store.Spec.HostNetwork = new(bool)
+					c.store.Spec.Gateway.HostNetwork = new(bool)
 				}
 			}
 			podTemplateSpec, _ := c.makeRGWPodSpec(rgwConfig)
 
 			if tt.isSet {
-				assert.Equal(t, *c.store.Spec.HostNetwork, podTemplateSpec.Spec.HostNetwork)
+				assert.Equal(t, *c.store.Spec.Gateway.HostNetwork, podTemplateSpec.Spec.HostNetwork)
 			} else {
 				assert.Equal(t, c.clusterSpec.Network.IsHost(), podTemplateSpec.Spec.HostNetwork)
 			}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
 hostNetwork setting should be under spec.gateway instead of spec in the ObjectStore CRD

**Which issue is resolved by this Pull Request:**
Resolves #10649 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
