### PR TITLE
docs: add krew plugin to the troubleshooting docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ labels: bug
 
   To get the health of the cluster, use `kubectl rook-ceph health`
   To get the status of the cluster, use `kubectl rook-ceph ceph status`
-  For other commands and how to use Krew Read [Krew Plugin](https://rook.io/docs/rook/latest/Troubleshooting/krew-plugin)
+  For more details, see the [Rook Krew Plugin](https://rook.io/docs/rook/latest-release/Troubleshooting/krew-plugin)
 
 **Environment**:
 * OS (e.g. from /etc/os-release):
@@ -47,4 +47,4 @@ labels: bug
 * Storage backend version (e.g. for ceph do `ceph -v`):
 * Kubernetes version (use `kubectl version`):
 * Kubernetes cluster type (e.g. Tectonic, GKE, OpenShift):
-* Storage backend status (e.g. for Ceph use `ceph health` in the [Rook Ceph toolbox](https://rook.io/docs/rook/latest/Troubleshooting/ceph-toolbox/#interactive-toolbox)):
+* Storage backend status (e.g. for Ceph use `ceph health` in the [Rook Ceph toolbox](https://rook.io/docs/rook/latest-release/Troubleshooting/ceph-toolbox/#interactive-toolbox)):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,12 +21,23 @@ labels: bug
 **File(s) to submit**:
 
 * Cluster CR (custom resource), typically called `cluster.yaml`, if necessary
+
+**Logs to submit**:
+
 * Operator's logs, if necessary
 * Crashing pod(s) logs, if necessary
 
- To get logs, use `kubectl -n <namespace> logs <pod name>`
-When pasting logs, always surround them with backticks or use the `insert code` button from the Github UI.
-Read [GitHub documentation if you need help](https://help.github.com/en/articles/creating-and-highlighting-code-blocks).
+  To get logs, use `kubectl -n <namespace> logs <pod name>`
+  When pasting logs, always surround them with backticks or use the `insert code` button from the Github UI.
+  Read [GitHub documentation if you need help](https://help.github.com/en/articles/creating-and-highlighting-code-blocks).
+
+**Cluster Status to submit**:
+
+* Output of krew commands, if necessary
+
+  To get the health of the cluster, use `kubectl rook-ceph health`
+  To get the status of the cluster, use `kubectl rook-ceph ceph status`
+  For other commands and how to use Krew Read [Krew Plugin](https://rook.io/docs/rook/latest/Troubleshooting/krew-plugin)
 
 **Environment**:
 * OS (e.g. from /etc/os-release):

--- a/Documentation/Troubleshooting/.pages
+++ b/Documentation/Troubleshooting/.pages
@@ -1,4 +1,5 @@
 nav:
+    - krew-plugin.md
     - ceph-toolbox.md
     - common-issues.md
     - ceph-common-issues.md

--- a/Documentation/Troubleshooting/ceph-toolbox.md
+++ b/Documentation/Troubleshooting/ceph-toolbox.md
@@ -13,6 +13,9 @@ The toolbox can be run in two modes:
 !!! hint
     Before running the toolbox you should have a running Rook cluster deployed (see the [Quickstart Guide](../Getting-Started/quickstart.md)).
 
+!!! note
+    The toolbox is not necessary if you are using [Krew plugin](krew-plugin.md) to execute Ceph commands.
+
 ## Interactive Toolbox
 
 The rook toolbox can run as a deployment in a Kubernetes cluster where you can connect and

--- a/Documentation/Troubleshooting/krew-plugin.md
+++ b/Documentation/Troubleshooting/krew-plugin.md
@@ -2,21 +2,27 @@
 title: Krew Plugin
 ---
 
+The Rook Krew plugin is a tool to help troubleshoot your Rook cluster. Here are a few of the operations that the plugin will assist with:
+- Health of the Rook pods
+- Health of the Ceph cluster
+- Create "debug" pods for mons and OSDs that are in need of special Ceph maintenance operations
+- Restart the operator
+- Purge an OSD
+- Run any `ceph` command
+
+See the [kubectl-rook-ceph documentation](https://github.com/rook/kubectl-rook-ceph) for more details.
+
 ## Installation
 
 * Install [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)
-* Install Krew rook-ceph plugin
+* Install Rook plugin
   ```console
     kubectl krew install rook-ceph
   ```
 
-## Working
+## Ceph Commands
 
-Krew rook-ceph plugin will help in troubleshooting the cluster as by getting the stauts of the working cluster.
-
-### Example:
-
-* Get the ceph status:
+* Run any `ceph` command with `kubectl rook-ceph ceph <args>`. For example, get the Ceph status:
   ```console
     kubectl rook-ceph ceph status
   ```
@@ -44,4 +50,20 @@ Krew rook-ceph plugin will help in troubleshooting the cluster as by getting the
     client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr
   ```
 
-Reference: [kubectl-rook-ceph](https://github.com/rook/kubectl-rook-ceph#kubectl-rook-ceph)
+Reference: [Ceph Status](https://github.com/rook/kubectl-rook-ceph/blob/master/README.md#run-a-ceph-command)
+
+## Debug Mode
+
+Debug mode can be useful when a MON or OSD needs advanced maintenance operations that require the daemon to be stopped. Ceph tools such as `ceph-objectstore-tool`, `ceph-bluestore-tool`, or `ceph-monstore-tool` are commonly used in these scenarios. Debug mode will set up the MON or OSD so that these commands can be run.
+
+* Start the debug pod for mon b
+  ```console
+    kubectl rook-ceph debug start rook-ceph-mon-b
+  ```
+
+* Stop the debug pod for mon b
+  ```console
+    kubectl rook-ceph debug stop rook-ceph-mon-b
+  ```
+
+Reference: [Debug Mode](https://github.com/rook/kubectl-rook-ceph/blob/master/README.md#debug-mode)

--- a/Documentation/Troubleshooting/krew-plugin.md
+++ b/Documentation/Troubleshooting/krew-plugin.md
@@ -1,0 +1,47 @@
+---
+title: Krew Plugin
+---
+
+## Installation
+
+* Install [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)
+* Install Krew rook-ceph plugin
+  ```console
+    kubectl krew install rook-ceph
+  ```
+
+## Working
+
+Krew rook-ceph plugin will help in troubleshooting the cluster as by getting the stauts of the working cluster.
+
+### Example:
+
+* Get the ceph status:
+  ```console
+    kubectl rook-ceph ceph status
+  ```
+
+  Output:
+  ```console
+    cluster:
+    id:     a1ac6554-4cc8-4c3b-a8a3-f17f5ec6f529
+    health: HEALTH_OK
+
+    services:
+    mon: 3 daemons, quorum a,b,c (age 11m)
+    mgr: a(active, since 10m)
+    mds: 1/1 daemons up, 1 hot standby
+    osd: 3 osds: 3 up (since 10m), 3 in (since 8d)
+
+    data:
+    volumes: 1/1 healthy
+    pools:   6 pools, 137 pgs
+    objects: 34 objects, 4.1 KiB
+    usage:   58 MiB used, 59 GiB / 59 GiB avail
+    pgs:     137 active+clean
+
+    io:
+    client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr
+  ```
+
+Reference: [kubectl-rook-ceph](https://github.com/rook/kubectl-rook-ceph#kubectl-rook-ceph)


### PR DESCRIPTION
It's been a while we have the krew plugin capability for
troubleshooting that makes it easier but not added to rook
docs.
So adding it to rook docs and bug template

Closes: https://github.com/rook/rook/issues/10765
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
