### PR TITLE
csi: make cephcsi 3.6.0 as minimum supported version

### DIFF
--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -101,7 +101,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.6.2"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	//minimum supported version is 3.7.0
-	minimum = CephCSIVersion{3, 7, 0}
+	minimum = CephCSIVersion{3, 6, 0}
 	//supportedCSIVersions are versions that rook supports
 	releasev370 = CephCSIVersion{3, 7, 0}
 

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	testMinVersion         = CephCSIVersion{3, 7, 0}
+	testMinVersion         = CephCSIVersion{3, 6, 0}
 	testReleaseV350        = CephCSIVersion{3, 5, 0}
 	testReleaseV360        = CephCSIVersion{3, 6, 0}
 	testReleaseV361        = CephCSIVersion{3, 6, 1}
@@ -64,7 +64,7 @@ func TestSupported(t *testing.T) {
 	assert.Equal(t, false, ret)
 
 	ret = testReleaseV360.Supported()
-	assert.Equal(t, false, ret)
+	assert.Equal(t, true, ret)
 
 	ret = testReleaseV370.Supported()
 	assert.Equal(t, true, ret)


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Setting the min version to 3.7 will make the upgrade difficult. If someone is using a different/custom version, they won't be able to upgrade to rook v1.10 unless they also update their csi image simultaneously. If we set the min version to 3.6, it will give some time buffer to allow them to change the csi driver later.

ref: https://github.com/rook/rook/pull/10759#discussion_r953014295

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
