### PR TITLE
operator: improve ProbeHandler error message

### DIFF
--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -153,8 +153,13 @@ func TestGenerateLivenessProbeExecDaemon(t *testing.T) {
 		"-i",
 		"sh",
 		"-c",
-		"ceph --admin-daemon /run/ceph/ceph-osd.0.asok status",
-	}
+		`outp="$(ceph --admin-daemon /run/ceph/ceph-osd.0.asok status 2>&1)"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "ceph daemon health check failed with the following output:"
+  echo "$outp" | sed -e 's/^/> /g'
+  exit $rc
+fi`}
 
 	assert.Equal(t, expectedCommand, probe.ProbeHandler.Exec.Command)
 	assert.Equal(t, livenessProbeInitialDelaySeconds, probe.InitialDelaySeconds)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This commit implements more diagnostic error for unsccessful
Liveness- and Readiness-Probe of Pods.

Added codes are expected to catch failures of
`ceph status` and `ceph mon_status`, and report it.

**Which issue is resolved by this Pull Request:**
Resolves #9846,  #9852

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
