### PR TITLE
docs/storage-config: add yaml way of configuring pg_num and pgp_num

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
@@ -159,8 +159,10 @@ a common practice for those looking to target certain workloads onto faster
 
 !!! note
     Since Ceph Nautilus (v14.x), you can use the Ceph MGR `pg_autoscaler`
-    module to auto scale the PGs as needed. If you want to enable this feature,
-    please refer to [Default PG and PGP counts](ceph-configuration.md#default-pg-and-pgp-counts).
+    module to auto scale the PGs as needed. It is highly advisable to configure
+    default pg_num value on per-pool basis, If you want to enable this feature,
+    please refer to [Default PG and PGP
+    counts](configuration.md#default-pg-and-pgp-counts).
 
 The general rules for deciding how many PGs your pool(s) should contain is:
 

--- a/Documentation/Storage-Configuration/Advanced/configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/configuration.md
@@ -20,11 +20,37 @@ configuration options which users are well advised to consider for any productio
 
 ### Default PG and PGP counts
 
-The number of PGs and PGPs can be configured on a per-pool basis, but it is highly advised to set
-default values that are appropriate for your Ceph cluster. Appropriate values depend on the number
-of OSDs the user expects to have backing each pool. The Ceph [OSD and Pool config
+The number of PGs and PGPs can be configured on a per-pool basis, but it is
+advised to set default values that are appropriate for your Ceph
+cluster.
+Appropriate values depend on the number of OSDs the user expects to have
+backing each pool. These can be configured by declaring pg_num and pgp_num
+parameters under CephBlockPool resource.
+
+For determining the right value for pg_num please refer [placement group
+sizing](ceph-configuration.md#placement-group-sizing)
+
+In this example configuration, 128 PGs are applied to the pool:
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: ceph-block-pool-test
+  namespace: rook-ceph
+spec:
+  deviceClass: hdd
+  replicated:
+    size: 3
+spec:
+  parameters:
+    pg_num: '128' # create the pool with a pre-configured placement group number
+    pgp_num: '128' # this should at least match `pg_num` so that all PGs are used
+```
+
+ Ceph [OSD and Pool config
 docs](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#a-preselection-of-pg-num)
-provide detailed information about how to tune these parameters: `osd_pool_default_pg_num` and `osd_pool_default_pgp_num`.
+provide detailed information about how to tune these parameters.
 
 Nautilus [introduced the PG auto-scaler mgr module](https://ceph.com/rados/new-in-nautilus-pg-merging-and-autotuning/)
 capable of automatically managing PG and PGP values for pools. Please see


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- adds description on how to configure default pg_num and pgp_num
  parameters on per pool basis while deploying rook based ceph cluster.
- advices user to declare them during initial startup.

uptil now, docs only covered cli way of configuring them.

**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/rook/rook/issues/10361

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
