### PR TITLE
test: update logcollector to get secrets -oyaml

### DIFF
--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -85,6 +85,7 @@ func (s *TestCephSettings) readManifestFromGitHubWithClusterNamespace(filename, 
 }
 
 func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
+	manifest = strings.ReplaceAll(manifest, `ROOK_LOG_LEVEL: "INFO"`, `ROOK_LOG_LEVEL: "DEBUG"`)
 	manifest = strings.ReplaceAll(manifest, `# CSI_LOG_LEVEL: "0"`, `CSI_LOG_LEVEL: "5"`)
 	manifest = strings.ReplaceAll(manifest, `ROOK_ENABLE_DISCOVERY_DAEMON: "false"`, fmt.Sprintf(`ROOK_ENABLE_DISCOVERY_DAEMON: "%t"`, s.EnableDiscovery))
 	manifest = strings.ReplaceAll(manifest, `CSI_ENABLE_VOLUME_REPLICATION: "false"`, fmt.Sprintf(`CSI_ENABLE_VOLUME_REPLICATION: "%t"`, s.EnableVolumeReplication))

--- a/tests/scripts/collect-logs.sh
+++ b/tests/scripts/collect-logs.sh
@@ -12,9 +12,9 @@ mkdir -p "${LOG_DIR}"
 
 CEPH_CMD="kubectl -n ${CLUSTER_NAMESPACE} exec deploy/rook-ceph-tools -- ceph --connect-timeout 3"
 
-$CEPH_CMD -s > "${LOG_DIR}"/ceph-status.txt
-$CEPH_CMD osd dump > "${LOG_DIR}"/ceph-osd-dump.txt
-$CEPH_CMD report > "${LOG_DIR}"/ceph-report.txt
+$CEPH_CMD -s >"${LOG_DIR}"/ceph-status.txt
+$CEPH_CMD osd dump >"${LOG_DIR}"/ceph-osd-dump.txt
+$CEPH_CMD report >"${LOG_DIR}"/ceph-report.txt
 
 NAMESPACES=("$CLUSTER_NAMESPACE")
 if [[ "$OPERATOR_NAMESPACE" != "$CLUSTER_NAMESPACE" ]]; then
@@ -27,16 +27,22 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
   mkdir "${NS_DIR}"
 
   # describe every one of the k8s resources in the namespace which rook commonly uses
-  for KIND in 'pod' 'deployment' 'job' 'daemonset' 'secret' 'cm'; do
-    kubectl -n "$NAMESPACE" get "$KIND" -o wide > "${NS_DIR}"/"$KIND"-list.txt
+  for KIND in 'pod' 'deployment' 'job' 'daemonset' 'cm'; do
+    kubectl -n "$NAMESPACE" get "$KIND" -o wide >"${NS_DIR}"/"$KIND"-list.txt
     for resource in $(kubectl -n "$NAMESPACE" get "$KIND" -o jsonpath='{.items[*].metadata.name}'); do
-      kubectl -n "$NAMESPACE" describe "$KIND" "$resource" > "${NS_DIR}"/"$KIND"-describe--"$resource".txt
+      kubectl -n "$NAMESPACE" describe "$KIND" "$resource" >"${NS_DIR}"/"$KIND"-describe--"$resource".txt
 
       # collect logs for pods along the way
       if [[ "$KIND" == 'pod' ]]; then
-        kubectl -n "$NAMESPACE" logs --all-containers "$resource" > "${NS_DIR}"/logs--"$resource".txt
+        kubectl -n "$NAMESPACE" logs --all-containers "$resource" >"${NS_DIR}"/logs--"$resource".txt
       fi
     done
+  done
+
+  # secret need `-oyaml` to read the content instead of `describe` since secrets `describe` will be encrypted.
+  # so keeping it in a different block.
+  for secret in $(kubectl -n "$NAMESPACE" get secrets -o jsonpath='{.items[*].metadata.name}'); do
+    kubectl -n "$NAMESPACE" get -o yaml secret "$secret" >"${NS_DIR}"/secret-describe--"$secret".txt
   done
 
   # describe every one of the custom resources in the namespace since all should be rook-related and
@@ -44,15 +50,15 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
   for CRD in $(kubectl get crds -o jsonpath='{.items[*].metadata.name}'); do
     for resource in $(kubectl -n "$NAMESPACE" get "$CRD" -o jsonpath='{.items[*].metadata.name}'); do
       crd_main_type="${CRD%%.*}" # e.g., for cephclusters.ceph.rook.io, only use 'cephclusters'
-      kubectl -n "$NAMESPACE" get -o yaml "$CRD" "$resource" > "${NS_DIR}"/"$crd_main_type"-describe--"$resource".txt
+      kubectl -n "$NAMESPACE" get -o yaml "$CRD" "$resource" >"${NS_DIR}"/"$crd_main_type"-describe--"$resource".txt
     done
   done
 
   # do simple 'get all' calls for resources we don't often want to look at
-  kubectl get all -n "$NAMESPACE" -o wide > "${NS_DIR}"/all-wide.txt
-  kubectl get all -n "$NAMESPACE" -o yaml > "${NS_DIR}"/all-yaml.txt
+  kubectl get all -n "$NAMESPACE" -o wide >"${NS_DIR}"/all-wide.txt
+  kubectl get all -n "$NAMESPACE" -o yaml >"${NS_DIR}"/all-yaml.txt
 done
 
 sudo lsblk | sudo tee -a "${LOG_DIR}"/lsblk.txt
-journalctl -o short-precise --dmesg > "${LOG_DIR}"/dmesg.txt
-journalctl > "${LOG_DIR}"/journalctl.txt
+journalctl -o short-precise --dmesg >"${LOG_DIR}"/dmesg.txt
+journalctl >"${LOG_DIR}"/journalctl.txt

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -192,6 +192,7 @@ function deploy_manifest_with_local_build() {
   if [[ "$USE_LOCAL_BUILD" != "false" ]]; then
     sed -i "s|image: rook/ceph:.*|image: rook/ceph:local-build|g" $1
   fi
+  sed -i "s|ROOK_LOG_LEVEL:.*|ROOK_LOG_LEVEL: DEBUG|g" "$1"
   kubectl create -f $1
 }
 


### PR DESCRIPTION
in case of secrets we need to get `-oyaml` instead
of `describe` since in describe it will be hidden.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
