### PR TITLE
ci: upgrade to latest k8s version v1.25.0 for ci test

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -102,7 +102,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -137,7 +137,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -172,7 +172,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -207,7 +207,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -242,7 +242,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -277,7 +277,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -312,7 +312,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.24.1"
+          kubernetes-version: "1.25.0"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17', 'v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.24.1"]
+        kubernetes-versions : ['v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.24.1"]
+        kubernetes-versions : ['v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17', 'v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17', 'v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17', 'v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.24.1"]
+        kubernetes-versions : ['v1.19.16', 'v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.19.16", "v1.21.7", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.25.0']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.19.16", "v1.21.7", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.19.16", "v1.21.7", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.19.16", "v1.21.7", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17','v1.19.16','v1.21.7','v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -249,7 +249,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.21.7", "v1.24.1"]
+        kubernetes-versions : ['v1.19.16','v1.21.7', 'v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.17.17", "v1.24.1"]
+        kubernetes-versions : ['v1.17.17', 'v1.24.1']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -462,7 +462,6 @@ spec:
       requireSafeReplicaSize: false
   gateway:
     resources: null
-    type: s3
     securePort: ` + strconv.Itoa(port) + `
     instances: ` + strconv.Itoa(replicaCount) + `
     sslCertificateRef: ` + name + `

--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// The version from which the upgrade test will start
-	Version1_9 = "v1.9.9"
+	Version1_9 = "v1.9.10"
 )
 
 // CephManifestsPreviousVersion wraps rook yaml definitions


### PR DESCRIPTION
integration test now run on the latest k8s v1.25.0.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
