### PR TITLE
build: remove psp from common.yaml generation

### DIFF
--- a/build/rbac/gen-common.sh
+++ b/build/rbac/gen-common.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -xeEuo pipefail
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 pushd "$SCRIPT_DIR" &>/dev/stderr
 
 COMMON_YAML_FILE="$SCRIPT_DIR/../../deploy/examples/common.yaml"
 
+export ADDITIONAL_HELM_CLI_OPTIONS="--set pspEnable=false"
+
 rm -f "$COMMON_YAML_FILE"
-cat common.yaml.header >> "$COMMON_YAML_FILE"
-./get-helm-rbac.sh >> "$COMMON_YAML_FILE"
+cat common.yaml.header >>"$COMMON_YAML_FILE"
+./get-helm-rbac.sh >>"$COMMON_YAML_FILE"
 
 popd &>/dev/stderr

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -64,24 +64,6 @@ rules:
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: 'psp:rook'
-  labels:
-    operator: rook
-    storage-backend: ceph
-    app.kubernetes.io/part-of: rook-ceph-operator
-rules:
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    resourceNames:
-      - 00-rook-privileged
-    verbs:
-      - use
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -672,156 +654,6 @@ subjects:
     name: rook-ceph-system
     namespace: rook-ceph # namespace:operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rook-ceph-system-psp
-  labels:
-    operator: rook
-    storage-backend: ceph
-    app.kubernetes.io/part-of: rook-ceph-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'psp:rook'
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-system
-    namespace: rook-ceph # namespace:operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rook-csi-cephfs-plugin-sa-psp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'psp:rook'
-subjects:
-  - kind: ServiceAccount
-    name: rook-csi-cephfs-plugin-sa
-    namespace: rook-ceph # namespace:operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rook-csi-cephfs-provisioner-sa-psp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'psp:rook'
-subjects:
-  - kind: ServiceAccount
-    name: rook-csi-cephfs-provisioner-sa
-    namespace: rook-ceph # namespace:operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rook-csi-rbd-plugin-sa-psp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'psp:rook'
-subjects:
-  - kind: ServiceAccount
-    name: rook-csi-rbd-plugin-sa
-    namespace: rook-ceph # namespace:operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rook-csi-rbd-provisioner-sa-psp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'psp:rook'
-subjects:
-  - kind: ServiceAccount
-    name: rook-csi-rbd-provisioner-sa
-    namespace: rook-ceph # namespace:operator
----
-# We expect most Kubernetes teams to follow the Kubernetes docs and have these PSPs.
-# * privileged (for kube-system namespace)
-# * restricted (for all logged in users)
-#
-# PSPs are applied based on the first match alphabetically. `rook-ceph-operator` comes after
-# `restricted` alphabetically, so we name this `00-rook-privileged`, so it stays somewhere
-# close to the top and so `rook-system` gets the intended PSP. This may need to be renamed in
-# environments with other `00`-prefixed PSPs.
-#
-# More on PSP ordering: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#policy-order
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: 00-rook-privileged
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
-spec:
-  privileged: true
-  allowedCapabilities:
-    # required by CSI
-    - SYS_ADMIN
-    - MKNOD
-  fsGroup:
-    rule: RunAsAny
-  # runAsUser, supplementalGroups - Rook needs to run some pods as root
-  # Ceph pods could be run as the Ceph user, but that user isn't always known ahead of time
-  runAsUser:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  # seLinux - seLinux context is unknown ahead of time; set if this is well-known
-  seLinux:
-    rule: RunAsAny
-  volumes:
-    # recommended minimum set
-    - configMap
-    - downwardAPI
-    - emptyDir
-    - persistentVolumeClaim
-    - secret
-    - projected
-    # required for Rook
-    - hostPath
-  # allowedHostPaths can be set to Rook's known host volume mount points when they are fully-known
-  # allowedHostPaths:
-  #   - pathPrefix: "/run/udev"  # for OSD prep
-  #     readOnly: false
-  #   - pathPrefix: "/dev"  # for OSD prep
-  #     readOnly: false
-  #   - pathPrefix: "/var/lib/rook"  # or whatever the dataDirHostPath value is set to
-  #     readOnly: false
-  # Ceph requires host IPC for setting up encrypted devices
-  hostIPC: true
-  # Ceph OSDs need to share the same PID namespace
-  hostPID: true
-  # hostNetwork can be set to 'false' if host networking isn't used
-  hostNetwork: true
-  hostPorts:
-    # Ceph messenger protocol v1
-    - min: 6789
-      max: 6790 # <- support old default port
-    # Ceph messenger protocol v2
-    - min: 3300
-      max: 3300
-    # Ceph RADOS ports for OSDs, MDSes
-    - min: 6800
-      max: 7300
-    # # Ceph dashboard port HTTP (not recommended)
-    # - min: 7000
-    #   max: 7000
-    # Ceph dashboard port HTTPS
-    - min: 8443
-      max: 8443
-    # Ceph mgr Prometheus Metrics
-    - min: 9283
-      max: 9283
-    # port for CSIAddons
-    - min: 9070
-      max: 9070
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -1126,38 +958,6 @@ subjects:
     name: rook-ceph-cmd-reporter
     namespace: rook-ceph # namespace:cluster
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-cmd-reporter-psp
-  namespace: rook-ceph # namespace:cluster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-cmd-reporter
-    namespace: rook-ceph # namespace:cluster
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-default-psp
-  namespace: rook-ceph # namespace:cluster
-  labels:
-    operator: rook
-    storage-backend: ceph
-    app.kubernetes.io/part-of: rook-ceph-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: rook-ceph # namespace:cluster
----
 # Allow the ceph mgr to access resources scoped to the CephCluster namespace necessary for mgr modules
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1168,20 +968,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rook-ceph-mgr
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-mgr
-    namespace: rook-ceph # namespace:cluster
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-mgr-psp
-  namespace: rook-ceph # namespace:cluster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-mgr
@@ -1217,20 +1003,6 @@ subjects:
     name: rook-ceph-osd
     namespace: rook-ceph # namespace:cluster
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-osd-psp
-  namespace: rook-ceph # namespace:cluster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-osd
-    namespace: rook-ceph # namespace:cluster
----
 # Allow the osd purge job to run in this namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1246,20 +1018,6 @@ subjects:
     name: rook-ceph-purge-osd
     namespace: rook-ceph # namespace:cluster
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-purge-osd-psp
-  namespace: rook-ceph # namespace:cluster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-purge-osd
-    namespace: rook-ceph # namespace:cluster
----
 # Allow the rgw pods in this namespace to work with configmaps
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1270,20 +1028,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rook-ceph-rgw
-subjects:
-  - kind: ServiceAccount
-    name: rook-ceph-rgw
-    namespace: rook-ceph # namespace:cluster
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rook-ceph-rgw-psp
-  namespace: rook-ceph # namespace:cluster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: psp:rook
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-rgw


### PR DESCRIPTION
Due to an oversight, PSP resources were left in generation of
common.yaml from #10797. Resolve that by setting
pspEnable=false when generating common.yaml.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
