### PR TITLE
csi: use the latest sidecars for ceph csi driver

### DIFF
--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -20,10 +20,10 @@ The default upstream images are included below, which you can change to your des
 ```yaml
 ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.0"
 ROOK_CSI_REGISTRAR_IMAGE: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"
-ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"
-ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"
-ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"
-ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"
+ROOK_CSI_PROVISIONER_IMAGE: "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1"
+ROOK_CSI_ATTACHER_IMAGE: "k8s.gcr.io/sig-storage/csi-attacher:v3.5.0"
+ROOK_CSI_RESIZER_IMAGE: "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0"
+ROOK_CSI_SNAPSHOTTER_IMAGE: "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1"
 CSI_VOLUME_REPLICATION_IMAGE: "quay.io/csiaddons/volumereplication-operator:v0.3.0"
 ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.4.0"
 ```

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -364,13 +364,13 @@ csi:
   #registrar:
   #  image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
   #provisioner:
-  #  image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+  #  image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
   #snapshotter:
   #  image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
   #attacher:
-  #  image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  #  image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
   #resizer:
-  #  image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+  #  image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
   # Labels to add to the CSI CephFS Deployments and DaemonSets Pods.
   #cephfsPodLabels: "key1=value1,key2=value2"
   # Labels to add to the CSI NFS Deployments and DaemonSets Pods.

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -2,10 +2,10 @@
  quay.io/cephcsi/cephcsi:v3.7.0
  quay.io/csiaddons/k8s-sidecar:v0.4.0
  quay.io/csiaddons/volumereplication-operator:v0.3.0
- registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+ registry.k8s.io/sig-storage/csi-attacher:v3.5.0
  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
- registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
- registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+ registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
+ registry.k8s.io/sig-storage/csi-resizer:v1.5.0
  registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
  registry.k8s.io/sig-storage/nfsplugin:v4.0.0
  rook/ceph:master

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -186,10 +186,10 @@ data:
   # these images to the desired release of the CSI driver.
   # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"
-  # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"
-  # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"
+  # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.5.0"
+  # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.2.1"
   # ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"
-  # ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"
+  # ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v3.5.0"
   # ROOK_CSI_NFS_IMAGE: "registry.k8s.io/sig-storage/nfsplugin:v4.0.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -130,10 +130,10 @@ var (
 	DefaultCSIPluginImage         = "quay.io/cephcsi/cephcsi:v3.7.0"
 	DefaultNFSPluginImage         = "registry.k8s.io/sig-storage/nfsplugin:v4.0.0"
 	DefaultRegistrarImage         = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"
-	DefaultProvisionerImage       = "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"
-	DefaultAttacherImage          = "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"
+	DefaultProvisionerImage       = "registry.k8s.io/sig-storage/csi-provisioner:v3.2.1"
+	DefaultAttacherImage          = "registry.k8s.io/sig-storage/csi-attacher:v3.5.0"
 	DefaultSnapshotterImage       = "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"
-	DefaultResizerImage           = "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"
+	DefaultResizerImage           = "registry.k8s.io/sig-storage/csi-resizer:v1.5.0"
 	DefaultVolumeReplicationImage = "quay.io/csiaddons/volumereplication-operator:v0.3.0"
 	DefaultCSIAddonsImage         = "quay.io/csiaddons/k8s-sidecar:v0.4.0"
 


### PR DESCRIPTION
at present, the csi sidecars are older versions and not in parity
with the latest ceph csi release v3.7.0. This commit update the
same to make it.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
