### PR TITLE
ci: Revert ibm canary test to ubuntu 18

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1320,7 +1320,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-kms-ibm-kp:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -256,16 +256,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup latest cluster resources
-        if: ${{ matrix.kubernetes-versions }} != "v1.24.1"
+      - name: setup cluster resources
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: ${{ matrix.kubernetes-versions }}
-
-      - name: setup older cluster resources
-        if: ${{ matrix.kubernetes-versions }} == "v1.19.16"
-        uses: ./.github/workflows/integration-test-config-older-k8s
 
       - name: TestHelmUpgradeSuite
         run: |


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The ibm test has been failing since the move to ubuntu 20 was merged a couple days ago. Reverting back to 18 for now.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
