### PR TITLE
osd: disallow to create osd on lv with metadata device

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -484,11 +484,18 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 							break
 						}
 					}
-				} else if device.Name == desiredDevice.Name || filepath.Join("/dev", device.Name) == desiredDevice.Name {
-					logger.Infof("%q found in the desired devices", device.Name)
-					matched = true
-				} else if strings.HasPrefix(desiredDevice.Name, "/dev/") {
-					matched = matchDevLinks(device.DevLinks, desiredDevice.Name)
+				} else {
+					// the desired device is a file
+					if device.Name == desiredDevice.Name || filepath.Join("/dev", device.Name) == desiredDevice.Name {
+						logger.Infof("%q found in the desired devices", device.Name)
+						matched = true
+					} else if strings.HasPrefix(desiredDevice.Name, "/dev/") {
+						matched = matchDevLinks(device.DevLinks, desiredDevice.Name)
+					}
+					if matched && device.Type == sys.LVMType && desiredDevice.MetadataDevice != "" {
+						logger.Infof("logical volume %q is not picked because OSD on LV with metadata device is not allowed", device.Name)
+						continue
+					}
 				}
 				matchedDevice = desiredDevice
 


### PR DESCRIPTION
**Description of your changes:**

OSD on logical volume is raw mode. This mode can'set metadata device. We should not mark a logical volume as available in this case.

**Which issue is resolved by this Pull Request:**
Resolves #10747

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
