### PR TITLE
docs: add missed sssdConfigFile params for NFS CRD

### DIFF
--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -58,8 +58,10 @@ spec:
         image: registry.access.redhat.com/rhel7/sssd:latest
 
         sssdConfigFile:
-          configMap:
-            name: my-nfs-sssd-config
+          volumeSource:
+            configMap:
+              name: my-nfs-sssd-config
+              defaultMode: 0600 # mode must be 0600
 
         debugLevel: 0
 ```


### PR DESCRIPTION
Initial commit of NFS CRD docs missed two params, causing some users to
experience problems setting it up.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
