### PR TITLE
mon: Remove out of quorum mons from ceph.conf

### DIFF
--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -63,6 +63,8 @@ type ClusterInfo struct {
 type MonInfo struct {
 	Name     string `json:"name"`
 	Endpoint string `json:"endpoint"`
+	// Whether detected out of quorum by rook. May be different from actual ceph quorum.
+	OutOfQuorum bool `json:"outOfQuorum"`
 }
 
 // CephCred represents the Ceph cluster username and key used by the operator.


### PR DESCRIPTION
**Description of your changes:**
The mons that are out of quorum may cause ceph commands to timeout or fail unnecessarily trying to connect to a mon that is no longer online. Now the mon health check will update the mon endpoints configmap when a mon is detected out of quorum. This also means that if the operator is restarted during a mon failover, the failed mon will no longer remain in the ceph.conf, thus allowing the quorum to be more likely to respond to the mons that are still in quorum.

The update for mons out of quorum only applies if other mons are in quorum. If quorum is down, the configmap will not keep track of the offline mons since too many are offline.

**Which issue is resolved by this Pull Request:**
Resolves #10650

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
