### PR TITLE
bot: Fix automerge for 1.10 backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -162,7 +162,7 @@ pull_request_rules:
       - "check-success=TestCephSmokeSuite (v1.25.0)"
       - "check-success=TestCephHelmSuite (v1.19.16)"
       - "check-success=TestCephHelmSuite (v1.25.0)"
-      - "check-success=TestCephMultiClusterDeploySuite (v1.25.0"
+      - "check-success=TestCephMultiClusterDeploySuite (v1.25.0)"
       - "check-success=TestCephUpgradeSuite (v1.19.16)"
       - "check-success=TestCephUpgradeSuite (v1.25.0)"
     actions:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The success of all the CI actions must exactly match the list for the mergify config. The config was missing a paren, so the merges were not happening automatically.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
