### PR TITLE
ci: improve the log on intermittent build failure

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -143,6 +143,8 @@ function build_rook() {
         ;;
       *)
         # valid failure
+        echo "failed with the following log:"
+        echo "$o"
         exit 1
         ;;
       esac


### PR DESCRIPTION
**Description of your changes:**

The build process sometimes fails with intermittent problems. Some of them are known problems and then we retry the build process. However, there still are unknown problems. In this case, it's hard to find the reason because the build process exits immediately.

ref.
https://github.com/rook/rook/runs/8225144002?check_suite_focus=true#step:3:926

```
+ case "$o" in
+ exit 1
Error: Process completed with exit code 1.
```

To make debugging easier, let's print the output of `make`. This log won't be too long since `make` prints most messages to stderr.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
