### PR TITLE
docs: Simplify code owners for ceph provider

### DIFF
--- a/CODE-OWNERS
+++ b/CODE-OWNERS
@@ -1,29 +1,15 @@
-# Code ownership file that specifies maintainers and reviewers for all areas of the Rook codebase.
-# all: These members have the given role for all areas of the codebase.
-# Specific storage provider ownership and covers all portions of code that is specific to their project.
-# Maintainers have push access to merge PRs after approved by another maintainer or reviewer.
-# With the intention of using the Prow bot in the future, the term "approver" is used below.
+# Code ownership file that specifies approvers and reviewers for the Rook codebase.
+# Approvers have push access to merge PRs after approved by another approver or reviewer.
 # An approver is equivalent to a Rook maintainer for all intents and purposes as described in the Rook governance.
 
-areas:
-  all:
-    approvers:
-    - travisn
-    - galexrt
-    - jbw976
-  ceph:
-    approvers:
-    - travisn
-    - BlaineEXE
-    - leseb
-    - satoru-takeuchi
-    reviewers:
-    - Madhu-1
-    - sp98
-    - subhamkrai
-  cassandra:
-    approvers:
-    - yanniszark
-  nfs:
-    reviewers:
-    - rohan47
+approvers:
+- travisn
+- galexrt
+- jbw976
+- BlaineEXE
+- leseb
+- satoru-takeuchi
+reviewers:
+- Madhu-1
+- sp98
+- subhamkrai


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The storage providers have long since been split to their own repo, so there is no need to define the code owners for different storage providers in this repo. The owners for cassandra and nfs are therefore removed, and the list simplified.

@jbw976 Requesting steering committee approval.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
