### PR TITLE
nfs: allow users to include additional files in the SSSD sidecar

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -7678,6 +7678,941 @@ spec:
                                       type: object
                                   type: object
                               type: object
+                            sssdGenericFiles:
+                              description: SSSDGenericFiles defines where additional files for the SSSD configuration should be sourced from. The referenced VolumeSource will be made available at the requested mountPath. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                              properties:
+                                mountPath:
+                                  description: MountPath contains the path where the contents of the VolumeSource will made available inside the SSSD sidecar.
+                                  type: string
+                                volumeSource:
+                                  description: 'VolumeSource accepts a standard Kubernetes VolumeSource for additional SSSD files like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. There are two requirements for the source''s content:   1. The config file must be mountable via `subPath: sssd.conf`. For example, in a ConfigMap,      the data item must be named `sssd.conf`, or `items` must be defined to select the key      and give it path `sssd.conf`. A HostPath directory must have the `sssd.conf` file.   2. The volume or config file must have mode 0600.'
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                        - diskName
+                                        - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                      properties:
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share Name
+                                          type: string
+                                      required:
+                                        - secretName
+                                        - shareName
+                                      type: object
+                                    cephfs:
+                                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                        - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeID:
+                                          description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    csi:
+                                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        readOnly:
+                                          description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                          type: object
+                                      required:
+                                        - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward API about the pod that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field to select in the specified API version.
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name: required for volumes, optional for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource to select'
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                            required:
+                                              - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              type: object
+                                            spec:
+                                              description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name of resource being referenced
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                dataSourceRef:
+                                                  description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name of resource being referenced
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                resources:
+                                                  description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label query over volumes to consider for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                      items:
+                                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the label key that the selector applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                storageClassName:
+                                                  description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                            - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                      required:
+                                        - driver
+                                      type: object
+                                    flocker:
+                                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                      properties:
+                                        datasetName:
+                                          description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                        - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash for the specified revision.
+                                          type: string
+                                      required:
+                                        - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                        - endpoints
+                                        - path
+                                      type: object
+                                    hostPath:
+                                      description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                      properties:
+                                        path:
+                                          description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                    iscsi:
+                                      description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        initiatorName:
+                                          description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        targetPortal:
+                                          description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                        - iqn
+                                        - lun
+                                        - targetPortal
+                                      type: object
+                                    nfs:
+                                      description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                        - path
+                                        - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                        - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                        - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies a Portworx volume
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one resources secrets, configmaps, and downward API
+                                      properties:
+                                        defaultMode:
+                                          description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: sources is the list of volume projections
+                                          items:
+                                            description: Projection that may be projected along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: configMap information about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                        - key
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                                    type: boolean
+                                                type: object
+                                              downwardAPI:
+                                                description: downwardAPI information about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of the field to select in the specified API version.
+                                                              type: string
+                                                          required:
+                                                            - fieldPath
+                                                          type: object
+                                                        mode:
+                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container name: required for volumes, optional for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required: resource to select'
+                                                              type: string
+                                                          required:
+                                                            - resource
+                                                          type: object
+                                                      required:
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: secret information about the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                        - key
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify whether the Secret or its key must be defined
+                                                    type: boolean
+                                                type: object
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is information about the serviceAccountToken data to project
+                                                properties:
+                                                  audience:
+                                                    description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: path is the path relative to the mount point of the file to project the token into.
+                                                    type: string
+                                                required:
+                                                  - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: group to map volume access to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                          type: string
+                                        tenant:
+                                          description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                          type: string
+                                        user:
+                                          description: user to map volume access to Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                        - registry
+                                        - volume
+                                      type: object
+                                    rbd:
+                                      description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        image:
+                                          description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                        - image
+                                        - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                          type: boolean
+                                        storageMode:
+                                          description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                          type: string
+                                      required:
+                                        - gateway
+                                        - secretRef
+                                        - system
+                                      type: object
+                                    secret:
+                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: optional field specify whether the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeName:
+                                          description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                        - volumePath
+                                      type: object
+                                  type: object
+                              required:
+                                - mountPath
+                                - volumeSource
+                              type: object
                           required:
                             - image
                           type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -7672,6 +7672,941 @@ spec:
                                       type: object
                                   type: object
                               type: object
+                            sssdGenericFiles:
+                              description: SSSDGenericFiles defines where additional files for the SSSD configuration should be sourced from. The referenced VolumeSource will be made available at the requested mountPath. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                              properties:
+                                mountPath:
+                                  description: MountPath contains the path where the contents of the VolumeSource will made available inside the SSSD sidecar.
+                                  type: string
+                                volumeSource:
+                                  description: 'VolumeSource accepts a standard Kubernetes VolumeSource for additional SSSD files like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. There are two requirements for the source''s content:   1. The config file must be mountable via `subPath: sssd.conf`. For example, in a ConfigMap,      the data item must be named `sssd.conf`, or `items` must be defined to select the key      and give it path `sssd.conf`. A HostPath directory must have the `sssd.conf` file.   2. The volume or config file must have mode 0600.'
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                        - diskName
+                                        - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                      properties:
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share Name
+                                          type: string
+                                      required:
+                                        - secretName
+                                        - shareName
+                                      type: object
+                                    cephfs:
+                                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                        - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeID:
+                                          description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    csi:
+                                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        readOnly:
+                                          description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                          type: object
+                                      required:
+                                        - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward API about the pod that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field to select in the specified API version.
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name: required for volumes, optional for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource to select'
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                            required:
+                                              - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              type: object
+                                            spec:
+                                              description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name of resource being referenced
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                dataSourceRef:
+                                                  description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name of resource being referenced
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                resources:
+                                                  description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label query over volumes to consider for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                      items:
+                                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the label key that the selector applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                storageClassName:
+                                                  description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                            - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                      required:
+                                        - driver
+                                      type: object
+                                    flocker:
+                                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                      properties:
+                                        datasetName:
+                                          description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                        - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash for the specified revision.
+                                          type: string
+                                      required:
+                                        - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                        - endpoints
+                                        - path
+                                      type: object
+                                    hostPath:
+                                      description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                      properties:
+                                        path:
+                                          description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                    iscsi:
+                                      description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        initiatorName:
+                                          description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        targetPortal:
+                                          description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                        - iqn
+                                        - lun
+                                        - targetPortal
+                                      type: object
+                                    nfs:
+                                      description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                        - path
+                                        - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                        - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                        - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies a Portworx volume
+                                          type: string
+                                      required:
+                                        - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one resources secrets, configmaps, and downward API
+                                      properties:
+                                        defaultMode:
+                                          description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: sources is the list of volume projections
+                                          items:
+                                            description: Projection that may be projected along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: configMap information about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                        - key
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                                    type: boolean
+                                                type: object
+                                              downwardAPI:
+                                                description: downwardAPI information about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of the field to select in the specified API version.
+                                                              type: string
+                                                          required:
+                                                            - fieldPath
+                                                          type: object
+                                                        mode:
+                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container name: required for volumes, optional for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required: resource to select'
+                                                              type: string
+                                                          required:
+                                                            - resource
+                                                          type: object
+                                                      required:
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: secret information about the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                        - key
+                                                        - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify whether the Secret or its key must be defined
+                                                    type: boolean
+                                                type: object
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is information about the serviceAccountToken data to project
+                                                properties:
+                                                  audience:
+                                                    description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: path is the path relative to the mount point of the file to project the token into.
+                                                    type: string
+                                                required:
+                                                  - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: group to map volume access to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                          type: string
+                                        tenant:
+                                          description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                          type: string
+                                        user:
+                                          description: user to map volume access to Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                        - registry
+                                        - volume
+                                      type: object
+                                    rbd:
+                                      description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                          type: string
+                                        image:
+                                          description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                        - image
+                                        - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                          type: boolean
+                                        storageMode:
+                                          description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                          type: string
+                                      required:
+                                        - gateway
+                                        - secretRef
+                                        - system
+                                      type: object
+                                    secret:
+                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: optional field specify whether the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeName:
+                                          description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                        - volumePath
+                                      type: object
+                                  type: object
+                              required:
+                                - mountPath
+                                - volumeSource
+                              type: object
                           required:
                             - image
                           type: object

--- a/deploy/examples/nfs.yaml
+++ b/deploy/examples/nfs.yaml
@@ -70,6 +70,12 @@ spec:
   #           configMap:
   #             name: my-nfs-sssd-config
   #             defaultMode: 0600 # mode must be 0600
+  #       sssdGenericFiles:
+  #         volumeSource:
+  #           secret:
+  #             name: sssd-tls-certificates
+  #             defaultMode: 0600 # mode must be 0600
+  #           mountPath: /etc/local/certs
   #       # debugLevel: 6
   #
   #       resources:

--- a/design/ceph/ceph-nfs-ganesha.md
+++ b/design/ceph/ceph-nfs-ganesha.md
@@ -73,6 +73,7 @@ This allows the NFS-Ganesha server cluster to be scalable and highly available.
              will mount the file into the SSSD sidecar.
           2. The file mode must be 0600.
         - Users only need one SSSD conf Volume per CephNFS that has this option path enabled.
+      - Users must be able to provide additional files that are referenced in the the SSSD config file
 
 #### Example
 Below is an example NFS-Ganesha CRD, `nfs-ganesha.yaml`
@@ -129,6 +130,13 @@ spec:
             configMap:
               name: rook-ceph-nfs-organization-sssd-config
               defaultMode: 0600 # mode must be 0600
+        sssdGenericFiles:
+          volumeSource:
+            # example
+            configMap:
+              name: rook-ceph-nfs-organization-sssd-ca-bundle
+              defaultMode: 0600 # mode must be 0600
+            mountPath: /etc/local/certs
         resources:
           # requests:
           #   cpu: "2"

--- a/pkg/apis/ceph.rook.io/v1/nfs.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs.go
@@ -55,6 +55,14 @@ func (sec *NFSSecuritySpec) Validate() error {
 		if volSource != nil && reflect.DeepEqual(*volSource, v1.VolumeSource{}) {
 			return errors.New("System Security Services Daemon (SSSD) sidecar is enabled with config from a VolumeSource, but no source is specified")
 		}
+
+		volSource = sidecar.SSSDGenericFiles.VolumeSource
+		if volSource != nil && reflect.DeepEqual(*volSource, v1.VolumeSource{}) {
+			return errors.New("System Security Services Daemon (SSSD) sidecar is enabled with generic files from a VolumeSource, but no source is specified")
+		}
+		if volSource != nil && sidecar.SSSDGenericFiles.MountPath == "" {
+			return errors.New("System Security Services Daemon (SSSD) sidecar is enabled with generic files from a VolumeSource, but no mountPath is specified")
+		}
 	}
 
 	return nil

--- a/pkg/apis/ceph.rook.io/v1/nfs_test.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs_test.go
@@ -87,6 +87,50 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 				},
 			}),
 			isFailing},
+		{"security.sssd.sidecar.sssdGenericFiles empty",
+			withSSSD(&SSSDSpec{
+				Sidecar: &SSSDSidecar{
+					Image:            "myimage",
+					SSSDGenericFiles: SSSDSidecarGenericFiles{},
+				},
+			}),
+			isOkay},
+		{"security.sssd.sidecar.sssdGenericFiles.volumeSource empty",
+			withSSSD(&SSSDSpec{
+				Sidecar: &SSSDSidecar{
+					Image: "myimage",
+					SSSDGenericFiles: SSSDSidecarGenericFiles{
+						VolumeSource: &v1.VolumeSource{},
+						MountPath:    "/etc/local/config",
+					},
+				},
+			}),
+			isFailing},
+		{"security.sssd.sidecar.sssdGenericFiles.mountPath empty",
+			withSSSD(&SSSDSpec{
+				Sidecar: &SSSDSidecar{
+					Image: "myimage",
+					SSSDGenericFiles: SSSDSidecarGenericFiles{
+						VolumeSource: &v1.VolumeSource{
+							ConfigMap: &v1.ConfigMapVolumeSource{},
+						},
+					},
+				},
+			}),
+			isFailing},
+		{"security.sssd.sidecar.sssdGenericFiles sufficiently specified",
+			withSSSD(&SSSDSpec{
+				Sidecar: &SSSDSidecar{
+					Image: "myimage",
+					SSSDGenericFiles: SSSDSidecarGenericFiles{
+						VolumeSource: &v1.VolumeSource{
+							ConfigMap: &v1.ConfigMapVolumeSource{},
+						},
+						MountPath: "/etc/local/config",
+					},
+				},
+			}),
+			isOkay},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1994,6 +1994,14 @@ type SSSDSidecar struct {
 	// +optional
 	SSSDConfigFile SSSDSidecarConfigFile `json:"sssdConfigFile"`
 
+	// SSSDGenericFiles defines where additional files for the SSSD configuration should be sourced
+	// from. The referenced VolumeSource will be made available at the requested mountPath. For
+	// example, you may build it into your custom Ceph container image or use the Vault agent
+	// injector to securely add the file via annotations on the CephNFS spec (passed to the NFS
+	// server pods).
+	// +optional
+	SSSDGenericFiles SSSDSidecarGenericFiles `json:"sssdGenericFiles,omitempty"`
+
 	// Resources allow specifying resource requests/limits on the SSSD sidecar container.
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
@@ -2029,6 +2037,23 @@ type SSSDSidecarConfigFileConfigMap struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
+}
+
+// SSSDSidecarGenericFiles represents the source from where additional files for the the SSSD
+// configuration should come from and are made available.
+type SSSDSidecarGenericFiles struct {
+	// VolumeSource accepts a standard Kubernetes VolumeSource for additional SSSD files like what
+	// is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or
+	// HostPath. There are two requirements for the source's content:
+	//   1. The config file must be mountable via `subPath: sssd.conf`. For example, in a ConfigMap,
+	//      the data item must be named `sssd.conf`, or `items` must be defined to select the key
+	//      and give it path `sssd.conf`. A HostPath directory must have the `sssd.conf` file.
+	//   2. The volume or config file must have mode 0600.
+	VolumeSource *v1.VolumeSource `json:"volumeSource"`
+
+	// MountPath contains the path where the contents of the VolumeSource will made available inside
+	// the SSSD sidecar.
+	MountPath string `json:"mountPath"`
 }
 
 // NetworkSpec for Ceph includes backward compatibility code

--- a/pkg/operator/ceph/nfs/security.go
+++ b/pkg/operator/ceph/nfs/security.go
@@ -115,6 +115,15 @@ func generateSssdSidecarResources(sidecarCfg *cephv1.SSSDSidecar) (
 		sssdMounts = append(sssdMounts, mount)
 	}
 
+	genericFiles := sidecarCfg.SSSDGenericFiles.VolumeSource
+	genericMountPath := sidecarCfg.SSSDGenericFiles.MountPath
+	if genericFiles != nil {
+		vol, mount := genericVolAndMount(*genericFiles, genericMountPath)
+
+		volumes = append(volumes, vol)
+		sssdMounts = append(sssdMounts, mount)
+	}
+
 	// the init container is needed to copy the starting content from the /var/lib/sss/pipes
 	// directory into the shared sockets dir so that SSSD has the content it needs to start up
 	init = &v1.Container{
@@ -163,6 +172,20 @@ func configVolAndMount(volSource v1.VolumeSource) (v1.Volume, v1.VolumeMount) {
 		Name:      volName,
 		MountPath: "/etc/sssd/sssd.conf",
 		SubPath:   "sssd.conf",
+	}
+
+	return vol, mount
+}
+
+func genericVolAndMount(volSource v1.VolumeSource, mountPath string) (v1.Volume, v1.VolumeMount) {
+	volName := "sssd-generic-files"
+	vol := v1.Volume{
+		Name:         volName,
+		VolumeSource: volSource,
+	}
+	mount := v1.VolumeMount{
+		Name:      volName,
+		MountPath: mountPath,
 	}
 
 	return vol, mount


### PR DESCRIPTION
**Description of your changes:**

The sssd.conf may refer to additional files, like a CA bundle or TLS certificates. These files need to be made available in the SSSD sidecar. With the new `sssdGenericFiles` reference to a VolumeSource and a `MountPath`, a provided `sssd.conf` can use the additional files.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
