### PR TITLE
core: use assimilate-conf command to run commands

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -153,68 +153,57 @@ func TestPreMonChecks(t *testing.T) {
 
 func TestConfigureMsgr2(t *testing.T) {
 	type fields struct {
-		encryptionExpected   bool
-		compressionExpected  bool
-		disabledBothExpected bool
-		cephVersion          cephver.CephVersion
-		Spec                 *cephv1.ClusterSpec
+		encryptionExpected  bool
+		compressionExpected bool
+		cephVersion         cephver.CephVersion
+		Spec                *cephv1.ClusterSpec
 	}
+
 	tests := []struct {
 		name   string
 		fields fields
 	}{
-		{"default settings", fields{false, false, false, cephver.CephVersion{Major: 15}, &cephv1.ClusterSpec{}}},
-		{"encryption enabled", fields{true, false, false, cephver.CephVersion{Major: 16}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Encryption: &cephv1.EncryptionSpec{Enabled: true}}}}}},
-		{"compression enabled old version", fields{false, false, false, cephver.CephVersion{Major: 16}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Compression: &cephv1.CompressionSpec{Enabled: true}}}}}},
-		{"compression enabled good version", fields{false, true, false, cephver.CephVersion{Major: 17}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Compression: &cephv1.CompressionSpec{Enabled: true}}}}}},
-		{"both enabled", fields{true, true, false, cephver.CephVersion{Major: 17}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Encryption: &cephv1.EncryptionSpec{Enabled: true}, Compression: &cephv1.CompressionSpec{Enabled: true}}}}}},
-		{"both disabled", fields{false, false, true, cephver.CephVersion{Major: 17}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Encryption: &cephv1.EncryptionSpec{Enabled: false}, Compression: &cephv1.CompressionSpec{Enabled: false}}}}}},
+		{"default settings", fields{false, false, cephver.CephVersion{Major: 15}, &cephv1.ClusterSpec{}}},
+		{"encryption enabled", fields{true, false, cephver.CephVersion{Major: 16}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Encryption: &cephv1.EncryptionSpec{Enabled: true}}}}}},
+		{"compression enabled old version", fields{false, false, cephver.CephVersion{Major: 16}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Compression: &cephv1.CompressionSpec{Enabled: true}}}}}},
+		{"compression enabled good version", fields{false, true, cephver.CephVersion{Major: 17}, &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{Connections: &cephv1.ConnectionsSpec{Compression: &cephv1.CompressionSpec{Enabled: true}}}}}},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			enabledCompression := false
-			disabledCompression := false
 			enabledEncryption := false
-			disabledEncryption := false
 			executor := &exectest.MockExecutor{
 				MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
-					logger.Infof("Execute: %s %v", command, args)
-					if args[0] == "config" && args[1] == "set" {
-						if args[3] == "ms_osd_compress_mode" {
-							if args[4] == "force" {
-								enabledCompression = true
-							} else if args[4] == "none" {
-								disabledCompression = true
-							}
+					if args[0] == "config" && args[1] == "assimilate-conf" && args[2] == "-i" && args[4] == "-o" {
+						if tt.fields.Spec.Network.Connections.Encryption != nil && tt.fields.Spec.Network.Connections.Compression == nil {
+							enabledEncryption = true
+						} else if tt.fields.Spec.Network.Connections.Encryption == nil && tt.fields.Spec.Network.Connections.Compression != nil {
+							enabledCompression = true
 						}
-						if args[3] == "ms_cluster_mode" {
-							if args[4] == "secure" {
-								enabledEncryption = true
-							} else if args[4] == "crc secure" {
-								disabledEncryption = true
-							}
-						}
-
 						return "", nil
 					}
-					return "", errors.Errorf("unrecognized command")
+
+					return "", errors.Errorf("unexpected ceph command %q", args)
 				},
 			}
 			clusterInfo := cephclient.AdminTestClusterInfo("rook-ceph")
 			clusterInfo.CephVersion = tt.fields.cephVersion
-			context := &clusterd.Context{Clientset: testop.New(t, 3), Executor: executor}
+			context := &clusterd.Context{
+				Clientset: testop.New(t, 3),
+				Executor:  executor,
+			}
 			c := &cluster{
 				ClusterInfo: clusterInfo,
 				Spec:        tt.fields.Spec,
 				context:     context,
+				Namespace:   "rook-ceph",
 			}
 
 			err := c.configureMsgr2()
 			assert.NoError(t, err)
 			assert.Equal(t, tt.fields.compressionExpected, enabledCompression)
 			assert.Equal(t, tt.fields.encryptionExpected, enabledEncryption)
-			assert.Equal(t, tt.fields.disabledBothExpected, disabledCompression)
-			assert.Equal(t, tt.fields.disabledBothExpected, disabledEncryption)
 		})
 	}
 }


### PR DESCRIPTION
this commit uses the ceph feature assimilate-conf to set multiple configurations for ceph global/pods at one file
and use that in command to set the required configuration in one line command.
for example:
`ceph config assimilate-conf -i <input file> -o <output file>`

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #10531 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
