### PR TITLE
helm: Warn to upgrade to 1.9.10 before k8s 1.25

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -52,6 +52,11 @@ those releases.
 * The minimum supported version of Ceph-CSI is v3.6.0. You must update to at least this version of
   Ceph-CSI before or at the same time you update the Rook operator image to v1.10
 
+* Before upgrading to K8s 1.25, ensure that you are running at least Rook v1.9.10, or v1.10.x.
+  If you upgrade to K8s 1.25 before upgrading to v1.9.10 or newer, the Helm chart may be
+  blocked from upgrading to newer versions of Rook. See [#10826](https://github.com/rook/rook/issues/10826)
+  for a possible workaround.
+
 ## Considerations
 
 With this upgrade guide, there are a few notes to consider:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The helm chart is blocked from upgrading to newer versions of Rook if v1.9.10 is not installed before upgrading to K8s 1.25. The helm chart is confused by the PSPs that still exist in the installed chart and fails to upgrade to the new chart.

**Which issue is resolved by this Pull Request:**
Related to #10826

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
