### PR TITLE
ci: add debug flag to identify any failing yaml origin

### DIFF
--- a/build/rbac/get-helm-rbac.sh
+++ b/build/rbac/get-helm-rbac.sh
@@ -27,6 +27,6 @@ done
 
 echo "generating Helm template with options: ${options[*]}" &>/dev/stderr
 
-${HELM} template ../../deploy/charts/rook-ceph "${options[@]}" | ./keep-rbac-yaml.sh
+${HELM} template ../../deploy/charts/rook-ceph "${options[@]}" --debug | ./keep-rbac-yaml.sh
 
 popd &>/dev/stderr


### PR DESCRIPTION
this is for the diagnosis of flaky github test, to know what is wrong and failing in tests like :
https://github.com/rook/rook/runs/8236140354?check_suite_focus=true

it would be helpful to have this debug option in ci setup.

Signed-off-by: Deepika Upadhyay <deepika@koor.tech>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
