### PR TITLE
docs: Clarify storage prereqs in quickstart guide

### DIFF
--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -19,7 +19,7 @@ In order to configure the Ceph storage cluster, at least one of these local stor
 
 * Raw devices (no partitions or formatted filesystems)
 * Raw partitions (no formatted filesystem)
-* PVs available from a storage class in `block` mode
+* Persistent Volumes available from a storage class in `block` mode
 
 You can confirm whether your partitions or devices are formatted with filesystems with the following command.
 

--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -26,8 +26,6 @@ To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [fo
 In order to configure the Ceph storage cluster, at least one of these local storage options are required:
 
 * Raw devices (no partitions or formatted filesystems)
-  * This requires `lvm2` to be installed on the host.
-    To avoid this dependency, you can create a single full-disk partition on the disk (see below)
 * Raw partitions (no formatted filesystem)
 * Persistent Volumes available from a storage class in `block` mode
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The quickstart guide prerequisites have diverged from the storage requirements on the [prereqs doc](https://rook.io/docs/rook/latest/Getting-Started/Prerequisites/prerequisites/#ceph-prerequisites) page, now they are in sync again.

@satoru-takeuchi After this is merged, want to add another line to the storage options for LVs?

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
