### PR TITLE
ceph: Add imagePullSecrets to Cluster CRD

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -90,6 +90,7 @@ For more details on the mons and when to choose a number other than `3`, see the
 * `removeOSDsIfOutAndSafeToRemove`: If `true` the operator will remove the OSDs that are down and whose data has been restored to other OSDs. In Ceph terms, the OSDs are `out` and `safe-to-destroy` when they are removed.
 * `cleanupPolicy`: [cleanup policy settings](#cleanup-policy)
 * `security`: [security page for key management configuration](../../Storage-Configuration/Advanced/key-management-system.md)
+* `imagePullSecrets`: List of image pull secrets to apply to Ceph cluster Pods. Does not apply to CSI Pods.
 
 ### Ceph container images
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1281,6 +1281,17 @@ spec:
                       description: StartupProbe allows changing the startupProbe configuration for a given daemon
                       type: object
                   type: object
+                imagePullSecrets:
+                  description: Image pull secrets to apply to all Ceph Pods
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
                 labels:
                   additionalProperties:
                     additionalProperties:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1279,6 +1279,17 @@ spec:
                       description: StartupProbe allows changing the startupProbe configuration for a given daemon
                       type: object
                   type: object
+                imagePullSecrets:
+                  description: Image pull secrets to apply to all Ceph Pods
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
                 labels:
                   additionalProperties:
                     additionalProperties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -220,6 +220,11 @@ type ClusterSpec struct {
 	// +optional
 	// +nullable
 	LogCollector LogCollectorSpec `json:"logCollector,omitempty"`
+
+	// Image pull secrets to apply to all Ceph Pods
+	// +optional
+	// +nullable
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // LogCollectorSpec is the logging spec

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -65,6 +65,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 			Volumes:            volumes,
 			HostNetwork:        c.spec.Network.IsHost(),
 			PriorityClassName:  cephv1.GetMgrPriorityClassName(c.spec.PriorityClassNames),
+			ImagePullSecrets:   c.spec.ImagePullSecrets,
 		},
 	}
 	cephv1.GetMgrPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec.Spec)

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -184,6 +184,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*corev1.Pod, er
 		Volumes:           controller.DaemonVolumesBase(monConfig.DataPathMap, keyringStoreName),
 		HostNetwork:       c.spec.Network.IsHost(),
 		PriorityClassName: cephv1.GetMonPriorityClassName(c.spec.PriorityClassNames),
+		ImagePullSecrets:  c.spec.ImagePullSecrets,
 	}
 
 	// If the log collector is enabled we add the side-car container

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -587,6 +587,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			},
 			Volumes:       volumes,
 			SchedulerName: osdProps.schedulerName,
+			ImagePullSecrets:  c.spec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -585,9 +585,9 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 					WorkingDir:      opconfig.VarLogCephDir,
 				},
 			},
-			Volumes:       volumes,
-			SchedulerName: osdProps.schedulerName,
-			ImagePullSecrets:  c.spec.ImagePullSecrets,
+			Volumes:          volumes,
+			SchedulerName:    osdProps.schedulerName,
+			ImagePullSecrets: c.spec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -43,6 +43,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 			Volumes:           controller.DaemonVolumes(daemonConfig.DataPathMap, daemonConfig.ResourceName),
 			HostNetwork:       r.cephClusterSpec.Network.IsHost(),
 			PriorityClassName: rbdMirror.Spec.PriorityClassName,
+			ImagePullSecrets:  r.cephClusterSpec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -73,6 +73,7 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 		[]string{"--version"},
 		rookImage,
 		cephImage,
+		cephClusterSpec.ImagePullSecrets
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up ceph version job")

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -73,7 +73,7 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 		[]string{"--version"},
 		rookImage,
 		cephImage,
-		cephClusterSpec.ImagePullSecrets
+		cephClusterSpec.ImagePullSecrets,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up ceph version job")

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -725,6 +725,7 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 		[]string{"--version"},
 		r.opConfig.Image,
 		CSIParam.CSIPluginImage,
+		nil,
 	)
 
 	if err != nil {

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -63,6 +63,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig, namespace string) (*apps.
 			Volumes:           controller.DaemonVolumes(mdsConfig.DataPathMap, mdsConfig.ResourceName),
 			HostNetwork:       c.clusterSpec.Network.IsHost(),
 			PriorityClassName: c.fs.Spec.MetadataServer.PriorityClassName,
+			ImagePullSecrets:  c.clusterSpec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -46,6 +46,7 @@ func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, f
 			Volumes:           controller.DaemonVolumes(daemonConfig.DataPathMap, daemonConfig.ResourceName),
 			HostNetwork:       r.cephClusterSpec.Network.IsHost(),
 			PriorityClassName: fsMirror.Spec.PriorityClassName,
+			ImagePullSecrets:  r.cephClusterSpec.ImagePullSecrets,
 		},
 	}
 

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -128,6 +128,7 @@ func (r *ReconcileCephNFS) makeDeployment(nfs *cephv1.CephNFS, cfg daemonConfig)
 		},
 		HostNetwork:       r.cephClusterSpec.Network.IsHost(),
 		PriorityClassName: nfs.Spec.Server.PriorityClassName,
+		ImagePullSecrets:  r.cephClusterSpec.ImagePullSecrets,
 	}
 	// Replace default unreachable node toleration
 	k8sutil.AddUnreachableNodeToleration(&podSpec)

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -129,6 +129,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 		HostNetwork:        hostNetwork,
 		PriorityClassName:  c.store.Spec.Gateway.PriorityClassName,
 		ServiceAccountName: serviceAccountName,
+		ImagePullSecrets:   c.clusterSpec.ImagePullSecrets,
 	}
 
 	// If the log collector is enabled we add the side-car container

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -65,15 +65,15 @@ type CmdReporter struct {
 }
 
 type cmdReporterCfg struct {
-	clientset    	 kubernetes.Interface
-	ownerInfo    	 *k8sutil.OwnerInfo
-	appName      	 string
-	jobName      	 string
-	jobNamespace 	 string
-	cmd          	 []string
-	args         	 []string
-	rookImage    	 string
-	runImage     	 string
+	clientset        kubernetes.Interface
+	ownerInfo        *k8sutil.OwnerInfo
+	appName          string
+	jobName          string
+	jobNamespace     string
+	cmd              []string
+	args             []string
+	rookImage        string
+	runImage         string
 	imagePullSecrets []v1.LocalObjectReference
 }
 
@@ -98,16 +98,16 @@ func New(
 	imagePullSecrets []v1.LocalObjectReference,
 ) (*CmdReporter, error) {
 	cfg := &cmdReporterCfg{
-		clientset:    	  clientset,
-		ownerInfo:    	  ownerInfo,
-		appName:      	  appName,
-		jobName:      	  jobName,
-		jobNamespace: 	  jobNamespace,
-		cmd:          	  cmd,
-		args:         	  args,
-		rookImage:    	  rookImage,
-		runImage:     	  runImage,
-		imagePullSecrets: imagePullSecrets
+		clientset:        clientset,
+		ownerInfo:        ownerInfo,
+		appName:          appName,
+		jobName:          jobName,
+		jobNamespace:     jobNamespace,
+		cmd:              cmd,
+		args:             args,
+		rookImage:        rookImage,
+		runImage:         runImage,
+		imagePullSecrets: imagePullSecrets,
 	}
 
 	// Validate contents of config struct, not inputs to function to catch any developer errors
@@ -296,8 +296,8 @@ func (cr *cmdReporterCfg) initJobSpec() (*batch.Job, error) {
 		Containers: []v1.Container{
 			*cmdReporterContainer,
 		},
-		RestartPolicy: v1.RestartPolicyOnFailure,
-		ImagePullSecrets: cmdReporterCfg.imagePullSecrets,
+		RestartPolicy:    v1.RestartPolicyOnFailure,
+		ImagePullSecrets: cr.imagePullSecrets,
 	}
 	copyBinsVol, _ := copyBinariesVolAndMount()
 	podSpec.Volumes = []v1.Volume{copyBinsVol}

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -65,15 +65,16 @@ type CmdReporter struct {
 }
 
 type cmdReporterCfg struct {
-	clientset    kubernetes.Interface
-	ownerInfo    *k8sutil.OwnerInfo
-	appName      string
-	jobName      string
-	jobNamespace string
-	cmd          []string
-	args         []string
-	rookImage    string
-	runImage     string
+	clientset    	 kubernetes.Interface
+	ownerInfo    	 *k8sutil.OwnerInfo
+	appName      	 string
+	jobName      	 string
+	jobNamespace 	 string
+	cmd          	 []string
+	args         	 []string
+	rookImage    	 string
+	runImage     	 string
+	imagePullSecrets []v1.LocalObjectReference
 }
 
 // New creates a new CmdReporter.
@@ -94,17 +95,19 @@ func New(
 	appName, jobName, jobNamespace string,
 	cmd, args []string,
 	rookImage, runImage string,
+	imagePullSecrets []v1.LocalObjectReference,
 ) (*CmdReporter, error) {
 	cfg := &cmdReporterCfg{
-		clientset:    clientset,
-		ownerInfo:    ownerInfo,
-		appName:      appName,
-		jobName:      jobName,
-		jobNamespace: jobNamespace,
-		cmd:          cmd,
-		args:         args,
-		rookImage:    rookImage,
-		runImage:     runImage,
+		clientset:    	  clientset,
+		ownerInfo:    	  ownerInfo,
+		appName:      	  appName,
+		jobName:      	  jobName,
+		jobNamespace: 	  jobNamespace,
+		cmd:          	  cmd,
+		args:         	  args,
+		rookImage:    	  rookImage,
+		runImage:     	  runImage,
+		imagePullSecrets: imagePullSecrets
 	}
 
 	// Validate contents of config struct, not inputs to function to catch any developer errors
@@ -294,6 +297,7 @@ func (cr *cmdReporterCfg) initJobSpec() (*batch.Job, error) {
 			*cmdReporterContainer,
 		},
 		RestartPolicy: v1.RestartPolicyOnFailure,
+		ImagePullSecrets: cmdReporterCfg.imagePullSecrets,
 	}
 	copyBinsVol, _ := copyBinariesVolAndMount()
 	podSpec.Volumes = []v1.Volume{copyBinsVol}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Introduce optional field on `CephCluster` CRD to specify `imagePullSecrets` which should be used on all cluster Pods. This is a solution which does not rely on customized RBAC roles managed by the Helm charts.

Note that it did not make sense to add image pull secrets to CSI or Discover Pods. 

**Which issue is resolved by this Pull Request:**

Resolves #6673 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
