### PR TITLE
pool: initialize only rbd application pools

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -385,13 +385,16 @@ func createPool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 		return errors.Wrapf(err, "failed to create pool %q", p.Name)
 	}
 
-	logger.Infof("initializing pool %q", p.Name)
+	if appName != poolApplicationNameRBD {
+		return nil
+	}
+	logger.Infof("initializing pool %q for RBD use", p.Name)
 	args := []string{"pool", "init", p.Name}
 	output, err := cephclient.NewRBDCommand(context, clusterInfo, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to initialize pool %q. %s", p.Name, string(output))
+		return errors.Wrapf(err, "failed to initialize pool %q for RBD use. %s", p.Name, string(output))
 	}
-	logger.Infof("successfully initialized pool %q", p.Name)
+	logger.Infof("successfully initialized pool %q for RBD use", p.Name)
 
 	return nil
 }


### PR DESCRIPTION
`rbd pool init` cmd initializes pool for rbd images. This commit makes modification to init only
rbd application pools, since it is not required
by other pools like ".nfs",".mgr" & "mgr_devicehealth".

Signed-off-by: Rakshith R <rar@redhat.com>

refer: https://github.com/rook/rook/pull/8923#discussion_r723117689

This maybe the reason cephnfs with multus is failing too.
@parth-gr ^

@idryomov can you please take a look too.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
