### PR TITLE
ci:  disallow to create encrypted osd on lv and osd on lv with metadata device

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -499,6 +499,7 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 						}
 						if desiredDevice.MetadataDevice != "" {
 							logger.Infof("logical volume %q is not picked because OSD on LV with metadata device is not allowed", device.Name)
+							matched = false
 							continue
 						}
 					}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -491,9 +491,16 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 					} else if strings.HasPrefix(desiredDevice.Name, "/dev/") {
 						matched = matchDevLinks(device.DevLinks, desiredDevice.Name)
 					}
-					if matched && device.Type == sys.LVMType && desiredDevice.MetadataDevice != "" {
-						logger.Infof("logical volume %q is not picked because OSD on LV with metadata device is not allowed", device.Name)
-						continue
+					if matched && device.Type == sys.LVMType {
+						if agent.storeConfig.EncryptedDevice {
+							logger.Infof("logical volume %q is not picked because encrypted OSD on LV is not allowed", device.Name)
+							matched = false
+							continue
+						}
+						if desiredDevice.MetadataDevice != "" {
+							logger.Infof("logical volume %q is not picked because OSD on LV with metadata device is not allowed", device.Name)
+							continue
+						}
 					}
 				}
 


### PR DESCRIPTION
**Description of your changes:**

Disallow the creation of the following un-supported configurations.

- encrypted osd on lv
- osd on lv with metadata device

**Which issue is resolved by this Pull Request:**
Resolves #10782

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
