### PR TITLE
build: Stop printing verbose rbac generation details

### DIFF
--- a/build/rbac/keep-rbac-yaml.sh
+++ b/build/rbac/keep-rbac-yaml.sh
@@ -41,10 +41,10 @@ while read -r line; do
 done < <(find . -type f -name '*.yml' | sort)
 
 # For debugging, output the resource kinds and names we processed and the number we are keeping
-for file in "${RBAC_FILES[@]}"; do
+#for file in "${RBAC_FILES[@]}"; do
   # basename to get rid of the leading './' which find adds; %.yml to remove the .yml suffix
-  basename "${file%.yml}" >/dev/stderr
-done
+#  basename "${file%.yml}" >/dev/stderr
+#done
 # shellcheck disable=SC2012 # we know filenames are alphanumeric from being k8s resources
 echo "Number of RBAC resources: ${#RBAC_FILES[@]}" >/dev/stderr
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The rbac generation prints a lot of info that is not necessary unless troubleshooting the rbac build, so we can comment it out by default.

@BlaineEXE Per our discussion, ok to comment this out, right?

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
