### PR TITLE
Configure  cluster-test example for minikube

### DIFF
--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -26,7 +26,10 @@ metadata:
   name: my-cluster
   namespace: rook-ceph # namespace:cluster
 spec:
-  dataDirHostPath: /var/lib/rook
+  # In Minikube, the '/data' directory is configured to persist across
+  # reboots.  You may need to use another location for other test
+  # environments.
+  dataDirHostPath: /data/rook
   cephVersion:
     image: quay.io/ceph/ceph:v17
     allowUnsupported: true


### PR DESCRIPTION
The Quickstart document says[1]:

    cluster-test.yaml: Cluster settings for a test environment such as minikube.

But the cluster-test is using:

     spec:
     -  dataDirHostPath: /var/lib/rook

which does not work for minikube because `/var/lib` is not persisted.

This can be fix by all users[2] but it seems more useful if we the example would work out of the box on minikube.

Change to use the recommended `/data/rook`, and add a comment for people using other test environments that may need to use something else.

[1] https://rook.io/docs/rook/latest/Getting-Started/quickstart/#cluster-environments
[2] https://github.com/RamenDR/ramen/commit/eb5814aa8be799c2668558ddd6e7208813a85392