### PR TITLE
build: Fix intermittent gen-rbac failure

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -71,7 +71,8 @@ EOF
 }
 
 build_helm_resources() {
-  echo "Generating helm resources.yaml"
+  TMP_FILE=$(mktemp -q /tmp/resources.XXXXXX || exit 1)
+  echo "Generating helm resources.yaml to temp file: $TMP_FILE"
   {
     # add header
     echo "{{- if .Values.crds.enabled }}"
@@ -83,7 +84,9 @@ build_helm_resources() {
     # DO NOT REMOVE the empty line, it is necessary
     echo ""
     echo "{{- end }}"
-  } >>"$CEPH_HELM_CRDS_FILE_PATH"
+  } >>"$TMP_FILE"
+  echo "updating helm crds file $CEPH_HELM_CRDS_FILE_PATH from temp file"
+  mv "$TMP_FILE" "$CEPH_HELM_CRDS_FILE_PATH"
 }
 
 ########


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The crds generation for the helm crds is intermittently hitting a build error due to multiple builds generating the crds at the same time. We avoid this race condition by first writing the crds to a temp file then move the file to the helm crd resources file.

@ideepika hopefully this will fix the intermittent issue we were discussing recently, I finally had some time to take a look.

**Which issue is resolved by this Pull Request:**
Related to #10948 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
