### PR TITLE
ci: move to ubuntu 20.04 runner completely

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -270,7 +270,7 @@ jobs:
         timeout-minutes: 60
 
   two-osds-in-device:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -324,7 +324,7 @@ jobs:
         timeout-minutes: 60
 
   osd-with-metadata-device:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -384,7 +384,7 @@ jobs:
         timeout-minutes: 60
 
   encryption:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -430,7 +430,7 @@ jobs:
         timeout-minutes: 60
 
   lvm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -677,7 +677,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -753,7 +753,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-db:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -811,7 +811,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-db-wal:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -870,7 +870,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-kms-vault-token-auth:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -956,7 +956,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-kms-vault-k8s-auth:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -1025,7 +1025,7 @@ jobs:
         timeout-minutes: 60
 
   lvm-pvc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - name: checkout
@@ -1320,7 +1320,7 @@ jobs:
         timeout-minutes: 60
 
   encryption-pvc-kms-ibm-kp:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -41,6 +41,7 @@ function print_k8s_cluster_status() {
 
 function use_local_disk() {
   BLOCK_DATA_PART=${BLOCK}1
+  sudo apt purge snapd -y
   sudo dmsetup version || true
   sudo swapoff --all --verbose
   if mountpoint -q /mnt; then
@@ -57,6 +58,7 @@ function use_local_disk() {
 }
 
 function use_local_disk_for_integration_test() {
+  sudo apt purge snapd -y
   sudo udevadm control --log-priority=debug
   sudo swapoff --all --verbose
   sudo umount /mnt


### PR DESCRIPTION
**Description of your changes:**

github-hosted runner ubuntu-18.04 will be removed by Dec. 1st, 2022.
    
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
    
So, let's change the all runnners to ubuntu-20.04.
    
We need to uninstall `snapd` because `snapd` prevents kernel from unmounting `/mnt` completely.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
