### PR TITLE
build: use script to reliably determine latest released release branch

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -20,7 +20,6 @@ include ../makelib/helm.mk
 # ====================================================================================
 # Options
 
-LATEST_DOCS_BRANCH=release-1.10
 CHANNEL ?= master
 ifeq ($(filter master release,$(CHANNEL)),)
 $(error invalid channel $(CHANNEL))
@@ -40,7 +39,7 @@ else
 DOCS_VERSION := $(shell echo $(BRANCH_NAME) | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 endif
 
-ifeq ($(shell echo $(BRANCH_NAME)),$(LATEST_DOCS_BRANCH))
+ifeq ($(shell echo $(BRANCH_NAME)),$(shell $(ROOT_DIR)/build/release/latest_release_branch.sh))
 DOCS_VERSION_ALIAS := latest-release
 else
 DOCS_VERSION_ALIAS :=

--- a/build/release/latest_release_branch.sh
+++ b/build/release/latest_release_branch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+# Get list of release- branches
+RELEASE_BRANCHES="$(git branch -r | grep -v mergify | grep '/release-' | cut -d'/' -f2 | sort | uniq)"
+LATEST_RELEASE_BRANCH=""
+MAX_TRIES=2
+
+TRY=1
+until [ -n "${LATEST_RELEASE_BRANCH}" ] || [ ${TRY} -gt ${MAX_TRIES} ]; do
+    LATEST_RELEASE_BRANCH="$(echo "${RELEASE_BRANCHES}" | sort --version-sort | tail -n 1 | cut -d'/' -f2)"
+    BRANCH_VERSION="v$(echo "${LATEST_RELEASE_BRANCH}" | cut -d'-' -f2-)"
+
+    # Get tags for the release version and filter out any alpha or beta versions
+    set +o pipefail
+    set +e
+    TAGS="$(git tag | grep -F "${BRANCH_VERSION}.0" | grep -Ev "alpha|beta")"
+    set -o pipefail
+    set -e
+
+    # If the list is empty remove last line from $RELEASE_BRANCHES and
+    # clear $LATEST_RELEASE_BRANCH var
+    if [ -z "${TAGS}" ]; then
+        LATEST_RELEASE_BRANCH=""
+        RELEASE_BRANCHES="$(echo "${RELEASE_BRANCHES}" | sed '$d')"
+    fi
+    (( TRY++ ))
+done
+
+if [ -z "${LATEST_RELEASE_BRANCH}" ]; then
+    echo "Failed to find latest released release branch!"
+    exit 1
+fi
+
+echo "${LATEST_RELEASE_BRANCH}"


### PR DESCRIPTION
**Description of your changes:**

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

This makes a script determine what the latest release branch is. This enables us to not need to update an additional variable during every release to make the docs point to the actual currently released release branch.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.