### PR TITLE
operator: silence 'cm is handled by another watcher' DEBUG messages

### DIFF
--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -63,7 +63,6 @@ func predicateForHotPlugCMWatcher(client client.Client) predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			isHotPlugCM := isHotPlugCM(e.ObjectNew)
 			if !isHotPlugCM {
-				logger.Debugf("hot-plug cm watcher: only reconcile on hot plug cm changes, this %q cm is handled by another watcher", e.ObjectNew.GetName())
 				return false
 			}
 


### PR DESCRIPTION
I guesstimate that around 50% of the operator log volume when set to log level `DEBUG` are messages about cm's which aren't relevant to rook.

E.g.:

```
2022-09-16 23:03:05.430839 D | ceph-cluster-controller: hot-plug cm watcher: only reconcile on hot plug cm changes, this "ingress-controller-leader" cm is handled by another watcher
2022-09-16 23:03:05.643255 D | ceph-cluster-controller: hot-plug cm watcher: only reconcile on hot plug cm changes, this "fleet-agent-lock" cm is handled by another watcher
2022-09-16 23:03:05.799526 D | ceph-cluster-controller: hot-plug cm watcher: only reconcile on hot plug cm changes, this "cattle-controllers" cm is handled by another watcher
```

Yes, it is `DEBUG` and noise is expected. However, there is no message about checking the status of the cm's rook actually needs to watch and these messages don't seem very useful. I have been resorting to piping the operators logs through `| grep -v 'hot-plug cm watcher'` to cut down the noise.

Signed-off-by: Joshua Hoblitt <josh@hoblitt.com>