### PR TITLE
osd: allow raw partitions to be picked up by discover daemon

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -46,7 +46,7 @@ func supportedDeviceType(device string) bool {
 
 // GetDeviceEmpty check whether a device is completely empty
 func GetDeviceEmpty(device *sys.LocalDisk) bool {
-	return device.Parent == "" && supportedDeviceType(device.Type) && len(device.Partitions) == 0 && device.Filesystem == ""
+	return supportedDeviceType(device.Type) && len(device.Partitions) == 0 && device.Filesystem == ""
 }
 
 func ignoreDevice(d string) bool {

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -434,9 +434,6 @@ func probeDevices(context *clusterd.Context) ([]sys.LocalDisk, error) {
 		if device == nil {
 			continue
 		}
-		if device.Type == sys.PartType {
-			continue
-		}
 
 		partitions, _, err := sys.GetDevicePartitions(device.Name, context.Executor)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: dkeven <dkvvven@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Remove the filter in `rook-discover` that skips partitions when reporting availabel devices to the operator.
Remove the logic in `GetDeviceEmpty` which checks whether the target device has a parent.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/11038

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
