### PR TITLE
examples: CephBlockPool does not have spec.annotations

### DIFF
--- a/deploy/examples/pool-ec.yaml
+++ b/deploy/examples/pool-ec.yaml
@@ -21,6 +21,3 @@ spec:
   parameters:
     # Inline compression mode for the data pool
     compression_mode: none
-  # A key/value list of annotations
-  annotations:
-  #  key: value

--- a/deploy/examples/pool.yaml
+++ b/deploy/examples/pool.yaml
@@ -62,6 +62,3 @@ spec:
   # quotas:
     # maxSize: "10Gi" # valid suffixes include k, M, G, T, P, E, Ki, Mi, Gi, Ti, Pi, Ei
     # maxObjects: 1000000000 # 1 billion objects
-  # A key/value list of annotations
-  annotations:
-  #  key: value


### PR DESCRIPTION
**Description of your changes:**
With Kubernetes 1.25 it seems that applying the yaml files that have a CephBlockPool with spec.annotations fail with errors like this:

    CephBlockPool in version "v1" cannot be handled as a CephBlockPool:
    strict decoding error: unknown field "spec.annotations"

**Which issue is resolved by this Pull Request:**
Updates: ceph/ceph-csi#3362

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
