### PR TITLE
osd: use 256 as cryptographicLength for keys using kmip kms

### DIFF
--- a/pkg/daemon/ceph/osd/kms/kmip.go
+++ b/pkg/daemon/ceph/osd/kms/kmip.go
@@ -48,7 +48,7 @@ const (
 	kmipDefaultWriteTimeout = uint8(10)
 
 	// cryptographicLength of the key.
-	cryptographicLength = 128
+	cryptographicLength = 256
 
 	//nolint:gosec, value not credential, just configuration keys.
 	kmipEndpoint         = "KMIP_ENDPOINT"


### PR DESCRIPTION

**Description of your changes:**

This commit changes cryptographic length for keys created for kmip kms to 256 from 128, since it is more secure.

Signed-off-by: Rakshith R <rar@redhat.com>

#### Only newly created osd encryption keys will start to have 256 as their cryptographic length, already existing keys will be unaffected. This pr is completely backward compatible

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
