### PR TITLE
osd: Prepare job needs significant more memory for provisioning

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -513,9 +513,16 @@ If a user configures a limit or request value that is too low, Rook will still r
 * `mon`: 1024MB
 * `mgr`: 512MB
 * `osd`: 2048MB
-* `prepareosd`: 50MB
+* `prepareosd`: 1200MB (see the note below)
 * `crashcollector`: 60MB
 * `mgr-sidecar`: 100MB limit, 40MB requests
+
+!!! note
+    * The OSD prepare job may burst its memory usage during the OSD provisioning.
+    We either recommend not setting memory limits on the OSD prepare job, or setting limits over 1GB to prevent OSD
+    provisioning failure due to memory constraints that are difficult to troubleshoot. The OSD prepare job
+    only bursts a single time per OSD. All future runs of the OSD prepare job will detect the OSD is already
+    provisioned and not require a burst.
 
 !!! hint
     The resources for MDS daemons are not configured in the Cluster. Refer to the [Ceph Filesystem CRD](../Shared-Filesystem/ceph-filesystem-crd.md) instead.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -259,7 +259,7 @@ cephClusterSpec:
     prepareosd:
       limits:
         cpu: "500m"
-        memory: "400Mi"
+        memory: "1200Mi"
       requests:
         cpu: "500m"
         memory: "50Mi"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD creation may need to burst during OSD provisioning depending on the size of the OSD or similar factors. If the OSD prepare job is OOM killed it will cause OSD provisioning to fail and have various side effects that are difficult to troubleshoot to get the OSD to succeed. So we increase the recommendation significantly to avoid the OOM kill.

**Which issue is resolved by this Pull Request:**
Resolves #10219 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
