### PR TITLE
mgr: Set the public dashboard port differently from the target port

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -129,7 +129,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 	hasChanged = hasChanged || changed
 
 	// server port
-	port := strconv.Itoa(c.dashboardPort())
+	port := strconv.Itoa(c.dashboardInternalPort())
 	changed, err = monStore.SetIfChanged(daemonID, "mgr/dashboard/server_port", port)
 	if err != nil {
 		return false, err

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -32,6 +32,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -176,7 +177,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 			},
 			{
 				Name:          "dashboard",
-				ContainerPort: int32(c.dashboardPort()),
+				ContainerPort: int32(c.dashboardInternalPort()),
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
@@ -310,8 +311,11 @@ func (c *Cluster) makeDashboardService(name, activeDaemon string) (*v1.Service, 
 			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{
-					Name:     portName,
-					Port:     int32(c.dashboardPort()),
+					Name: portName,
+					Port: int32(c.dashboardPublicPort()),
+					TargetPort: intstr.IntOrString{
+						IntVal: int32(c.dashboardInternalPort()),
+					},
 					Protocol: v1.ProtocolTCP,
 				},
 			},


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the port is greater than 1024, for backward compatibility the port and targetPort should be the same value. If the port is less than 1024, the internal port must use a higher port number. In that case, the internal port will be the default port numbers and only the public port will be the desired port in the cluster CR.

**Which issue is resolved by this Pull Request:**
Resolves #11092

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
