### PR TITLE
osd: Recommend removing memory limits from osd prepare job

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -513,16 +513,15 @@ If a user configures a limit or request value that is too low, Rook will still r
 * `mon`: 1024MB
 * `mgr`: 512MB
 * `osd`: 2048MB
-* `prepareosd`: 1200MB (see the note below)
 * `crashcollector`: 60MB
 * `mgr-sidecar`: 100MB limit, 40MB requests
+* `prepareosd`: no limits (see the note)
 
 !!! note
-    * The OSD prepare job may burst its memory usage during the OSD provisioning.
-    We either recommend not setting memory limits on the OSD prepare job, or setting limits over 1GB to prevent OSD
-    provisioning failure due to memory constraints that are difficult to troubleshoot. The OSD prepare job
-    only bursts a single time per OSD. All future runs of the OSD prepare job will detect the OSD is already
-    provisioned and not require a burst.
+    We recommend not setting memory limits on the OSD prepare job to prevent OSD provisioning failure due to memory constraints.
+    The OSD prepare job bursts memory usage during the OSD provisioning depending on the size of the device, typically
+    1-2Gi for large disks. The OSD prepare job only bursts a single time per OSD.
+    All future runs of the OSD prepare job will detect the OSD is already provisioned and skip the provisioning.
 
 !!! hint
     The resources for MDS daemons are not configured in the Cluster. Refer to the [Ceph Filesystem CRD](../Shared-Filesystem/ceph-filesystem-crd.md) instead.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -257,9 +257,8 @@ cephClusterSpec:
         cpu: "1000m"
         memory: "4Gi"
     prepareosd:
-      limits:
-        cpu: "500m"
-        memory: "1200Mi"
+      # limits: It is not recommended to set limits on the OSD prepare job since it's a one-time burst for memory
+      # that must be allowed to complete without an OOM kill
       requests:
         cpu: "500m"
         memory: "50Mi"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The osd prepare job is not recommended to have memory limits since it's a one-time operation depending on the size of the disk that must be allowed to complete successfully.

This is a follow-up from #11103 where more data showed we really should not recommend limits on the osd prepare.

**Which issue is resolved by this Pull Request:**
Resolves #10219

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
