### PR TITLE
nfs: fix nfs grace period when multus is enabled

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1423,9 +1423,8 @@ jobs:
       - name: test ceph-csi-cephfs plugin restart
         run: tests/scripts/github-action-helper.sh test_csi_cephfs_workload
 
-      # uncomment once https://github.com/rook/rook/issues/10812 is resolved.
-      # - name: test ceph-csi-nfs plugin restart
-      #   run: tests/scripts/github-action-helper.sh test_csi_nfs_workload
+      - name: test ceph-csi-nfs plugin restart
+        run: tests/scripts/github-action-helper.sh test_csi_nfs_workload
 
       - name: collect common logs
         if: always()

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -480,7 +480,6 @@ function deploy_multus_cluster() {
   sed -i "s|#deviceFilter:|deviceFilter: ${BLOCK/\/dev\//}|g" cluster-multus-test.yaml
   kubectl create -f cluster-multus-test.yaml
   kubectl create -f filesystem-test.yaml
-  # uncomment once https://github.com/rook/rook/issues/10812 is resolved.
   kubectl create -f nfs-test.yaml
 }
 


### PR DESCRIPTION
Run the ganesha-rados-grace command in a remote pod when multus networking is enabled.

Signed-off-by: parth-gr <paarora@redhat.com>
Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #11039

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
