### PR TITLE
helm: allow disabling cluster creation

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | Parameter                               | Description                                                                                | Default         |
 | --------------------------------------- | ------------------------------------------------------------------------------------------ | --------------- |
 | `operatorNamespace`                     | Namespace of the Rook Operator                                                             | `rook-ceph`     |
+| `createCluster`                         | Ability to disable cluster creation (create only supporting resources)                     | `true`          |
 | `kubeVersion`                           | Optional override of the target kubernetes version                                         | ``              |
 | `configOverride`                        | Cluster ceph.conf override                                                                 | `<none>`        |
 | `toolbox.enabled`                       | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md)    | `false`         |

--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createCluster }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
@@ -17,3 +18,4 @@ spec:
 {{- end }}
 
 {{ toYaml .Values.cephClusterSpec | indent 2 }}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -8,6 +8,10 @@ operatorNamespace: rook-ceph
 # The metadata.name of the CephCluster CR. The default name is the same as the namespace.
 # clusterName: rook-ceph
 
+# Ability to disable the creation of the cluster itself,
+# but still create all supporting resources
+createCluster: true
+
 # Ability to override the kubernetes version used in rendering the helm chart
 # kubeVersion: 1.21
 


### PR DESCRIPTION
**Description of your changes:**

Add the value `createCluster`, defaulting to `true`; when false, the chart will still create all the supporting resources (RBAC), but not the cluster itself.

**Which issue is resolved by this Pull Request:**

Workaround for https://github.com/rook/rook/issues/11114

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
