### PR TITLE
helm: remove uncompatible keys from spec when external is enabled

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -22,3 +22,16 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1" -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Remove incompatible keys from cluster spec when creating an external cluster
+*/}}
+{{- define "rook-ceph-cluster.cephClusterSpec" -}}
+{{- $cephClusterSpec := .Values.cephClusterSpec -}}
+{{- if .Values.cephClusterSpec.external.enable -}}
+{{- range tuple "dashboard" "disruptionManagement" "mgr" "mon" "monitoring" "network" "storage" -}}
+{{- $cephClusterSpec := unset $cephClusterSpec . -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $cephClusterSpec -}}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -15,5 +15,7 @@ spec:
     externalMgrPrometheusPort: {{ toYaml .Values.monitoring.externalMgrPrometheusPort }}
 {{- end }}
 {{- end }}
-
-{{ toYaml .Values.cephClusterSpec | indent 2 }}
+{{- /*
+This function is defined in the helper templates (_helpers.tpl).
+*/ }}
+{{ include "rook-ceph-cluster.cephClusterSpec" . | indent 2 }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -366,6 +366,12 @@ cephClusterSpec:
       osd:
         disabled: false
 
+  # Create an external cluster, which will be used to access a distant Ceph cluster.
+  # Enabling will unset the following keys from cephClusterSpec:
+  # dashboard, disruptionManagement, mon, monitoring, network, storage
+  external:
+    enable: false
+
 ingress:
   dashboard:
     {}


### PR DESCRIPTION
**Description of your changes:**

This changes enables the creation of an external cluster by removing uncompatible keys from the spec when `cephClusterSpec.external.enable` is true.

**Which issue is resolved by this Pull Request:**

Resolves #11114 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
