### PR TITLE
operator: reconcile operator when webhook cert updates

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -20,7 +20,10 @@ rules:
     verbs: ["create"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["create", "get", "delete", "update"]
+    verbs: ["*"]
+  - apiGroups: [cert-manager.io]
+    resources: [""]
+    verbs: [""]
 ---
 # The cluster role for managing all the cluster-specific resources in a namespace
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -533,7 +533,10 @@ rules:
     verbs: ["create"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["create", "get", "delete", "update"]
+    verbs: ["*"]
+  - apiGroups: [cert-manager.io]
+    resources: [""]
+    verbs: [""]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/olm/generate-rook-csv.sh
+++ b/deploy/olm/generate-rook-csv.sh
@@ -214,7 +214,6 @@ function apply_rook_op_img() {
     "${YQ_CMD_WRITE[@]}" "$CSV_FILE_NAME" metadata.annotations.containerImage "$ROOK_OP_VERSION"
     "${YQ_CMD_WRITE[@]}" "$CSV_FILE_NAME" spec.install.spec.deployments[0].spec.template.spec.containers[0].image "$ROOK_OP_VERSION"
 }
-
 function validate_crds() {
     crds=$(awk '/Kind:/ {print $2}' $CRDS_FILE | grep -vE "ObjectBucketList|ObjectBucketClaimList" | sed 's/List//' | sort)
     csv_crds=$(awk '/kind:/ {print $3}' "$CSV_FILE_NAME" | sort)

--- a/pkg/operator/ceph/controller.go
+++ b/pkg/operator/ceph/controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	api "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
@@ -83,6 +84,13 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 	// Watch for Secret (admission controller secret)
 	err = c.Watch(&source.Kind{
 		Type: &v1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
+	if err != nil {
+		return err
+	}
+
+	// Watch for certificate rook-ceph-admission-controller
+	err = c.Watch(&source.Kind{
+		Type: &api.Certificate{TypeMeta: metav1.TypeMeta{Kind: "Certificate", APIVersion: v1.SchemeGroupVersion.String()}}}, &handler.EnqueueRequestForObject{}, predicateController(ctx, mgr.GetClient()))
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -47,6 +47,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/pool/radosnamespace"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	healthchecking "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -66,6 +67,7 @@ var (
 		mapiv1.AddToScheme,
 		healthchecking.AddToScheme,
 		cephv1.AddToScheme,
+		certmanagerv1.AddToScheme,
 	}
 )
 

--- a/pkg/operator/ceph/predicate.go
+++ b/pkg/operator/ceph/predicate.go
@@ -20,6 +20,7 @@ package operator
 import (
 	"context"
 
+	api "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,11 +48,32 @@ func predicateController(ctx context.Context, client client.Client) predicate.Fu
 							// No need to ask for reconciliation since the context is going to be terminated when
 							// the signal is caught and the reconcile will run when the controller
 							// starts.
-							logger.Debug("webhook secret created reloading the manager to enable the webhook server")
+							logger.Info("webhook secret created reloading the manager to enable the webhook server")
 							controller.ReloadManager()
 						}
 					} else {
-						logger.Debug("webhook service already set up, not reloading the manager")
+						logger.Info("webhook service already set up, not reloading the manager")
+					}
+
+					return false
+				}
+			} else if s, ok := e.Object.(*api.Certificate); ok {
+				if s.Name == certificateName {
+					err := client.Get(ctx, types.NamespacedName{Name: certificateName, Namespace: e.Object.GetNamespace()}, &api.Certificate{})
+					if err != nil {
+						if kerrors.IsNotFound(err) {
+							// If the service is present we don't need to reload again. If we don't perform
+							// this check it will result in an infinite
+							// reconcile loop. CREATE event is only triggered when the controller is started
+							// no matter what.
+							// No need to ask for reconciliation since the context is going to be terminated when
+							// the signal is caught and the reconcile will run when the controller
+							// starts.
+							logger.Infof("webhook certificate %s created reloading the manager to enable the webhook server", certificateName)
+							controller.ReloadManager()
+						}
+					} else {
+						logger.Info("webhook service already set up, not reloading the manager")
 					}
 
 					return false
@@ -66,7 +88,7 @@ func predicateController(ctx context.Context, client client.Client) predicate.Fu
 				if new, ok := e.ObjectNew.(*v1.ConfigMap); ok {
 					if old.Name == controller.OperatorSettingConfigMapName && new.Name == controller.OperatorSettingConfigMapName {
 						if old.Data["ROOK_CURRENT_NAMESPACE_ONLY"] != new.Data["ROOK_CURRENT_NAMESPACE_ONLY"] {
-							logger.Debug("ROOK_CURRENT_NAMESPACE_ONLY config updated, reloading the manager")
+							logger.Info("ROOK_CURRENT_NAMESPACE_ONLY config updated, reloading the manager")
 							controller.ReloadManager()
 
 							// No need to ask for reconciliation since the context is going to be terminated when
@@ -77,17 +99,28 @@ func predicateController(ctx context.Context, client client.Client) predicate.Fu
 						// We still want to reconcile the operator manager if the configmap is updated
 						return true
 					}
-				} else if s, ok := e.ObjectNew.(*v1.Secret); ok {
-					if s.Name == admissionControllerAppName {
-						logger.Debug("webhook secret updated, reloading the manager")
+				}
+			} else if s, ok := e.ObjectNew.(*v1.Secret); ok {
+				if s.Name == admissionControllerAppName {
+					logger.Info("webhook secret updated, reloading the manager")
+					controller.ReloadManager()
+
+					// No need to ask for reconciliation since the context is going to be terminated when
+					// the signal is caught and the reconcile will run when the controller starts.
+					// If the admission controller secret is created or deleted we still need to reload and
+					// the webhook might be enabled or disabled
+					//
+					// The same goes the update, the secret changes we still need to reload the webhook
+					return false
+				}
+			} else if old, ok := e.ObjectOld.(*api.Certificate); ok {
+				if new, ok := e.ObjectNew.(*api.Certificate); ok {
+					if old.Name == certificateName && new.Name == certificateName {
+						logger.Infof("webhook certificate %s updated reloading the manager to enable the webhook server", certificateName)
 						controller.ReloadManager()
 
 						// No need to ask for reconciliation since the context is going to be terminated when
 						// the signal is caught and the reconcile will run when the controller starts.
-						// If the admission controller secret is created or deleted we still need to reload and
-						// the webhook might be enabled or disabled
-						//
-						// The same goes the update, the secret changes we still need to reload the webhook
 						return false
 					}
 				}
@@ -99,13 +132,13 @@ func predicateController(ctx context.Context, client client.Client) predicate.Fu
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			if cm, ok := e.Object.(*v1.ConfigMap); ok {
 				if cm.Name == controller.OperatorSettingConfigMapName {
-					logger.Debug("operator configmap deleted, not reconciling")
+					logger.Info("operator configmap deleted, not reconciling")
 					return false
 				}
 			}
 			if s, ok := e.Object.(*v1.Secret); ok {
 				if s.Name == admissionControllerAppName {
-					logger.Debug("webhook secret deleted, reloading the manager")
+					logger.Info("webhook secret deleted, reloading the manager")
 					controller.ReloadManager()
 
 					// No need to ask for reconciliation since the context is going to be terminated when
@@ -116,6 +149,21 @@ func predicateController(ctx context.Context, client client.Client) predicate.Fu
 					// The same goes the update, the secret changes we still need to reload the webhook
 					return false
 				}
+			} else if s, ok := e.Object.(*api.Certificate); ok {
+				if s.Name == certificateName {
+					// If the service is present we don't need to reload again. If we don't perform
+					// this check it will result in an infinite
+					// reconcile loop. CREATE event is only triggered when the controller is started
+					// no matter what.
+					// No need to ask for reconciliation since the context is going to be terminated when
+					// the signal is caught and the reconcile will run when the controller
+					// starts.
+					logger.Infof("webhook certificate %s deleted reloading the manager to enable the webhook server", certificateName)
+					controller.ReloadManager()
+
+					return false
+				}
+				return false
 			}
 
 			return false


### PR DESCRIPTION
when webhook certificates are renewed by cert-manager automatically. But the operator doesn't have the right watch to reconcile and get the latest cert. So, adding watcher for the webhook certs.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #10719

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
