### PR TITLE
docs: updated syntax in markdown files

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -150,7 +150,8 @@ Authoring a design document for big features has many advantages:
 * Gets agreement amongst the community before code is written that could be wasted effort in the wrong direction
 * Serves as an artifact of the architecture that is easier to read for visitors to the project than just the code by itself
 
-Note that writing code to prototype the feature while working on the design may be very useful to help flesh out the approach.
+!!! Note
+    Writing code to prototype the feature while working on the design may be very useful to help flesh out the approach.
 
 A design document should be written as a markdown file in the [design folder](https://github.com/rook/rook/tree/master/design).
 You can follow the process outlined in the [design template](https://github.com/rook/rook/tree/master/design/design_template.md).
@@ -287,7 +288,8 @@ Signed-off-by: First Name Last Name <email address>
 
 The `component` **MUST** be in the [list checked by the CI](https://github.com/rook/rook/blob/master/.commitlintrc.json).
 
-Note: sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text.
+!!! Note
+    Sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text.
 In that case, it is acceptable to shorten the commit message.
 Also, you don't always need to close an issue, again for a very small fix.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,8 @@ On every commit to PR and master the CI will build, run unit tests, and run inte
 If the build is for master or a release, the build will also be published to
 [dockerhub.com](https://cloud.docker.com/u/rook/repository/list).
 
-> Note that if the pull request title follows Rook's [contribution guidelines](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure), the CI will automatically run the appropriate test scenario. For example if a pull request title is "ceph: add a feature", then the tests for the Ceph storage provider will run. Similarly, tests will only run for a single provider with the "cassandra:" and "nfs:" prefixes.
+!!! Note
+    If the pull request title follows Rook's [contribution guidelines](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure), the CI will automatically run the appropriate test scenario. For example if a pull request title is "ceph: add a feature", then the tests for the Ceph storage provider will run. Similarly, tests will only run for a single provider with the "cassandra:" and "nfs:" prefixes.
 
 ## Building for other platforms
 

--- a/design/ceph/ceph-config-updates.md
+++ b/design/ceph/ceph-config-updates.md
@@ -135,7 +135,8 @@ spec:
       debug_osd: 10
    # ...
 ```
-**Note on the above:** all values under config are reported to Ceph as strings, but the yaml should
+!!! Note
+    All values under config are reported to Ceph as strings, but the yaml should
 support integer values as well if at all possible
 
 As stated in the example yaml, above, the 'config' section adds or overrides values in the Ceph

--- a/design/ceph/interacting-with-rook-resources.md
+++ b/design/ceph/interacting-with-rook-resources.md
@@ -38,6 +38,7 @@ Another example on CephFilesystem with ID=a:
 	app.kubernetes.io/managed-by : "rook-ceph-operator"
 	app.kubernetes.io/created-by : "rook-ceph-operator"
 	rook.io/operator-namespace   : "rook-ceph"
-``` 
+```
 
-**NOTE** : A totally unique string for an application can be built up from (a) app.kubernetes.io/component, (b) app.kubernetes.io/part-of, (c) the resource's namespace, (d) app.kubernetes.io/name, and (e) app.kubernetes.io/instance fields. For the example above, we could join those fields with underscore connectors like this: cephclusters.ceph.rook.io_rook-ceph_rook-ceph_ceph-mon_a. Note that this full spec can easily exceed the 64-character limit imposed on Kubernetes labels.
+!!! Note
+    A totally unique string for an application can be built up from (a) app.kubernetes.io/component, (b) app.kubernetes.io/part-of, (c) the resource's namespace, (d) app.kubernetes.io/name, and (e) app.kubernetes.io/instance fields. For the example above, we could join those fields with underscore connectors like this: cephclusters.ceph.rook.io_rook-ceph_rook-ceph_ceph-mon_a. Note that this full spec can easily exceed the 64-character limit imposed on Kubernetes labels.


### PR DESCRIPTION
The `Note` label is updated in several places in the docs for improved rendering.
Multiple markdown files have been updated.
Closes: https://github.com/rook/rook/issues/10458

Signed-off-by: Yashasvi Chaurasia <yashasvi12977@gmail.com>