### PR TITLE
build: move to Go 1.19 as default version for building services

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.18", "1.19"]
+        go-version: ["1.19"]
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1427,7 +1427,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: setup minikube
         uses: manusa/actions-setup-minikube@v2.7.0

--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -11,7 +11,7 @@ runs:
     - name: setup golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.7.0

--- a/.github/workflows/crds-gen.yml
+++ b/.github/workflows/crds-gen.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: setup minikube
         run: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: setup golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.7.0

--- a/.github/workflows/mod-check.yml
+++ b/.github/workflows/mod-check.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: run mod check
         run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check

--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
         # docker/setup-qemu action installs QEMU static binaries, which are used to run builders for architectures other than the host.
       - name: set up QEMU

--- a/.github/workflows/rbac-gen.yaml
+++ b/.github/workflows/rbac-gen.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: run unit tests
         run: GOPATH=$(go env GOPATH) make -j $(nproc) test

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -7,7 +7,7 @@ don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev 
 
 ## Prerequisites
 
-1. [GO 1.18](https://golang.org/dl/) or greater installed
+1. [GO 1.19](https://golang.org/dl/) or greater installed
 2. Git client installed
 3. GitHub account
 
@@ -44,26 +44,27 @@ make build
 If you want to use `podman` instead of `docker` then uninstall `docker` packages from your machine, make will automatically pick up `podman`.
 
 !!! tip
-    If you are in linux environment and `make build` command throws an error like `unknown revision` for some imports, try adding `export GOPROXY=https://proxy.golang.org,direct` to `~/.bashrc` and then run `source ~/.bashrc` or to a similar file to update your environment and confirm with `go env` that `GOPROXY` is updated.
+If you are in linux environment and `make build` command throws an error like `unknown revision` for some imports, try adding `export GOPROXY=https://proxy.golang.org,direct` to `~/.bashrc` and then run `source ~/.bashrc` or to a similar file to update your environment and confirm with `go env` that `GOPROXY` is updated.
+
 ### Development Settings
 
 To provide consistent whitespace and other formatting in your `go` and other source files (e.g., Markdown), it is recommended you apply
 the following settings in your IDE:
 
-* Format with the `goreturns` tool
-* Trim trailing whitespace
-* Markdown Table of Contents is correctly updated automatically
+- Format with the `goreturns` tool
+- Trim trailing whitespace
+- Markdown Table of Contents is correctly updated automatically
 
 #### VS Code
 
 !!! tip
-    VS Code should prompt you automatically with some recommended extensions to install.
-    E.g., Markdown All in One, Go and YAML validator.
+VS Code should prompt you automatically with some recommended extensions to install.
+E.g., Markdown All in One, Go and YAML validator.
 
 A set of recommended settings when working on Rook, can be found [here](https://github.com/rook/rook/blob/master/.vscode/settings.json).
 
 !!! tip
-    VS Code should automatically use these settings through the `.vscode/settings.json` file.
+VS Code should automatically use these settings through the `.vscode/settings.json` file.
 
 ### Add Upstream Remote
 
@@ -140,15 +141,15 @@ To add a feature or to make a bug fix, you will need to create a branch in your 
 For new features of significant scope and complexity, a design document is recommended before work begins on the implementation.
 So create a design document if:
 
-* Adding a new CRD
-* Adding a significant feature to an existing storage provider. If the design is simple enough to describe in a github issue, you likely don't need a full design doc.
+- Adding a new CRD
+- Adding a significant feature to an existing storage provider. If the design is simple enough to describe in a github issue, you likely don't need a full design doc.
 
 For smaller, straightforward features and bug fixes, there is no need for a design document.
 Authoring a design document for big features has many advantages:
 
-* Helps flesh out the approach by forcing the author to think critically about the feature and can identify potential issues early on
-* Gets agreement amongst the community before code is written that could be wasted effort in the wrong direction
-* Serves as an artifact of the architecture that is easier to read for visitors to the project than just the code by itself
+- Helps flesh out the approach by forcing the author to think critically about the feature and can identify potential issues early on
+- Gets agreement amongst the community before code is written that could be wasted effort in the wrong direction
+- Serves as an artifact of the architecture that is easier to read for visitors to the project than just the code by itself
 
 Note that writing code to prototype the feature while working on the design may be very useful to help flesh out the approach.
 
@@ -189,11 +190,11 @@ git rebase upstream/master
 
 Rebasing is a very powerful feature of Git. You need to understand how it works or else you will risk losing your work. Read about it in the [Git documentation](https://git-scm.com/docs/git-rebase), it will be well worth it. In a nutshell, rebasing does the following:
 
-* "Unwinds" your local commits. Your local commits are removed temporarily from the history.
-* The latest changes from upstream are added to the history
-* Your local commits are re-applied one by one
-* If there are merge conflicts, you will be prompted to fix them before continuing. Read the output closely. It will tell you how to complete the rebase.
-* When done rebasing, you will see all of your commits in the history.
+- "Unwinds" your local commits. Your local commits are removed temporarily from the history.
+- The latest changes from upstream are added to the history
+- Your local commits are re-applied one by one
+- If there are merge conflicts, you will be prompted to fix them before continuing. Read the output closely. It will tell you how to complete the rebase.
+- When done rebasing, you will see all of your commits in the history.
 
 ## Submitting a Pull Request
 
@@ -242,16 +243,16 @@ can more easily verify that the units are combined together correctly.
 
 Common cases that may need tests:
 
-* the feature is enabled
-* the feature is disabled
-* the feature is only partially enabled, for every possible way it can be partially enabled
-* every error that can be encountered during execution of the feature
-* the feature can be disabled (including partially) after it was enabled
-* the feature can be modified (including partially) after it was enabled
-* if there is a slice/array involved, test length = 0, length = 1, length = 3, length == max, length > max
-* an input is not specified, for each input
-* an input is specified incorrectly, for each input
-* a resource the code relies on doesn't exist, for each dependency
+- the feature is enabled
+- the feature is disabled
+- the feature is only partially enabled, for every possible way it can be partially enabled
+- every error that can be encountered during execution of the feature
+- the feature can be disabled (including partially) after it was enabled
+- the feature can be modified (including partially) after it was enabled
+- if there is a slice/array involved, test length = 0, length = 1, length = 3, length == max, length > max
+- an input is not specified, for each input
+- an input is specified incorrectly, for each input
+- a resource the code relies on doesn't exist, for each dependency
 
 #### Running the Integration Tests
 
@@ -265,13 +266,13 @@ so, follow the [test instructions](https://github.com/rook/rook/blob/master/test
 
 Rook maintainers value clear, lengthy and explanatory commit messages. So by default each of your commits must:
 
-* be prefixed by the component it's affecting, if Ceph, then the title of the commit message should be `ceph: my commit title`. If not the commit-lint bot will complain.
-* contain a commit message which explains the original issue and how it was fixed if a bug.
-If a feature it is a full description of the new functionality.
-* refer to the issue it's closing, this is mandatory when fixing a bug
-* have a sign-off, this is achieved by adding `-s` when committing so in practice run `git commit -s`. If not the DCO bot will complain.
-If you forgot to add the sign-off you can also amend a previous commit with the sign-off by running `git commit --amend -s`.
-If you've pushed your changes to GitHub already you'll need to force push your branch with `git push -f`.
+- be prefixed by the component it's affecting, if Ceph, then the title of the commit message should be `ceph: my commit title`. If not the commit-lint bot will complain.
+- contain a commit message which explains the original issue and how it was fixed if a bug.
+  If a feature it is a full description of the new functionality.
+- refer to the issue it's closing, this is mandatory when fixing a bug
+- have a sign-off, this is achieved by adding `-s` when committing so in practice run `git commit -s`. If not the DCO bot will complain.
+  If you forgot to add the sign-off you can also amend a previous commit with the sign-off by running `git commit --amend -s`.
+  If you've pushed your changes to GitHub already you'll need to force push your branch with `git push -f`.
 
 Here is an example of an acceptable commit message:
 

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -48,7 +48,7 @@ GO_TEST_FLAGS ?=
 # ====================================================================================
 # Setup go environment
 
-GO_SUPPORTED_VERSIONS ?= 1.18|1.19
+GO_SUPPORTED_VERSIONS ?= 1.19
 
 GO_PACKAGES := $(foreach t,$(GO_SUBDIRS),$(GO_PROJECT)/$(t)/...)
 GO_INTEGRATION_TEST_PACKAGES := $(foreach t,$(GO_INTEGRATION_TESTS_SUBDIRS),$(GO_PROJECT)/$(t)/integration)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook
 
-go 1.18
+go 1.19
 
 require (
 	github.com/IBM/keyprotect-go-client v0.8.0


### PR DESCRIPTION
**Description of your changes:**

Go 1.18.5 and other Go 1.18 version patches provided many vulnerability fixes
but as go.mod doesn't support minor version i.e why moving to next go release

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>


**Which issue is resolved by this Pull Request:**
Resolves #11176 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.