### PR TITLE
core: Retry when removing finalizers from cluster resources

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -478,26 +478,28 @@ func (c *ClusterController) checkPVPresentInCluster(drivers []string, clusterID 
 	return false, nil
 }
 
-func (r *ReconcileCephCluster) removeFinalizers(client client.Client, name types.NamespacedName) error {
-	// Remove cephcluster finalizer
-	err := r.removeFinalizer(client, name, &cephv1.CephCluster{}, "")
-	if err != nil {
-		return errors.Wrap(err, "failed to remove cephcluster finalizer")
-	}
+func (r *ReconcileCephCluster) removeFinalizers(client client.Client, clusterName types.NamespacedName) error {
 
 	// Remove finalizer for rook-ceph-mon secret
-	name = types.NamespacedName{Name: mon.AppName, Namespace: name.Namespace}
-	err = r.removeFinalizer(client, name, &corev1.Secret{}, mon.DisasterProtectionFinalizerName)
+	name := types.NamespacedName{Name: mon.AppName, Namespace: clusterName.Namespace}
+	err := r.removeFinalizer(client, name, &corev1.Secret{}, mon.DisasterProtectionFinalizerName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to remove finalizer for the secret %q", name.Name)
 	}
 
 	// Remove finalizer for rook-ceph-mon-endpoints configmap
-	name = types.NamespacedName{Name: mon.EndpointConfigMapName, Namespace: name.Namespace}
+	name = types.NamespacedName{Name: mon.EndpointConfigMapName, Namespace: clusterName.Namespace}
 	err = r.removeFinalizer(client, name, &corev1.ConfigMap{}, mon.DisasterProtectionFinalizerName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to remove finalizer for the configmap %q", name.Name)
 	}
+
+	// Remove cephcluster finalizer
+	err = r.removeFinalizer(client, clusterName, &cephv1.CephCluster{}, "")
+	if err != nil {
+		return errors.Wrap(err, "failed to remove cephcluster finalizer")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Removing the finalizers from cluster resources can intermittently fail in the CI if other updates are made at similar times. Now we retry the finalizer removal to improve the reliability of the finalizer removal.

The finalizer removal error was seen in the daily CI, but then the removal never retried so the test timed out waiting.
```
2022-10-18 00:49:14.337813 E | ceph-cluster-controller: failed to reconcile CephCluster "object-ns/object-cluster". 
failed to remove finalizers: failed to remove finalizer for the secret "rook-ceph-mon": failed to remove finalizer "ceph.rook.io/disaster-protection": 
failed to remove finalizer "ceph.rook.io/disaster-protection" on "rook-ceph-mon": 
Operation cannot be fulfilled on secrets "rook-ceph-mon": the object has been modified; please apply your changes to the latest version and try again
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
