### PR TITLE
Add DeviceSet hint to reconcile error message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
+<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest-release/Contributing/development-flow/)
 documentation before submitting a Pull Request!
 Thank you for contributing to Rook! -->
 

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -178,7 +178,7 @@ func (c *updateConfig) updateExistingOSDs(errs *provisionErrors) {
 			updateConditionFunc(c.cluster.clusterInfo.Context, c.cluster.context, c.cluster.clusterInfo.NamespacedName(), k8sutil.ObservedGenerationNotAvailable, cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, message)
 		}
 		if err != nil {
-			errs.addError("%v", errors.Wrapf(err, "failed to update OSD %d", osdID))
+			errs.addError("%v", errors.Wrapf(err, "failed to update OSD %d - DeviceSets may have changed", osdID))
 			continue
 		}
 


### PR DESCRIPTION
**Description of your changes:**

Add a tiny amount of verbiage to an error that arises during reconciliation.

The existing error mentions not being able to configure OSDs,
which was confusing to me, since the OSDs and the named PVCs all existed.
The issue was that our DeviceSets had recently changed, and mentioning that possibility
(which appears to be the only cause of the issue)
would have helped guide me to a resolution faster,
which I hope this change will for future encounters.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
