### PR TITLE
operator: Remove obsolete flex driver properties

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -77,8 +77,6 @@ spec:
 {{- end }}
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "{{ .Values.hostpathRequiresPrivileged }}"
-        - name: ROOK_ENABLE_SELINUX_RELABELING
-          value: "{{ .Values.enableSelinuxRelabeling }}"
         - name: ROOK_DISABLE_DEVICE_HOTPLUG
           value: "{{ .Values.disableDeviceHotplug }}"
         - name: ROOK_ENABLE_DISCOVERY_DAEMON

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -450,11 +450,6 @@ cephCommandsTimeoutSeconds: "15"
 #   nodeAffinity: key1=value1,value2; key2=value3
 #   podLabels: "key1=value1,key2=value2"
 
-# In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
-# Disable it here if you have similar issues.
-# For more details see https://github.com/rook/rook/issues/2417
-enableSelinuxRelabeling: true
-
 disableAdmissionController: false
 
 # Writing to the hostPath is required for the Ceph mon and osd pods. Given the restricted permissions in OpenShift with SELinux,

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -637,15 +637,6 @@ spec:
             # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641
             - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
               value: "true"
-            # In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
-            # Disable it here if you have similar issues.
-            # For more details see https://github.com/rook/rook/issues/2417
-            - name: ROOK_ENABLE_SELINUX_RELABELING
-              value: "true"
-            # In large volumes it will take some time to chown all the files. Disable it here if you have performance issues.
-            # For more details see https://github.com/rook/rook/issues/2254
-            - name: ROOK_ENABLE_FSGROUP
-              value: "true"
             # Disable automatic orchestration when new devices are discovered
             - name: ROOK_DISABLE_DEVICE_HOTPLUG
               value: "false"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -577,17 +577,6 @@ spec:
             - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
               value: "false"
 
-            # In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
-            # Disable it here if you have similar issues.
-            # For more details see https://github.com/rook/rook/issues/2417
-            - name: ROOK_ENABLE_SELINUX_RELABELING
-              value: "true"
-
-            # In large volumes it will take some time to chown all the files. Disable it here if you have performance issues.
-            # For more details see https://github.com/rook/rook/issues/2254
-            - name: ROOK_ENABLE_FSGROUP
-              value: "true"
-
             # Disable automatic orchestration when new devices are discovered
             - name: ROOK_DISABLE_DEVICE_HOTPLUG
               value: "false"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The flex driver was deprecated and fully purged long ago, and now finally we are purging the related properties from the operator deployment that are no longer applied anywhere.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
