### PR TITLE
mon: The mon daemons maintain host network settings to allow change in config

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -186,6 +186,12 @@ Configure the network that will be enabled for the cluster and services.
 
 To use host networking, set `provider: host`.
 
+If the host networking setting is changed in a cluster where mons are already running, the existing mons will
+remain running with the same network settings with which they were created. To complete the conversion
+to or from host networking after you update this setting, you will need to
+[failover the mons](../../Storage-Configuration/Advanced/ceph-mon-health.md#failing-over-a-monitor)
+in order to have mons on the desired network configuration.
+
 #### Multus
 
 Rook supports addition of public and cluster network for ceph using Multus

--- a/pkg/apis/ceph.rook.io/v1/cluster.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"reflect"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,11 +72,10 @@ func validateUpdatedCephCluster(updatedCephCluster *CephCluster, found *CephClus
 		return errors.Errorf("invalid update: DataDirHostPath change from %q to %q is not allowed", found.Spec.DataDirHostPath, updatedCephCluster.Spec.DataDirHostPath)
 	}
 
-	if updatedCephCluster.Spec.Network.HostNetwork != found.Spec.Network.HostNetwork {
-		return errors.Errorf("invalid update: HostNetwork change from %q to %q is not allowed", strconv.FormatBool(found.Spec.Network.HostNetwork), strconv.FormatBool(updatedCephCluster.Spec.Network.HostNetwork))
-	}
-
-	if updatedCephCluster.Spec.Network.Provider != found.Spec.Network.Provider {
+	// Allow an attempt to enable or disable host networking, but not other provider changes
+	oldProvider := updatedCephCluster.Spec.Network.Provider
+	newProvider := found.Spec.Network.Provider
+	if oldProvider != newProvider && oldProvider != "host" && newProvider != "host" {
 		return errors.Errorf("invalid update: Provider change from %q to %q is not allowed", found.Spec.Network.Provider, updatedCephCluster.Spec.Network.Provider)
 	}
 

--- a/pkg/apis/ceph.rook.io/v1/cluster_test.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster_test.go
@@ -38,7 +38,7 @@ func Test_validateUpdatedCephCluster(t *testing.T) {
 		{"even mon count", args{&CephCluster{Spec: ClusterSpec{Mon: MonSpec{Count: 2}}}, &CephCluster{}}, false},
 		{"good mon count", args{&CephCluster{Spec: ClusterSpec{Mon: MonSpec{Count: 3}}}, &CephCluster{}}, false},
 		{"changed DataDirHostPath", args{&CephCluster{Spec: ClusterSpec{DataDirHostPath: "foo"}}, &CephCluster{Spec: ClusterSpec{DataDirHostPath: "bar"}}}, true},
-		{"changed HostNetwork", args{&CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: false}}}, &CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: true}}}}, true},
+		{"changed network provider", args{&CephCluster{Spec: ClusterSpec{Network: NetworkSpec{Provider: "foo"}}}, &CephCluster{Spec: ClusterSpec{Network: NetworkSpec{Provider: "bar"}}}}, true},
 		{"changed storageClassDeviceSet encryption", args{&CephCluster{Spec: ClusterSpec{Storage: StorageScopeSpec{StorageClassDeviceSets: []StorageClassDeviceSet{{Name: "foo", Encrypted: false}}}}}, &CephCluster{Spec: ClusterSpec{Storage: StorageScopeSpec{StorageClassDeviceSets: []StorageClassDeviceSet{{Name: "foo", Encrypted: true}}}}}}, true},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -589,6 +589,7 @@ func (c *Cluster) failoverMon(name string) error {
 			return errors.Errorf("mon %s doesn't exist in assignment map", m.DaemonName)
 		}
 		m.PublicIP = schedule.Address
+		m.UseHostNetwork = true
 	} else {
 		// Create the service endpoint
 		serviceIP, err := c.createService(m)

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -173,11 +173,12 @@ func TestHostNetwork(t *testing.T) {
 	c.spec.Network.HostNetwork = true
 
 	monConfig := testGenMonConfig("c")
+	monConfig.UseHostNetwork = true
 	pod, err := c.makeMonPod(monConfig, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, pod)
-	assert.Equal(t, true, pod.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
+	assert.Equal(t, true, pod.Spec.HostNetwork)
 	val, message := extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3", val, message)
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
@@ -190,6 +191,14 @@ func TestHostNetwork(t *testing.T) {
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3:6790", val, message)
 	assert.NotNil(t, pod)
+
+	// Host network setting of mons should be maintained even if the cluster spec hostnetwork is different
+	// from the mons to not be using host networking
+	monConfig.UseHostNetwork = false
+	pod, err = c.makeMonPod(monConfig, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod)
+	assert.Equal(t, false, pod.Spec.HostNetwork)
 }
 
 func extractArgValue(args []string, name string) (string, string) {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -182,7 +182,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*corev1.Pod, er
 		// we decide later whether to use a PVC volume or host volumes for mons, so only populate
 		// the base volumes at this point.
 		Volumes:           controller.DaemonVolumesBase(monConfig.DataPathMap, keyringStoreName),
-		HostNetwork:       c.spec.Network.IsHost(),
+		HostNetwork:       monConfig.UseHostNetwork,
 		PriorityClassName: cephv1.GetMonPriorityClassName(c.spec.PriorityClassNames),
 	}
 
@@ -209,7 +209,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*corev1.Pod, er
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&pod.ObjectMeta)
 	cephv1.GetMonLabels(c.spec.Labels).ApplyToObjectMeta(&pod.ObjectMeta)
 
-	if c.spec.Network.IsHost() {
+	if monConfig.UseHostNetwork {
 		pod.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	} else if c.spec.Network.IsMultus() {
 		if err := k8sutil.ApplyMultus(c.spec.Network, &pod.ObjectMeta); err != nil {
@@ -274,7 +274,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 
 	// Handle the non-default port for host networking. If host networking is not being used,
 	// the service created elsewhere will handle the non-default port redirection to the default port inside the container.
-	if c.spec.Network.IsHost() && monConfig.Port != DefaultMsgr1Port {
+	if monConfig.UseHostNetwork && monConfig.Port != DefaultMsgr1Port {
 		logger.Warningf("Starting mon %s with host networking on a non-default port %d. The mon must be failed over before enabling msgr2.",
 			monConfig.DaemonName, monConfig.Port)
 		publicAddr = fmt.Sprintf("%s:%d", publicAddr, monConfig.Port)
@@ -342,7 +342,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 	container = config.ConfigureLivenessProbe(container, c.spec.HealthCheck.LivenessProbe[cephv1.KeyMon])
 
 	// If host networking is enabled, we don't need a bind addr that is different from the public addr
-	if !c.spec.Network.IsHost() {
+	if !monConfig.UseHostNetwork {
 		// Opposite of the above, --public-bind-addr will *not* still advertise on the previous
 		// port, which makes sense because this is the pod IP, which changes with every new pod.
 		container.Args = append(container.Args,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the host network setting is changed in the cluster CR, the existing mons must continue using the same network settings or else the operator would update their pod specs with the incorrect settings and cause mon quorum to go down. Now the network setting is preserved so the admin could switch between host and non-host network configuration without reinstalling.

**Which issue is resolved by this Pull Request:**
Resolves #11121 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
