### PR TITLE
osd: Reduce duplication of arguments

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -367,42 +367,28 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			args = []string{
 				"ceph", "osd", "start",
 				"--",
-				"--foreground",
-				"--id", osdID,
-				"--fsid", c.clusterInfo.FSID,
-				"--cluster", "ceph",
-				"--setuser", "ceph",
-				"--setgroup", "ceph",
-				fmt.Sprintf("--crush-location=%s", osd.Location),
 			}
 			osd.LVBackedPV = true
 		} else {
-			// raw mode
+			// raw mode on pvc
 			doBinaryCopyInit = false
 			doConfigInit = false
 			command = []string{"ceph-osd"}
-			args = []string{
-				"--foreground",
-				"--id", osdID,
-				"--fsid", c.clusterInfo.FSID,
-				"--setuser", "ceph",
-				"--setgroup", "ceph",
-				fmt.Sprintf("--crush-location=%s", osd.Location),
-			}
 		}
 	} else {
+		// non-pvc
 		doBinaryCopyInit = false
 		doConfigInit = false
 		command = []string{"ceph-osd"}
-		args = []string{
-			"--foreground",
-			"--id", osdID,
-			"--fsid", c.clusterInfo.FSID,
-			"--setuser", "ceph",
-			"--setgroup", "ceph",
-			fmt.Sprintf("--crush-location=%s", osd.Location),
-		}
 	}
+	args = append(args, []string{
+		"--foreground",
+		"--id", osdID,
+		"--fsid", c.clusterInfo.FSID,
+		"--setuser", "ceph",
+		"--setgroup", "ceph",
+		fmt.Sprintf("--crush-location=%s", osd.Location),
+	}...)
 
 	// Ceph expects initial weight as float value in tera-bytes units
 	if osdProps.storeConfig.InitialWeight != "" {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The osd arguments had a few duplicate lines that could be factored out and thus simplified for code maintainability. Just a small change I stumbled on while investigating another osd issue.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
