### PR TITLE
mon: Apply mon store settings more efficiently with the assimilate conf

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -615,7 +615,7 @@ func (c *cluster) configureMsgr2() error {
 		}
 
 		logger.Infof("setting msgr2 encryption mode to %q", encryptionSetting)
-		if err := monStore.AddSettingsToMonDB("global", globalConfigSettings); err != nil {
+		if err := monStore.SetAll("global", globalConfigSettings); err != nil {
 			return err
 		}
 	}
@@ -631,7 +631,7 @@ func (c *cluster) configureMsgr2() error {
 				"ms_osd_compress_mode": compressionSetting,
 			}
 			logger.Infof("setting msgr2 compression mode to %q", compressionSetting)
-			if err := monStore.AddSettingsToMonDB("global", globalConfigSettings); err != nil {
+			if err := monStore.SetAll("global", globalConfigSettings); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -20,8 +20,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path"
 	"strconv"
@@ -29,9 +27,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
-	"gopkg.in/ini.v1"
 
-	"github.com/rook/rook/cmd/rook/rook"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -46,7 +42,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	pkgexec "github.com/rook/rook/pkg/util/exec"
 	rookversion "github.com/rook/rook/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -600,74 +595,13 @@ func (c *cluster) reportTelemetry() {
 	telemetry.ReportKeyValue(c.context, c.ClusterInfo, telemetry.ExternalModeEnabledKey, strconv.FormatBool(c.Spec.External.Enable))
 }
 
-func (c *cluster) addSettingsToMonDB(clientName string, settings map[string]string) error {
-
-	assimilateConfPath, err := ioutil.TempFile("", "")
-	if err != nil {
-		return errors.Wrapf(err, "failed to create assimilateConf temp dir for  %s.", clientName)
-	}
-
-	err = ioutil.WriteFile(assimilateConfPath.Name(), []byte(""), 0600)
-	if err != nil {
-		rook.TerminateFatal(errors.Wrapf(err, "failed to write config file"))
-	}
-
-	defer func() {
-		err := os.Remove(assimilateConfPath.Name())
-		if err != nil {
-			logger.Errorf("failed to remove file %q. %v", assimilateConfPath.Name(), err)
-		}
-	}()
-
-	configFile := ini.Empty()
-	s, err := configFile.NewSection(clientName)
-	if err != nil {
-		return err
-	}
-
-	for key, val := range settings {
-		if _, err := s.NewKey(key, val); err != nil {
-			return errors.Wrapf(err, "failed to add key %s", key)
-		}
-	}
-
-	if err := configFile.SaveTo(assimilateConfPath.Name()); err != nil {
-		return errors.Wrapf(err, "failed to save config file %s", assimilateConfPath.Name())
-	}
-
-	fileContent, err := ioutil.ReadFile(assimilateConfPath.Name())
-	if err != nil {
-		logger.Errorf("failed to open assimilate input file %s. %c", assimilateConfPath.Name(), err)
-	}
-	logger.Infof("applying ceph settings:\n%s", string(fileContent))
-
-	args := []string{"config", "assimilate-conf", "-i", assimilateConfPath.Name(), "-o", assimilateConfPath.Name() + ".out"}
-	cephCmd := client.NewCephCommand(c.context, c.ClusterInfo, args)
-
-	out, err := cephCmd.RunWithTimeout(pkgexec.CephCommandsTimeout)
-	if err != nil {
-		logger.Errorf("failed to run command ceph %s", args)
-
-		fileContent, err := ioutil.ReadFile(assimilateConfPath.Name() + ".out")
-		if err != nil {
-			logger.Errorf("failed to open assimilate output file %s.out. %v", assimilateConfPath.Name(), err)
-		}
-		logger.Infof("failed to apply ceph settings:\n%s", string(fileContent))
-
-		return errors.Wrapf(err, "failed to set ceph config in the centralized mon configuration database; "+
-			"output: %s", string(out))
-	}
-
-	logger.Info("successfully applied settings to the mon configuration database")
-	return nil
-}
-
 func (c *cluster) configureMsgr2() error {
 	if c.Spec.Network.Connections == nil {
 		return nil
 	}
 
 	// Set network encryption
+	monStore := config.GetMonStore(c.context, c.ClusterInfo)
 	if c.Spec.Network.Connections.Encryption != nil {
 		encryptionSetting := "crc secure"
 		if c.Spec.Network.Connections.Encryption.Enabled {
@@ -681,7 +615,7 @@ func (c *cluster) configureMsgr2() error {
 		}
 
 		logger.Infof("setting msgr2 encryption mode to %q", encryptionSetting)
-		if err := c.addSettingsToMonDB("global", globalConfigSettings); err != nil {
+		if err := monStore.AddSettingsToMonDB("global", globalConfigSettings); err != nil {
 			return err
 		}
 	}
@@ -697,7 +631,7 @@ func (c *cluster) configureMsgr2() error {
 				"ms_osd_compress_mode": compressionSetting,
 			}
 			logger.Infof("setting msgr2 compression mode to %q", compressionSetting)
-			if err := c.addSettingsToMonDB("global", globalConfigSettings); err != nil {
+			if err := monStore.AddSettingsToMonDB("global", globalConfigSettings); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -114,27 +114,25 @@ func SetOrRemoveDefaultConfigs(
 	// or they are specified on the commandline when daemons are called.
 	monStore := GetMonStore(context, clusterInfo)
 
-	if err := monStore.SetAll(DefaultCentralizedConfigs(clusterInfo.CephVersion)...); err != nil {
+	if err := monStore.SetAll("global", DefaultCentralizedConfigs(clusterInfo.CephVersion)); err != nil {
 		return errors.Wrapf(err, "failed to apply default Ceph configurations")
 	}
 
 	// When enabled the collector will logrotate logs from files
 	if clusterSpec.LogCollector.Enabled {
 		// Override "log file" for existing clusters since it is empty
-		logOptions := []Option{
-			configOverride("global", "log to file", "true"),
+		logOptions := map[string]string{
+			"log to file": "true",
 		}
-
-		if err := monStore.SetAll(logOptions...); err != nil {
+		if err := monStore.SetAll("global", logOptions); err != nil {
 			return errors.Wrapf(err, "failed to apply logging configuration for log collector")
 		}
 		// If the log collector is disabled we do not log to file since we collect nothing
 	} else {
-		logOptions := []Option{
-			configOverride("global", "log to file", "false"),
+		logOptions := map[string]string{
+			"log to file": "false",
 		}
-
-		if err := monStore.SetAll(logOptions...); err != nil {
+		if err := monStore.SetAll("global", logOptions); err != nil {
 			return errors.Wrapf(err, "failed to apply logging configuration")
 		}
 	}
@@ -148,7 +146,7 @@ func SetOrRemoveDefaultConfigs(
 		}
 
 		// Apply ceph network settings to the mon config store
-		if err := monStore.SetAll(cephNetworks...); err != nil {
+		if err := monStore.SetAll("global", cephNetworks); err != nil {
 			return errors.Wrap(err, "failed to network config overrides")
 		}
 	}

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -37,11 +37,6 @@ func DefaultFlags(fsid, mountedKeyringPath string) []string {
 	return flags
 }
 
-// makes it possible to be slightly less verbose to create a ConfigOverride here
-func configOverride(who, option, value string) Option {
-	return Option{Who: who, Option: option, Value: value}
-}
-
 func LoggingFlags() []string {
 	return []string{
 		// For containers, we're expected to log everything to stderr
@@ -57,18 +52,16 @@ func LoggingFlags() []string {
 
 // DefaultCentralizedConfigs returns the default configuration options Rook will set in Ceph's
 // centralized config store.
-func DefaultCentralizedConfigs(cephVersion version.CephVersion) []Option {
-	overrides := []Option{
-		configOverride("global", "mon allow pool delete", "true"),
-		configOverride("global", "mon cluster log file", ""),
-		configOverride("global", "mon allow pool size one", "true"),
+func DefaultCentralizedConfigs(cephVersion version.CephVersion) map[string]string {
+	overrides := map[string]string{
+		"mon allow pool delete":   "true",
+		"mon cluster log file":    "",
+		"mon allow pool size one": "true",
 	}
 
 	// Every release before Quincy will enable PG auto repair on Bluestore OSDs
 	if !cephVersion.IsAtLeastQuincy() {
-		overrides = append(overrides, []Option{
-			configOverride("global", "osd scrub auto repair", "true"),
-		}...)
+		overrides["osd scrub auto repair"] = "true"
 	}
 
 	return overrides


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The monstore has a `SetAll()` method for applying multiple settings that was applying them individually. Now we use the assimilate config option to make this more efficient.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
