### PR TITLE
docs: update disaster recovery guide for webhook

### DIFF
--- a/Documentation/Troubleshooting/disaster-recovery.md
+++ b/Documentation/Troubleshooting/disaster-recovery.md
@@ -57,18 +57,10 @@ the CRs to their prior state without even necessarily suffering cluster downtime
     kubectl -n rook-ceph get configmap -o yaml > configmaps.yaml
     ```
 
-3.  Back up and remove the `ValidatingWebhookConfiguration`. This is the resource which connects Rook custom resources to the
-    operator pod's validating webhook. Because the operator is unavailable, we must temporarily disable the valdiating webhook in
-    order to make changes.
-
-    1.  Save the `ValidatingWebhookConfiguration` responsible for controlling Rook resources. (These are not namespaced
-        resources.)
-
-        ```console
-        kubectl get ValidatingWebhookConfiguration rook-ceph-webhook -o yaml > rook-ceph-webhook.yaml
-        ```
-
-    2.  Delete the `ValidatingWebhookConfiguration`.
+3.  (Optional, if webhook is enabled)
+    Delete the `ValidatingWebhookConfiguration`. This is the resource which connects Rook custom resources
+    to the operator pod's validating webhook. Because the operator is unavailable, we must temporarily disable
+    the valdiating webhook in order to make changes.
 
         ```console
         kubectl delete ValidatingWebhookConfiguration rook-ceph-webhook
@@ -144,20 +136,13 @@ the CRs to their prior state without even necessarily suffering cluster downtime
       2.  Remove the finalizer and confirm the CR is deleted (the underlying Ceph resources will be preserved)
       3.  Create the CR again
 
-8.  Restore the `ValidatingWebhookConfiguration`.
-
-    ```console
-    kubectl create -f rook-ceph-webhook.yaml
-    ```
-
-9.  Scale up the operator
+8.  Scale up the operator
 
     ```console
     kubectl -n rook-ceph scale --replicas=1 deploy/rook-ceph-operator
     ```
 
-
-10. Watch the operator log to confirm that the reconcile completes successfully.
+9.  Watch the operator log to confirm that the reconcile completes successfully.
 
     ```console
     kubectl -n rook-ceph logs -f deployment/rook-ceph-operator


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Since we moved to cert-manager for the webhook a long time back, 
we just need to disable the webhook instead of backing the whole webhook. 
And, after crs are restored we need to enable the webhook and all the resources will be created by the operator.


Signed-off-by: subhamkrai <srai@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
