### PR TITLE
fix: bugs following docs for NixOS deployment

### DIFF
--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -116,10 +116,10 @@ They have to be bind-mounted as volumes in the CephFS and RBD plugin pods.
 
 If you install Rook with Helm, uncomment these example settings in `values.yaml`:
 
-- `csiCephFSPluginVolume`
-- `csiCephFSPluginVolumeMount`
-- `csiRBDPluginVolume`
-- `csiRBDPluginVolumeMount`
+- `csi.csiCephFSPluginVolume`
+- `csi.csiCephFSPluginVolumeMount`
+- `csi.csiRBDPluginVolume`
+- `csi.csiRBDPluginVolumeMount`
 
 If you deploy without Helm, add those same values to the corresponding environment variables in the operator pod,
 or the corresponding keys in its `ConfigMap`:

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -213,7 +213,7 @@ data:
   CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiRBDPluginVolumeMount | quote }}
 {{- end }}
 {{- if .Values.csi.csiCephFSPluginVolume }}
-  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiRBDPluginVolumes | quote }}
+  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiCephFSPluginVolume | quote }}
 {{- end }}
 {{- if .Values.csi.csiCephFSPluginVolumeMount }}
   CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiCephFSPluginVolumeMount | quote }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -133,31 +133,31 @@ csi:
   allowUnsupportedVersion: false
 
   # CephCSI RBD plugin Volumes
-  # csiRBDPluginVolumes: |
+  # csiRBDPluginVolume:
   #  - name: lib-modules
   #    hostPath:
-  #      path: /run/current-system/kernel-modules/lib/modules/
+  #      path: /run/booted-system/kernel-modules/lib/modules/
   #  - name: host-nix
   #    hostPath:
   #      path: /nix
 
   # CephCSI RBD plugin Volume mounts
-  # csiRBDPluginVolumeMounts: |
+  # csiRBDPluginVolumeMount:
   #  - name: host-nix
   #    mountPath: /nix
   #    readOnly: true
 
   # CephCSI CephFS plugin Volumes
-  # csiCephFSPluginVolumes: |
+  # csiCephFSPluginVolume:
   #  - name: lib-modules
   #    hostPath:
-  #      path: /run/current-system/kernel-modules/lib/modules/
+  #      path: /run/booted-system/kernel-modules/lib/modules/
   #  - name: host-nix
   #    hostPath:
   #      path: /nix
 
   # CephCSI CephFS plugin Volume mounts
-  # csiCephFSPluginVolumeMounts: |
+  # csiCephFSPluginVolumeMount:
   #  - name: host-nix
   #    mountPath: /nix
   #    readOnly: true


### PR DESCRIPTION
85b079105b62752c10edaf3ccdaf637f9ca39d02 (from https://github.com/rook/rook/issues/10932) introduced some bugs that here I'm fixing.

1. Docs missing `csi.` prefix.
2. Chart was using `cis.csiRBDPluginVolumes` instead of `csi.csiCephFSPluginVolume`.
3. Values had to be a scalar value, not a raw string. Otherwise, the operator can't parse it.
4. Link to `/run/booted-system` instead of `/run/current-system`. In the former, the kernel modules will always match the current kernel; in the latter, it could happen that after a new `nixos-rebuild switch`, plugin containers can't find the kernel modules for the booted kernel version.
5. Values included in the `values.yaml` template were plural. These are not supported, they must all be singular.

About that 3rd point, this was the error being logged:

```
2022-11-04 09:54:47.489851 I | op-k8sutil: CSI_RBD_PLUGIN_VOLUME="|\n - name: lib-modules\n hostPath:\n path: /run/current-system/kernel-modules/lib/modules/\n - name: host-nix\n hostPath:\n path: /nix" (configmap)
2022-11-04 09:54:47.489907 W | ceph-csi: failed to parse "|\n - name: lib-modules\n hostPath:\n path: /run/current-system/kernel-modules/lib/modules/\n - name: host-nix\n hostPath:\n path: /nix" for "CSI_RBD_PLUGIN_VOLUME". json: cannot unmarshal string into Go value of type []v1.Volume
2022-11-04 09:54:47.489916 I | op-k8sutil: CSI_RBD_PLUGIN_VOLUME_MOUNT="|\n - name: host-nix\n mountPath: /nix\n readOnly: true" (configmap)
2022-11-04 09:54:47.489937 W | ceph-csi: failed to parse "|\n - name: host-nix\n mountPath: /nix\n readOnly: true" for "CSI_RBD_PLUGIN_VOLUME_MOUNT". json: cannot unmarshal string into Go value of type []v1.VolumeMount
```

@moduon MT-1503

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
