### PR TITLE
ci: fix docs check issues

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -34,7 +34,9 @@ jobs:
           python-version: 3.9
 
       - name: Install mkdocs and dependencies
-        run: cd build/release/ && make deps.docs
+        run: |
+          sudo apt-get -q install -y python3-pygit2
+          cd build/release/ && make deps.docs
 
       - name: Build documentation using mkdocs
         run: make docs-build


### PR DESCRIPTION
**Description of your changes:**

This fixes the pygit2 pip install for the mkdocs build/ check.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>
(cherry picked from commit 202b83fd8460b7812c1263cf42d7330ac0c7f89b)

We have seen some issues at Koor that the master branch CI started failing because of the git library being missing for some reason.
I have not yet seen this issue occur in Rook but I'm opening this in case we start hitting it (soon).

Let's merge it when we see the issue occuring.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
