### PR TITLE
core: include userID/userKey to secret generated from CephClient

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -257,6 +257,12 @@ func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient
 		},
 		StringData: map[string]string{
 			cephClient.Name: key,
+			// CSI requires userID and userKey for RBD
+			"userID":  cephClient.Name,
+			"userKey": key,
+			// CSI requires adminID and adminKey for CephFS
+			"adminID":  cephClient.Name,
+			"adminKey": key,
 		},
 		Type: k8sutil.RookType,
 	}

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -295,6 +295,10 @@ func TestCephClientController(t *testing.T) {
 	cephClientSecret, err := c.Clientset.CoreV1().Secrets(namespace).Get(ctx, cephClient.Status.Info["secretName"], metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cephClientSecret.StringData)
+	assert.Contains(t, cephClientSecret.StringData, "userID")
+	assert.Contains(t, cephClientSecret.StringData, "userKey")
+	assert.Contains(t, cephClientSecret.StringData, "adminID")
+	assert.Contains(t, cephClientSecret.StringData, "adminKey")
 }
 
 func TestBuildUpdateStatusInfo(t *testing.T) {


### PR DESCRIPTION

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Adding two new entries(userID/userKey) in the cephClient secret, so that the csi driver can easily consume

**Which issue is resolved by this Pull Request:**
Resolves #10810

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
