### PR TITLE
object: allow status endpoints to be null

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -12774,10 +12774,12 @@ spec:
                     insecure:
                       items:
                         type: string
+                      nullable: true
                       type: array
                     secure:
                       items:
                         type: string
+                      nullable: true
                       type: array
                   type: object
                 info:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -12766,10 +12766,12 @@ spec:
                     insecure:
                       items:
                         type: string
+                      nullable: true
                       type: array
                     secure:
                       items:
                         type: string
+                      nullable: true
                       type: array
                   type: object
                 info:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1479,8 +1479,10 @@ type ObjectStoreStatus struct {
 
 type ObjectEndpoints struct {
 	// +optional
+	// +nullable
 	Insecure []string `json:"insecure"`
 	// +optional
+	// +nullable
 	Secure []string `json:"secure"`
 }
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -258,7 +258,7 @@ func (k8sh *K8sHelper) DeleteResource(args ...string) error {
 func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace, name string, checkerFunc func() error) error {
 
 	// wait for the operator to finalize and delete the CRD
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 90; i++ {
 		err := checkerFunc()
 		if err == nil {
 			logger.Infof("custom resource %q in namespace %q still exists", name, namespace)


### PR DESCRIPTION
For the upgrade case, Rook can fail to set status information on CephObjectStores after CRDs are updated but before the operator is updated. To fix this, merely allow the slices to be null in the CephObjectStore's status.endpoints.

This PR seems to be aggravating the helm filesystem upgrade test. Allow 30 more seconds for CRDs to be done before bailing. In debugging, the filesystem often needed only an extra 3 seconds to succeed.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**I will add this to backport #11279 manually once this is merged since it is needed for that PR to pass tests**

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
