### PR TITLE
docs: Set CRD page titles to the CRD name

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Block Pool CRD
+title: CephBlockPool CRD
 ---
 
 Rook allows creation and customization of storage pools through the custom resource definitions (CRDs). The following settings are available for pools.

--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-rados-namespace-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-rados-namespace-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Block Pool RADOS Namespace CRD
+title: CephBlockPoolRados Namespace CRD
 ---
 
 This guide assumes you have created a Rook cluster as explained in the main [Quickstart guide](../../Getting-Started/quickstart.md)

--- a/Documentation/CRDs/Block-Storage/ceph-rbd-mirror-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-rbd-mirror-crd.md
@@ -1,5 +1,5 @@
 ---
-title: RBD Mirror CRD
+title: CephRBDMirror CRD
 ---
 
 Rook allows creation and updating rbd-mirror daemon(s) through the custom resource definitions (CRDs).

--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Cluster CRD
+title: CephCluster CRD
 ---
 
 Rook allows creation and customization of storage clusters through the custom resource definitions (CRDs).

--- a/Documentation/CRDs/Object-Storage/.pages
+++ b/Documentation/CRDs/Object-Storage/.pages
@@ -1,4 +1,7 @@
 nav:
     - ceph-object-store-crd.md
     - ceph-object-store-user-crd.md
+    - ceph-object-realm-crd.md
+    - ceph-object-zonegroup-crd.md
+    - ceph-object-zone-crd.md
     - ...

--- a/Documentation/CRDs/Object-Storage/ceph-object-realm-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-realm-crd.md
@@ -1,0 +1,32 @@
+---
+title: CephObjectRealm CRD
+---
+
+Rook allows creation of a realm in a [Ceph Object Multisite](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md)
+configuration through a CRD. The following settings are available for Ceph object store realms.
+
+## Example
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: realm-a
+  namespace: rook-ceph
+# This endpoint in this section needs is an endpoint from the master zone  in the master zone group of realm-a. See object-multisite.md for more details.
+spec:
+  pull:
+    endpoint: http://10.2.105.133:80
+```
+
+## Settings
+
+### Metadata
+
+* `name`: The name of the object realm to create
+* `namespace`: The namespace of the Rook cluster where the object realm is created.
+
+### Spec
+
+* `pull`: This optional section is for the pulling the realm for another ceph cluster.
+  * `endpoint`: The endpoint in the realm from another ceph cluster you want to pull from. This endpoint must be in the master zone of the master zone group of the realm.

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Object Store CRD
+title: CephObjectStore CRD
 ---
 
 Rook allows creation and customization of object stores through the custom resource definitions (CRDs). The following settings are available for Ceph object stores.
@@ -142,7 +142,7 @@ All the other settings from the gateway section will be ignored, except for `sec
 
 ## Zone Settings
 
-The [zone](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md) settings allow the object store to join custom created [ceph-object-zone](ceph-object-multisite-crd.md).
+The [zone](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md) settings allow the object store to join custom created [ceph-object-zone](ceph-object-zone-crd.md).
 
 * `name`: the name of the ceph-object-zone the object store will be in.
 
@@ -253,6 +253,6 @@ Rook will warn about which buckets are blocking deletion in three ways:
 1. A status condition will be added to the CephObjectStore resource
 1. An error will be added to the Rook Ceph Operator log
 
-If the CephObjectStore is configured in a [multisite setup](ceph-object-multisite-crd.md) the above conditions are applicable only to stores that belong to a single master zone.
+If the CephObjectStore is configured in a [multisite setup](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md) the above conditions are applicable only to stores that belong to a single master zone.
 Otherwise the conditions are ignored. Even if the store is removed the user can access the
 data from a peer object store.

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Object Store User CRD
+title: CephObjectStoreUser CRD
 ---
 
 Rook allows creation and customization of object store users through the custom resource definitions (CRDs). The following settings are available

--- a/Documentation/CRDs/Object-Storage/ceph-object-zone-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-zone-crd.md
@@ -1,71 +1,11 @@
 ---
-title: Object Multisite CRDs
+title: CephObjectZone CRD
 ---
 
-The following CRDs enable Ceph object stores to isolate or replicate data via multisite. For more information on multisite, visit the [Ceph Object Multisite CRDs documentation](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md).
+Rook allows creation of zones in a ceph cluster for a [Ceph Object Multisite](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md)
+ configuration through a CRD. The following settings are available for Ceph object store zones.
 
-## Ceph Object Realm CRD
-
-Rook allows creation of a realm in a ceph cluster for object stores through the custom resource definitions (CRDs). The following settings are available for Ceph object store realms.
-
-### Example
-
-```yaml
-apiVersion: ceph.rook.io/v1
-kind: CephObjectRealm
-metadata:
-  name: realm-a
-  namespace: rook-ceph
-# This endpoint in this section needs is an endpoint from the master zone  in the master zone group of realm-a. See object-multisite.md for more details.
-spec:
-  pull:
-    endpoint: http://10.2.105.133:80
-```
-
-### Object Realm Settings
-
-#### Metadata
-
-* `name`: The name of the object realm to create
-* `namespace`: The namespace of the Rook cluster where the object realm is created.
-
-#### Spec
-
-* `pull`: This optional section is for the pulling the realm for another ceph cluster.
-  * `endpoint`: The endpoint in the realm from another ceph cluster you want to pull from. This endpoint must be in the master zone of the master zone group of the realm.
-
-## Ceph Object Zone Group CRD
-
-Rook allows creation of zone groups in a ceph cluster for object stores through the custom resource definitions (CRDs). The following settings are available for Ceph object store zone groups.
-
-### Example
-
-```yaml
-apiVersion: ceph.rook.io/v1
-kind: CephObjectZoneGroup
-metadata:
-  name: zonegroup-a
-  namespace: rook-ceph
-spec:
-  realm: realm-a
-```
-
-### Object Zone Group Settings
-
-#### Metadata
-
-* `name`: The name of the object zone group to create
-* `namespace`: The namespace of the Rook cluster where the object zone group is created.
-
-#### Spec
-
-* `realm`: The object realm in which the zone group will be created. This matches the name of the object realm CRD.
-
-## Ceph Object Zone CRD
-
-Rook allows creation of zones in a ceph cluster for object stores through the custom resource definitions (CRDs). The following settings are available for Ceph object store zone.
-
-### Example
+## Example
 
 ```yaml
 apiVersion: ceph.rook.io/v1
@@ -89,9 +29,9 @@ spec:
   preservePoolsOnDelete: true
 ```
 
-### Object Zone Settings
+## Settings
 
-#### Metadata
+### Metadata
 
 * `name`: The name of the object zone to create
 * `namespace`: The namespace of the Rook cluster where the object zone is created.
@@ -100,7 +40,7 @@ spec:
 
 The pools allow all of the settings defined in the Pool CRD spec. For more details, see the [Pool CRD](../Block-Storage/ceph-block-pool-crd.md) settings. In the example above, there must be at least three hosts (size 3) and at least three devices (2 data + 1 coding chunks) in the cluster.
 
-#### Spec
+### Spec
 
 * `zonegroup`: The object zonegroup in which the zone will be created. This matches the name of the object zone group CRD.
 * `metadataPool`: The settings used to create all of the object store metadata pools. Must use replication.

--- a/Documentation/CRDs/Object-Storage/ceph-object-zonegroup-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-zonegroup-crd.md
@@ -1,0 +1,29 @@
+---
+title: CephObjectZoneGroup CRD
+---
+
+Rook allows creation of zone groups in a [Ceph Object Multisite](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md)
+configuration through a CRD. The following settings are available for Ceph object store zone groups.
+
+## Example
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: zonegroup-a
+  namespace: rook-ceph
+spec:
+  realm: realm-a
+```
+
+## Settings
+
+### Metadata
+
+* `name`: The name of the object zone group to create
+* `namespace`: The namespace of the Rook cluster where the object zone group is created.
+
+### Spec
+
+* `realm`: The object realm in which the zone group will be created. This matches the name of the object realm CRD.

--- a/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Filesystem CRD
+title: CephFilesystem CRD
 ---
 
 Rook allows creation and customization of shared filesystems through the custom resource definitions (CRDs). The following settings are available for Ceph filesystems.

--- a/Documentation/CRDs/Shared-Filesystem/ceph-fs-mirror-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-fs-mirror-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Filesystem Mirror CRD
+title: CephFilesystemMirror CRD
 ---
 
 This guide assumes you have created a Rook cluster as explained in the main [Quickstart guide](../../Getting-Started/quickstart.md)

--- a/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Filesystem SubVolume Group CRD
+title: FilesystemSubVolumeGroup CRD
 ---
 
 !!! info

--- a/Documentation/CRDs/ceph-client-crd.md
+++ b/Documentation/CRDs/ceph-client-crd.md
@@ -1,5 +1,5 @@
 ---
-title: Client CRD
+title: CephClient CRD
 ---
 
 Rook allows creation and updating clients through the custom resource definitions (CRDs).

--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -1,5 +1,5 @@
 ---
-title: NFS Server CRD
+title: CephNFS CRD
 ---
 
 Rook allows exporting NFS shares of a CephFilesystem or CephObjectStore through the CephNFS custom

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
@@ -23,11 +23,11 @@ This guide assumes a Rook cluster as explained in the [Quickstart](../../Getting
 
 ## Creating Object Multisite
 
-If an admin wants to set up multisite on a Rook Ceph cluster, the admin should create:
+If an admin wants to set up multisite on a Rook Ceph cluster, the following resources must be created:
 
-1. A [realm](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-realm-settings)
-1. A [zonegroup](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-zone-group-settings)
-1. A [zone](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-zone-settings)
+1. A [realm](../../CRDs/Object-Storage/ceph-object-realm-crd.md#settings)
+1. A [zonegroup](../../CRDs/Object-Storage/ceph-object-zonegroup-crd.md#settings)
+1. A [zone](../../CRDs/Object-Storage/ceph-object-zone-crd.md#settings)
 1. A ceph object store with the `zone` section
 
 object-multisite.yaml in the [examples](https://github.com/rook/rook/blob/master/deploy/examples/) directory can be used to create the multisite CRDs.
@@ -44,7 +44,10 @@ The zone will create the pools for the object-store(s) that are in the zone to u
 
 When one of the multisite CRs (realm, zone group, zone) is deleted the underlying ceph realm/zone group/zone is not deleted, neither are the pools created by the zone. See the "Multisite Cleanup" section for more information.
 
-For more information on the multisite CRDs please read [ceph-object-multisite-crd](../../CRDs/Object-Storage/ceph-object-multisite-crd.md).
+For more information on the multisite CRDs, see the related CRDs:
+- [CephObjectRealm](../../CRDs/Object-Storage/ceph-object-realm-crd.md)
+- [CephObjectZoneGroup](../../CRDs/Object-Storage/ceph-object-zonegroup-crd.md)
+- [CephObjectZone](../../CRDs/Object-Storage/ceph-object-zone-crd.md)
 
 ## Pulling a Realm
 
@@ -172,9 +175,9 @@ kubectl create -f realm-a-keys.yaml
 
 Once the admin knows the endpoint and the secret for the keys has been created, the admin should create:
 
-1. A [CephObjectRealm](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-realm-settings) matching to the realm on the other Ceph cluster, with an endpoint as described above.
-1. A [CephObjectZoneGroup](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-zone-group-settings) matching the master zone group name or the master CephObjectZoneGroup from the cluster the realm was pulled from.
-1. A [CephObjectZone](../../CRDs/Object-Storage/ceph-object-multisite-crd.md#object-zone-settings) referring to the CephObjectZoneGroup created above.
+1. A [CephObjectRealm](../../CRDs/Object-Storage/ceph-object-realm-crd.md#settings) matching to the realm on the other Ceph cluster, with an endpoint as described above.
+1. A [CephObjectZoneGroup](../../CRDs/Object-Storage/ceph-object-zonegroup-crd.md#settings) matching the master zone group name or the master CephObjectZoneGroup from the cluster the realm was pulled from.
+1. A [CephObjectZone](../../CRDs/Object-Storage/ceph-object-zone-crd.md#settings) referring to the CephObjectZoneGroup created above.
 1. A CephObjectStore referring to the new CephObjectZone resource.
 
 object-multisite-pull-realm.yaml (with changes) in the [examples](https://github.com/rook/rook/blob/master/deploy/examples/) directory can be used to create the multisite CRDs.
@@ -337,7 +340,7 @@ spec:
   #   - "http://rgw-a.fqdn"
 ```
 
-Now modify the existing `CephObjectStore` CR to exclude pool settings and add a reference to the zone. 
+Now modify the existing `CephObjectStore` CR to exclude pool settings and add a reference to the zone.
 
 ```yaml
 apiVersion: ceph.rook.io/v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The name of the CRD is more clear for finding the CRD specs instead of a modified form of the name that was intended to be more human readable. When someone is looking for the CRD settings, they more naturally expect the CRD name in the title.

@galexrt How do we increase the width of the TOC on the left column of the docs? With this change, the last three letters of `CephBlockPoolRadosNamespace` is cut off in that pane.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
