### PR TITLE
Update annotations for rbd imageFeatures

### DIFF
--- a/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md
+++ b/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md
@@ -59,8 +59,13 @@ parameters:
     # RBD image format. Defaults to "2".
     imageFormat: "2"
 
-    # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-    imageFeatures: layering
+    # RBD image features. Available for imageFormat: "2". CSI
+    # RBD currently supports `layering`, `journaling`, `exclusive-lock`,
+    # `object-map`, `fast-diff`, `deep-flatten` features.
+    # Refer https://docs.ceph.com/en/latest/rbd/rbd-config-ref/#image-features
+    # for image feature dependencies.
+    # imageFeatures: "layering,journaling,exclusive-lock,object-map,fast-diff"
+    imageFeatures: "layering"
 
     # The secrets contain Ceph admin credentials.
     csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -424,8 +424,13 @@ cephBlockPools:
 
         # RBD image format. Defaults to "2".
         imageFormat: "2"
-        # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-        imageFeatures: layering
+        # RBD image features. Available for imageFormat: "2". CSI
+        # RBD currently supports `layering`, `journaling`, `exclusive-lock`,
+        # `object-map`, `fast-diff`, `deep-flatten` features.
+        # Refer https://docs.ceph.com/en/latest/rbd/rbd-config-ref/#image-features
+        # for image feature dependencies.
+        # imageFeatures: "layering,journaling,exclusive-lock,object-map,fast-diff"
+        imageFeatures: "layering"
         # The secrets contain Ceph admin credentials.
         csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
         csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph

--- a/deploy/examples/csi/rbd/storageclass-ec.yaml
+++ b/deploy/examples/csi/rbd/storageclass-ec.yaml
@@ -62,8 +62,13 @@ parameters:
   # RBD image format. Defaults to "2".
   imageFormat: "2"
 
-  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-  imageFeatures: layering
+  # RBD image features. Available for imageFormat: "2". CSI
+  # RBD currently supports `layering`, `journaling`, `exclusive-lock`,
+  # `object-map`, `fast-diff`, `deep-flatten` features.
+  # Refer https://docs.ceph.com/en/latest/rbd/rbd-config-ref/#image-features
+  # for image feature dependencies.
+  # imageFeatures: "layering,journaling,exclusive-lock,object-map,fast-diff"
+  imageFeatures: "layering"
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.

--- a/deploy/examples/csi/rbd/storageclass-test.yaml
+++ b/deploy/examples/csi/rbd/storageclass-test.yaml
@@ -36,8 +36,13 @@ parameters:
   # RBD image format. Defaults to "2".
   imageFormat: "2"
 
-  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-  imageFeatures: layering
+  # RBD image features. Available for imageFormat: "2". CSI
+  # RBD currently supports `layering`, `journaling`, `exclusive-lock`,
+  # `object-map`, `fast-diff`, `deep-flatten` features.
+  # Refer https://docs.ceph.com/en/latest/rbd/rbd-config-ref/#image-features
+  # for image feature dependencies.
+  # imageFeatures: "layering,journaling,exclusive-lock,object-map,fast-diff"
+  imageFeatures: "layering"
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.

--- a/deploy/examples/csi/rbd/storageclass.yaml
+++ b/deploy/examples/csi/rbd/storageclass.yaml
@@ -47,20 +47,25 @@ parameters:
   # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
   # unmapOptions: force
 
-   # (optional) Set it to true to encrypt each volume with encryption keys
-   # from a key management system (KMS)
-   # encrypted: "true"
+  # (optional) Set it to true to encrypt each volume with encryption keys
+  # from a key management system (KMS)
+  # encrypted: "true"
 
-   # (optional) Use external key management system (KMS) for encryption key by
-   # specifying a unique ID matching a KMS ConfigMap. The ID is only used for
-   # correlation to configmap entry.
-   # encryptionKMSID: <kms-config-id>
+  # (optional) Use external key management system (KMS) for encryption key by
+  # specifying a unique ID matching a KMS ConfigMap. The ID is only used for
+  # correlation to configmap entry.
+  # encryptionKMSID: <kms-config-id>
 
   # RBD image format. Defaults to "2".
   imageFormat: "2"
 
-  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-  imageFeatures: layering
+  # RBD image features. Available for imageFormat: "2". CSI
+  # RBD currently supports `layering`, `journaling`, `exclusive-lock`,
+  # `object-map`, `fast-diff`, `deep-flatten` features.
+  # Refer https://docs.ceph.com/en/latest/rbd/rbd-config-ref/#image-features
+  # for image feature dependencies.
+  # imageFeatures: "layering,journaling,exclusive-lock,object-map,fast-diff"
+  imageFeatures: "layering"
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.


### PR DESCRIPTION
component: csi

Update annotations for rbd imageFeatures:
According to Ceph CSI documentation
https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-rbd.md supported features are now
`layering`, `journaling`, `exclusive-lock`, `object-map`, `fast-diff`, `deep-flatten`.
This also is reflected in Ceph CSI rbd example:
https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml#L32

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.