### PR TITLE
docs: Clarify csi already exists error in docs

### DIFF
--- a/Documentation/Troubleshooting/ceph-csi-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-csi-common-issues.md
@@ -230,11 +230,11 @@ If any issue exists in the snapshot Create/Delete operation you can check the lo
 kubectl -n rook-ceph logs deploy/csi-rbdplugin-provisioner -c csi-snapshotter
 ```
 
-If you see an error such as:
+If you see an error about a volume already existing such as:
 
 ```console
 GRPC error: rpc error: code = Aborted desc = an operation with the given Volume ID
-0001-0009-rook-ceph-0000000000000001-8d0ba728-0e17-11eb-a680-ce6eecc894de already >exists.
+0001-0009-rook-ceph-0000000000000001-8d0ba728-0e17-11eb-a680-ce6eecc894de already exists.
 ```
 
 The issue typically is in the Ceph cluster or network connectivity. If the issue is


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The already exists error message is perhaps the most common issue with the csi driver. The csi troubleshooting guide is now clarified to make that error message easier to find.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
