### PR TITLE
osd: re-open encrypted disk during osd-prepare-job if closed

### DIFF
--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -46,12 +46,12 @@ func encryptionKeyPath() string {
 	return path.Join(opconfig.EtcCephDir, encryptionKeyFileName)
 }
 
-func encryptionDMName(pvcName, blockType string) string {
+func EncryptionDMName(pvcName, blockType string) string {
 	return fmt.Sprintf("%s-%s", pvcName, blockType)
 }
 
-func encryptionDMPath(pvcName, blockType string) string {
-	return path.Join("/dev/mapper", encryptionDMName(pvcName, blockType))
+func EncryptionDMPath(pvcName, blockType string) string {
+	return path.Join("/dev/mapper", EncryptionDMName(pvcName, blockType))
 }
 
 func encryptionBlockDestinationCopy(mountPath, blockType string) string {

--- a/pkg/operator/ceph/cluster/osd/config_test.go
+++ b/pkg/operator/ceph/cluster/osd/config_test.go
@@ -46,9 +46,9 @@ func TestEncryptionBlockDestinationCopy(t *testing.T) {
 }
 
 func TestEncryptionDMPath(t *testing.T) {
-	assert.Equal(t, "/dev/mapper/set1-data-0-6rqdn-block-dmcrypt", encryptionDMPath("set1-data-0-6rqdn", DmcryptBlockType))
+	assert.Equal(t, "/dev/mapper/set1-data-0-6rqdn-block-dmcrypt", EncryptionDMPath("set1-data-0-6rqdn", DmcryptBlockType))
 }
 
 func TestEncryptionDMName(t *testing.T) {
-	assert.Equal(t, "set1-data-0-6rqdn-block-dmcrypt", encryptionDMName("set1-data-0-6rqdn", DmcryptBlockType))
+	assert.Equal(t, "set1-data-0-6rqdn-block-dmcrypt", EncryptionDMName("set1-data-0-6rqdn", DmcryptBlockType))
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -871,7 +871,7 @@ func (c *Cluster) generateEncryptionOpenBlockContainer(resources v1.ResourceRequ
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			fmt.Sprintf(openEncryptedBlock, c.clusterInfo.FSID, pvcName, encryptionKeyPath(), encryptionBlockDestinationCopy(mountPath, blockType), encryptionDMName(pvcName, cryptBlockType), encryptionDMPath(pvcName, cryptBlockType)),
+			fmt.Sprintf(openEncryptedBlock, c.clusterInfo.FSID, pvcName, encryptionKeyPath(), encryptionBlockDestinationCopy(mountPath, blockType), EncryptionDMName(pvcName, cryptBlockType), EncryptionDMPath(pvcName, cryptBlockType)),
 		},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, volumeMountPVCName), getDeviceMapperMount()},
 		SecurityContext: controller.PrivilegedContext(true),
@@ -958,7 +958,7 @@ func (c *Cluster) generateEncryptionCopyBlockContainer(resources v1.ResourceRequ
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			fmt.Sprintf(blockDevMapper, encryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
+			fmt.Sprintf(blockDevMapper, EncryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
 		},
 		// volumeMountPVCName is crucial, especially when the block we copy is the metadata block
 		// its value must be the name of the block PV so that all init containers use the same bridge (the emptyDir shared by all the init containers)
@@ -1187,7 +1187,7 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 		Command: []string{
 			"cryptsetup",
 		},
-		Args:            []string{"--verbose", "resize", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
+		Args:            []string{"--verbose", "resize", EncryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    volMount,
 		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
@@ -1218,7 +1218,7 @@ func (c *Cluster) getEncryptedStatusPVCInitContainer(mountPath string, osdProps 
 		Command: []string{
 			"cryptsetup",
 		},
-		Args:            []string{"--verbose", "status", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
+		Args:            []string{"--verbose", "status", EncryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)},
 		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -34,12 +34,22 @@ type MockExecutor struct {
 	MockExecuteCommandWithOutput         func(command string, arg ...string) (string, error)
 	MockExecuteCommandWithCombinedOutput func(command string, arg ...string) (string, error)
 	MockExecuteCommandWithTimeout        func(timeout time.Duration, command string, arg ...string) (string, error)
+	MockExecuteCommandWithStdin          func(timeout time.Duration, command string, stdin *string, arg ...string) error
 }
 
 // ExecuteCommand mocks ExecuteCommand
 func (e *MockExecutor) ExecuteCommand(command string, arg ...string) error {
 	if e.MockExecuteCommand != nil {
 		return e.MockExecuteCommand(command, arg...)
+	}
+
+	return nil
+}
+
+// ExecuteCommandWithStdin starts a process, provides stdin and wait for its completion with timeout.
+func (e *MockExecutor) ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error {
+	if e.MockExecuteCommand != nil {
+		return e.MockExecuteCommandWithStdin(timeout, command, stdin, arg...)
 	}
 
 	return nil

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -38,6 +38,12 @@ func (e *TranslateCommandExecutor) ExecuteCommand(command string, arg ...string)
 	return e.Executor.ExecuteCommand(transCommand, transArgs...)
 }
 
+// ExecuteCommandWithStdin starts a process, provides stdin and wait for its completion with timeout.
+func (e *TranslateCommandExecutor) ExecuteCommandWithStdin(timeout time.Duration, command string, stdin *string, arg ...string) error {
+	transCommand, transArgs := e.Translator(command, arg...)
+	return e.Executor.ExecuteCommandWithStdin(timeout, transCommand, stdin, transArgs...)
+}
+
 // ExecuteCommandWithEnv starts a process with an env variable and wait for its completion
 func (e *TranslateCommandExecutor) ExecuteCommandWithEnv(env []string, command string, arg ...string) error {
 	transCommand, transArgs := e.Translator(command, arg...)


### PR DESCRIPTION
**Description of your changes:**

This commit implements this corner case during osd-prepare job.
```
The encrypted block is not opened, this is an extreme corner case
The OSD deployment has been removed manually AND the node rebooted
So we need to re-open the block to re-hydrate the OSDInfo.

Handling this case would mean, writing the encryption key on a
temporary file, then call luksOpen to open the encrypted block and
then call ceph-volume to list against the opened encrypted block.
We don't implement this, yet and return an error.
```
When underlying PVC for osd are CSI provisioned, the encrypted device is closed when PVC is unmounted due to osd pod being deleted. Therefore, this is no longer a corner case and needs to be handled. This commit implements the fix for the same.

Signed-off-by: Rakshith R <rar@redhat.com>


refer: #9434

---
Steps: 
- Deploy a encrypted cephcluster backed up dynamically CSI provisioned PVC for osd
- Delete OSD deployment
- watch osd-prepare-job logs 

---
<details>
<summary>
Before fix:
</summary>

```
[rakshith@fedora rook]$ k logs rook-ceph-osd-prepare-set1-data-1s9k9w-5gqcp 
Defaulted container "provision" out of: provision, copy-bins (init), blkdevmapper (init)
2022-11-21 13:53:11.342069 I | cephcmd: desired devices to configure osds: [{Name:/mnt/set1-data-1s9k9w OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2022-11-21 13:53:11.342608 I | rookcmd: starting Rook v1.10.0-alpha.0.398.gfdc2ab55d with arguments '/rook/rook ceph osd provision'
2022-11-21 13:53:11.342620 I | rookcmd: flag values: --cluster-id=6ec0a6ea-99a5-4281-a70f-322e2ecdd666, --cluster-name=my-cluster, --data-device-filter=, --data-device-path-filter=, --data-devices=[{"id":"/mnt/set1-data-1s9k9w","storeConfig":{"osdsPerDevice":1}}], --encrypted-device=true, --force-format=false, --help=false, --location=, --log-level=DEBUG, --metadata-device=, --node-name=set1-data-1s9k9w, --operator-image=, --osd-crush-device-class=, --osd-crush-initial-weight=, --osd-database-size=0, --osd-wal-size=576, --osds-per-device=1, --pvc-backed-osd=true, --service-account=
2022-11-21 13:53:11.342624 I | op-mon: parsing mon endpoints: a=10.107.169.17:6789
2022-11-21 13:53:11.349240 I | op-osd: CRUSH location=root=default host=set1-data-1s9k9w
2022-11-21 13:53:11.349255 I | cephcmd: crush location of osd: root=default host=set1-data-1s9k9w
2022-11-21 13:53:11.349261 D | cephosd: encryption configuration detecting, populating kek to an env variable
2022-11-21 13:53:11.349274 D | cephosd: cluster-wide encryption is enabled with kubernetes secrets and the kek is attached to the provision env spec
2022-11-21 13:53:11.349341 D | exec: Running command: dmsetup version
2022-11-21 13:53:11.352040 I | cephosd: Library version:   1.02.181-RHEL8 (2021-10-20)
Driver version:    4.43.0
2022-11-21 13:53:11.360727 D | cephclient: No ceph configuration override to merge as "rook-config-override" configmap is empty
2022-11-21 13:53:11.360746 I | cephclient: writing config file /var/lib/rook/enc/enc.config
2022-11-21 13:53:11.360862 I | cephclient: generated admin config in /var/lib/rook/enc
2022-11-21 13:53:11.360988 D | cephclient: config file @ /etc/ceph/ceph.conf:
[global]
fsid                = 2b0dc3de-c683-4ccd-b2c5-4a26c9fb964d
mon initial members = a
mon host            = [v2:10.107.169.17:3300,v1:10.107.169.17:6789]

[client.admin]
keyring = /var/lib/rook/enc/client.admin.keyring
2022-11-21 13:53:11.360993 I | cephosd: discovering hardware
2022-11-21 13:53:11.361003 D | exec: Running command: lsblk /mnt/set1-data-1s9k9w --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE
2022-11-21 13:53:11.363890 D | sys: lsblk output: "SIZE=\"10737418240\" ROTA=\"0\" RO=\"0\" TYPE=\"disk\" PKNAME=\"\" NAME=\"/dev/rbd0\" KNAME=\"/dev/rbd0\" MOUNTPOINT=\"\" FSTYPE=\"\""
2022-11-21 13:53:11.363933 D | exec: Running command: sgdisk --print /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.366033 D | exec: Running command: udevadm info --query=property /dev/rbd0
2022-11-21 13:53:11.370839 D | sys: udevadm info output: "DEVNAME=/dev/rbd0\nDEVPATH=/devices/rbd/0/block/rbd0\nDEVTYPE=disk\nMAJOR=251\nMINOR=0\nSUBSYSTEM=block\nTAGS=:systemd:\nUSEC_INITIALIZED=2068042192"
2022-11-21 13:53:11.370862 I | cephosd: creating and starting the osds
2022-11-21 13:53:11.370968 D | cephosd: desiredDevices are [{Name:/mnt/set1-data-1s9k9w OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2022-11-21 13:53:11.370976 D | cephosd: context.Devices are:
2022-11-21 13:53:11.371001 D | cephosd: &{Name:/mnt/set1-data-1s9k9w Parent: HasChildren:false DevLinks: Size:10737418240 UUID:401766c2-db89-40be-a77e-82546497753b Serial: Type:data Rotational:false Readonly:false Partitions:[] Filesystem: Mountpoint: Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/rbd0 KernelName:rbd0 Encrypted:false}
2022-11-21 13:53:11.371021 I | cephosd: old lsblk can't detect bluestore signature, so try to detect here
2022-11-21 13:53:11.371079 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.392270 D | exec: Running command: lsblk --noheadings --path --list --output NAME /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.394738 I | cephosd: skipping device "/mnt/set1-data-1s9k9w": failed to detect if there is already an osd. failed to find the encrypted block device for "/mnt/set1-data-1s9k9w", not opened?.
2022-11-21 13:53:11.403057 I | cephosd: configuring osd devices: {"Entries":{}}
2022-11-21 13:53:11.403331 I | cephosd: no new devices to configure. returning devices already configured with ceph-volume.
2022-11-21 13:53:11.403443 D | exec: Running command: pvdisplay -C -o lvpath --noheadings /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.482979 W | cephosd: failed to retrieve logical volume path for "/mnt/set1-data-1s9k9w". exit status 5
2022-11-21 13:53:11.483049 D | exec: Running command: lsblk /mnt/set1-data-1s9k9w --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE
2022-11-21 13:53:11.489011 D | sys: lsblk output: "SIZE=\"10737418240\" ROTA=\"0\" RO=\"0\" TYPE=\"disk\" PKNAME=\"\" NAME=\"/dev/rbd0\" KNAME=\"/dev/rbd0\" MOUNTPOINT=\"\" FSTYPE=\"\""
2022-11-21 13:53:11.489308 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log lvm list  --format json
2022-11-21 13:53:11.901643 D | cephosd: {}
2022-11-21 13:53:11.901695 I | cephosd: 0 ceph-volume lvm osd devices configured on this node
2022-11-21 13:53:11.901705 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.921288 D | exec: Running command: lsblk --noheadings --path --list --output NAME /mnt/set1-data-1s9k9w
2022-11-21 13:53:11.935549 C | rookcmd: failed to configure devices: failed to get device already provisioned by ceph-volume raw: failed to find the encrypted block device for "/mnt/set1-data-1s9k9w", not opened?
```
</details>



<details>
<summary>
After fix:
</summary>

```
2022-11-21 13:41:14.216619 I | cephcmd: desired devices to configure osds: [{Name:/mnt/set1-data-1s9k9w OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2022-11-21 13:41:14.219440 I | rookcmd: starting Rook v1.8.0-alpha.0.1391.g48a3879ca with arguments '/rook/rook ceph osd provision'
2022-11-21 13:41:14.219458 I | rookcmd: flag values: --cluster-id=6ec0a6ea-99a5-4281-a70f-322e2ecdd666, --cluster-name=my-cluster, --data-device-filter=, --data-device-path-filter=, --data-devices=[{"id":"/mnt/set1-data-1s9k9w","storeConfig":{"osdsPerDevice":1}}], --encrypted-device=true, --force-format=false, --help=false, --location=, --log-level=DEBUG, --metadata-device=, --node-name=set1-data-1s9k9w, --operator-image=, --osd-crush-device-class=, --osd-crush-initial-weight=, --osd-database-size=0, --osd-wal-size=576, --osds-per-device=1, --pvc-backed-osd=true, --service-account=
2022-11-21 13:41:14.219464 I | op-mon: parsing mon endpoints: a=10.107.169.17:6789
2022-11-21 13:41:14.226495 I | op-osd: CRUSH location=root=default host=set1-data-1s9k9w
2022-11-21 13:41:14.226519 I | cephcmd: crush location of osd: root=default host=set1-data-1s9k9w
2022-11-21 13:41:14.226526 D | cephosd: encryption configuration detecting, populating kek to an env variable
2022-11-21 13:41:14.226542 D | cephosd: cluster-wide encryption is enabled with kubernetes secrets and the kek is attached to the provision env spec
2022-11-21 13:41:14.226546 D | exec: Running command: dmsetup version
2022-11-21 13:41:14.229333 I | cephosd: Library version:   1.02.181-RHEL8 (2021-10-20)
Driver version:    4.43.0
2022-11-21 13:41:14.237855 D | cephclient: No ceph configuration override to merge as "rook-config-override" configmap is empty
2022-11-21 13:41:14.237901 I | cephclient: writing config file /var/lib/rook/enc/enc.config
2022-11-21 13:41:14.238068 I | cephclient: generated admin config in /var/lib/rook/enc
2022-11-21 13:41:14.238220 D | cephclient: config file @ /etc/ceph/ceph.conf:
[global]
fsid                = 2b0dc3de-c683-4ccd-b2c5-4a26c9fb964d
mon initial members = a
mon host            = [v2:10.107.169.17:3300,v1:10.107.169.17:6789]

[client.admin]
keyring = /var/lib/rook/enc/client.admin.keyring
2022-11-21 13:41:14.238256 I | cephosd: discovering hardware
2022-11-21 13:41:14.238264 D | exec: Running command: lsblk /mnt/set1-data-1s9k9w --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE
2022-11-21 13:41:14.245250 D | sys: lsblk output: "SIZE=\"10737418240\" ROTA=\"0\" RO=\"0\" TYPE=\"disk\" PKNAME=\"\" NAME=\"/dev/rbd0\" KNAME=\"/dev/rbd0\" MOUNTPOINT=\"\" FSTYPE=\"\""
2022-11-21 13:41:14.245382 D | exec: Running command: sgdisk --print /mnt/set1-data-1s9k9w
2022-11-21 13:41:14.248506 D | exec: Running command: udevadm info --query=property /dev/rbd0
2022-11-21 13:41:14.253954 D | sys: udevadm info output: "DEVNAME=/dev/rbd0\nDEVPATH=/devices/rbd/0/block/rbd0\nDEVTYPE=disk\nMAJOR=251\nMINOR=0\nSUBSYSTEM=block\nTAGS=:systemd:\nUSEC_INITIALIZED=2068042192"
2022-11-21 13:41:14.253977 I | cephosd: creating and starting the osds
2022-11-21 13:41:14.253991 D | cephosd: desiredDevices are [{Name:/mnt/set1-data-1s9k9w OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2022-11-21 13:41:14.253994 D | cephosd: context.Devices are:
2022-11-21 13:41:14.254029 D | cephosd: &{Name:/mnt/set1-data-1s9k9w Parent: HasChildren:false DevLinks: Size:10737418240 UUID:51bebcba-2dad-45d6-a6ec-7a88f35a822c Serial: Type:data Rotational:false Readonly:false Partitions:[] Filesystem: Mountpoint: Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/rbd0 KernelName:rbd0 Encrypted:false}
2022-11-21 13:41:14.254043 I | cephosd: old lsblk can't detect bluestore signature, so try to detect here
2022-11-21 13:41:14.254070 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:41:14.265422 D | exec: Running command: lsblk --noheadings --path --list --output NAME /mnt/set1-data-1s9k9w
2022-11-21 13:41:14.267579 D | exec: Running command: lsblk --noheadings --output TYPE /dev/mapper/set1-data-1s9k9w-block-dmcrypt
2022-11-21 13:41:14.270470 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list /dev/mapper/set1-data-1s9k9w-block-dmcrypt --format json
2022-11-21 13:41:14.612073 D | cephosd: {
    "959b244d-043e-4603-9e89-20067b85888d": {
        "ceph_fsid": "2b0dc3de-c683-4ccd-b2c5-4a26c9fb964d",
        "device": "/dev/mapper/set1-data-1s9k9w-block-dmcrypt",
        "osd_id": 0,
        "osd_uuid": "959b244d-043e-4603-9e89-20067b85888d",
        "type": "bluestore"
    }
}
2022-11-21 13:41:14.612701 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:41:14.632525 D | exec: Running command: cryptsetup --verbose luksClose /dev/mapper/set1-data-1s9k9w-block-dmcrypt
2022-11-21 13:41:14.652763 I | cephosd: dm version:
Command successful.
2022-11-21 13:41:14.652784 I | cephosd: 1 ceph-volume raw osd devices configured on this node
2022-11-21 13:41:14.652790 I | cephosd: skipping device "/mnt/set1-data-1s9k9w": already in use by a raw OSD, no need to reconfigure.
2022-11-21 13:41:14.659073 I | cephosd: configuring osd devices: {"Entries":{}}
2022-11-21 13:41:14.659089 I | cephosd: no new devices to configure. returning devices already configured with ceph-volume.
2022-11-21 13:41:14.659095 D | exec: Running command: pvdisplay -C -o lvpath --noheadings /mnt/set1-data-1s9k9w
2022-11-21 13:41:14.721583 W | cephosd: failed to retrieve logical volume path for "/mnt/set1-data-1s9k9w". exit status 5
2022-11-21 13:41:14.721605 D | exec: Running command: lsblk /mnt/set1-data-1s9k9w --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE
2022-11-21 13:41:14.724336 D | sys: lsblk output: "SIZE=\"10737418240\" ROTA=\"0\" RO=\"0\" TYPE=\"disk\" PKNAME=\"\" NAME=\"/dev/rbd0\" KNAME=\"/dev/rbd0\" MOUNTPOINT=\"\" FSTYPE=\"\""
2022-11-21 13:41:14.724364 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log lvm list  --format json
2022-11-21 13:41:15.104965 D | cephosd: {}
2022-11-21 13:41:15.105013 I | cephosd: 0 ceph-volume lvm osd devices configured on this node
2022-11-21 13:41:15.105022 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:41:15.111933 D | exec: Running command: lsblk --noheadings --path --list --output NAME /mnt/set1-data-1s9k9w
2022-11-21 13:41:15.113515 D | cephosd: encrypted block device "/mnt/set1-data-1s9k9w" is not open, opening it now
2022-11-21 13:41:15.113535 D | exec: Running command: cryptsetup luksOpen --verbose --allow-discards /mnt/set1-data-1s9k9w set1-data-1s9k9w-block-dmcrypt
2022-11-21 13:41:16.628777 D | exec: Key slot 0 unlocked.
2022-11-21 13:41:16.628795 D | exec: Command successful.
2022-11-21 13:41:16.630546 D | exec: Running command: lsblk --noheadings --output TYPE /dev/mapper/set1-data-1s9k9w-block-dmcrypt
2022-11-21 13:41:16.632304 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list /dev/mapper/set1-data-1s9k9w-block-dmcrypt --format json
2022-11-21 13:41:16.904036 D | cephosd: {
    "959b244d-043e-4603-9e89-20067b85888d": {
        "ceph_fsid": "2b0dc3de-c683-4ccd-b2c5-4a26c9fb964d",
        "device": "/dev/mapper/set1-data-1s9k9w-block-dmcrypt",
        "osd_id": 0,
        "osd_uuid": "959b244d-043e-4603-9e89-20067b85888d",
        "type": "bluestore"
    }
}
2022-11-21 13:41:16.904087 D | exec: Running command: lsblk /dev/mapper/set1-data-1s9k9w-block-dmcrypt --bytes --nodeps --pairs --paths --output SIZE,ROTA,RO,TYPE,PKNAME,NAME,KNAME,MOUNTPOINT,FSTYPE
2022-11-21 13:41:16.906371 D | sys: lsblk output: "SIZE=\"10720641024\" ROTA=\"0\" RO=\"0\" TYPE=\"crypt\" PKNAME=\"\" NAME=\"/dev/mapper/set1-data-1s9k9w-block-dmcrypt\" KNAME=\"/dev/dm-2\" MOUNTPOINT=\"\" FSTYPE=\"ceph_bluestore\""
2022-11-21 13:41:16.906393 I | cephosd: setting device class "ssd" for device "/dev/mapper/set1-data-1s9k9w-block-dmcrypt"
2022-11-21 13:41:16.906401 D | exec: Running command: cryptsetup luksDump /mnt/set1-data-1s9k9w
2022-11-21 13:41:16.913197 D | exec: Running command: cryptsetup --verbose luksClose /dev/mapper/set1-data-1s9k9w-block-dmcrypt
2022-11-21 13:41:16.925925 I | cephosd: dm version:
Command successful.
2022-11-21 13:41:16.925950 I | cephosd: 1 ceph-volume raw osd devices configured on this node
2022-11-21 13:41:16.925981 I | cephosd: devices = [{ID:0 Cluster:ceph UUID:959b244d-043e-4603-9e89-20067b85888d DevicePartUUID: DeviceClass:ssd BlockPath:/dev/mapper/set1-data-1s9k9w-block-dmcrypt MetadataPath: WalPath: SkipLVRelease:true Location:root=default host=set1-data-1s9k9w LVBackedPV:false CVMode:raw Store:bluestore TopologyAffinity: Encrypted:true}]
```
</details>