### PR TITLE
Improve POSIX compliance of local scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # set the shell to bash in case some environments use sh
-SHELL := /bin/bash
+SHELL := $(shell command -v bash)
 
 # Can be used or additional go build flags
 BUILDFLAGS ?=

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2018 The Rook Authors. All rights reserved.
 #

--- a/build/common.sh
+++ b/build/common.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 set -u
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -15,7 +15,7 @@
 # remove default suffixes as we dont use them
 .SUFFIXES:
 
-SHELL := /bin/bash
+SHELL := $(shell command -v bash)
 ifneq (, $(shell command -v shasum))
 SHA256CMD := shasum -a 256
 else ifneq (, $(shell command -v sha256sum))

--- a/build/reset
+++ b/build/reset
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set-e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ##############

--- a/deploy/olm/generate-rook-csv-templates.sh
+++ b/deploy/olm/generate-rook-csv-templates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export OLM_SKIP_PKG_FILE_GEN="true"

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -1,4 +1,5 @@
-#!/bin/bash +e
+#!/usr/bin/env bash
+set +e
 
 temp="/tmp/rook-tests-scripts-helm"
 

--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash +e
+#!/usr/bin/env bash
+set +e
 
 KUBE_VERSION=${1:-"v1.15.12"}
 null_str=

--- a/tests/scripts/validate_modified_files.sh
+++ b/tests/scripts/validate_modified_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 #############


### PR DESCRIPTION
POSIX does not guarantee `/bin/bash` to exist. It mandates the presence of `env`, however, which can be used to find bash.

This PR changes the shebang of local scripts to use `/usr/bin/env` to improve platform compatibility of the toolchain.
It also adds lookups using `command -v` to replace any hard-coded `/bin/bash` in the makefiles.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
