### PR TITLE
osd: improve log on specifying lv and loop device as osd

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -455,10 +455,10 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 		} else if len(desiredDevices) == 1 && desiredDevices[0].Name == "all" {
 			// user has specified all devices, use the current one for data
 			if device.Type == sys.LVMType {
-				logger.Infof("logical volume %q is not picked by `useAllDevices: true`. please specify the exact device name (e.g. /dev/vg/lv) instead", device.Name)
+				logger.Infof("logical volume %q is not picked by `useAllDevices: true`. please specify the exact device name (e.g. /dev/vg/lv) in `devices` field instead", device.Name)
 				continue
 			} else if device.Type == sys.LoopType {
-				logger.Infof("loop device %q is not picked by `useAllDevices: true`. please specify the exact device name (e.g. /dev/loop0) instead", device.Name)
+				logger.Infof("loop device %q is not picked by `useAllDevices: true`. please specify the exact device name (e.g. /dev/loop0) in `devices` field  instead", device.Name)
 				continue
 			}
 			deviceInfo = &DeviceOsdIDEntry{Data: unassignedOSDID, DeviceInfo: device}
@@ -469,10 +469,10 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 				if desiredDevice.IsFilter {
 					// the desired devices is a regular expression
 					if device.Type == sys.LVMType {
-						logger.Infof("logical volume %q is not picked by `deviceFilter`. please specify the exact device name (e.g. /dev/vg/lv) instead", device.Name)
+						logger.Infof("logical volume %q is not picked by `deviceFilter`. please specify the exact device name (e.g. /dev/vg/lv) in `devices` field instead", device.Name)
 						continue
 					} else if device.Type == sys.LoopType {
-						logger.Infof("loop device %q is not picked by `deviceFilter`. please specify the exact device name (e.g. /dev/loop0) instead", device.Name)
+						logger.Infof("loop device %q is not picked by `deviceFilter`. please specify the exact device name (e.g. /dev/loop0) in `devices` field instead", device.Name)
 						continue
 					}
 					matched, err = regexp.Match(desiredDevice.Name, []byte(device.Name))
@@ -486,10 +486,10 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 					}
 				} else if desiredDevice.IsDevicePathFilter {
 					if device.Type == sys.LVMType {
-						logger.Infof("logical volume %q is not picked by `devicePathFilter`. please specify the exact device name (e.g. /dev/vg/lv) instead", device.Name)
+						logger.Infof("logical volume %q is not picked by `devicePathFilter`. please specify the exact device name (e.g. /dev/vg/lv) in `devices` field instead", device.Name)
 						continue
 					} else if device.Type == sys.LoopType {
-						logger.Infof("loop device %q is not picked by `devicePathFilter`. please specify the exact device name (e.g. /dev/loop0) instead", device.Name)
+						logger.Infof("loop device %q is not picked by `devicePathFilter`. please specify the exact device name (e.g. /dev/loop0) in `devices` field instead", device.Name)
 						continue
 					}
 					pathnames := append(strings.Fields(device.DevLinks), filepath.Join("/dev", device.Name))


### PR DESCRIPTION
**Description of your changes:**

We can use LVM logical volumes and loop devices as OSD iff we specify them in the `devices` field. If we use filters like `deviceFilter`, these devices are not picked with a log message which let users specify the exact device name. It's better to mention which field users should use in this case.

**Which issue is resolved by this Pull Request:**
Resolves #11353

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
