### PR TITLE
helm: allow to specify allowed topologies for storage class

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -75,6 +75,7 @@ The `cephBlockPools` array in the values file will define a list of CephBlockPoo
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
 | `storageClass.mountOptions` | Specifies the mount options for storageClass | `[]` |
+| `storageClass.allowedTopologies` | Specifies the [allowedTopologies](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies) for storageClass | `[]` |
 
 ### **Ceph File Systems**
 

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -102,6 +102,7 @@ The `cephBlockPools` array in the values file will define a list of CephBlockPoo
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
 | `storageClass.mountOptions` | Specifies the mount options for storageClass | `[]` |
+| `storageClass.allowedTopologies` | Specifies the [allowedTopologies](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies) for storageClass | `[]` |
 
 ### **Ceph File Systems**
 

--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -30,5 +30,11 @@ mountOptions:
   - {{ . }}
   {{- end }}
 {{- end }}
+{{ if $blockpool.storageClass.allowedTopologies }}
+allowedTopologies:
+{{ with $blockpool.storageClass.allowedTopologies }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -420,6 +420,12 @@ cephBlockPools:
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       mountOptions: []
+      # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
+      allowedTopologies: []
+#        - matchLabelExpressions:
+#            - key: rook-ceph-role
+#              values:
+#                - storage-node
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-block.md#provision-storage for available configuration
       parameters:
         # (optional) mapOptions is a comma-separated list of map options.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

 - allow to specify **allowedTopologies** for **storageClass** defined in here https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
