### PR TITLE
osd: remove stale dm device during osd-prepare-job 

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -974,6 +974,11 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 				}
 
 				target := oposd.EncryptionDMName(pvcName, oposd.DmcryptBlockType)
+				// remove stale dm device left by previous OSD.
+				err = removeEncryptedDevice(context, target)
+				if err != nil {
+					logger.Warningf("failed to remove stale dm device %q: %q", target, err)
+				}
 				err = openEncryptedDevice(context, block, target, passphrase)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to open encrypted block device %q on %q", block, target)


### PR DESCRIPTION
**Description of your changes:**

During osd-prepare-job,

The encrypted device is found to be closed in some cases when the OSD deployment has been removed manually accompanied by any of following cases:
- node reboot
- csi managed PVC being unmounted etc

while re-opening the block to re-hydrate the OSDInfo,
the dm device `<pvc-name>-block-dmcrypt` clashes with
the one used by OSD pod which is stale by now.
This commit adds cmd to remove this stale dm device.
Error with output "No such device" is ignored.

Signed-off-by: Rakshith R <rar@redhat.com>

---

refer: #11338

The error is 
```
2022-12-06 07:34:16.804076 D | exec: Running command: cryptsetup luksOpen --verbose --allow-discards /mnt/ocs-deviceset-gp3-csi-0-data-0qsvjg ocs-deviceset-gp3-csi-0-data-0qsvjg-block-dmcrypt
2022-12-06 07:34:16.813620 I | exec: Command "cryptsetup" output: "Device ocs-deviceset-gp3-csi-0-data-0qsvjg-block-dmcrypt already exists.\nCommand failed with code -5 (device already exists or device is busy)."
2022-12-06 07:34:16.827466 C | rookcmd: failed to configure devices: failed to get device already provisioned by ceph-volume raw: failed to open encrypted block device "/mnt/ocs-deviceset-gp3-csi-0-data-0qsvjg" on "ocs-deviceset-gp3-csi-0-data-0qsvjg-block-dmcrypt": failed to open encrypted device "/mnt/ocs-deviceset-gp3-csi-0-data-0qsvjg": exit status 5
```

This resolves the case which @leseb mentioned here https://github.com/rook/rook/pull/11338#discussion_r1034910311

I did not observe this issue while testing locally for the previous pr.
The behaviour seems to be different on different platform. 

Logs after fix: 
```
2022-12-07 10:02:28.966710 D | cephosd: encrypted block device "/mnt/ocs-deviceset-ssd-csi-0-data-0fxvkr" is not open, opening it now
2022-12-07 10:02:28.966746 D | exec: Running command: dmsetup remove --force ocs-deviceset-ssd-csi-0-data-0fxvkr-block-dmcrypt
2022-12-07 10:02:28.984178 D | exec: Running command: cryptsetup luksOpen --verbose --allow-discards /mnt/ocs-deviceset-ssd-csi-0-data-0fxvkr ocs-deviceset-ssd-csi-0-data-0fxvkr-block-dmcrypt
2022-12-07 10:02:31.466620 I | exec: Command "cryptsetup" output: "Key slot 0 unlocked.\nCommand successful."
2022-12-07 10:02:31.466661 D | exec: Running command: lsblk --noheadings --output TYPE /dev/mapper/ocs-deviceset-ssd-csi-0-data-0fxvkr-block-dmcrypt
2022-12-07 10:02:31.470768 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list /dev/mapper/ocs-deviceset-ssd-csi-0-data-0fxvkr-block-dmcrypt --format json
2022-12-07 10:02:31.942287 D | cephosd: {
    "58c8fedd-6ca7-42e5-8477-0a368797a8c9": {
        "ceph_fsid": "d574ffae-5b0a-4475-8626-bcc2372fe0fb",
        "device": "/dev/mapper/ocs-deviceset-ssd-csi-0-data-0fxvkr-block-dmcrypt",
        "osd_id": 0,
        "osd_uuid": "58c8fedd-6ca7-42e5-8477-0a368797a8c9",
        "type": "bluestore"
    }
}
...
```

---

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
