### PR TITLE
core: Allow ceph.conf to be updated if already exists

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -293,7 +293,7 @@ func WriteCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) error 
 	if err != nil {
 		return errors.Wrap(err, "failed to copy connection config to /etc/ceph. failed to read the connection config")
 	}
-	err = ioutil.WriteFile(DefaultConfigFilePath(), src, 0444)
+	err = ioutil.WriteFile(DefaultConfigFilePath(), src, 0600)
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy connection config to /etc/ceph. failed to write %q", DefaultConfigFilePath())
 	}

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -107,11 +107,11 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 		} else {
 			// If we arrive here and forceOSDRemoval is true, we should proceed with the OSD removal
 			if forceOSDRemoval {
-				logger.Infof("osd.%d is NOT be ok to destroy but force removal is enabled so proceeding with removal", osdID)
+				logger.Infof("osd.%d is NOT ok to destroy but force removal is enabled so proceeding with removal", osdID)
 				break
 			}
 			// Else we wait until the OSD can be removed
-			logger.Warningf("osd.%d is NOT be ok to destroy, retrying in 1m until success", osdID)
+			logger.Warningf("osd.%d is NOT ok to destroy, retrying in 1m until success", osdID)
 			time.Sleep(1 * time.Minute)
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The ceph.conf was being written with 0x444 permissions, which means the file could not be updated if it already exists. Specifically, when an osd is purged, if the operation is retried multiple times, only the first operation was succeeding. The subsequent requests to purge an osd were failing due to the config already existing. If we make the config writeable with 0x644 then the operator can always write the file.

A small typo is also fixed in the osd purge message.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
