### PR TITLE
core: Refactor crash collector for more node daemons

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -32,9 +32,9 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/nodedaemon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/telemetry"
 	"github.com/rook/rook/pkg/operator/ceph/config"
@@ -502,7 +502,7 @@ func (c *cluster) postMonStartupActions() error {
 	}
 
 	// Create crash collector Kubernetes Secret
-	err = crash.CreateCrashCollectorSecret(c.context, c.ClusterInfo)
+	err = nodedaemon.CreateCrashCollectorSecret(c.context, c.ClusterInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to create crash collector kubernetes secret")
 	}

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -24,9 +24,9 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/nodedaemon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
@@ -122,7 +122,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	// Create Crash Collector Secret
 	// In 14.2.5 the crash daemon will read the client.crash key instead of the admin key
 	if !cluster.Spec.CrashCollector.Disable {
-		err = crash.CreateCrashCollectorSecret(c.context, cluster.ClusterInfo)
+		err = nodedaemon.CreateCrashCollectorSecret(c.context, cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to create crash collector kubernetes secret")
 		}

--- a/pkg/operator/ceph/cluster/nodedaemon/add_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/add_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package crash
+package nodedaemon
 
 import (
 	"testing"
@@ -22,7 +22,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCephCrashCollectorKeyringCaps(t *testing.T) {
-	caps := cephCrashCollectorKeyringCaps()
-	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
+func TestIsCephPod(t *testing.T) {
+	labels := make(map[string]string)
+
+	labels["foo"] = "bar"
+	podName := "ceph"
+	b := isCephPod(labels, podName)
+	assert.False(t, b)
+
+	// Label is correct but this is a canary pod, this is not valid!
+	podName = "rook-ceph-mon-b-canary-664f5bf8cd-697hh"
+	labels["rook_cluster"] = "rook-ceph"
+	b = isCephPod(labels, podName)
+	assert.False(t, b)
+
+	// Label is correct and this is not a canary pod
+	podName = "rook-ceph-mon"
+	b = isCephPod(labels, podName)
+	assert.True(t, b)
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedaemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestGenerateCrashEnvVar(t *testing.T) {
+	env := generateCrashEnvVar()
+	assert.Equal(t, "CEPH_ARGS", env.Name)
+	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring", env.Value)
+}
+
+func TestCreateOrUpdateCephCrash(t *testing.T) {
+	cephCluster := cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph"},
+	}
+	cephCluster.Spec.Labels = cephv1.LabelsSpec{}
+	cephCluster.Spec.PriorityClassNames = cephv1.PriorityClassNamesSpec{}
+	cephVersion := &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
+	ctx := context.TODO()
+	context := &clusterd.Context{
+		Clientset:     test.New(t, 1),
+		RookClientset: rookclient.NewSimpleClientset(),
+	}
+
+	s := scheme.Scheme
+	err := appsv1.AddToScheme(s)
+	if err != nil {
+		assert.Fail(t, "failed to build scheme")
+	}
+	r := &ReconcileNode{
+		scheme:  s,
+		client:  fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects().Build(),
+		context: context,
+	}
+
+	node := corev1.Node{}
+	nodeSelector := map[string]string{corev1.LabelHostname: "testnode"}
+	node.SetLabels(nodeSelector)
+	tolerations := []corev1.Toleration{{}}
+	res, err := r.createOrUpdateCephCrash(node, tolerations, cephCluster, cephVersion)
+	assert.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResult("created"), res)
+	name := k8sutil.TruncateNodeName(fmt.Sprintf("%s-%%s", crashCollectorAppName), "testnode")
+	deploy := appsv1.Deployment{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: name}, &deploy)
+	assert.NoError(t, err)
+	podSpec := deploy.Spec.Template
+	assert.Equal(t, nodeSelector, podSpec.Spec.NodeSelector)
+	assert.Equal(t, "", podSpec.ObjectMeta.Labels["foo"])
+	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
+	assert.Equal(t, false, podSpec.Spec.HostNetwork)
+	assert.Equal(t, "", podSpec.Spec.PriorityClassName)
+	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsUser)
+	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsGroup)
+
+	cephCluster.Spec.Labels[cephv1.KeyCrashCollector] = map[string]string{"foo": "bar"}
+	cephCluster.Spec.Network.HostNetwork = true
+	cephCluster.Spec.PriorityClassNames[cephv1.KeyCrashCollector] = "test-priority-class"
+	tolerations = []corev1.Toleration{{Key: "key", Operator: "Equal", Value: "value", Effect: "NoSchedule"}}
+	res, err = r.createOrUpdateCephCrash(node, tolerations, cephCluster, cephVersion)
+	assert.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResult("updated"), res)
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: name}, &deploy)
+	assert.NoError(t, err)
+	podSpec = deploy.Spec.Template
+	assert.Equal(t, "bar", podSpec.ObjectMeta.Labels["foo"])
+	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
+	assert.Equal(t, true, podSpec.Spec.HostNetwork)
+	assert.Equal(t, "test-priority-class", podSpec.Spec.PriorityClassName)
+}

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package crash
+package nodedaemon
 
 import (
 	"fmt"

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package crash
+package nodedaemon
 
 import (
 	"testing"
@@ -22,22 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsCephPod(t *testing.T) {
-	labels := make(map[string]string)
-
-	labels["foo"] = "bar"
-	podName := "ceph"
-	b := isCephPod(labels, podName)
-	assert.False(t, b)
-
-	// Label is correct but this is a canary pod, this is not valid!
-	podName = "rook-ceph-mon-b-canary-664f5bf8cd-697hh"
-	labels["rook_cluster"] = "rook-ceph"
-	b = isCephPod(labels, podName)
-	assert.False(t, b)
-
-	// Label is correct and this is not a canary pod
-	podName = "rook-ceph-mon"
-	b = isCephPod(labels, podName)
-	assert.True(t, b)
+func TestCephCrashCollectorKeyringCaps(t *testing.T) {
+	caps := cephCrashCollectorKeyringCaps()
+	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/pruner.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2022 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedaemon
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	v1 "k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) error {
+	if cephCluster.Spec.CrashCollector.Disable {
+		logger.Debugf("crash collector is disabled in namespace %q so skipping crash retention reconcile", namespace)
+		return nil
+	}
+
+	k8sVersion, err := k8sutil.GetK8SVersion(r.context.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to get k8s version")
+	}
+	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(MinVersionForCronV1))
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      prunerName,
+		Namespace: namespace,
+	}
+
+	if cephCluster.Spec.CrashCollector.DaysToRetain == 0 {
+		logger.Debug("deleting cronjob if it exists...")
+
+		var cronJob client.Object
+		// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
+		if useCronJobV1 {
+			cronJob = &v1.CronJob{ObjectMeta: objectMeta}
+		} else {
+			cronJob = &v1beta1.CronJob{ObjectMeta: objectMeta}
+		}
+
+		err := r.client.Delete(r.opManagerContext, cronJob)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				logger.Debug("cronJob resource not found. Ignoring since object must be deleted.")
+			} else {
+				return err
+			}
+		} else {
+			logger.Debug("successfully deleted crash pruner cronjob.")
+		}
+	} else {
+		logger.Debugf("daysToRetain set to: %d", cephCluster.Spec.CrashCollector.DaysToRetain)
+		op, err := r.createOrUpdateCephCron(cephCluster, cephVersion, useCronJobV1)
+		if err != nil {
+			return errors.Wrapf(err, "node reconcile failed on op %q", op)
+		}
+		logger.Debugf("cronjob successfully reconciled. operation: %q", op)
+	}
+	return nil
+}
+func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion, useCronJobV1 bool) (controllerutil.OperationResult, error) {
+	objectMeta := metav1.ObjectMeta{
+		Name:      prunerName,
+		Namespace: cephCluster.GetNamespace(),
+	}
+	// Adding volumes to pods containing data needed to connect to the ceph cluster.
+	volumes := controller.DaemonVolumesBase(config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath), "")
+	volumes = append(volumes, keyring.Volume().CrashCollector())
+
+	// labels for the pod, the deployment, and the deploymentSelector
+	cronJobLabels := map[string]string{
+		k8sutil.AppAttr: prunerName,
+	}
+	cronJobLabels[k8sutil.ClusterAttr] = cephCluster.GetNamespace()
+
+	podTemplateSpec := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: cronJobLabels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				getCrashPruneContainer(cephCluster, *cephVersion),
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			HostNetwork:   cephCluster.Spec.Network.IsHost(),
+			Volumes:       volumes,
+		},
+	}
+
+	// After 100 failures, the cron job will no longer run.
+	// To avoid this, the cronjob is configured to only count the failures
+	// that occurred in the last hour.
+	deadline := int64(60)
+
+	// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
+	if useCronJobV1 {
+		r.deletev1betaJob(objectMeta)
+
+		cronJob := &v1.CronJob{ObjectMeta: objectMeta}
+		err := controllerutil.SetControllerReference(&cephCluster, cronJob, r.scheme)
+		if err != nil {
+			return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of deployment %q", cronJob.Name)
+		}
+		mutateFunc := func() error {
+			cronJob.ObjectMeta.Labels = cronJobLabels
+			cronJob.Spec.JobTemplate.Spec.Template = podTemplateSpec
+			cronJob.Spec.Schedule = pruneSchedule
+			cronJob.Spec.StartingDeadlineSeconds = &deadline
+
+			return nil
+		}
+
+		return controllerutil.CreateOrUpdate(r.opManagerContext, r.client, cronJob, mutateFunc)
+	}
+	cronJob := &v1beta1.CronJob{ObjectMeta: objectMeta}
+	err := controllerutil.SetControllerReference(&cephCluster, cronJob, r.scheme)
+	if err != nil {
+		return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of deployment %q", cronJob.Name)
+	}
+
+	mutateFunc := func() error {
+		cronJob.ObjectMeta.Labels = cronJobLabels
+		cronJob.Spec.JobTemplate.Spec.Template = podTemplateSpec
+		cronJob.Spec.Schedule = pruneSchedule
+		cronJob.Spec.StartingDeadlineSeconds = &deadline
+
+		return nil
+	}
+
+	return controllerutil.CreateOrUpdate(r.opManagerContext, r.client, cronJob, mutateFunc)
+}
+
+func (r *ReconcileNode) deletev1betaJob(objectMeta metav1.ObjectMeta) {
+	// delete v1beta1 cronJob on an update to v1 job,only if v1 job is not created yet
+	if _, err := r.context.Clientset.BatchV1().CronJobs(objectMeta.Namespace).Get(r.opManagerContext, prunerName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			err = r.client.Delete(r.opManagerContext, &v1beta1.CronJob{ObjectMeta: objectMeta})
+			if err != nil && !apierrors.IsNotFound(err) {
+				logger.Debugf("could not delete CronJob v1Beta1 %q. %v", prunerName, err)
+			}
+		}
+	}
+}
+
+func getCrashPruneContainer(cephCluster cephv1.CephCluster, cephVersion cephver.CephVersion) corev1.Container {
+	cephImage := cephCluster.Spec.CephVersion.Image
+	envVars := append(controller.DaemonEnvVars(cephImage), generateCrashEnvVar())
+	dataPathMap := config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath)
+	volumeMounts := controller.DaemonVolumeMounts(dataPathMap, "")
+	volumeMounts = append(volumeMounts, keyring.VolumeMount().CrashCollector())
+
+	container := corev1.Container{
+		Name: "ceph-crash-pruner",
+		Command: []string{
+			"ceph",
+			"-n",
+			crashClient,
+			"crash",
+			"prune",
+		},
+		Args: []string{
+			fmt.Sprintf("%d", cephCluster.Spec.CrashCollector.DaysToRetain),
+		},
+		Image:           cephImage,
+		ImagePullPolicy: controller.GetContainerImagePullPolicy(cephCluster.Spec.CephVersion.ImagePullPolicy),
+		Env:             envVars,
+		VolumeMounts:    volumeMounts,
+		Resources:       cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
+		SecurityContext: controller.PodSecurityContext(),
+	}
+
+	return container
+}

--- a/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Rook Authors. All rights reserved.
+Copyright 2022 The Rook Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,38 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package crash
+package nodedaemon
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/api/batch/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
-
-func TestGenerateCrashEnvVar(t *testing.T) {
-	env := generateCrashEnvVar()
-	assert.Equal(t, "CEPH_ARGS", env.Name)
-	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring", env.Value)
-}
 
 func TestCreateOrUpdateCephCron(t *testing.T) {
 	cephCluster := cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph"}}
@@ -109,64 +98,4 @@ func TestCreateOrUpdateCephCron(t *testing.T) {
 	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1Beta1)
 	assert.Error(t, err)
 	assert.True(t, kerrors.IsNotFound(err))
-}
-
-func TestCreateOrUpdateCephCrash(t *testing.T) {
-	cephCluster := cephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph"},
-	}
-	cephCluster.Spec.Labels = cephv1.LabelsSpec{}
-	cephCluster.Spec.PriorityClassNames = cephv1.PriorityClassNamesSpec{}
-	cephVersion := &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
-	ctx := context.TODO()
-	context := &clusterd.Context{
-		Clientset:     test.New(t, 1),
-		RookClientset: rookclient.NewSimpleClientset(),
-	}
-
-	s := scheme.Scheme
-	err := appsv1.AddToScheme(s)
-	if err != nil {
-		assert.Fail(t, "failed to build scheme")
-	}
-	r := &ReconcileNode{
-		scheme:  s,
-		client:  fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects().Build(),
-		context: context,
-	}
-
-	node := corev1.Node{}
-	nodeSelector := map[string]string{corev1.LabelHostname: "testnode"}
-	node.SetLabels(nodeSelector)
-	tolerations := []corev1.Toleration{{}}
-	res, err := r.createOrUpdateCephCrash(node, tolerations, cephCluster, cephVersion)
-	assert.NoError(t, err)
-	assert.Equal(t, controllerutil.OperationResult("created"), res)
-	name := k8sutil.TruncateNodeName(fmt.Sprintf("%s-%%s", AppName), "testnode")
-	deploy := appsv1.Deployment{}
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: name}, &deploy)
-	assert.NoError(t, err)
-	podSpec := deploy.Spec.Template
-	assert.Equal(t, nodeSelector, podSpec.Spec.NodeSelector)
-	assert.Equal(t, "", podSpec.ObjectMeta.Labels["foo"])
-	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
-	assert.Equal(t, false, podSpec.Spec.HostNetwork)
-	assert.Equal(t, "", podSpec.Spec.PriorityClassName)
-	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsUser)
-	assert.Equal(t, int64(controller.CephUserID), *podSpec.Spec.Containers[0].SecurityContext.RunAsGroup)
-
-	cephCluster.Spec.Labels[cephv1.KeyCrashCollector] = map[string]string{"foo": "bar"}
-	cephCluster.Spec.Network.HostNetwork = true
-	cephCluster.Spec.PriorityClassNames[cephv1.KeyCrashCollector] = "test-priority-class"
-	tolerations = []corev1.Toleration{{Key: "key", Operator: "Equal", Value: "value", Effect: "NoSchedule"}}
-	res, err = r.createOrUpdateCephCrash(node, tolerations, cephCluster, cephVersion)
-	assert.NoError(t, err)
-	assert.Equal(t, controllerutil.OperationResult("updated"), res)
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: name}, &deploy)
-	assert.NoError(t, err)
-	podSpec = deploy.Spec.Template
-	assert.Equal(t, "bar", podSpec.ObjectMeta.Labels["foo"])
-	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
-	assert.Equal(t, true, podSpec.Spec.HostNetwork)
-	assert.Equal(t, "test-priority-class", podSpec.Spec.PriorityClassName)
 }

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/nodedaemon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/rbd"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
@@ -97,7 +97,7 @@ var MachineDisruptionBudgetAddToManagerFuncs = []func(manager.Manager, *controll
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager (entrypoint for controller)
 var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context, context.Context, opcontroller.OperatorConfig) error{
-	crash.Add,
+	nodedaemon.Add,
 	pool.Add,
 	objectuser.Add,
 	realm.Add,

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -34,7 +34,7 @@ import (
 	"github.com/pkg/errors"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/nodedaemon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/stretchr/testify/require"
@@ -1577,7 +1577,7 @@ func (k8sh *K8sHelper) WaitForCronJob(name, namespace string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get k8s version")
 	}
-	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(crash.MinVersionForCronV1))
+	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(nodedaemon.MinVersionForCronV1))
 	for i := 0; i < RetryLoop; i++ {
 		var err error
 		if useCronJobV1 {


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The crash collector controller is designed for watching nodes where ceph daemons are running, and ensuring a special daemon is running on that node to provide additional support for ceph on that node. The crash collector is the first example of a daemon that should be running on all the ceph daemon nodes. The next example of such a node daemon will be the ceph exporter that will listen for the ceph metrics as described in the design doc and in #10687.
https://github.com/rook/rook/blob/master/design/ceph/ceph-exporter.md

Now the crash collector controller is renamed to the node daemon controller so the ceph exporter daemon can also be managed by the same controller. This PR really just moved around the code and made it simpler to add the ceph exporter to the same controller.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
