### PR TITLE
osd: Replace dot with dash in storageClassDeviceSet names since used as volume names

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -290,5 +290,6 @@ func legacyDeviceSetPVCID(deviceSetName string, setIndex int) string {
 // It includes the pvcTemplateName in it
 func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) string {
 	cleanName := strings.Replace(pvcTemplateName, " ", "-", -1)
+	deviceSetName = strings.Replace(deviceSetName, ".", "-", -1)
 	return fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
 }

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -270,3 +270,17 @@ func TestPrepareDeviceSetsWithCrushParams(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(pvcs.Items))
 }
+
+func TestPVCName(t *testing.T) {
+	id := deviceSetPVCID("mydeviceset", "a", 0)
+	assert.Equal(t, "mydeviceset-a-0", id)
+
+	id = deviceSetPVCID("mydeviceset", "a", 10)
+	assert.Equal(t, "mydeviceset-a-10", id)
+
+	id = deviceSetPVCID("device-set", "a", 10)
+	assert.Equal(t, "device-set-a-10", id)
+
+	id = deviceSetPVCID("device.set.with.dots", "b", 10)
+	assert.Equal(t, "device-set-with-dots-b-10", id)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The volume names of a pod must follow a schema that does not allow periods in the name. Since the device set name is used as the pvc name and then the volume name to attach to the osd prepare job, we must sanitize the device set name for the invalid character and replace it.

edit: Here is the error found in the volume of the osd prepare job when attempting to create the volume with the dot. When the storageClassDeviceName is set to `name.with.dots`, we see this error:
```
2022-12-12 15:08:01.120368 E | op-osd: failed to run osd provisioning job for PVC "name.with.dots-data-02rnf7": 
Job.batch "rook-ceph-osd-prepare-name.with.dots-data-02rnf7" is invalid: [spec.template.spec.volumes[7].name: Invalid value: "name.with.dots-data-02rnf7": 
a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', 
regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), 
spec.template.spec.volumes[8].name: Invalid value: "name.with.dots-data-02rnf7-bridge": 
a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), 
spec.template.spec.containers[0].volumeMounts[7].name: Not found: "name.with.dots-data-02rnf7-bridge", spec.template.spec.initContainers[1].volumeMounts[0].name: Not found: "name.with.dots-data-02rnf7-bridge", spec.template.spec.initContainers[1].volumeDevices[0].name: Not found: "name.with.dots-data-02rnf7"]
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
