### PR TITLE
ci: Update min K8s support to 1.21 and add 1.26 support

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -14,10 +14,13 @@ runs:
         go-version: 1.19
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.2
+      uses: medyagh/setup-minikube@latest
+      id: minikube
       with:
+        cache: false
         minikube version: "v1.27.0"
-        kubernetes version: "v1.25.0"
+        kubernetes version: "v1.26.1"
+        driver: docker
         start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 

--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -13,16 +13,10 @@ runs:
       with:
         go-version: 1.19
 
-    - name: setup minikube
-      uses: medyagh/setup-minikube@latest
-      id: minikube
-      with:
-        cache: false
-        minikube version: "v1.27.0"
-        kubernetes version: "v1.26.1"
-        driver: docker
-        start args: --memory 6g --cpus=2 --addons ingress
-        github token: ${{ inputs.github-token }}
+    - name: Setup Minikube
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.26.0
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -17,10 +17,14 @@ runs:
         go-version: 1.19
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.2
+      uses: medyagh/setup-minikube@latest
+      id: minikube
       with:
-        minikube version: "v1.26.1"
+        minikube version: "v1.27.0"
         kubernetes version: ${{ inputs.kubernetes-version }}
+        driver: docker
+        addons: registry
+        insecure-registry: 'localhost:5000,10.0.0.0/24'
         start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -16,17 +16,10 @@ runs:
       with:
         go-version: 1.19
 
-    - name: setup minikube
-      uses: medyagh/setup-minikube@latest
-      id: minikube
-      with:
-        minikube version: "v1.27.0"
-        kubernetes version: ${{ inputs.kubernetes-version }}
-        driver: docker
-        addons: registry
-        insecure-registry: 'localhost:5000,10.0.0.0/24'
-        start args: --memory 6g --cpus=2 --addons ingress
-        github token: ${{ inputs.github-token }}
+    - name: Setup Minikube
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        tests/scripts/github-action-helper.sh install_minikube_with_none_driver ${{ inputs.kubernetes-version }}
 
     - name: print k8s cluster status
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.25.0']
+        kubernetes-versions: ["v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.25.0']
+        kubernetes-versions: ["v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.21.14", "v1.23.10", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.21.14", "v1.23.10", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.21.14", "v1.23.10", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.21.14", "v1.23.10", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.23.10", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.23.10", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+        kubernetes-versions: ["v1.21.14", "v1.26.1"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -7,7 +7,7 @@ and Rook is granted the required privileges (see below for more information).
 
 ## Minimum Version
 
-Kubernetes **v1.19** or higher is supported for the Ceph operator.
+Kubernetes **v1.21** or higher is supported for the Ceph operator.
 
 ## CPU Architecture
 
@@ -126,15 +126,15 @@ They have to be bind-mounted as volumes in the CephFS and RBD plugin pods.
 
 If you install Rook with Helm, uncomment these example settings in `values.yaml`:
 
-- `csi.csiCephFSPluginVolume`
-- `csi.csiCephFSPluginVolumeMount`
-- `csi.csiRBDPluginVolume`
-- `csi.csiRBDPluginVolumeMount`
+* `csi.csiCephFSPluginVolume`
+* `csi.csiCephFSPluginVolumeMount`
+* `csi.csiRBDPluginVolume`
+* `csi.csiRBDPluginVolumeMount`
 
 If you deploy without Helm, add those same values to the corresponding environment variables in the operator pod,
 or the corresponding keys in its `ConfigMap`:
 
-- `CSI_CEPHFS_PLUGIN_VOLUME`
-- `CSI_CEPHFS_PLUGIN_VOLUME_MOUNT`
-- `CSI_RBD_PLUGIN_VOLUME`
-- `CSI_RBD_PLUGIN_VOLUME_MOUNT`
+* `CSI_CEPHFS_PLUGIN_VOLUME`
+* `CSI_CEPHFS_PLUGIN_VOLUME_MOUNT`
+* `CSI_RBD_PLUGIN_VOLUME`
+* `CSI_RBD_PLUGIN_VOLUME_MOUNT`

--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -13,7 +13,7 @@ from other pods running in your cluster.
 
 ## Minimum Version
 
-Kubernetes **v1.19** or higher is supported by Rook.
+Kubernetes **v1.21** or higher is supported by Rook.
 
 ## CPU Architecture
 

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -40,20 +40,20 @@ function print_k8s_cluster_status() {
 }
 
 function prepare_loop_devices() {
-    if [ $# -ne 1 ]; then
-        echo "usage: $0 loop_deivce_count"
-        exit 1
-    fi
-    OSD_COUNT=$1
-    if [ $OSD_COUNT -le 0 ]; then
-        echo "Invalid OSD_COUNT $OSD_COUNT. OSD_COUNT must be larger than 0."
-        exit 1
-    fi
-    for i in $(seq 1 $OSD_COUNT); do
-        sudo dd if=/dev/zero of=~/data${i}.img bs=1M seek=6144 count=0
-        sudo losetup /dev/loop${i} ~/data${i}.img
-    done
-    sudo lsblk
+  if [ $# -ne 1 ]; then
+    echo "usage: $0 loop_deivce_count"
+    exit 1
+  fi
+  OSD_COUNT=$1
+  if [ $OSD_COUNT -le 0 ]; then
+    echo "Invalid OSD_COUNT $OSD_COUNT. OSD_COUNT must be larger than 0."
+    exit 1
+  fi
+  for i in $(seq 1 $OSD_COUNT); do
+    sudo dd if=/dev/zero of=~/data${i}.img bs=1M seek=6144 count=0
+    sudo losetup /dev/loop${i} ~/data${i}.img
+  done
+  sudo lsblk
 }
 
 function use_local_disk() {
@@ -450,7 +450,7 @@ function write_object_read_from_replica_cluster() {
   local test_object_name="${test_bucket_name}-1mib-test.dat"
   fallocate -l 1M "$test_object_name"
   # ensure that test file has unique data
-  echo "$test_object_name" >> "$test_object_name"
+  echo "$test_object_name" >>"$test_object_name"
 
   s3cmd --host="${write_cluster_ip}" mb "s3://${test_bucket_name}"
   s3cmd --host="${write_cluster_ip}" put "$test_object_name" "s3://${test_bucket_name}"
@@ -463,7 +463,7 @@ function write_object_read_from_replica_cluster() {
   (
     sleep 60
     kill -s SIGUSR1 $$
-  ) 2> /dev/null &
+  ) 2>/dev/null &
   trap "{ S3CMD_ERROR=1; break; }" SIGUSR1
 
   until s3cmd --host="${read_cluster_ip}" get "s3://${test_bucket_name}/${test_object_name}" "${test_object_name}.get" --force; do
@@ -491,7 +491,7 @@ function test_multisite_object_replication() {
   cluster_2_ip=$(get_clusterip rook-ceph-secondary rook-ceph-rgw-zone-b-multisite-store)
 
   cd deploy/examples
-  cat <<- EOF > s3cfg
+  cat <<-EOF >s3cfg
 	[default]
 	host_bucket = no.way
 	use_https = False
@@ -620,6 +620,26 @@ function test_csi_nfs_workload {
   kubectl -n rook-ceph delete "$(kubectl -n rook-ceph get pod --selector=app=csi-nfsplugin --field-selector=status.phase=Running -o name)"
   kubectl exec -t pod/csinfs-demo-pod -- dd if=/dev/random of=/var/lib/www/html/test1 oflag=direct bs=1M count=1
   kubectl exec -t pod/csinfs-demo-pod -- ls -alh /var/lib/www/html/
+}
+
+function install_minikube_with_none_driver() {
+  CRICTL_VERSION="v1.26.0"
+  MINIKUBE_VERSION="v1.29.0"
+
+  sudo apt update
+  sudo apt install -y conntrack socat
+  curl -LO https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_amd64.deb
+  sudo dpkg -i minikube_latest_amd64.deb
+  rm -f minikube_latest_amd64.deb
+  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
+  sudo dpkg -i cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
+  rm -f cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
+  wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+  sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+  rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+  sudo sysctl fs.protected_regular=0
+  export MINIKUBE_HOME=$HOME CHANGE_MINIKUBE_NONE_USER=true KUBECONFIG=$HOME/.kube/config
+  sudo -E minikube start --kubernetes-version="$1" --driver=none --memory 6g --cpus=2 --addons ingress --cni=calico
 }
 
 FUNCTION="$1"


### PR DESCRIPTION
this commit bump minmum k8s version to 1.21.14 and max k8s version to latest 1.26.0. Keeping support for most recent 6 versions.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
