### PR TITLE
ci: upgrade minikube action to latest version

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1443,7 +1443,7 @@ jobs:
           go-version: 1.18
 
       - name: setup minikube
-        uses: manusa/actions-setup-minikube@v2.7.1
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: "v1.26.1"
           kubernetes version: "v1.23.0"

--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -14,7 +14,7 @@ runs:
         go-version: 1.18
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.0
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
         minikube version: "v1.27.0"
         kubernetes version: "v1.25.0"

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -17,7 +17,7 @@ runs:
         go-version: 1.18
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.7.0
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
         minikube version: "v1.26.1"
         kubernetes version: ${{ inputs.kubernetes-version }}


### PR DESCRIPTION
upgrading minikube action to latest version which has the fix of crictl, currently CI is failing due to this.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
