### PR TITLE
Fix CephFS Status updates

### DIFF
--- a/pkg/operator/ceph/file/status.go
+++ b/pkg/operator/ceph/file/status.go
@@ -28,16 +28,16 @@ import (
 )
 
 // updateStatus updates a fs CR with the given status
-func (r *ReconcileCephFilesystem) updateStatus(observedGeneration int64, namespacedName types.NamespacedName, status cephv1.ConditionType, info map[string]string) {
+func (r *ReconcileCephFilesystem) updateStatus(observedGeneration int64, namespacedName types.NamespacedName, status cephv1.ConditionType, info map[string]string) *cephv1.CephFilesystem {
 	fs := &cephv1.CephFilesystem{}
 	err := r.client.Get(r.opManagerContext, namespacedName, fs)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.Debug("CephFilesystem resource not found. Ignoring since object must be deleted.")
-			return
+			return nil
 		}
 		logger.Warningf("failed to retrieve filesystem %q to update status to %q. %v", namespacedName, status, err)
-		return
+		return nil
 	}
 
 	if fs.Status == nil {
@@ -51,9 +51,10 @@ func (r *ReconcileCephFilesystem) updateStatus(observedGeneration int64, namespa
 	}
 	if err := reporting.UpdateStatus(r.client, fs); err != nil {
 		logger.Warningf("failed to set filesystem %q status to %q. %v", fs.Name, status, err)
-		return
+		return nil
 	}
 	logger.Debugf("filesystem %q status updated to %q", fs.Name, status)
+	return fs
 }
 
 // updateStatusBucket updates an object with a given status


### PR DESCRIPTION
CephFS object fails to do a initial status update.
Operator shows the following error message in logs,

'Error while updation: Operation cannot be fulfilled on
cephfilesystems.ceph.rook.io "myfs": the object has been
modified; please apply your changes to the latest version
and try again'

Function 'updateStatus' now returns the new/updated
CephFilesystem object if successfully updated or nil.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves issue https://github.com/rook/rook/issues/10767

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
