### PR TITLE
docs: Add link to failover and failback topic

### DIFF
--- a/Documentation/Storage-Configuration/Block-Storage-RBD/rbd-mirroring.md
+++ b/Documentation/Storage-Configuration/Block-Storage-RBD/rbd-mirroring.md
@@ -25,7 +25,7 @@ One of the solutions, to achieve the same, is [RBD mirroring](https://docs.ceph.
 
 !!! note
     This document sheds light on rbd mirroring and how to set it up using rook.
-    For steps on failover or failback scenarios
+    See also the topic on [Failover and Failback](rbd-async-disaster-recovery-failover-failback.md)
 
 ## Create RBD Pools
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
A note in the rbd mirroring topic was missing a link to the failover and failback doc.

**Which issue is resolved by this Pull Request:**
Resolves #10741 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
