### PR TITLE
helm: document installing different types of CephClusters

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -60,6 +60,12 @@ The following table lists the configurable parameters of the rook-operator chart
 The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
 For the full list, see the [Cluster CRD](../CRDs/Cluster/ceph-cluster-crd.md) topic.
 
+The cluster spec example is for a converged cluster where all the Ceph daemons are running locally,
+as in the host-based example (cluster.yaml). For a different configuration such as a
+PVC-based cluster (cluster-on-pvc.yaml), external cluster (cluster-external.yaml),
+or stretch cluster (cluster-stretched.yaml), replace this entire `cephClusterSpec`
+with the specs from those examples.
+
 ### **Ceph Block Pools**
 
 The `cephBlockPools` array in the values file will define a list of CephBlockPool as described in the table below.

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -87,6 +87,12 @@ The following table lists the configurable parameters of the rook-operator chart
 The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
 For the full list, see the [Cluster CRD](../CRDs/Cluster/ceph-cluster-crd.md) topic.
 
+The cluster spec example is for a converged cluster where all the Ceph daemons are running locally,
+as in the host-based example (cluster.yaml). For a different configuration such as a
+PVC-based cluster (cluster-on-pvc.yaml), external cluster (cluster-external.yaml),
+or stretch cluster (cluster-stretched.yaml), replace this entire `cephClusterSpec`
+with the specs from those examples.
+
 ### **Ceph Block Pools**
 
 The `cephBlockPools` array in the values file will define a list of CephBlockPool as described in the table below.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -72,6 +72,12 @@ pspEnable: false
 # -- Cluster configuration.
 # @default -- See [below](#ceph-cluster-spec)
 cephClusterSpec:
+  # This cluster spec example is for a converged cluster where all the Ceph daemons are running locally,
+  # as in the host-based example (cluster.yaml). For a different configuration such as a
+  # PVC-based cluster (cluster-on-pvc.yaml), external cluster (cluster-external.yaml),
+  # or stretch cluster (cluster-stretched.yaml), replace this entire `cephClusterSpec`
+  # with the specs from those examples.
+
   # For more details, check https://rook.io/docs/rook/v1.10/CRDs/Cluster/ceph-cluster-crd/
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).


### PR DESCRIPTION
currently helm has only the config of cephclusterSpec
for a converged cluster, document installing pvc based,
strech based , external based cluster

Closes: https://github.com/rook/rook/issues/11480
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
