### PR TITLE
docs: add limitRange comment to deploy/charts/rook-ceph-cluster/values.yaml

### DIFF
--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -269,8 +269,14 @@ cephClusterSpec:
         cpu: "1000m"
         memory: "4Gi"
     prepareosd:
-      # limits: It is not recommended to set limits on the OSD prepare job since it's a one-time burst for memory
-      # that must be allowed to complete without an OOM kill
+      # limits: It is not recommended to set limits on the OSD prepare job
+      #         since it's a one-time burst for memory that must be allowed to
+      #         complete without an OOM kill.  Note however that if a k8s
+      #         limitRange guardrail is defined external to Rook, the lack of
+      #         a limit here may result in a sync failure, in which case a
+      #         limit should be added.  1200Mi may suffice for up to 15Ti
+      #         OSDs ; for larger devices 2Gi may be required.
+      #         cf. https://github.com/rook/rook/pull/11103
       requests:
         cpu: "500m"
         memory: "50Mi"


### PR DESCRIPTION
Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Expand a comment that recommends no `limit` for the `prepareosd` pod to note a conflict with an external `limitRange`.  Also wrap lines to a traditional length.

**Which issue is resolved by this Pull Request:**
Resolves #11511

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
