### PR TITLE
ceph: set rbd_default_map_options for encryption

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -604,14 +604,18 @@ func (c *cluster) configureMsgr2() error {
 	monStore := config.GetMonStore(c.context, c.ClusterInfo)
 	if c.Spec.Network.Connections.Encryption != nil {
 		encryptionSetting := "crc secure"
+		// crc mode, if denied agree to secure mode
+		defaultRBDMapOptions := "ms_mode=prefer-crc"
 		if c.Spec.Network.Connections.Encryption.Enabled {
 			encryptionSetting = "secure"
+			defaultRBDMapOptions = "ms_mode=secure"
 		}
 
 		globalConfigSettings := map[string]string{
-			"ms_cluster_mode": encryptionSetting,
-			"ms_service_mode": encryptionSetting,
-			"ms_client_mode":  encryptionSetting,
+			"ms_cluster_mode":         encryptionSetting,
+			"ms_service_mode":         encryptionSetting,
+			"ms_client_mode":          encryptionSetting,
+			"rbd_default_map_options": defaultRBDMapOptions,
 		}
 
 		logger.Infof("setting msgr2 encryption mode to %q", encryptionSetting)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -314,11 +314,6 @@ parameters:
   imageFeatures: layering
   csi.storage.k8s.io/fstype: ext4
 `
-	if m.settings.ConnectionsEncrypted {
-		// encryption requires either the 5.11 kernel or the nbd mounter. Until the newer
-		// kernel is available in minikube, we need to test with nbd.
-		sc += "  mounter: rbd-nbd"
-	}
 	return sc
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Set rbd_default_map_options to secure when encryption is enabled.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #11522 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
