### PR TITLE
mgr: role rook-ceph-mgr is lack of patch verb to compete ceph request(fix 11537)

### DIFF
--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -93,6 +93,7 @@ rules:
       - create
       - update
       - delete
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -760,6 +760,7 @@ rules:
       - create
       - update
       - delete
+      - patch
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
ceph orch command uses patch method to update cephcluster. Adding patch to verbs list of rook-ceph-mgr(Role) to make it work. It was allright with deploy/charts/rook-ceph-cluster/charts/library/templates/_cluster-role.tpl to justify the changes quite a bit.

Signed-off-by: Ben Gao <bengao168@msn.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #11537 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
