### PR TITLE
osd: handle device name change and device removel correctly

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -164,6 +164,15 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 	fi
 	[[ -z "$DEVICE" ]] && { echo "no device" ; exit 1 ; }
 
+	# If a kernel device name change happens and a block device file
+	# in the OSD directory becomes missing, this OSD fails to start
+	# continuously. This problem can be resolved by confirming
+	# the validity of the device file and recreating it if necessary.
+	OSD_BLOCK_PATH=/var/lib/ceph/osd/ceph-$OSD_ID/block
+	if [ -L $OSD_BLOCK_PATH -a "$(readlink $OSD_BLOCK_PATH)" != $DEVICE ] ; then
+		rm $OSD_BLOCK_PATH
+	fi
+
 	# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag
 	ceph-volume raw activate --device "$DEVICE" --no-systemd --no-tmpfs
 fi


### PR DESCRIPTION
**Description of your changes:**

If a kernel device name change happens and a block device file in the OSD directory becomes dangling link, this OSD fails to start continuously. This problem can be resolved by confirming the validity of the device file and recreating it if necessary.

**Which issue is resolved by this Pull Request:**
Resolves #10860 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
