### PR TITLE
test: stub out CephNFSSuite integration test

### DIFF
--- a/.github/workflows/integration-test-nfs-suite.yaml
+++ b/.github/workflows/integration-test-nfs-suite.yaml
@@ -1,0 +1,70 @@
+name: Integration test CephNFSSuite
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  TestCephNFSSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions: ["v1.19.16", "v1.25.0"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-config-latest-k8s
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          kubernetes-version: ${{ matrix.kubernetes-versions }}
+
+      - name: TestCephNFSSuite
+        run: |
+          tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+          export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+          SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephNFSSuite github.com/rook/rook/tests/integration
+
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="nfs-ns"
+          export OPERATOR_NAMESPACE="nfs-ns-system"
+          tests/scripts/collect-logs.sh
+
+      - name: Artifact
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ceph-nfs-suite-artifact-${{ matrix.kubernetes-versions }}
+          path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
+      - name: consider debugging
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
+          if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ secrets.USE_TMATE }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo USE_TMATE=1 >> $GITHUB_ENV
+          fi
+
+      - name: set up tmate session for debugging
+        if: failure() && env.USE_TMATE
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60

--- a/tests/integration/ceph_nfs_test.go
+++ b/tests/integration/ceph_nfs_test.go
@@ -61,6 +61,7 @@ func (s *NFSSuite) SetupSuite() {
 		ChangeHostName:            true,
 		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.ReturnCephVersion(),
+		SkipClusterCleanup:        true,
 	}
 	s.settings.ApplyEnvVars()
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)

--- a/tests/integration/ceph_nfs_test.go
+++ b/tests/integration/ceph_nfs_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/rook/rook/tests/framework/clients"
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestCephNFSSuite(t *testing.T) {
+	s := new(NFSSuite)
+	defer func(s *NFSSuite) {
+		HandlePanics(recover(), s.TearDownSuite, s.T)
+	}(s)
+	suite.Run(t, s)
+}
+
+type NFSSuite struct {
+	suite.Suite
+	helper    *clients.TestClient
+	settings  *installer.TestCephSettings
+	installer *installer.CephInstaller
+	k8sh      *utils.K8sHelper
+}
+
+func (s *NFSSuite) SetupSuite() {
+	namespace := "nfs-ns"
+	s.settings = &installer.TestCephSettings{
+		ClusterName:               "nfs-cluster",
+		Namespace:                 namespace,
+		OperatorNamespace:         installer.SystemNamespace(namespace),
+		StorageClassName:          installer.StorageClassName(),
+		UseHelm:                   false,
+		UsePVC:                    installer.UsePVC(),
+		Mons:                      3,
+		SkipOSDCreation:           false,
+		EnableAdmissionController: true,
+		ConnectionsEncrypted:      true,
+		ConnectionsCompressed:     true,
+		UseCrashPruner:            true,
+		EnableVolumeReplication:   true,
+		TestNFSCSI:                true,
+		ChangeHostName:            true,
+		RookVersion:               installer.LocalBuildTag,
+		CephVersion:               installer.ReturnCephVersion(),
+	}
+	s.settings.ApplyEnvVars()
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
+	s.helper = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
+}
+
+func (s *NFSSuite) AfterTest(suiteName, testName string) {
+	s.installer.CollectOperatorLog(suiteName, testName)
+}
+
+func (s *NFSSuite) TearDownSuite() {
+	s.installer.UninstallRook()
+}
+
+func (s *NFSSuite) TestNFSE2E_NFSTest() {
+	runNFSFileE2ETest(s.helper, s.k8sh, &s.Suite, s.settings, "nfs-test")
+}


### PR DESCRIPTION
**Description of your changes:**

Create a new NFS specific integration test. This is desired to host future NFS tests rather than adding additional test scenarios to the smoke suite. Initially, runNFSFileE2ETest() from the CephSmokeSuite is the only test scenario.

The intent is to eventually provide test coverage for this issue: https://tracker.ceph.com/issues/58514

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
