### PR TITLE
rbdmirror: set log rotation from 7 to 4x i.e 28

### DIFF
--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -382,15 +382,15 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("Periodicity 1d and no MaxlogSize", func(t *testing.T) {
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d"}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "0")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "0", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
 	t.Run("Periodicity 1h and MaxlogSize 1M", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1M")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1h", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "hourly", "1M")
+		got := LogCollectorContainer("ceph-client.rbd-mirror.a", ns, c)
+		want := fmt.Sprintf(cronLogRotate, "ceph-client.rbd-mirror.a", "hourly", "1M", "28")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -398,7 +398,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1Gi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "weekly", MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "1073M")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "1073M", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -406,7 +406,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1Mi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -414,7 +414,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("10G")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "10G")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "10G", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -422,7 +422,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("10Mi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "weekly", MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "10M")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "10M", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -430,7 +430,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1M")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 
@@ -438,7 +438,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("500K")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
 		got := LogCollectorContainer(daemonId, ns, c)
-		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M")
+		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7")
 		assert.Equal(t, want, got.Command[5])
 	})
 }


### PR DESCRIPTION
increasing the rotation from default 7 to 28 as
in case of rbdmirror logs seems not enough in some cases
with maxLogSize 500 so it's better to increase the rotation
for rbdmirror specific.


Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
