### PR TITLE
Initialise the rook-config-override configmap using helm

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `cephFileSystems` | A list of CephFileSystem configurations to deploy | See [below](#ceph-file-systems) |
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
-| `configOverride` | Cluster ceph.conf override | `nil` |
+| `configOverride` | Cluster ceph.conf override - default value initialises empty config map per rook issue #11302 | `"[global]\n"` |
 | `ingress.dashboard` | Enable an ingress for the ceph-dashboard | `{}` |
 | `kubeVersion` | Optional override of the target kubernetes version | `nil` |
 | `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts | `false` |

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -12,10 +12,9 @@ clusterName:
 # -- Optional override of the target kubernetes version
 kubeVersion:
 
-# -- Cluster ceph.conf override
-configOverride:
-# configOverride: |
-#   [global]
+# -- Cluster ceph.conf override - default value initialises empty config map per rook issue #11302
+configOverride: |
+  [global]
 #   mon_allow_pool_delete = true
 #   osd_pool_default_size = 3
 #   osd_pool_default_min_size = 2


### PR DESCRIPTION
**Description of your changes:**
Fix issue #11302 by creating blank rook-config-override configmap (but for the [general] section heading) using helm.

**Which issue is resolved by this Pull Request:**
Resolves #11302