### PR TITLE
docs: add export path example for NFS CSI

### DIFF
--- a/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
+++ b/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
@@ -96,7 +96,14 @@ application pod.
 
 ### Connecting to an export directly
 After a PVC is created successfully, the `share` parameter set on the resulting PV contains the
-`share` path which can be used as the export path when [mounting the export manually](nfs.md#mounting-exports).
+`share` path which can be used as the export path when
+[mounting the export manually](nfs.md#mounting-exports). In the example below
+`/0001-0009-rook-ceph-0000000000000001-55c910f9-a1af-11ed-9772-1a471870b2f5` is the export path.
+
+```console
+$ kubectl get pv pvc-b559f225-de79-451b-a327-3dbec1f95a1c -o jsonpath='{.spec.csi.volumeAttributes}'
+/0001-0009-rook-ceph-0000000000000001-55c910f9-a1af-11ed-9772-1a471870b2f5
+```
 
 ## Taking snapshots of NFS exports
 


### PR DESCRIPTION
Add an example of getting the export path for an NFS PVC to the NFS CSI docs.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
