### PR TITLE
docs: fixing build instructions

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -29,15 +29,31 @@ mkdir -p $GOPATH/src/github.com/rook
 cd $GOPATH/src/github.com/rook
 
 # Clone your fork, where <user> is your GitHub account name
-$ git clone https://github.com/<user>/rook.git
-cd rook
+git clone https://github.com/<user>/rook.git
 ```
+
+### Add Upstream Remote
+
+First you will need to add the upstream remote to your local git:
+
+```console
+# Add 'upstream' to the list of remotes
+cd rook
+git remote add upstream https://github.com/rook/rook.git
+
+# Verify the remote was added
+git remote -v
+```
+
+Now you should have at least `origin` and `upstream` remotes. You can also add other remotes to collaborate with other contributors.
 
 ### Build
 
-Building Rook Ceph is simple.
+Before building the project you have to fetch the upstream to synchronize tags.
 
 ```console
+# Fetch all from 'upstream'
+git fetch -a
 make build
 ```
 
@@ -64,20 +80,6 @@ A set of recommended settings when working on Rook, can be found [here](https://
 
 !!! tip
     VS Code should automatically use these settings through the `.vscode/settings.json` file.
-
-### Add Upstream Remote
-
-First you will need to add the upstream remote to your local git:
-
-```console
-# Add 'upstream' to the list of remotes
-git remote add upstream https://github.com/rook/rook.git
-
-# Verify the remote was added
-git remote -v
-```
-
-Now you should have at least `origin` and `upstream` remotes. You can also add other remotes to collaborate with other contributors.
 
 ### Self assign Issue
 


### PR DESCRIPTION
Adding instructions to fetch the tags as they are used during the build process. The current instructions only require the user to clone the project which results in build errors later on.

Closes: https://github.com/rook/rook/issues/11619
Signed-off-by: Redouane Kachach <rkachach@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
