### PR TITLE
docs: fix formatting issues

### DIFF
--- a/Documentation/Storage-Configuration/Monitoring/ceph-dashboard.md
+++ b/Documentation/Storage-Configuration/Monitoring/ceph-dashboard.md
@@ -75,7 +75,7 @@ Information about physical disks is available only in [Rook host clusters](../..
 
 The Rook manager module is required by the dashboard to obtain the information about physical disks, but it is disabled by default. Before it is enabled, the dashboard 'Physical Disks' section will show an error message.
 
-To prepare the Rook manager module to be used in the dashboard, modify your cluster CRD:
+To prepare the Rook manager module to be used in the dashboard, modify your Ceph Cluster CRD:
 
 ```yaml
   mgr:
@@ -87,17 +87,18 @@ To prepare the Rook manager module to be used in the dashboard, modify your clus
 And apply the changes:
 
 ```console
-$ kubectl apply cluster.yaml
+$ kubectl apply -f cluster.yaml
 ```
 
 Once the Rook manager module is enabled as the orchestrator backend, there are two settings required for showing disk information:
-- `ROOK_ENABLE_DISCOVERY_DAEMON`: Set to `true` to provide the dashboard the information about physical disks. The default is `false`.
-- `ROOK_DISCOVER_DEVICES_INTERVAL`: The interval for changes to be refreshed in the set of physical disks in the cluster. The default is `60` minutes.  
+
+* `ROOK_ENABLE_DISCOVERY_DAEMON`: Set to `true` to provide the dashboard the information about physical disks. The default is `false`.
+* `ROOK_DISCOVER_DEVICES_INTERVAL`: The interval for changes to be refreshed in the set of physical disks in the cluster. The default is `60` minutes.
 
 Modify the operator.yaml, and apply the changes:
 
 ```console
-$ kubectl apply operator.yaml
+$ kubectl apply -f operator.yaml
 ```
 
 ## Viewing the Dashboard External to the Cluster


### PR DESCRIPTION
**Description of your changes:**

Fix some formatting issues and the kubectl apply command `-f` flag missing.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
