### PR TITLE
core: Option to require msgrv2 even without encryption

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -164,6 +164,9 @@ Configure the network that will be enabled for the cluster and services.
 * `ipFamily`: Specifies the network stack Ceph daemons should listen on.
 * `dualStack`: Specifies that Ceph daemon should listen on both IPv4 and IPv6 network stacks.
 * `connections`: Settings for network connections using Ceph's msgr2 protocol
+    * `requireMsgr2`: Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+        and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+        Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer). Default is false.
     * `encryption`: Settings for encryption on the wire to Ceph daemons
         * `enabled`: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.
           The default is false. When encryption is enabled, all communication between clients and Ceph daemons, or between

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,6 +8,9 @@
 
 ## Features
 
+- Added setting `requireMsgr2` on the CephCluster CR to allow clusters with a kernel of 5.11 or newer
+  to fully communicate with msgr2 and disable the msgr1 port. This allows for more flexibility to enable
+  msgr2 features such as encryption and compression on the wire.
 - Change `pspEnable` default value to `false` in helm charts.
 - [Bucket notifications and topics](https://rook.io/docs/rook/latest/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications/)
   for object stores moved to stable from experimental.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -145,7 +145,24 @@ cephClusterSpec:
     ssl: true
 
   # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/CRDs/ceph-cluster-crd.md#network-configuration-settings
-  # network:
+  network:
+    connections:
+      # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.
+      # The default is false. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
+      # When encryption is not enabled, clients still establish a strong initial authentication and data integrity is still validated with a crc check.
+      # IMPORTANT: Encryption requires the 5.11 kernel for the latest nbd and cephfs drivers. Alternatively for testing only,
+      # you can set the "mounter: rbd-nbd" in the rbd storage class, or "mounter: fuse" in the cephfs storage class.
+      # The nbd and fuse drivers are *not* recommended in production since restarting the csi driver pod will disconnect the volumes.
+      encryption:
+        enabled: false
+      # Whether to compress the data in transit across the wire. The default is false.
+      # Requires Ceph Quincy (v17) or newer. Also see the kernel requirements above for encryption.
+      compression:
+        enabled: false
+      # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+      # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+      # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
+      requireMsgr2: false
   #   # enable host networking
   #   provider: host
   #   # EXPERIMENTAL: enable the Multus network provider

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1875,6 +1875,9 @@ spec:
                               description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network. The default is not set. Even if encryption is not enabled, clients still establish a strong initial authentication for the connection and data integrity is still validated with a crc check. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
                               type: boolean
                           type: object
+                        requireMsgr2:
+                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled. If true, the msgr1 port (6789) will be disabled. Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer).
+                          type: boolean
                       type: object
                     dualStack:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -88,6 +88,10 @@ spec:
       # Requires Ceph Quincy (v17) or newer. Also see the kernel requirements above for encryption.
       compression:
         enabled: false
+      # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+      # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+      # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
+      requireMsgr2: false
     # enable host networking
     #provider: host
     # enable the Multus network provider

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1873,6 +1873,9 @@ spec:
                               description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network. The default is not set. Even if encryption is not enabled, clients still establish a strong initial authentication for the connection and data integrity is still validated with a crc check. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
                               type: boolean
                           type: object
+                        requireMsgr2:
+                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled. If true, the msgr1 port (6789) will be disabled. Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer).
+                          type: boolean
                       type: object
                     dualStack:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6

--- a/pkg/apis/ceph.rook.io/v1/cluster.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster.go
@@ -33,6 +33,9 @@ func (c *ClusterSpec) RequireMsgr2() bool {
 	if c.Network.Connections == nil {
 		return false
 	}
+	if c.Network.Connections.RequireMsgr2 {
+		return true
+	}
 	if c.Network.Connections.Compression != nil && c.Network.Connections.Compression.Enabled {
 		return true
 	}

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2170,6 +2170,12 @@ type ConnectionsSpec struct {
 	// +nullable
 	// +optional
 	Compression *CompressionSpec `json:"compression,omitempty"`
+
+	// Whether to require msgr2 (port 3300) even if compression or encryption are not enabled.
+	// If true, the msgr1 port (6789) will be disabled.
+	// Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer).
+	// +optional
+	RequireMsgr2 bool `json:"requireMsgr2,omitempty"`
 }
 
 type EncryptionSpec struct {

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -257,16 +257,13 @@ func PopulateMonHostMembers(clusterInfo *ClusterInfo) ([]string, []string) {
 		}
 		monMembers = append(monMembers, monitor.Name)
 		monIP := cephutil.GetIPFromEndpoint(monitor.Endpoint)
-		if clusterInfo.RequireMsgr2 {
+		// Detect the current port if the mon already exists
+		// so the same msgr1 port can be preserved if needed (6789 or 6790)
+		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
+
+		if currentMonPort == Msgr2port {
 			monHosts = append(monHosts, fmt.Sprintf("[v2:%s:%d]", monIP, Msgr2port))
 		} else {
-			// Detect the current port if the mon already exists
-			// so the same msgr1 port can be preserved if needed (6789 or 6790)
-			currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
-			// Ensure we're setting a msgr1 port, rather than duplicating msgr2
-			if currentMonPort == Msgr2port {
-				currentMonPort = Msgr1port
-			}
 			msgr2Endpoint := net.JoinHostPort(monIP, strconv.Itoa(int(Msgr2port)))
 			msgr1Endpoint := net.JoinHostPort(monIP, strconv.Itoa(int(currentMonPort)))
 			monHosts = append(monHosts, "[v2:"+msgr2Endpoint+",v1:"+msgr1Endpoint+"]")

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -43,7 +43,6 @@ type ClusterInfo struct {
 	CephVersion   cephver.CephVersion
 	Namespace     string
 	OwnerInfo     *k8sutil.OwnerInfo
-	RequireMsgr2  bool
 	// Hide the name of the cluster since in 99% of uses we want to use the cluster namespace.
 	// If the CR name is needed, access it through the NamespacedName() method.
 	name              string

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -197,7 +197,6 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 		} else {
 			clusterInfo.OwnerInfo = cluster.ownerInfo
 			clusterInfo.SetName(c.namespacedName.Name)
-			clusterInfo.RequireMsgr2 = cluster.Spec.RequireMsgr2()
 			cluster.ClusterInfo = clusterInfo
 		}
 		// If the local cluster has already been configured, immediately start monitoring the cluster.

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -498,7 +498,6 @@ func (c *Cluster) initClusterInfo(cephVersion cephver.CephVersion, clusterName s
 	c.ClusterInfo.OwnerInfo = c.ownerInfo
 	c.ClusterInfo.Context = context
 	c.ClusterInfo.SetName(clusterName)
-	c.ClusterInfo.RequireMsgr2 = c.spec.RequireMsgr2()
 
 	// save cluster monitor config
 	if err = c.saveMonConfig(); err != nil {

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -40,9 +40,9 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 		return "", errors.Wrapf(err, "failed to set owner reference to mon service %q", svcDef.Name)
 	}
 
-	// If the cluster doesn't require msgr2 we allow msgr1 as well
-	if !c.ClusterInfo.RequireMsgr2 {
-		addServicePort(svcDef, "tcp-msgr1", DefaultMsgr1Port)
+	// If the mon port was not msgr2, add the msgr1 port
+	if mon.Port != DefaultMsgr2Port {
+		addServicePort(svcDef, "tcp-msgr1", mon.Port)
 	}
 	addServicePort(svcDef, "tcp-msgr2", DefaultMsgr2Port)
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -320,11 +320,11 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 		WorkingDir:    config.VarLogCephDir,
 	}
 
-	if !c.spec.RequireMsgr2() {
+	if monConfig.Port != DefaultMsgr2Port {
 		// Add messenger 1 port
 		container.Ports = append(container.Ports, corev1.ContainerPort{
 			Name:          "tcp-msgr1",
-			ContainerPort: DefaultMsgr1Port,
+			ContainerPort: monConfig.Port,
 			Protocol:      corev1.ProtocolTCP,
 		})
 	}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -159,6 +159,7 @@ spec:
   network:
     hostNetwork: false
     connections:
+      requireMsgr2: ` + strconv.FormatBool(m.settings.RequireMsgr2) + `
       encryption:
         enabled: ` + strconv.FormatBool(m.settings.ConnectionsEncrypted) + `
       compression:

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -46,6 +46,7 @@ type TestCephSettings struct {
 	DirectMountToolbox          bool
 	ConnectionsEncrypted        bool
 	ConnectionsCompressed       bool
+	RequireMsgr2                bool
 	EnableVolumeReplication     bool
 	TestNFSCSI                  bool
 	ChangeHostName              bool

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -83,6 +83,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		EnableAdmissionController: true,
 		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.PacificVersion,
+		RequireMsgr2:              true,
 	}
 	s.settings.ApplyEnvVars()
 	externalSettings := &installer.TestCephSettings{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Enabling msgr v2 and disabling msgr v1 currently requires enabling either encryption on the wire or compression on the wire. As more clients are running on the latest kernel, allow the clients to run on v2 even when encryption and compression are not enabled. Clusters that are fully running on v2 will more easily be able to change configuration between enabling or disabling msgr v2 features.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
