### PR TITLE
csi: add support for enabling read affinity for rbd volumes.

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -110,6 +110,8 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.rbdPluginUpdateStrategy` | CSI RBD plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
 | `csi.rbdPluginUpdateStrategyMaxUnavailable` | A maxUnavailable parameter of CSI RBD plugin daemonset update strategy. | `1` |
 | `csi.rbdPodLabels` | Labels to add to the CSI RBD Deployments and DaemonSets Pods | `nil` |
+| `csi.readAffinity.crushLocationLabels` | Define which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map. | labels listed [here](../CRDs/Cluster/ceph-cluster-crd.md#osd-topology) |
+| `csi.readAffinity.enabled` | Enable read affinity for RBD volumes. Recommended to set to true if running kernel 5.8 or newer. | `false` |
 | `csi.registrar.image` | Kubernetes CSI registrar image | `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0` |
 | `csi.resizer.image` | Kubernetes CSI resizer image | `registry.k8s.io/sig-storage/csi-resizer:v1.7.0` |
 | `csi.sidecarLogLevel` | Set logging level for Kubernetes-csi sidecar containers. Supported values from 0 to 5. 0 for general useful logs (the default), 5 for trace level verbosity. | `0` |

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
@@ -238,3 +238,33 @@ parameters:
 ```
 
 * PVCs created using the new storageclass will be encrypted.
+
+## Enable Read affinity for RBD volumes
+
+Ceph CSI supports mapping RBD volumes with krbd options to allow
+serving reads from an OSD in proximity to the client, according to
+OSD locations defined in the CRUSH map and topology labels on nodes.
+
+Refer to the [krbd-options](https://docs.ceph.com/en/latest/man/8/rbd/#kernel-rbd-krbd-options)
+for more details.
+
+Execute the following steps:
+
+* Patch the `rook-ceph-operator-config` configmap using the following
+command.
+```console
+kubectl patch cm rook-ceph-operator-config -nrook-ceph -p $'data:\n "CSI_ENABLE_READ_AFFINITY": "true"'
+```
+
+* Add topology labels to the Kubernetes nodes. The same labels may be used as mentioned in the
+[OSD topology](../../CRDs/Cluster/ceph-cluster-crd.md#osd-topology) topic.
+
+* (optional) Rook will pass the labels mentioned in [osd-topology](../../CRDs/Cluster/ceph-cluster-crd.md#osd-topology)
+as the default set of labels. This can overridden to supply custom labels by updating the
+`CSI_CRUSH_LOCATION_LABELS` value in the `rook-ceph-operator-config` configmap.
+
+Ceph CSI will extract the CRUSH location from the topology labels found on the node
+and pass it though krbd options during mapping RBD volumes.
+
+!!! note
+    This requires kernel version 5.8 or higher.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,3 +15,4 @@
 - [Bucket notifications and topics](https://rook.io/docs/rook/latest/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications/)
   for object stores moved to stable from experimental.
 - Introduce [Ceph exporter](https://github.com/rook/rook/blob/master/design/ceph/ceph-exporter.md) as the new source of metrics based on performance counters coming from every Ceph daemon.
+- Added support to enable read affinity for RBD volumes. It leverages the [krbd map options](https://docs.ceph.com/en/latest/man/8/rbd/#kernel-rbd-krbd-options) to allow serving reads from an OSD in proximity to the client, according to OSD locations defined in the CRUSH map and topology labels on nodes.

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -100,6 +100,12 @@ data:
   CSI_TOPOLOGY_DOMAIN_LABELS: {{ .Values.csi.topology.domainLabels | join "," }}
 {{- end }}
 {{- end }}
+{{- if .Values.csi.readAffinity }}
+  CSI_ENABLE_READ_AFFINITY : {{ .Values.csi.readAffinity.enabled | quote }}
+{{- if .Values.csi.readAffinity.crushLocationLabels }}
+  CSI_CRUSH_LOCATION_LABELS: {{ .Values.csi.readAffinity.crushLocationLabels | join "," }}
+{{- end }}
+{{- end }}
 {{- if .Values.csi.nfs }}
   ROOK_CSI_ENABLE_NFS: {{ .Values.csi.nfs.enabled | quote }}
 {{- end }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -518,6 +518,17 @@ csi:
     # - topology.kubernetes.io/zone
     # - topology.rook.io/rack
 
+  readAffinity:
+    # -- Enable read affinity for RBD volumes. Recommended to
+    # set to true if running kernel 5.8 or newer.
+    # @default -- `false`
+    enabled: false
+    # -- Define which node labels to use
+    # as CRUSH location. This should correspond to the values set
+    # in the CRUSH map.
+    # @default -- labels listed [here](../CRDs/Cluster/ceph-cluster-crd.md#osd-topology)
+    crushLocationLabels:
+
 # -- Enable discovery daemon
 enableDiscoveryDaemon: false
 

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -574,6 +574,16 @@ data:
   # NOTE: the value here serves as an example and needs to be
   # updated with node labels that define domains of interest
   # CSI_TOPOLOGY_DOMAIN_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
+
+  # Enable read affinity for RBD volumes. Recommended to
+  # set to true if running kernel 5.8 or newer.
+  CSI_ENABLE_READ_AFFINITY: "false"
+  # CRUSH location labels define which node labels to use
+  # as CRUSH location. This should correspond to the values set in
+  # the CRUSH map.
+  # Defaults to all the labels mentioned in
+  # https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/#osd-topology
+  # CSI_CRUSH_LOCATION_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
 ---
 # The deployment for the rook operator
 # OLM: BEGIN OPERATOR DEPLOYMENT

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -502,6 +502,16 @@ data:
   # NOTE: the value here serves as an example and needs to be
   # updated with node labels that define domains of interest
   # CSI_TOPOLOGY_DOMAIN_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
+
+  # Enable read affinity for RBD volumes. Recommended to
+  # set to true if running kernel 5.8 or newer.
+  CSI_ENABLE_READ_AFFINITY: "false"
+  # CRUSH location labels define which node labels to use
+  # as CRUSH location. This should correspond to the values set in
+  # the CRUSH map.
+  # Defaults to all the labels mentioned in
+  # https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/#osd-topology
+  # CSI_CRUSH_LOCATION_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
 ---
 # OLM: BEGIN OPERATOR DEPLOYMENT
 apiVersion: apps/v1

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -26,22 +26,23 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/coreos/pkg/capnslog"
-	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -662,7 +663,7 @@ func getTopologyFromNode(ctx context.Context, clientset kubernetes.Interface, d 
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get the node for topology affinity")
 	}
-	_, topologyAffinity := ExtractOSDTopologyFromLabels(node.Labels)
+	_, topologyAffinity := topology.ExtractOSDTopologyFromLabels(node.Labels)
 	logger.Infof("found osd %d topology affinity at %q", osd.ID, topologyAffinity)
 	return topologyAffinity, nil
 }
@@ -722,7 +723,7 @@ func getNode(ctx context.Context, clientset kubernetes.Interface, nodeName strin
 }
 
 func updateLocationWithNodeLabels(location *[]string, nodeLabels map[string]string) string {
-	topology, topologyAffinity := ExtractOSDTopologyFromLabels(nodeLabels)
+	topology, topologyAffinity := topology.ExtractOSDTopologyFromLabels(nodeLabels)
 
 	keys := make([]string, 0, len(topology))
 	for k := range topology {

--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -17,10 +17,11 @@ limitations under the License.
 // Package config provides methods for generating the Ceph config for a Ceph cluster and for
 // producing a "ceph.conf" compatible file from the config as well as Ceph command line-compatible
 // flags.
-package osd
+package topology
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	corev1 "k8s.io/api/core/v1"
@@ -120,4 +121,14 @@ func extractTopologyFromLabels(labels map[string]string) (map[string]string, str
 
 func formatTopologyAffinity(label, value string) string {
 	return fmt.Sprintf("%s=%s", label, value)
+}
+
+// GetDefaultTopologyLabels returns the supported default topology labels.
+func GetDefaultTopologyLabels() string {
+	Labels := []string{corev1.LabelHostname, corev1.LabelZoneRegionStable, corev1.LabelZoneFailureDomainStable}
+	for _, label := range CRUSHTopologyLabels {
+		Labels = append(Labels, topologyLabelPrefix+label)
+	}
+
+	return strings.Join(Labels, ",")
 }

--- a/pkg/operator/ceph/cluster/osd/topology/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package config provides methods for generating the Ceph config for a Ceph cluster and for
 // producing a "ceph.conf" compatible file from the config as well as Ceph command line-compatible
 // flags.
-package osd
+package topology
 
 import (
 	"testing"
@@ -144,4 +144,18 @@ func TestTopologyLabels(t *testing.T) {
 	assert.Equal(t, 1, len(topology))
 	assert.Equal(t, "zone", topology["zone"])
 	assert.Equal(t, "topology.kubernetes.io/zone=zone", affinity)
+}
+
+func TestGetDefaultTopologyLabels(t *testing.T) {
+	expectedLabels := "kubernetes.io/hostname," +
+		"topology.kubernetes.io/region," +
+		"topology.kubernetes.io/zone," +
+		"topology.rook.io/chassis," +
+		"topology.rook.io/rack," +
+		"topology.rook.io/row," +
+		"topology.rook.io/pdu," +
+		"topology.rook.io/pod," +
+		"topology.rook.io/room," +
+		"topology.rook.io/datacenter"
+	assert.Equal(t, expectedLabels, GetDefaultTopologyLabels())
 }

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -22,8 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -87,6 +89,11 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 	if CSIParam.EnableCSIHostNetwork, err = strconv.ParseBool(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_HOST_NETWORK", "true")); err != nil {
 		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_HOST_NETWORK'")
 	}
+
+	if CSIParam.EnableReadAffinity, err = strconv.ParseBool(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_READ_AFFINITY", "false")); err != nil {
+		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_READ_AFFINITY'")
+	}
+	CSIParam.CrushLocationLabels = k8sutil.GetValue(r.opConfig.Parameters, "CSI_CRUSH_LOCATION_LABELS", topology.GetDefaultTopologyLabels())
 
 	// If not set or set to anything but "false", the kernel client will be enabled
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_FORCE_CEPHFS_KERNEL_CLIENT", "true"), "false") {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -62,6 +62,7 @@ type Param struct {
 	ImagePullPolicy                       string
 	CSIClusterName                        string
 	CSIDomainLabels                       string
+	CrushLocationLabels                   string
 	GRPCTimeout                           time.Duration
 	CSIEnableMetadata                     bool
 	EnablePluginSelinuxHostMount          bool
@@ -76,6 +77,7 @@ type Param struct {
 	EnableCSIEncryption                   bool
 	EnableCSITopology                     bool
 	EnableLiveness                        bool
+	EnableReadAffinity                    bool
 	LogLevel                              uint8
 	SidecarLogLevel                       uint8
 	CephFSGRPCMetricsPort                 uint16

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -79,6 +79,10 @@ spec:
             {{- if .EnableCSITopology }}
             - "--domainlabels={{ .CSIDomainLabels }}"
             {{- end }}
+            {{- if .EnableReadAffinity }}
+            - "--enable-read-affinity=true"
+            - "--crush-location-labels={{ .CrushLocationLabels }}"
+            {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools.go
@@ -19,19 +19,18 @@ package clusterdisruption
 import (
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/pkg/errors"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
-
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*cephv1.CephObjectStoreList, *cephv1.CephFilesystemList, string, int, error) {
@@ -85,11 +84,11 @@ func getMinimumFailureDomain(poolList []cephv1.PoolSpec) string {
 	}
 
 	//start with max as the min
-	minfailureDomainIndex := len(osd.CRUSHMapLevelsOrdered) - 1
+	minfailureDomainIndex := len(topology.CRUSHMapLevelsOrdered) - 1
 	matched := false
 
 	for _, pool := range poolList {
-		for index, failureDomain := range osd.CRUSHMapLevelsOrdered {
+		for index, failureDomain := range topology.CRUSHMapLevelsOrdered {
 			if index == minfailureDomainIndex {
 				// index is higher-than/equal-to the min
 				break
@@ -105,7 +104,7 @@ func getMinimumFailureDomain(poolList []cephv1.PoolSpec) string {
 		logger.Debugf("could not match failure domain. defaulting to %q", cephv1.DefaultFailureDomain)
 		return cephv1.DefaultFailureDomain
 	}
-	return osd.CRUSHMapLevelsOrdered[minfailureDomainIndex]
+	return topology.CRUSHMapLevelsOrdered[minfailureDomainIndex]
 }
 
 // Setting naive minAvailable for RGW at: n - 1


### PR DESCRIPTION
**Description of your changes:**

- csi: add option to enable read affinity for rbd volumes

This commit adds code to supply variables required
to enable read affinity for rbd volumes.
It leverages `read_from_replica=localize,crush_locations=key:value`
krbd map option from ceph to serve reads from the most local OSD.
refer:
https://docs.ceph.com/en/latest/man/8/rbd/#kernel-rbd-krbd-options

- docs: add documentation about rbd read affinity

This commit documents steps to enable read affinity
for rbd volumes.

- helm: add option for rbd read affinity

This commit documents and adds helm options
to enable read affinity for rbd volumes.

Signed-off-by: Rakshith R <rar@redhat.com>

refer: https://github.com/ceph/ceph-csi/pull/3639

**Which issue is resolved by this Pull Request:**
Resolves #8935

PTAL @idryomov

---

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
