### PR TITLE
mgr: use k8s readiness probe to implement mgr HA

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -190,6 +190,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 		SecurityContext: controller.PodSecurityContext(),
 		StartupProbe:    controller.GenerateStartupProbeExecDaemon(config.MgrType, mgrConfig.DaemonID),
 		LivenessProbe:   controller.GenerateLivenessProbeExecDaemon(config.MgrType, mgrConfig.DaemonID),
+		ReadinessProbe:  controller.GenerateMgrReadinessProbeExecDaemon(config.MgrType, mgrConfig.DaemonID),
 		WorkingDir:      config.VarLogCephDir,
 	}
 

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -57,6 +57,8 @@ const (
 	CephUserID                              = 167
 	livenessProbeTimeoutSeconds       int32 = 5
 	livenessProbeInitialDelaySeconds  int32 = 10
+	readinessProbePeriodSeconds       int32 = 5
+	readinessProbeInitialDelaySeconds int32 = 5
 	startupProbeFailuresDaemonDefault int32 = 6 // multiply by 10 = effective startup timeout
 	// The OSD requires a long timeout in case the OSD is taking extra time to
 	// scrub data during startup. We don't want the probe to disrupt the OSD update
@@ -563,41 +565,78 @@ func StoredLogAndCrashVolumeMount(varLogCephDir, varLibCephCrashDir string) []v1
 	}
 }
 
+// Generate an exec ProbeHandler
+func GenProbeHandler(command []string) v1.ProbeHandler {
+	return v1.ProbeHandler{
+		Exec: &v1.ExecAction{
+			Command: command,
+		},
+	}
+}
+
 // GenerateLivenessProbeExecDaemon generates a liveness probe that makes sure a daemon has a socket,
 // that it can be called, and that it returns 0
 func GenerateLivenessProbeExecDaemon(daemonType, daemonID string) *v1.Probe {
+	// Run with env -i to clean env variables in the exec context
+	// This avoids conflict with the CEPH_ARGS env
+	//
+	// Example:
+	// env -i sh -c "ceph --admin-daemon /run/ceph/ceph-osd.0.asok status"
+	//
+	// Ceph gives pretty un-diagnostic error message when `ceph status` or `ceph mon_status` command fails.
+	// Add a clear message after Ceph's to help.
+	// ref: https://github.com/rook/rook/issues/9846
 	confDaemon := getDaemonConfig(daemonType, daemonID)
-
-	return &v1.Probe{
-		ProbeHandler: v1.ProbeHandler{
-			Exec: &v1.ExecAction{
-				// Run with env -i to clean env variables in the exec context
-				// This avoids conflict with the CEPH_ARGS env
-				//
-				// Example:
-				// env -i sh -c "ceph --admin-daemon /run/ceph/ceph-osd.0.asok status"
-				//
-				// Ceph gives pretty un-diagnostic error message when `ceph status` or `ceph mon_status` command fails.
-				// Add a clear message after Ceph's to help.
-				// ref: https://github.com/rook/rook/issues/9846
-				Command: []string{
-					"env",
-					"-i",
-					"sh",
-					"-c",
-					fmt.Sprintf(`outp="$(ceph --admin-daemon %s %s 2>&1)"
+	command := []string{
+		"env",
+		"-i",
+		"sh",
+		"-c",
+		fmt.Sprintf(`outp="$(ceph --admin-daemon %s %s 2>&1)"
 rc=$?
 if [ $rc -ne 0 ]; then
   echo "ceph daemon health check failed with the following output:"
   echo "$outp" | sed -e 's/^/> /g'
   exit $rc
 fi`,
-						confDaemon.buildSocketPath(), confDaemon.buildAdminSocketCommand()),
-				},
-			},
-		},
+			confDaemon.buildSocketPath(), confDaemon.buildAdminSocketCommand()),
+	}
+
+	return &v1.Probe{
+		ProbeHandler:        GenProbeHandler(command),
 		InitialDelaySeconds: livenessProbeInitialDelaySeconds,
 		TimeoutSeconds:      livenessProbeTimeoutSeconds,
+	}
+}
+
+// GenerateMgrReadinessProbeExecDaemon generates a readiness probe that makes sure
+// a mgr daemon is ready to process traffic
+func GenerateMgrReadinessProbeExecDaemon(daemonType, daemonID string) *v1.Probe {
+	// Run with env -i to clean env variables in the exec context
+	// This avoids conflict with the CEPH_ARGS env
+	//
+	// Example:
+	// env -i sh -c "ceph --admin-daemon /run/ceph/ceph-mgr.a.asok mgr_status"
+	//
+	confDaemon := getDaemonConfig(daemonType, daemonID)
+	command := []string{
+		"env",
+		"-i",
+		"sh",
+		"-c",
+		fmt.Sprintf(`ceph --admin-daemon %s mgr_status &>/dev/null
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "Ceph standby manager does not process requests."
+  exit $rc
+fi`,
+			confDaemon.buildSocketPath()),
+	}
+
+	return &v1.Probe{
+		ProbeHandler:        GenProbeHandler(command),
+		InitialDelaySeconds: readinessProbeInitialDelaySeconds,
+		PeriodSeconds:       readinessProbePeriodSeconds,
 	}
 }
 

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -171,6 +171,24 @@ fi`}
 	assert.Equal(t, livenessProbeTimeoutSeconds, probe.TimeoutSeconds)
 }
 
+func TestGenerateReadinessProbeExecDaemon(t *testing.T) {
+	daemonID := "a"
+	probe := GenerateMgrReadinessProbeExecDaemon(config.MgrType, daemonID)
+	expectedCommand := []string{"env",
+		"-i",
+		"sh",
+		"-c",
+		`ceph --admin-daemon /run/ceph/ceph-mgr.a.asok mgr_status &>/dev/null
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "Ceph standby manager does not process requests."
+  exit $rc
+fi`}
+
+	assert.Equal(t, expectedCommand, probe.ProbeHandler.Exec.Command)
+	assert.Equal(t, readinessProbeInitialDelaySeconds, probe.InitialDelaySeconds)
+}
+
 func TestDaemonFlags(t *testing.T) {
 	testcases := []struct {
 		label       string


### PR DESCRIPTION
The idea behind this change is to use the readiness probe to implement the mgr HA mechanism. In the current ceph mgr implementation only the active instance offers the command 'mgr_status' through the admin socket. We use this command combined with a Readiness Exec Probe to detect which manager is active. Kubernetes will automatically mark it as ready and redirect any service traffic to the active instance.

Closes: https://github.com/rook/rook/issues/11640
Closes: https://github.com/rook/rook/issues/11638
Signed-off-by: Redouane Kachach <rkachach@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #11640
Resolves https://github.com/rook/rook/issues/11638

============== Manual Testing ===========
Starting from a clean environment, pull the image with the changes:

```
[root@mykube1-ctlplane-0 examples]# k describe pod rook-ceph-operator-6bb95c9b49-xvsp2 | grep -i image
    Image:         rkachach/rook:v8
```

Check the active manager:
```
bash-4.4$ ceph mgr stat
{
    "epoch": 311,
    "available": true,
    "active_name": "a",
    "num_standby": 1
}
```

`Active` manager should be ready (3/3) meanwhile, `standby` instance must not be ready:
```
[root@mykube1-ctlplane-0 examples]# k get pods | grep mgr
rook-ceph-mgr-a-bcdf59d6c-5gx5r                                   3/3     Running     0              132m
rook-ceph-mgr-b-7c9fc54d8c-lpzfn                                  2/3     Running     0              132m
```

Inspecting the standby mgr instance we can see it's not ready because the readines probe has failed:
```
Events:
  Type     Reason          Age                     From               Message
  ----     ------          ----                    ----               -------
  Normal   Scheduled       8m49s                   default-scheduler  Successfully assigned rook-ceph/rook-ceph-mgr-b-74dbbf564-9kn7l to mykube1-ctlplane-0.karmalabs.corp
  Normal   AddedInterface  8m49s                   multus             Add eth0 [10.244.0.185/24] from cbr0
  Normal   Pulled          8m48s                   kubelet            Container image "quay.io/ceph/ceph:v17.2.5" already present on machine
  Normal   Created         8m47s                   kubelet            Created container chown-container-data-dir
  Normal   Started         8m47s                   kubelet            Started container chown-container-data-dir
  Normal   Pulled          8m47s                   kubelet            Container image "quay.io/ceph/ceph:v17.2.5" already present on machine
  Normal   Created         8m47s                   kubelet            Created container mgr
  Normal   Started         8m46s                   kubelet            Started container mgr
  Normal   Pulling         8m46s                   kubelet            Pulling image "rkachach/rook:v9"
  Normal   Pulled          8m43s                   kubelet            Successfully pulled image "rkachach/rook:v9" in 3.314146757s (3.31415288s including waiting)
  Normal   Created         8m43s                   kubelet            Created container watch-active
  Normal   Started         8m43s                   kubelet            Started container watch-active
  Normal   Pulled          8m43s                   kubelet            Container image "quay.io/ceph/ceph:v17.2.5" already present on machine
  Normal   Created         8m43s                   kubelet            Created container log-collector
  Normal   Started         8m43s                   kubelet            Started container log-collector
  Warning  Unhealthy       3m44s (x61 over 8m29s)  kubelet            Readiness probe failed: ceph mgr daemon readiness check failed. Standby manager does not process requests.
```

Now let's define a dashboard service (which no special `ceph-rook-mgr` tag):
```
[root@mykube1-ctlplane-0 examples]# cat ceph-dashboard.yaml 
apiVersion: v1
kind: Service
metadata:
  name: ceph-dashboard
  namespace: rook-ceph
  labels:
    rook_cluster: rook-ceph
spec:
  type: NodePort
  selector:
    app: rook-ceph-mgr
    rook_cluster: rook-ceph
  ports:
    - protocol: TCP
      port: 8443
      targetPort: 8443
      nodePort: 30200
```

Make sure endpoint of the new created service is pointing to the active mgr instance:
```
[root@mykube1-ctlplane-0 examples]# k get pods -o wide | grep mgr
rook-ceph-mgr-a-bcdf59d6c-5gx5r                                   3/3     Running     0              135m   10.244.2.151      mykube1-worker-0.karmalabs.corp     <none>           <none>
rook-ceph-mgr-b-7c9fc54d8c-lpzfn                                  2/3     Running     0              135m   10.244.0.173      mykube1-ctlplane-0.karmalabs.corp   <none>           <none>
[root@mykube1-ctlplane-0 examples]# 
[root@mykube1-ctlplane-0 examples]# k -n rook-ceph get endpoints ceph-dashboard
NAME             ENDPOINTS           AGE
ceph-dashboard   10.244.2.151:8443   25h
```

Curl the dashboard service to make sure it's working:
```
[root@mykube1-ctlplane-0 examples]# curl -k https://192.168.122.8:30200
<!DOCTYPE html><html lang="en-US"><head>
  <meta charset="utf-8">
  <title>Ceph</title>
```

Force a mgr failover by runing `ceph mgr fail` from tool box. And check the mgr pods status:
```
[root@mykube1-ctlplane-0 examples]# k get pods -o wide | grep mgr
rook-ceph-mgr-a-bcdf59d6c-5gx5r                                   2/3     Running     0              139m    10.244.2.151      mykube1-worker-0.karmalabs.corp     <none>           <none>
rook-ceph-mgr-b-7c9fc54d8c-lpzfn                                  3/3     Running     0              139m    10.244.0.173      mykube1-ctlplane-0.karmalabs.corp   <none>           <none>
```

We can see that the new active mgr `b` is now ready, meanwhile the mgr `a` (now standby) is not ready. Checking the ceph dashboard endpoint we can see that now the service is poiting to the new active mgr:

```
[root@mykube1-ctlplane-0 examples]# k get pods -o wide | grep mgr
rook-ceph-mgr-a-bcdf59d6c-5gx5r                                   2/3     Running     0              140m    10.244.2.151      mykube1-worker-0.karmalabs.corp     <none>           <none>
rook-ceph-mgr-b-7c9fc54d8c-lpzfn                                  3/3     Running     0              140m    10.244.0.173      mykube1-ctlplane-0.karmalabs.corp   <none>           <none>
[root@mykube1-ctlplane-0 examples]# k -n rook-ceph get endpoints ceph-dashboard
NAME             ENDPOINTS           AGE
ceph-dashboard   10.244.0.173:8443   25h
```

Curling the dashboard url is still working without issues:
```
[root@mykube1-ctlplane-0 examples]# curl -k https://192.168.122.8:30200
<!DOCTYPE html><html lang="en-US"><head>
  <meta charset="utf-8">
  <title>Ceph</title>

```





**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
