### PR TITLE
test: change ceph version of osd on pvc canary test to avoid failures

### DIFF
--- a/tests/manifests/test-cluster-on-pvc-encrypted.yaml
+++ b/tests/manifests/test-cluster-on-pvc-encrypted.yaml
@@ -14,7 +14,7 @@ spec:
           requests:
             storage: 5Gi
   cephVersion:
-    image: quay.io/ceph/ceph:v16
+    image: quay.io/ceph/ceph:v17.2.3
   dashboard:
     enabled: false
   network:


### PR DESCRIPTION
**Description of your changes:**

This is to fix the following CI failure.

ci: Canary tests on PVCs are failing when creating OSDs #11600

We set the version of Ceph used for OSD on PVC to v16. It's the moving target and was recently changed the target version. The new version has a regression which fails `ceph-volume raw prepare`. Although this will be fixed in Ceph by the following PR, it's not been backported to Quincy yet.

ceph-volume: fix a bug in lsblk_all()
https://github.com/ceph/ceph/pull/49171

Let's change the version to v17.2.3, the latest version without the above-mentioned regression of Ceph.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
