### PR TITLE
rgw: allow specifying user when creating an object bucket

### DIFF
--- a/deploy/examples/object-bucket-claim-delete.yaml
+++ b/deploy/examples/object-bucket-claim-delete.yaml
@@ -15,3 +15,4 @@ spec:
     # To set for quota for OBC
     #maxObjects: "1000"
     #maxSize: "2G"
+    #userID: "os-user"

--- a/deploy/examples/object-bucket-claim-retain.yaml
+++ b/deploy/examples/object-bucket-claim-retain.yaml
@@ -15,3 +15,4 @@ spec:
     # To set for quota for OBC
     #maxObjects: "1000"
     #maxSize: "2G"
+    #userID: "os-user"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/keyprotect-go-client v0.9.2
 	github.com/aws/aws-sdk-go v1.44.157
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/ceph/go-ceph v0.18.0
+	github.com/ceph/go-ceph v0.19.0
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf
 	github.com/gemalto/kmip-go v0.0.8
 	github.com/go-ini/ini v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
 github.com/centrify/cloud-golang-sdk v0.0.0-20210923165758-a8c48d049166 h1:jQ93fKqb/wRmK/KiHpa7Tk9rmHeKXhp4j+5Sg/tENiY=
-github.com/ceph/go-ceph v0.18.0 h1:4WM6yAq/iqBDaeeADDiPKLqKiP0iZ4fffdgCr1lnOL4=
-github.com/ceph/go-ceph v0.18.0/go.mod h1:cflETVTBNAQM6jdr7hpNHHFHKYiJiWWcAeRDrRx/1ng=
+github.com/ceph/go-ceph v0.19.0 h1:cl5apHt98pCWSoUStiLdl7Mlk3ke8fUGF4HI66Nxy/A=
+github.com/ceph/go-ceph v0.19.0/go.mod h1:sdTcqdDeIPWX3TaR5HCi5YtT+BliI6fFvvWP6Io7VQE=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -27,15 +27,15 @@ import (
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
-	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/pkg/errors"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephutil "github.com/rook/rook/pkg/daemon/ceph/util"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 )
 
 type Provisioner struct {
@@ -63,14 +63,15 @@ func NewProvisioner(context *clusterd.Context, clusterInfo *client.ClusterInfo) 
 	return &Provisioner{context: context, clusterInfo: clusterInfo}
 }
 
+// GenerateUserID implements Provisioner.GenerateUserID()
 func (p Provisioner) GenerateUserID(obc *v1alpha1.ObjectBucketClaim, ob *v1alpha1.ObjectBucket) (string, error) {
-	if ob != nil {
-		return getCephUser(ob), nil
+	userID := UserID(obc.Spec.AdditionalConfig)
+	if userID != "" {
+		if ob != nil && getCephUser(ob) != userID {
+			return "", errors.Errorf("user id cannot be modified after ob is created")
+		}
 	}
-
-	username := p.genUserName(obc.Name, obc.Namespace)
-
-	return username, nil
+	return userID, nil
 }
 
 // Provision creates an s3 bucket and returns a connection info
@@ -82,9 +83,9 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Provision: creating bucket %q for OBC %q", p.bucketName, options.ObjectBucketClaim.Name)
+	logger.Infof("Provision: creating bucket %q for OBC %q for user %s", p.bucketName, options.ObjectBucketClaim.Name, options.UserID)
 
-	p.accessKeyID, p.secretAccessKey, err = p.createCephUser(options.UserID)
+	p.accessKeyID, p.secretAccessKey, err = p.getCephUser(options.UserID)
 	if err != nil {
 		return nil, errors.Wrap(err, "Provision: can't create ceph user")
 	}
@@ -117,13 +118,6 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		logger.Debugf("bucket %q already exists", p.bucketName)
 	}
 
-	singleBucketQuota := 1
-	_, err = p.adminOpsClient.ModifyUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName, MaxBuckets: &singleBucketQuota})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set user %q bucket quota to %d", p.cephUserName, singleBucketQuota)
-	}
-	logger.Infof("set user %q bucket max to %d", p.cephUserName, singleBucketQuota)
-
 	err = p.setAdditionalSettings(options)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set additional settings for OBC %q", options.ObjectBucketClaim.Name)
@@ -148,19 +142,6 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	logger.Infof("Checking for existing bucket %q", p.bucketName)
 	if exists, err := p.bucketExists(p.bucketName); !exists {
 		return nil, errors.Wrapf(err, "bucket %s does not exist", p.bucketName)
-	}
-
-	// get or create ceph user
-	p.accessKeyID, p.secretAccessKey, err = p.createCephUser(options.UserID)
-	if err != nil {
-		return nil, errors.Wrap(err, "Provision: can't create ceph user")
-	}
-
-	// restrict creation of new buckets in rgw
-	restrictBucketCreation := 0
-	_, err = p.adminOpsClient.ModifyUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName, MaxBuckets: &restrictBucketCreation})
-	if err != nil {
-		return nil, err
 	}
 
 	// get the bucket's owner via the bucket metadata
@@ -571,10 +552,12 @@ func (p *Provisioner) populateDomainAndPort(sc *storagev1.StorageClass) error {
 
 // Check for additional options mentioned in OBC and set them accordingly
 func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error {
-	var maxObjectsInt64 int64 = -1
-	var maxSizeInt64 int64 = -1
-	var err error
-	var quotaEnabled bool
+	var (
+		maxObjectsInt64 int64 = -1
+		maxSizeInt64    int64 = -1
+		err             error
+		quotaEnabled    bool
+	)
 
 	maxObjects := MaxObjectQuota(options.ObjectBucketClaim.Spec.AdditionalConfig)
 	if maxObjects != "" {
@@ -582,7 +565,7 @@ func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error
 
 		maxObjectsInt64, err = toInt64(maxObjects)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse maxObjects quota for user %q", p.cephUserName)
+			return errors.Wrapf(err, "failed to parse maxObjects quota for bucket %q", p.bucketName)
 		}
 	}
 
@@ -592,20 +575,27 @@ func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error
 
 		maxSizeInt64, err = toInt64(maxSize)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse maxSize quota for user %q", p.cephUserName)
+			return errors.Wrapf(err, "failed to parse maxSize quota for bucket %q", p.bucketName)
 		}
 	}
 
-	objectUser, err := p.adminOpsClient.GetUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName})
+	bucket, err := p.adminOpsClient.GetBucketInfo(p.clusterInfo.Context, admin.Bucket{Bucket: options.BucketName})
 	if err != nil {
-		return errors.Wrapf(err, "failed to fetch user %q", p.cephUserName)
+		return errors.Wrapf(err, "failed to fetch bucket %q", p.bucketName)
 	}
 
-	// enable or disable quota for user
-	if *objectUser.UserQuota.Enabled != quotaEnabled {
-		err = p.adminOpsClient.SetUserQuota(p.clusterInfo.Context, admin.QuotaSpec{UID: p.cephUserName, Enabled: &quotaEnabled})
+	// enable or disable quota for bucket
+	if *bucket.BucketQuota.Enabled != quotaEnabled {
+		logger.Infof("Try to enable/disable bucket %s quota from %t to %t",
+			options.BucketName, *bucket.BucketQuota.Enabled, quotaEnabled)
+		err = p.adminOpsClient.SetIndividualBucketQuota(p.clusterInfo.Context,
+			admin.QuotaSpec{
+				UID:     options.UserID,
+				Bucket:  p.bucketName,
+				Enabled: &quotaEnabled,
+			})
 		if err != nil {
-			return errors.Wrapf(err, "failed to set user %q quota enabled=%v for obc", p.cephUserName, quotaEnabled)
+			return errors.Wrapf(err, "failed to set bucket %q quota enabled=%v for obc", p.bucketName, quotaEnabled)
 		}
 	}
 
@@ -614,18 +604,36 @@ func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error
 		return nil
 	}
 
-	if *objectUser.UserQuota.MaxObjects != maxObjectsInt64 {
-		err = p.adminOpsClient.SetUserQuota(p.clusterInfo.Context, admin.QuotaSpec{UID: p.cephUserName, MaxObjects: &maxObjectsInt64})
-		if err != nil {
-			return errors.Wrapf(err, "failed to set MaxObjects=%v to user %q", maxObjectsInt64, p.cephUserName)
-		}
+	if *bucket.BucketQuota.MaxObjects == maxObjectsInt64 &&
+		*bucket.BucketQuota.MaxSize == maxSizeInt64 {
+		return nil
 	}
-
-	if objectUser.UserQuota.MaxSize != &maxSizeInt64 {
-		err = p.adminOpsClient.SetUserQuota(p.clusterInfo.Context, admin.QuotaSpec{UID: p.cephUserName, MaxSize: &maxSizeInt64})
-		if err != nil {
-			return errors.Wrapf(err, "failed to set MaxSize=%v to user %q", maxSizeInt64, p.cephUserName)
+	quotaSpec := &admin.QuotaSpec{
+		Bucket:    p.bucketName,
+		UID:       options.UserID,
+		QuotaType: "bucket",
+	}
+	logger.Infof("Currently, actual bucket %s quota(enabled: %+v, maxObjects: %+v, maxSize: %+v), expected quota(MaxObjects=%v, MaxSize=%v)",
+		bucket.Bucket, *bucket.BucketQuota.Enabled, *bucket.BucketQuota.MaxObjects,
+		*bucket.BucketQuota.MaxSize, maxObjectsInt64, maxSizeInt64)
+	if *bucket.BucketQuota.MaxObjects != maxObjectsInt64 {
+		quotaSpec.MaxObjects = &maxObjectsInt64
+	}
+	if *bucket.BucketQuota.MaxSize != maxSizeInt64 {
+		maxSizeKb := int(maxSizeInt64 / 1024)
+		if maxSizeInt64 > 0 && maxSizeKb < 1 {
+			maxSizeKb = 1
 		}
+		// NOTE: only `max-size-kb` will take effect
+		// https://github.com/ceph/go-ceph/issues/830
+		quotaSpec.MaxSizeKb = &maxSizeKb
+	}
+	logger.Infof("Try to set bucket %s quota with spec(uid: %s, quota type: %s, maxObjects: %d, maxSize: %d",
+		p.bucketName, quotaSpec.UID, quotaSpec.QuotaType, maxObjectsInt64, maxSizeInt64)
+	err = p.adminOpsClient.SetIndividualBucketQuota(p.clusterInfo.Context, *quotaSpec)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set MaxObjects=%v, MaxSize=%v to quota %q",
+			maxObjectsInt64, maxSizeInt64, p.bucketName)
 	}
 
 	return nil

--- a/pkg/operator/ceph/object/bucket/rgw-handlers.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers.go
@@ -16,15 +16,15 @@ func (p *Provisioner) bucketExists(name string) (bool, error) {
 	return true, nil
 }
 
-// Create a Ceph user based on the passed-in name or a generated name. Return the
+// Get a Ceph user based on the passed-in name or a generated name. Return the
 // accessKeys and set user name and keys in receiver.
-func (p *Provisioner) createCephUser(username string) (accKey string, secKey string, err error) {
+func (p *Provisioner) getCephUser(username string) (accKey string, secKey string, err error) {
 	if len(username) == 0 {
 		return "", "", errors.Wrap(err, "no user name provided")
 	}
 	p.cephUserName = username
 
-	logger.Infof("creating Ceph user %q", username)
+	logger.Infof("getting Ceph user %q", username)
 	userConfig := admin.User{
 		ID:          username,
 		DisplayName: p.cephUserName,
@@ -33,17 +33,10 @@ func (p *Provisioner) createCephUser(username string) (accKey string, secKey str
 	var u admin.User
 	u, err = p.adminOpsClient.GetUser(p.clusterInfo.Context, userConfig)
 	if err != nil {
-		if errors.Is(err, admin.ErrNoSuchUser) {
-			u, err = p.adminOpsClient.CreateUser(p.clusterInfo.Context, userConfig)
-			if err != nil {
-				return "", "", errors.Wrapf(err, "failed to create ceph object user %v", userConfig.ID)
-			}
-		} else {
-			return "", "", errors.Wrapf(err, "failed to get ceph user %q", username)
-		}
+		return "", "", errors.Wrapf(err, "failed to get ceph user %q", username)
 	}
 
-	logger.Infof("successfully created Ceph user %q with access keys", username)
+	logger.Infof("successfully get Ceph user %q with access keys", username)
 	return u.Keys[0].AccessKey, u.Keys[0].SecretKey, nil
 }
 
@@ -53,16 +46,13 @@ func (p *Provisioner) genUserName(obcName, obcNamespace string) string {
 	return "obc-" + obcNamespace + "-" + obcName
 }
 
-// Delete the user and bucket created by OBC with help of radosgw-admin commands
-// If delete user failed, error is no longer returned since its permission is
-// already revoked and hence user is no longer able to access the bucket
-// Empty string is passed for bucketName only if user needs to be removed, ex Revoke()
+// Delete the bucket created by OBC with help of radosgw-admin commands
 func (p *Provisioner) deleteOBCResource(bucketName string) error {
 
-	logger.Infof("deleting Ceph user %q and bucket %q", p.cephUserName, bucketName)
+	logger.Infof("deleting bucket %q from Ceph user %q ", bucketName, p.cephUserName)
 	if len(bucketName) > 0 {
 		// delete bucket with purge option to remove all objects
-		thePurge := true
+		thePurge := false
 		err := p.adminOpsClient.RemoveBucket(p.clusterInfo.Context, admin.Bucket{Bucket: bucketName, PurgeObject: &thePurge})
 		if err == nil {
 			logger.Infof("bucket %q successfully deleted", bucketName)
@@ -81,17 +71,6 @@ func (p *Provisioner) deleteOBCResource(bucketName string) error {
 			}
 		} else {
 			return errors.Wrapf(err, "failed to delete bucket %q", bucketName)
-		}
-	}
-	if len(p.cephUserName) > 0 {
-		err := p.adminOpsClient.RemoveUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName})
-		if err != nil {
-			if errors.Is(err, admin.ErrNoSuchUser) {
-				logger.Warningf("user %q does not exist, nothing to delete. %v", p.cephUserName, err)
-			}
-			logger.Warningf("failed to delete user %q. %v", p.cephUserName, err)
-		} else {
-			logger.Infof("user %q successfully deleted", p.cephUserName)
 		}
 	}
 	return nil

--- a/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
@@ -18,6 +18,7 @@ package bucket
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,9 +26,11 @@ import (
 	"testing"
 
 	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/pkg/errors"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	cephobject "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
@@ -42,11 +45,18 @@ type statusError struct {
 func TestDeleteOBCResource(t *testing.T) {
 	clusterInfo := client.AdminTestClusterInfo("ns")
 	p := NewProvisioner(&clusterd.Context{RookClientset: rookclient.NewSimpleClientset(), Clientset: test.New(t, 1)}, clusterInfo)
-	mockClient := func(errCodeRemoveBucket string, errCodeGetBucketInfo string) *cephobject.MockClient {
+	p.cephUserName = "bob"
+	mockClient := func(errCodeRemoveBucket string, errCodeGetBucketInfo string, success bool) *cephobject.MockClient {
 		return &cephobject.MockClient{
 			MockDo: func(req *http.Request) (*http.Response, error) {
 				if req.URL.Path == "rook-ceph-rgw-my-store.mycluster.svc/admin/bucket" {
 					if req.Method == http.MethodDelete {
+						if success {
+							return &http.Response{
+								StatusCode: 200,
+								Body:       io.NopCloser(bytes.NewReader([]byte{})),
+							}, nil
+						}
 						status, _ := json.Marshal(statusError{errCodeRemoveBucket, "requestid", "hostid"})
 						return &http.Response{
 							StatusCode: 404,
@@ -67,7 +77,7 @@ func TestDeleteOBCResource(t *testing.T) {
 	}
 
 	t.Run("remove bucket returns NoSuchBucket", func(t *testing.T) {
-		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchBucket", ""))
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchBucket", "", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
 		err = p.deleteOBCResource("bucket")
@@ -75,7 +85,7 @@ func TestDeleteOBCResource(t *testing.T) {
 	})
 
 	t.Run("remove bucket returns NoSuchKey and get bucket info returns NoSuchBucket", func(t *testing.T) {
-		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchBucket"))
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchBucket", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
 		err = p.deleteOBCResource("bucket")
@@ -83,10 +93,82 @@ func TestDeleteOBCResource(t *testing.T) {
 	})
 
 	t.Run("remove bucket returns NoSuchKey and get bucket info returns an error other than NoSuchBucket", func(t *testing.T) {
-		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchKey"))
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchKey", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
 		err = p.deleteOBCResource("bucket")
 		assert.Error(t, err)
 	})
+	t.Run("remove bucket successfully", func(t *testing.T) {
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("", "", true))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		err = p.deleteOBCResource("bucket")
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetCephUser(t *testing.T) {
+	newProvisioner := func(t *testing.T, getBucketResult string) *Provisioner {
+		mockClient := &object.MockClient{
+			MockDo: func(req *http.Request) (*http.Response, error) {
+				t.Logf("HTTP req: %#v", req.URL)
+				t.Logf("HTTP %s: %s %s", req.Method, req.URL.Path, req.URL.RawQuery)
+
+				assert.Contains(t, req.URL.RawQuery, "uid=bob")
+
+				if req.Method == http.MethodGet {
+					if req.URL.Path == "my.endpoint.net/admin/user" {
+						statusCode := 200
+						if getBucketResult == "" {
+							return &http.Response{
+								StatusCode: 500,
+								Body:       io.NopCloser(bytes.NewReader([]byte{})),
+							}, errors.New("error")
+						}
+						return &http.Response{
+							StatusCode: statusCode,
+							Body:       io.NopCloser(bytes.NewReader([]byte(getBucketResult))),
+						}, nil
+					}
+				}
+				panic(fmt.Sprintf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path))
+			},
+		}
+
+		adminClient, err := admin.New("my.endpoint.net", "accesskey", "secretkey", mockClient)
+		assert.NoError(t, err)
+
+		p := &Provisioner{
+			clusterInfo: &client.ClusterInfo{
+				Context: context.Background(),
+			},
+			cephUserName:   "bob",
+			bucketName:     "test-bucket",
+			adminOpsClient: adminClient,
+		}
+
+		return p
+	}
+
+	t.Run("Succeed to get ceph user", func(t *testing.T) {
+		p := newProvisioner(t,
+			`{"keys":[{"access_key":"ak","secret_key":"sk"}]}`,
+		)
+
+		ak, sk, err := p.getCephUser("bob")
+		assert.NoError(t, err)
+		assert.Equal(t, "ak", ak)
+		assert.Equal(t, "sk", sk)
+	})
+
+	t.Run("Failed to get ceph user", func(t *testing.T) {
+		p := newProvisioner(t, "")
+
+		ak, sk, err := p.getCephUser("bob")
+		assert.Error(t, err)
+		assert.Equal(t, "", ak)
+		assert.Equal(t, "", sk)
+	})
+
 }

--- a/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
@@ -80,7 +80,7 @@ func TestDeleteOBCResource(t *testing.T) {
 		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchBucket", "", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
-		err = p.deleteOBCResource("bucket")
+		err = p.deleteOBCResource("bucket", true)
 		assert.NoError(t, err)
 	})
 
@@ -88,7 +88,7 @@ func TestDeleteOBCResource(t *testing.T) {
 		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchBucket", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
-		err = p.deleteOBCResource("bucket")
+		err = p.deleteOBCResource("bucket", true)
 		assert.NoError(t, err)
 	})
 
@@ -96,14 +96,14 @@ func TestDeleteOBCResource(t *testing.T) {
 		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchKey", false))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
-		err = p.deleteOBCResource("bucket")
+		err = p.deleteOBCResource("bucket", true)
 		assert.Error(t, err)
 	})
 	t.Run("remove bucket successfully", func(t *testing.T) {
 		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("", "", true))
 		assert.NoError(t, err)
 		p.adminOpsClient = adminClient
-		err = p.deleteOBCResource("bucket")
+		err = p.deleteOBCResource("bucket", true)
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -98,6 +98,10 @@ func (p *Provisioner) getCephCluster() (*cephv1.CephCluster, error) {
 	return &cephCluster.Items[0], err
 }
 
+func UserID(AdditionalConfig map[string]string) string {
+	return AdditionalConfig["userID"]
+}
+
 func MaxObjectQuota(AdditionalConfig map[string]string) string {
 	return AdditionalConfig["maxObjects"]
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The current [ObjectBucketClaimSpec.AdditionalConfig](https://github.com/kube-object-storage/lib-bucket-provisioner/blob/d1a8c34382f127670e363ae925ae6087e8b2c7bf/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go#L51) stores the bucket's `maxObjects` and `maxSize`, and we can also record the `userID` in it. In this way, this step does not need to modify the lib-bucket-provisioner library, and at the same time realizes the feature of specifying the user when creating a bucket.

**Which issue is resolved by this Pull Request:**
Resolves #11335

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
