### PR TITLE
build: clean rbac which are not required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
 
       - name: build rook
         run: |
+          # Install kubectl binary as required for generating csv
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+          chmod +x ./kubectl
+          sudo mv ./kubectl /usr/local/bin/kubectl
+          sudo chown root: /usr/local/bin/kubectl
+
           GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' BUILD_CONTAINER_IMAGE=false build
 
       - name: validate build

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ build.version:
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
+# Change how CRDs are generated for CSVs
+build.common: export NO_OB_OBC_VOL_GEN=true MAX_DESC_LEN=0
 build.common: build.version helm.build mod.check crds gen-rbac
 	@$(MAKE) go.init
 	@$(MAKE) go.validate

--- a/build/csv/csv-gen.sh
+++ b/build/csv/csv-gen.sh
@@ -13,7 +13,7 @@ YQ_CMD_DELETE=("$yq" delete -i)
 YQ_CMD_MERGE_OVERWRITE=("$yq" merge --inplace --overwrite --prettyPrint)
 YQ_CMD_MERGE=("$yq" merge --arrays=append --inplace)
 YQ_CMD_WRITE=("$yq" write --inplace -P)
-CSV_FILE_NAME="../../build/csv/ceph/$PLATFORM/manifests/ceph.clusterserviceversion.yaml"
+CSV_FILE_NAME="../../build/csv/ceph/$PLATFORM/manifests/rook-ceph.clusterserviceversion.yaml"
 CEPH_EXTERNAL_SCRIPT_FILE="../../deploy/examples/create-external-cluster-resources.py"
 ASSEMBLE_FILE_COMMON="../../deploy/olm/assemble/metadata-common.yaml"
 ASSEMBLE_FILE_OCP="../../deploy/olm/assemble/metadata-ocp.yaml"
@@ -23,7 +23,7 @@ ASSEMBLE_FILE_OCP="../../deploy/olm/assemble/metadata-ocp.yaml"
 #############
 
 function generate_csv() {
-    kubectl kustomize ../../deploy/examples/ | "$operator_sdk" generate bundle --package="ceph" --output-dir="../../build/csv/ceph/$PLATFORM" --extra-service-accounts=rook-ceph-system,rook-csi-rbd-provisioner-sa,rook-csi-rbd-plugin-sa,rook-csi-cephfs-provisioner-sa,rook-csi-nfs-provisioner-sa,rook-csi-nfs-plugin-sa,rook-csi-cephfs-plugin-sa,rook-ceph-system,rook-ceph-rgw,rook-ceph-purge-osd,rook-ceph-osd,rook-ceph-mgr,rook-ceph-cmd-reporter
+    kubectl kustomize ../../deploy/examples/ | "$operator_sdk" generate bundle --package="rook-ceph" --output-dir="../../build/csv/ceph/$PLATFORM" --extra-service-accounts=rook-ceph-system,rook-csi-rbd-provisioner-sa,rook-csi-rbd-plugin-sa,rook-csi-cephfs-provisioner-sa,rook-csi-nfs-provisioner-sa,rook-csi-nfs-plugin-sa,rook-csi-cephfs-plugin-sa,rook-ceph-system,rook-ceph-rgw,rook-ceph-purge-osd,rook-ceph-osd,rook-ceph-mgr,rook-ceph-cmd-reporter
 
     # cleanup to get the expected state before merging the real data from assembles
     "${YQ_CMD_DELETE[@]}" "$CSV_FILE_NAME" 'spec.icon[*]'
@@ -37,7 +37,21 @@ function generate_csv() {
 
     "${YQ_CMD_MERGE[@]}" "$CSV_FILE_NAME" "$ASSEMBLE_FILE_OCP"
 
+    # We don't need to include these files in csv as ocs-operator creates its own.
+    rm -rf "../../build/csv/ceph/$PLATFORM/manifests/rook-ceph-operator-config_v1_configmap.yaml"
+
+    # This change are just to make the CSV file as it was earlier and as ocs-operator reads.
+    # Skipping this change for darwin since `sed -i` doesn't work with darwin properly.
+    # and the csv is not ever needed in the mac builds.
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        sed -i 's/image: rook\/ceph:.*/image: {{.RookOperatorImage}}/g' "$CSV_FILE_NAME"
+        sed -i 's/name: rook-ceph.v.*/name: rook-ceph.v{{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
+        sed -i 's/version: 0.0.0/version: {{.RookOperatorCsvVersion}}/g' "$CSV_FILE_NAME"
+    fi
+
     mv "$CSV_FILE_NAME" "../../build/csv/"
+    mv "../../build/csv/ceph/$PLATFORM/manifests/"* "../../build/csv/ceph/"
+    rm -rf "../../build/csv/ceph/$PLATFORM"
 }
 
 generate_csv

--- a/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -74,6 +74,21 @@ roleRef:
   name: cephfs-external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
 ---
+# This is required by operator-sdk to map the cluster/clusterrolebindings with SA
+# otherwise operator-sdk will create a individual file for these.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin-role
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-plugin-sa
+    namespace: {{ .Release.Namespace }} # namespace:operator
+roleRef:
+  kind: ClusterRole
+  name: cephfs-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io
+---
 {{- if .Values.csi.nfs.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -535,6 +535,21 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["create", "get", "delete", "update"]
 ---
+# This is required by operator-sdk to map the cluster/clusterrolebindings with SA
+# otherwise operator-sdk will create a individual file for these.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin-role
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-plugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: ClusterRole
+  name: cephfs-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/olm/assemble/metadata-common.yaml
+++ b/deploy/olm/assemble/metadata-common.yaml
@@ -238,7 +238,7 @@ metadata:
   annotations:
     tectonic-visibility: ocs
     repository: https://github.com/rook/rook
-    containerImage: rook/ceph:v1.2.2
+    containerImage: '{{.RookOperatorImage}}'
     alm-examples: |-
       [
         {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -78,7 +78,6 @@ do.build:
 	@cp ../../tests/ceph-status-out $(TEMP)/rook-external/test-data/
 
 ifeq ($(INCLUDE_CSV_TEMPLATES),true)
-	@$(MAKE) CSV_TEMPLATE_DIR=$(TEMP) generate-csv-templates
 	@$(MAKE) csv
 	@cp -r ../../build/csv $(TEMP)/ceph-csv-templates
 	@rm $(TEMP)/ceph-csv-templates/csv-gen.sh
@@ -100,28 +99,6 @@ endif
 # call this before building multiple arches in parallel to prevent parallel build processes from
 # conflicting
 prerequisites: $(OPERATOR_SDK) $(YQv3)
-
-# generate CSV template files into the directory defined by the env var CSV_TEMPLATE_DIR
-# CSV_TEMPLATE_DIR will be created if it doesn't already exist
-generate-csv-templates: $(OPERATOR_SDK) $(YQv3) ## Generate CSV templates for OLM into CSV_TEMPLATE_DIR
-	@if [[ -z "$(CSV_TEMPLATE_DIR)" ]]; then echo "CSV_TEMPLATE_DIR is not set"; exit 1; fi
-	@# first, copy the existing CRDs and OLM catalog directory to CSV_TEMPLATE_DIR
-	@# then, generate or copy all prerequisites into CSV_TEMPLATE_DIR (e.g., CRDs)
-	@# finally, generate the templates in-place using CSV_TEMPLATE_DIR as a staging dir
-	@mkdir -p $(CSV_TEMPLATE_DIR)
-	@cp -a ../../deploy $(CSV_TEMPLATE_DIR)/deploy
-
-	@set -eE;\
-	BEFORE_GEN_CRD_SIZE=$$(wc -l < $(MANIFESTS_DIR)/crds.yaml);\
-	$(MAKE) -C ../.. NO_OB_OBC_VOL_GEN=true MAX_DESC_LEN=0 BUILD_CRDS_INTO_DIR=$(CSV_TEMPLATE_DIR) crds;\
-	AFTER_GEN_CRD_SIZE=$$(wc -l < $(CSV_TEMPLATE_DIR)/deploy/examples/crds.yaml);\
-	if [ "$$BEFORE_GEN_CRD_SIZE" -le "$$AFTER_GEN_CRD_SIZE" ]; then\
-		echo "the new crd file must be smaller since the description fields were stripped!";\
-		echo "length before $$BEFORE_GEN_CRD_SIZE";\
-		echo "length after $$AFTER_GEN_CRD_SIZE";\
-		exit 1;\
-	fi
-	@echo " === Generated CSV templates"
 
 $(YQv3):
 	@echo === installing yq $(YQv3_VERSION) $(REAL_HOST_PLATFORM)
@@ -146,7 +123,7 @@ csv: $(OPERATOR_SDK) $(YQv3)
 
 csv-clean: ## Remove existing OLM files.
 	@rm -fr ../../build/csv/ceph/${go env GOARCH}
-	@rm -f ../../build/csv/ceph.clusterserviceversion.yaml
+	@rm -f ../../build/csv/rook-ceph.clusterserviceversion.yaml
 	@git restore $(MANIFESTS_DIR)/crds.yaml ../../deploy/charts/rook-ceph/templates/resources.yaml
 
 # reading from a file and outputting to the same file can have undefined results, so use this intermediate


### PR DESCRIPTION
removing unnecessary rbac and also updating
csv-gen script.

ci: install kubectl binary in mac for csv gen
installing kubectl in mac build for csv generation
as without that it is failing with
```
./../build/csv/csv-gen.sh: line 26: kubectl: command not found
```

Closes: https://github.com/rook/rook/issues/10141
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
