### PR TITLE
object: RGW metadata pg count reduction on 16.2.11

### DIFF
--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -237,6 +237,15 @@ func TestGetObjectBucketProvisioner(t *testing.T) {
 	})
 }
 
+func TestRGWPGNumVersion(t *testing.T) {
+	assert.False(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 15, Minor: 2, Extra: 9}))
+	assert.False(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 16, Minor: 2, Extra: 10}))
+	assert.True(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 16, Minor: 2, Extra: 11}))
+	assert.False(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 17, Minor: 2, Extra: 1}))
+	assert.True(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 17, Minor: 2, Extra: 2}))
+	assert.True(t, rgwRadosPGNumIsNew(cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}))
+}
+
 func TestCheckDashboardUser(t *testing.T) {
 	storeName := "myobject"
 	executor := &exectest.MockExecutor{


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The removal of the rgw_rados_pool_pg_num_min property was completed in v16.2.11 for Pacific. The previous fix in #11024 only assumed the fix was in Quincy v17.2.2 or newer. Now we account for v16.2.11 as well.

**Which issue is resolved by this Pull Request:**
Resolves #11671 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
