### PR TITLE
osd: Ensure rook version label is not set on pod

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -436,6 +436,14 @@ func TestGetOSDInfo(t *testing.T) {
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, c.spec.DataDirHostPath),
 	}
 
+	t.Run("version labels are on deployment and not pod spec", func(t *testing.T) {
+		d1, _ := c.makeDeployment(osdProp, osd1, dataPathMap)
+		assert.NotEqual(t, "", d1.Labels["rook-version"])
+		assert.Equal(t, "", d1.Spec.Template.Labels["rook-version"])
+		assert.NotEqual(t, "", d1.Labels["ceph-version"])
+		assert.Equal(t, "", d1.Spec.Template.Labels["ceph-version"])
+	})
+
 	t.Run("get info from PVC-based OSDs", func(t *testing.T) {
 		d1, _ := c.makeDeployment(osdProp, osd1, dataPathMap)
 		osdInfo1, _ := c.getOSDInfo(d1)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -603,11 +603,21 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 
 	k8sutil.RemoveDuplicateEnvVars(&podTemplateSpec.Spec)
 
+	// Copy the pod labels into a new map so the deployment labels can
+	// diverge from the pod labels. For example, we don't want the
+	// rook-version label to be added to the pod labels or else it will
+	// cause the osd pods to be updated with every rook upgrade even if
+	// the osds don't need to restart.
+	deploymentLabels := map[string]string{}
+	for key, value := range podTemplateSpec.Labels {
+		deploymentLabels[key] = value
+	}
+
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
 			Namespace: c.clusterInfo.Namespace,
-			Labels:    podTemplateSpec.Labels,
+			Labels:    deploymentLabels,
 		},
 		Spec: apps.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -654,7 +664,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	cephv1.GetOSDAnnotations(c.spec.Annotations).ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
 	cephv1.GetOSDLabels(c.spec.Labels).ApplyToObjectMeta(&deployment.ObjectMeta)
 	cephv1.GetOSDLabels(c.spec.Labels).ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
-	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	err := c.clusterInfo.OwnerInfo.SetControllerReference(deployment)
 	if err != nil {

--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -173,18 +173,6 @@ func addRookVersionLabel(labels map[string]string) {
 	labels[RookVersionLabelKey] = value
 }
 
-// RookVersionLabelMatchesCurrent returns true if the Rook version on the resource label matches the
-// current Rook version running. It returns false if the label does not match. It returns an error
-// if the label does not exist.
-func RookVersionLabelMatchesCurrent(labels map[string]string) (bool, error) {
-	v, ok := labels[RookVersionLabelKey]
-	if !ok {
-		return false, fmt.Errorf("failed to find Rook version label %q", RookVersionLabelKey)
-	}
-	expectedVersion := validateLabelValue(rookversion.Version)
-	return (v == expectedVersion), nil
-}
-
 // validateLabelValue replaces any invalid characters
 // in the input string with a replacement character,
 // and enforces other limitations for k8s label values.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The rook-version tag must not be set on the pod spec labels since it will result in the ceph daemons being restarted every time there is a rook version update, even if the ceph version or pod spec was not otherwise updated.
    
The rook-version tag was being added to the OSD pod spec due to a shared pointer to the labels. The code intended to only add the version label to the deployment labels, but since the pod labels shared the map variable, the pod unintentionally also had the version label added.

Now the OSD pod will only be updated and restart if there is a ceph version change, or some other pod spec change on the OSD. 

Surprisingly, this does not appear to be a regression, at least not any time recently. 

**Which issue is resolved by this Pull Request:**
Resolves #11657

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
