### PR TITLE
test: Fix upgrade test for msgr2 setting

### DIFF
--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -86,7 +86,13 @@ func (m *CephManifestsPreviousVersion) GetCommonExternal() string {
 
 // GetRookCluster returns rook-cluster manifest
 func (m *CephManifestsPreviousVersion) GetCephCluster() string {
-	return m.latest.GetCephCluster()
+	c := m.latest.GetCephCluster()
+
+	// Remove the requireMsgr2 setting if in v1.10
+	if m.settings.RookVersion == Version1_10 {
+		return strings.Replace(c, "requireMsgr2: false", "", 1)
+	}
+	return c
 }
 
 func (m *CephManifestsPreviousVersion) GetBlockSnapshotClass(snapshotClassName, reclaimPolicy string) string {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The requireMsgr2 setting is not available in 1.10, therefore the setting must be removed from the cephcluster CR when the 1.10 cluster is created before the upgrade.

**Which issue is resolved by this Pull Request:**
Resolves #11672 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
