### PR TITLE
ci: fix MultiClusterDeploySuite CI

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -42,6 +42,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -58,8 +59,8 @@ func TestStartMgr(t *testing.T) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
-	waitForDeploymentToStart = func(ctx context.Context, clusterdContext *clusterd.Context, deployment *apps.Deployment) error {
-		logger.Infof("simulated mgr deployment starting")
+	waitForPodsWithLabelToRun = func(ctx context.Context, clientset kubernetes.Interface, namespace, label string) error {
+		logger.Infof("simulated mgr deployment waiting for deployment")
 		return nil
 	}
 

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -51,7 +51,7 @@ const (
 	daemonSocketDir                         = "/run/ceph"
 	logCollector                            = "log-collector"
 	DaemonIDLabel                           = "ceph_daemon_id"
-	daemonTypeLabel                         = "ceph_daemon_type"
+	DaemonTypeLabel                         = "ceph_daemon_type"
 	ExternalMgrAppName                      = "rook-ceph-mgr-external"
 	ServiceExternalMetricName               = "http-external-metrics"
 	CephUserID                              = 167
@@ -403,7 +403,7 @@ func CephDaemonAppLabels(appName, namespace, daemonType, daemonID, parentName, r
 
 	// New labels cannot be applied to match selectors during upgrade
 	if includeNewLabels {
-		labels[daemonTypeLabel] = daemonType
+		labels[DaemonTypeLabel] = daemonType
 		k8sutil.AddRecommendedLabels(labels, "ceph-"+daemonType, parentName, resourceKind, daemonID)
 	}
 	labels[DaemonIDLabel] = daemonID

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -144,6 +144,25 @@ func WaitForDeploymentToStart(ctx context.Context, clusterdContext *clusterd.Con
 	return fmt.Errorf("gave up waiting for deployment %q to update", deployment.Name)
 }
 
+func WaitForPodsWithLabelToRun(ctx context.Context, clientset kubernetes.Interface, namespace, label string) error {
+	// wait for the pods to run for a maximum of 300 sec
+	sleepTime := 5
+	attempts := 60
+	for i := 0; i < attempts; i++ {
+		allRunning, err := PodsWithLabelAreAllRunning(ctx, clientset, namespace, label)
+		if err != nil {
+			return errors.Wrapf(err, "failed to query pods with label %s to be in running state", label)
+		}
+		if allRunning {
+			logger.Infof("All pods with label %s are running", label)
+			return nil
+		}
+		logger.Infof("Waiting for all pods with label %s to be in running state", label)
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+	return fmt.Errorf("gave up waiting for all pods with label %s to run", label)
+}
+
 // DeploymentNames returns a list of the names of deployments in the deployment list
 func DeploymentNames(deployments *appsv1.DeploymentList) (names []string) {
 	for _, d := range deployments.Items {


### PR DESCRIPTION
This fixes the the MultiClusterDeploySuite CI failure. The operator is timing out waiting for the mgr deployments to be ready, according to the WaitForDeploymentToStart() method. After the reconcile times out after about five minutes, the next reconcile succeeds since the wait is only done for new mgr deployments.

Closes: https://github.com/rook/rook/issues/11685

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
