### PR TITLE
object: fix errorOrIsNotFound helper string error

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -1007,13 +1007,13 @@ func disableRGWDashboard(context *Context) {
 	logger.Info("done disabling the dashboard api secret key")
 }
 
-func errorOrIsNotFound(err error, msg string, args ...string) error {
+func errorOrIsNotFound(err error, msg string, args ...interface{}) error {
 	// This handles the case where the pod we use to exec command (act as a proxy) is not found/ready yet
 	// The caller can nicely handle the error and not overflow the op logs with misleading error messages
 	if kerrors.IsNotFound(err) {
 		return err
 	}
-	return errors.Wrapf(err, msg, args)
+	return errors.Wrapf(err, msg, args...)
 }
 
 // ShouldUpdateZoneEndpointList checks whether zone endpoint list need to be updated or not


### PR DESCRIPTION
Fix a minor issue with the errorOrIsNotFound() helper to avoid outputting error text (sample below) because of empty args:
  %!!(MISSING)(EXTRA []string=[])

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
