### PR TITLE
mgr: Wait for the mgr pod to be running after an update

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -31,12 +31,10 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -47,8 +45,6 @@ import (
 )
 
 func TestStartMgr(t *testing.T) {
-	var deploymentsUpdated *[]*apps.Deployment
-	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
@@ -97,16 +93,12 @@ func TestStartMgr(t *testing.T) {
 	err = c.Start()
 	assert.NoError(t, err)
 	validateStart(t, c)
-	assert.ElementsMatch(t, []string{}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
-	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
 	c.spec.Dashboard.URLPrefix = "/test"
 	c.spec.Dashboard.Port = 12345
 	err = c.Start()
 	assert.NoError(t, err)
 	validateStart(t, c)
-	assert.ElementsMatch(t, []string{"rook-ceph-mgr-a"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
-	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
 	// starting with more replicas
 	c.spec.Mgr.Count = 2

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -149,16 +149,16 @@ func WaitForPodsWithLabelToRun(ctx context.Context, clientset kubernetes.Interfa
 	sleepTime := 5
 	attempts := 60
 	for i := 0; i < attempts; i++ {
+		logger.Infof("waiting for all pods with label %s to be in running state", label)
+		time.Sleep(time.Duration(sleepTime) * time.Second)
 		allRunning, err := PodsWithLabelAreAllRunning(ctx, clientset, namespace, label)
 		if err != nil {
 			return errors.Wrapf(err, "failed to query pods with label %s to be in running state", label)
 		}
 		if allRunning {
-			logger.Infof("All pods with label %s are running", label)
+			logger.Infof("all pods with label %s are running", label)
 			return nil
 		}
-		logger.Infof("Waiting for all pods with label %s to be in running state", label)
-		time.Sleep(time.Duration(sleepTime) * time.Second)
 	}
 	return fmt.Errorf("gave up waiting for all pods with label %s to run", label)
 }

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -226,7 +226,8 @@ func podStatusWithLabel(ctx context.Context, clientset kubernetes.Interface, nam
 	running := 0
 	notRunning := 0
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == v1.PodRunning {
+		// The pod must be in running state and not deleted
+		if pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp.IsZero() {
 			running++
 		} else {
 			notRunning++


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
After an update, the mgr pod will be restarted. Since the readiness probe will indicate the standby mgr pod is never ready, we need to check simply for the running mgr pod and not whether or not it is ready.

**Which issue is resolved by this Pull Request:**
Resolves #11702

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
