### PR TITLE
build: fix csv generation during make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ build.version:
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
 # Change how CRDs are generated for CSVs
-build.common: export NO_OB_OBC_VOL_GEN=true MAX_DESC_LEN=0
+build.common: export NO_OB_OBC_VOL_GEN=true
+build.common: export MAX_DESC_LEN=0
 build.common: build.version helm.build mod.check crds gen-rbac
 	@$(MAKE) go.init
 	@$(MAKE) go.validate


### PR DESCRIPTION
we need to export variable in different lines
to work in Makefile, exporting in single doesn't
work.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
