### PR TITLE
csi: update cephcsi to v3.8.0

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.cephFSFSGroupPolicy` | Policy for modifying a volume's ownership or permissions when the CephFS PVC is being mounted. supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html | `"File"` |
 | `csi.cephFSKernelMountOptions` | Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options. Set to "ms_mode=secure" when connections.encrypted is enabled in CephCluster CR | `nil` |
 | `csi.cephFSPluginUpdateStrategy` | CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
-| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.7.2` |
+| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.8.0` |
 | `csi.cephfsGrpcMetricsPort` | CSI CephFS driver GRPC metrics port | `9091` |
 | `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port | `9081` |
 | `csi.cephfsPodLabels` | Labels to add to the CSI CephFS Deployments and DaemonSets Pods | `nil` |

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -18,7 +18,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-ceph-operator-config
 The default upstream images are included below, which you can change to your desired images.
 
 ```yaml
-ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.2"
+ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
 ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
 ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"
 ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"
@@ -32,7 +32,7 @@ ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.5.0"
 If image version is not passed along with the image name in any of the variables above,
 Rook will add the corresponding default version to that image.
 Example: if `ROOK_CSI_CEPH_IMAGE: "quay.io/private-repo/cephcsi"` is passed,
-Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.7.2"`.
+Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.8.0"`.
 
 ### **Use default images**
 

--- a/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
+++ b/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
@@ -6,11 +6,10 @@ title: CSI provisioner and driver
     This feature is experimental and will not support upgrades to future versions.
 
 In version 1.9.1, Rook is able to deploy the experimental NFS Ceph CSI driver. This requires Ceph
-CSI version 3.6.0 or above. We recommend Ceph v16.2.7 or above.
+CSI version 3.7.0 or above. We recommend Ceph v16.2.7 or above.
 
 For this section, we will refer to Rook's deployment examples in the
 [deploy/examples](https://github.com/rook/rook/tree/master/deploy/examples) directory.
-
 
 ## Enabling the CSI drivers
 
@@ -95,6 +94,7 @@ See `deploy/examples/csi/nfs/pod.yaml` for an example of how a PVC can be connec
 application pod.
 
 ### Connecting to an export directly
+
 After a PVC is created successfully, the `share` parameter set on the resulting PV contains the
 `share` path which can be used as the export path when
 [mounting the export manually](nfs.md#mounting-exports). In the example below

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -109,7 +109,6 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
   starting state.
 * All pods consuming Rook storage should be created, running, and in a steady state.
 
-
 ## Rook Operator Upgrade
 
 In the examples given in this guide, we will be upgrading a live Rook cluster running `v1.10.11` to
@@ -189,7 +188,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-cep
     If have not customized the CSI image versions, this is automatically updated.
 
 !!! important
-    The minimum supported version of Ceph-CSI is v3.6.0.
+    The minimum supported version of Ceph-CSI is v3.7.0.
 
 If you have specified custom CSI images, we recommended you update to the latest Ceph-CSI drivers.
 See the [CSI Custom Images](../Storage-Configuration/Ceph-CSI/custom-images.md) documentation.

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -456,7 +456,7 @@ csi:
 
   cephcsi:
     # -- Ceph CSI image
-    # @default -- `quay.io/cephcsi/cephcsi:v3.7.2`
+    # @default -- `quay.io/cephcsi/cephcsi:v3.8.0`
     image:
 
   registrar:

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,5 +1,5 @@
  quay.io/ceph/ceph:v17.2.5
- quay.io/cephcsi/cephcsi:v3.7.2
+ quay.io/cephcsi/cephcsi:v3.8.0
  quay.io/csiaddons/k8s-sidecar:v0.5.0
  registry.k8s.io/sig-storage/csi-attacher:v4.1.0
  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -190,7 +190,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.2"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -107,7 +107,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.7.2"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -134,7 +134,7 @@ var (
 // manually challenging.
 var (
 	// image names
-	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.7.2"
+	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.8.0"
 	DefaultRegistrarImage   = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
 	DefaultProvisionerImage = "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"
 	DefaultAttacherImage    = "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -268,7 +268,7 @@ func Test_getImage(t *testing.T) {
 			args: args{
 				data:         map[string]string{},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.7.2",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
 			},
 			want: DefaultCSIPluginImage,
 		},
@@ -279,7 +279,7 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi:v8",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.7.2",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
 			},
 			want: "registry.io/private/cephcsi:v8",
 		},
@@ -290,9 +290,9 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.7.2",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
 			},
-			want: "registry.io/private/cephcsi:v3.7.2",
+			want: "registry.io/private/cephcsi:v3.8.0",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -26,13 +26,13 @@ import (
 
 var (
 	//minimum supported version is 3.7.0
-	minimum = CephCSIVersion{3, 6, 0}
+	minimum = CephCSIVersion{3, 7, 0}
 	//supportedCSIVersions are versions that rook supports
-	releasev370 = CephCSIVersion{3, 7, 0}
+	releasev380 = CephCSIVersion{3, 8, 0}
 
 	supportedCSIVersions = []CephCSIVersion{
 		minimum,
-		releasev370,
+		releasev380,
 	}
 
 	// custom ceph.conf is supported in v3.5.0+

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -23,12 +23,15 @@ import (
 )
 
 var (
-	testMinVersion         = CephCSIVersion{3, 6, 0}
-	testReleaseV350        = CephCSIVersion{3, 5, 0}
-	testReleaseV360        = CephCSIVersion{3, 6, 0}
-	testReleaseV361        = CephCSIVersion{3, 6, 1}
-	testReleaseV370        = CephCSIVersion{3, 7, 0}
-	testReleaseV371        = CephCSIVersion{3, 7, 1}
+	testMinVersion  = CephCSIVersion{3, 7, 0}
+	testReleaseV350 = CephCSIVersion{3, 5, 0}
+	testReleaseV360 = CephCSIVersion{3, 6, 0}
+	testReleaseV361 = CephCSIVersion{3, 6, 1}
+	testReleaseV370 = CephCSIVersion{3, 7, 0}
+	testReleaseV371 = CephCSIVersion{3, 7, 1}
+	testReleaseV380 = CephCSIVersion{3, 8, 0}
+	testReleaseV381 = CephCSIVersion{3, 8, 1}
+
 	testVersionUnsupported = CephCSIVersion{4, 0, 0}
 )
 
@@ -53,6 +56,14 @@ func TestIsAtLeast(t *testing.T) {
 	// Test for 3.7.1
 	ret = testReleaseV371.isAtLeast(&testReleaseV360)
 	assert.Equal(t, true, ret)
+
+	// Test for 3.8.0
+	ret = testReleaseV380.isAtLeast(&testReleaseV370)
+	assert.Equal(t, true, ret)
+
+	// Test for 3.8.1
+	ret = testReleaseV381.isAtLeast(&testReleaseV371)
+	assert.Equal(t, true, ret)
 }
 
 func TestSupported(t *testing.T) {
@@ -63,13 +74,20 @@ func TestSupported(t *testing.T) {
 	ret = testVersionUnsupported.Supported()
 	assert.Equal(t, false, ret)
 
+	// 3.6 is not supported after 3.8.0 release
 	ret = testReleaseV360.Supported()
-	assert.Equal(t, true, ret)
+	assert.Equal(t, false, ret)
 
 	ret = testReleaseV370.Supported()
 	assert.Equal(t, true, ret)
 
 	ret = testReleaseV371.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testReleaseV380.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testReleaseV381.Supported()
 	assert.Equal(t, true, ret)
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Update the cephcsi image to the v3.8.0 release and remove support for 3.6.0, as it's deprecated and not supported anymore.

More details at
https://github.com/ceph/ceph-csi/releases/tag/v3.8.0 and https://github.com/ceph/ceph-csi/tree/release-v3.8#ceph-csi-container-images-and-release-compatibility

**Which issue is resolved by this Pull Request:**
Resolves #11688

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
