### PR TITLE
Implement OSD encryption key rotation 

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -696,11 +696,6 @@ jobs:
           kubectl -n rook-ceph get secrets
           sudo lsblk
 
-      - name: test osd deployment removal and re-hydration
-        run: |
-          kubectl -n rook-ceph delete deploy/rook-ceph-osd-0
-          tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
-
       - name: teardown cluster with cleanup policy
         run: |
           kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
@@ -806,6 +801,7 @@ jobs:
           cat tests/manifests/test-on-pvc-db.yaml >> tests/manifests/test-cluster-on-pvc-encrypted.yaml
           cat tests/manifests/test-on-pvc-wal.yaml >> tests/manifests/test-cluster-on-pvc-encrypted.yaml
           kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
+          kubectl patch -n rook-ceph cephcluster rook-ceph --type merge -p '{"spec":{"security":{"keyRotation":{"enabled": true, "schedule":"*/1 * * * *"}}}}'
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
@@ -816,6 +812,14 @@ jobs:
           tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
           kubectl -n rook-ceph get pods
           kubectl -n rook-ceph get secrets
+
+      - name: wait and verify key rotation
+        run: tests/scripts/github-action-helper.sh verify_key_rotation
+
+      - name: test osd deployment removal and re-hydration
+        run: |
+          kubectl -n rook-ceph delete deploy/rook-ceph-osd-0
+          tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
 
       - name: collect common logs
         if: always()

--- a/Documentation/Storage-Configuration/Advanced/key-management-system.md
+++ b/Documentation/Storage-Configuration/Advanced/key-management-system.md
@@ -3,6 +3,7 @@ title: Key Management System
 ---
 
 Rook has the ability to encrypt OSDs of clusters running on PVC via the flag (`encrypted: true`) in your `storageClassDeviceSets` [template](#pvc-based-cluster).
+Rook also has the ability to rotate encryption keys of OSDs using a cron job per OSD.
 By default, the Key Encryption Keys (also known as Data Encryption Keys) are stored in a Kubernetes Secret.
 However, if a Key Management System exists Rook is capable of using it.
 
@@ -12,6 +13,12 @@ The `security` section contains settings related to encryption of the cluster.
   * `kms`: Key Management System settings
     * `connectionDetails`: the list of parameters representing kms connection details
     * `tokenSecretName`: the name of the Kubernetes Secret containing the kms authentication token
+  * `keyRotation`: Key Rotation settings
+    * `enabled`: whether key rotation is enabled or not, default is `false`
+    * `schedule`: the schedule, written in [cron format](https://en.wikipedia.org/wiki/Cron), with which key rotation [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) is created, default value is `"@weekly"`.
+
+!!! note
+    Currently key rotation is only supported for the default type, where the Key Encryption Keys are stored in a Kubernetes Secret.
 
 Supported KMS providers:
 

--- a/cmd/rook/secret.go
+++ b/cmd/rook/secret.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/daemon/ceph/osd"
 	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	operator "github.com/rook/rook/pkg/operator/ceph"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -37,16 +39,18 @@ var KeyManagementCmd = &cobra.Command{
 	Use:   "key-management",
 	Short: "key-management interacts with a given Key Management System and perform actions.",
 	Long: `The secret sub-command helps interacting with Key Management System.
-	It can perform various actions such as retrieving the content of a Key Encryption Key.`,
+	It can perform various actions such as retrieving the content of a Key Encryption Key and
+	rotating Key Encryption Key.`,
 }
 
 func init() {
 	KeyManagementCmd.AddCommand(
 		cliGetSecret(),
+		cliRotateSecret(),
 	)
 }
 
-func startSecret() *kms.Config {
+func startSecret() (*kms.Config, *clusterd.Context) {
 	// Initialize the context
 	ctx, cancel := signal.NotifyContext(context.Background(), operator.ShutdownSignals...)
 	defer cancel()
@@ -71,13 +75,15 @@ func startSecret() *kms.Config {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to get ceph cluster in namespace %q", namespace))
 	}
 
-	// Validate connection details
-	err = kms.ValidateConnectionDetails(ctx, context, &cephCluster.Spec.Security.KeyManagementService, namespace)
-	if err != nil {
-		rook.TerminateFatal(errors.Wrap(err, "failed to validate kms connection details"))
+	if cephCluster.Spec.Security.KeyManagementService.IsEnabled() {
+		// Validate connection details
+		err = kms.ValidateConnectionDetails(ctx, context, &cephCluster.Spec.Security.KeyManagementService, namespace)
+		if err != nil {
+			rook.TerminateFatal(errors.Wrap(err, "failed to validate kms connection details"))
+		}
 	}
 
-	return kms.NewConfig(context, &cephCluster.Spec, clusterInfo)
+	return kms.NewConfig(context, &cephCluster.Spec, clusterInfo), context
 }
 
 // cliGetSecret is the Cobra CLI call
@@ -98,7 +104,7 @@ func getSecret(cmd *cobra.Command, args []string) {
 
 	secretName := args[0]
 	secretPath := args[1]
-	keyManagementService := startSecret()
+	keyManagementService, _ := startSecret()
 	keyManagementService.ClusterInfo.Context = ctx
 
 	// Fetch the secret
@@ -111,5 +117,35 @@ func getSecret(cmd *cobra.Command, args []string) {
 	err = os.WriteFile(secretPath, []byte(s), 0400)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to write secret %q file to %q", secretName, secretPath))
+	}
+}
+
+// cliRotateSecret is the Cobra CLI call
+func cliRotateSecret() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rotate-key kms-secret-key data-device [metadata-device] [wal-device]",
+		Short: "Rotate key",
+		Args:  cobra.RangeArgs(2, 4),
+		Run:   rotateSecret,
+	}
+	return cmd
+}
+
+// rotateSecret rotates the Key Encryption Key of a given OSD.
+// It accepts the name of the secret to rotate, and the path to the
+// encrypted devices.
+func rotateSecret(cmd *cobra.Command, args []string) {
+	rook.SetLogLevel()
+	// Initialize the context
+	ctx, cancel := signal.NotifyContext(context.Background(), operator.ShutdownSignals...)
+	defer cancel()
+	secretName := args[0]
+	devicePaths := args[1:]
+	keyManagementService, context := startSecret()
+	keyManagementService.ClusterInfo.Context = ctx
+
+	err := osd.RotateKeyEncryptionKey(context, keyManagementService, secretName, devicePaths)
+	if err != nil {
+		rook.TerminateFatal(errors.Wrapf(err, "failed to rotate secret %q", secretName))
 	}
 }

--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -9,10 +9,10 @@ metadata:
   namespace: {{ .Release.Namespace }} # namespace:cluster
 rules:
   # this is needed for rook's "key-management" CLI to fetch the vault token from the secret when
-  # validating the connection details
+  # validating the connection details and for key rotation operations.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get","update"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -121,6 +121,7 @@ rules:
   - create
   - update
   - delete
+  - deletecollection
 # The Rook operator must be able to watch all ceph.rook.io resources to reconcile them.
 - apiGroups: ["ceph.rook.io"]
   resources:
@@ -207,6 +208,14 @@ rules:
   - update
   - delete
   - deletecollection
+- apiGroups:
+  - apps
+  resources:
+  # This is to add osd deployment owner ref on key rotation
+  # cron jobs.
+  - deployments/finalizers
+  verbs:
+  - update
 - apiGroups:
   - healthchecking.openshift.io
   resources:

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2548,6 +2548,19 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    keyRotation:
+                      description: KeyRotation defines options for Key Rotation.
+                      nullable: true
+                      properties:
+                        enabled:
+                          default: false
+                          description: Enabled represents whether the key rotation is enabled.
+                          type: boolean
+                        schedule:
+                          default: '@weekly'
+                          description: Schedule represents the cron schedule for key rotation.
+                          type: string
+                      type: object
                     kms:
                       description: KeyManagementService is the main Key Management option
                       nullable: true
@@ -12986,6 +12999,19 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    keyRotation:
+                      description: KeyRotation defines options for Key Rotation.
+                      nullable: true
+                      properties:
+                        enabled:
+                          default: false
+                          description: Enabled represents whether the key rotation is enabled.
+                          type: boolean
+                        schedule:
+                          default: '@weekly'
+                          description: Schedule represents the cron schedule for key rotation.
+                          type: string
+                      type: object
                     kms:
                       description: KeyManagementService is the main Key Management option
                       nullable: true

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -185,6 +185,15 @@ spec:
     pgHealthCheckTimeout: 0
   # security oriented settings
   # security:
+  # Settings to enable key rotation for KEK(Key Encryption Key).
+  # Currently, this is supported only for the default encryption type,
+  # using kubernetes secrets.
+  #   keyRotation:
+  #     enabled: true
+  #     # The schedule, written in [cron format](https://en.wikipedia.org/wiki/Cron),
+  #     # with which key rotation [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+  #     # is created. The default value is `"@weekly"`.
+  #     schedule: "@monthly"
   # To enable the KMS configuration properly don't forget to uncomment the Secret at the end of the file
   #   kms:
   #     # name of the config map containing all the kms connection details

--- a/deploy/examples/common-second-cluster.yaml
+++ b/deploy/examples/common-second-cluster.yaml
@@ -166,6 +166,11 @@ metadata:
   name: rook-ceph-osd
   namespace: $NAMESPACE
 rules:
+  # this is needed for rook's "key-management" CLI to fetch the vault token from the secret when
+  # validating the connection details and for key rotation operations.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -801,10 +801,10 @@ metadata:
   namespace: rook-ceph # namespace:cluster
 rules:
   # this is needed for rook's "key-management" CLI to fetch the vault token from the secret when
-  # validating the connection details
+  # validating the connection details and for key rotation operations.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -260,6 +260,7 @@ rules:
       - create
       - update
       - delete
+      - deletecollection
   # The Rook operator must be able to watch all ceph.rook.io resources to reconcile them.
   - apiGroups: ["ceph.rook.io"]
     resources:
@@ -346,6 +347,14 @@ rules:
       - update
       - delete
       - deletecollection
+  - apiGroups:
+      - apps
+    resources:
+      # This is to add osd deployment owner ref on key rotation
+      # cron jobs.
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - healthchecking.openshift.io
     resources:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2546,6 +2546,19 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    keyRotation:
+                      description: KeyRotation defines options for Key Rotation.
+                      nullable: true
+                      properties:
+                        enabled:
+                          default: false
+                          description: Enabled represents whether the key rotation is enabled.
+                          type: boolean
+                        schedule:
+                          default: '@weekly'
+                          description: Schedule represents the cron schedule for key rotation.
+                          type: string
+                      type: object
                     kms:
                       description: KeyManagementService is the main Key Management option
                       nullable: true
@@ -12978,6 +12991,19 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    keyRotation:
+                      description: KeyRotation defines options for Key Rotation.
+                      nullable: true
+                      properties:
+                        enabled:
+                          default: false
+                          description: Enabled represents whether the key rotation is enabled.
+                          type: boolean
+                        schedule:
+                          default: '@weekly'
+                          description: Schedule represents the cron schedule for key rotation.
+                          type: string
+                      type: object
                     kms:
                       description: KeyManagementService is the main Key Management option
                       nullable: true

--- a/pkg/apis/ceph.rook.io/v1/annotations.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations.go
@@ -42,6 +42,11 @@ func GetMonAnnotations(a AnnotationsSpec) Annotations {
 	return mergeAllAnnotationsWithKey(a, KeyMon)
 }
 
+// GetKeyRotationAnnotations returns the annotations for the key rotation job
+func GetKeyRotationAnnotations(a AnnotationsSpec) Annotations {
+	return mergeAllAnnotationsWithKey(a, KeyRotation)
+}
+
 // GetOSDPrepareAnnotations returns the annotations for the OSD service
 func GetOSDPrepareAnnotations(a AnnotationsSpec) Annotations {
 	return mergeAllAnnotationsWithKey(a, KeyOSDPrepare)

--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -24,6 +24,7 @@ const (
 	KeyMonArbiter      KeyType = "arbiter"
 	KeyMgr             KeyType = "mgr"
 	KeyOSDPrepare      KeyType = "prepareosd"
+	KeyRotation        KeyType = "keyrotation"
 	KeyOSD             KeyType = "osd"
 	KeyCleanup         KeyType = "cleanup"
 	KeyMonitoring      KeyType = "monitoring"

--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -48,6 +48,11 @@ func GetMonLabels(a LabelsSpec) Labels {
 	return mergeAllLabelsWithKey(a, KeyMon)
 }
 
+// GetKeyRotationLabels returns labels for the key Rotation job
+func GetKeyRotationLabels(a LabelsSpec) Labels {
+	return mergeAllLabelsWithKey(a, KeyRotation)
+}
+
 // GetOSDPrepareLabels returns the Labels for the OSD prepare job
 func GetOSDPrepareLabels(a LabelsSpec) Labels {
 	return mergeAllLabelsWithKey(a, KeyOSDPrepare)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -242,6 +242,10 @@ type SecuritySpec struct {
 	// +optional
 	// +nullable
 	KeyManagementService KeyManagementServiceSpec `json:"kms,omitempty"`
+	// KeyRotation defines options for Key Rotation.
+	// +optional
+	// +nullable
+	KeyRotation KeyRotationSpec `json:"keyRotation,omitempty"`
 }
 
 // ObjectStoreSecuritySpec is spec to define security features like encryption
@@ -266,6 +270,18 @@ type KeyManagementServiceSpec struct {
 	// TokenSecretName is the kubernetes secret containing the KMS token
 	// +optional
 	TokenSecretName string `json:"tokenSecretName,omitempty"`
+}
+
+// KeyRotationSpec represents the settings for Key Rotation.
+type KeyRotationSpec struct {
+	// Enabled represents whether the key rotation is enabled.
+	// +optional
+	// +kubebuilder:default=false
+	Enabled bool `json:"enabled,omitempty"`
+	// Schedule represents the cron schedule for key rotation.
+	// +optional
+	// +kubebuilder:default="@weekly"
+	Schedule string `json:"schedule,omitempty"`
 }
 
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.

--- a/pkg/daemon/ceph/osd/key_rotation.go
+++ b/pkg/daemon/ceph/osd/key_rotation.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
+	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+)
+
+const (
+	slotZero string = "0"
+	slotOne  string = "1"
+)
+
+func RotateKeyEncryptionKey(context *clusterd.Context, kms *kms.Config, secretName string, devicePaths []string) error {
+	logger.Info("fetching the current key")
+	// Fetch the currentKey.
+	currentKey, err := kms.GetSecret(secretName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get secret %q", secretName)
+	}
+
+	// Ensure currentKey is in slot 1.
+	for _, devicePath := range devicePaths {
+		logger.Infof("adding the current key to slot %q of the device %q", slotOne, devicePath)
+		err = addEncryptionKey(context, devicePath, currentKey, currentKey, slotOne)
+		if err != nil {
+			return errors.Wrapf(err, "failed to add the current key to slot %q of the device", slotOne)
+		}
+	}
+
+	logger.Info("generating new key")
+	// Generate new key.
+	newKey, err := oposd.GenerateDmCryptKey()
+	if err != nil {
+		return errors.Wrapf(err, "failed to generate new key")
+	}
+
+	// Add newKey to slot 0.
+	for _, devicePath := range devicePaths {
+		logger.Infof("removing key slot %q, if found, of the device %q", slotZero, devicePath)
+		err = removeEncryptionKeySlot(context, devicePath, currentKey, slotZero)
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove key slot %q of the device %q", slotZero, devicePath)
+		}
+		logger.Infof("adding new key to slot %q of the device %q", slotZero, devicePath)
+		err = addEncryptionKey(context, devicePath, currentKey, newKey, slotZero)
+		if err != nil {
+			return errors.Wrapf(err, "failed to add new key to slot %q of the device %q", slotZero, devicePath)
+		}
+	}
+
+	logger.Info("updating the new key in the KMS")
+	// Update new key.
+	err = kms.UpdateSecret(secretName, newKey)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update secret %q with new key", secretName)
+	}
+
+	logger.Info("fetching the key from the KMS to verify it.")
+	// Fetch key to verify its the new key.
+	keyInKMS, err := kms.GetSecret(secretName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get secret %q", secretName)
+	}
+	if keyInKMS != newKey {
+		return errors.New("failed to verify the new key in the KMS, the fetched key is not the same as the new key")
+	}
+
+	// Remove old key from slot 1.
+	for _, devicePath := range devicePaths {
+		logger.Infof("removing the old key from the slot %q of the device %q", slotOne, devicePath)
+		err = removeEncryptionKeySlot(context, devicePath, newKey, slotOne)
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove the old key from the slot %q of the device %q", slotOne, devicePath)
+		}
+	}
+	logger.Infof("Successfully rotated the key")
+
+	return nil
+}

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -58,7 +58,7 @@ func encryptionBlockDestinationCopy(mountPath, blockType string) string {
 	return path.Join(mountPath, blockType) + "-tmp"
 }
 
-func generateDmCryptKey() (string, error) {
+func GenerateDmCryptKey() (string, error) {
 	key, err := mgr.GenerateRandomBytes(dmCryptKeySize)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate random bytes")

--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -187,7 +187,7 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig, errs *provi
 
 		if osdProps.encrypted {
 			// create encryption Kubernetes Secret if the PVC is encrypted
-			key, err := generateDmCryptKey()
+			key, err := GenerateDmCryptKey()
 			if err != nil {
 				errMsg := fmt.Sprintf("failed to generate dmcrypt key for osd claim %q. %v", osdProps.pvc.ClaimName, err)
 				errs.addError(errMsg)

--- a/pkg/operator/ceph/cluster/osd/key_rotation.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	keyRotationCronJobAppName    = "rook-ceph-osd-key-rotation"
+	keyRotationCronJobAppNameFmt = "rook-ceph-osd-key-rotation-%d"
+)
+
+// keyRotationCronJobName returns the name of the key rotation cron job for the given OSD ID.
+func keyRotationCronJobName(osdID int) string {
+	return fmt.Sprintf(keyRotationCronJobAppNameFmt, osdID)
+}
+
+// applyKeyRotationPlacement applies the placement settings for the key rotation job
+// so that it is scheduled on the same node as the OSD for which the key rotation is scheduled.
+func applyKeyRotationPlacement(spec *v1.PodSpec, labels map[string]string) {
+	spec.TopologySpreadConstraints = nil
+	if spec.Affinity == nil {
+		spec.Affinity = &v1.Affinity{}
+	} else {
+		spec.Affinity.PodAntiAffinity = nil
+	}
+	spec.Affinity.PodAffinity = &v1.PodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				TopologyKey: v1.LabelHostname,
+			},
+		},
+	}
+}
+
+// getKeyRotationContainer returns the container spec for the key rotation job.
+func (c *Cluster) getKeyRotationContainer(osdProps osdProperties, volumeMounts []v1.VolumeMount, devices []string) (v1.Container, error) {
+	envVars := c.getConfigEnvVars(osdProps, k8sutil.DataDir, true)
+
+	// enable debug logging
+	envVars = append(envVars, setDebugLogLevelEnvVar(true))
+	envVars = append(envVars, v1.EnvVar{Name: "ROOK_CEPH_VERSION", Value: c.clusterInfo.CephVersion.CephVersionFormatted()})
+	envVars = append(envVars, kms.ConfigToEnvVar(c.spec)...)
+
+	// run privileged always since we always mount /dev
+	privileged := true
+	runAsUser := int64(0)
+	runAsNonRoot := false
+	readOnlyRootFilesystem := false
+
+	args := []string{"key-management", "rotate-key", osdProps.pvc.ClaimName}
+	args = append(args, devices...)
+
+	osdProvisionContainer := v1.Container{
+		Args:            args,
+		Name:            keyRotationCronJobAppName,
+		Image:           c.rookVersion,
+		ImagePullPolicy: controller.GetContainerImagePullPolicy(c.spec.CephVersion.ImagePullPolicy),
+		VolumeMounts:    volumeMounts,
+		Env:             envVars,
+		EnvFrom:         getEnvFromSources(),
+		SecurityContext: &v1.SecurityContext{
+			Privileged:             &privileged,
+			RunAsUser:              &runAsUser,
+			RunAsNonRoot:           &runAsNonRoot,
+			ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+		},
+		Resources: osdProps.resources,
+	}
+
+	return osdProvisionContainer, nil
+}
+
+// getKeyRotationPodTemplateSpec returns the pod template spec for the key rotation job.
+func (c *Cluster) getKeyRotationPodTemplateSpec(osdProps osdProperties, osd OSDInfo, restart v1.RestartPolicy) (*v1.PodTemplateSpec, error) {
+	// create a volume on /dev so the pod can access devices on the host
+	devVolume := v1.Volume{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}}
+	udevVolume := v1.Volume{Name: "udev", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}}
+	hostPathType := v1.HostPathDirectory
+	hostPath := filepath.Join(c.spec.DataDirHostPath, c.clusterInfo.Namespace, osdProps.pvc.ClaimName, fmt.Sprintf("ceph-%d", osd.ID))
+	hostPathVolume := v1.Volume{
+		Name: "bridge",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: hostPath,
+				Type: &hostPathType,
+			},
+		},
+	}
+	devicesBasePath := "/var/lib/ceph/osd/"
+	volumes := []v1.Volume{
+		udevVolume,
+		devVolume,
+		hostPathVolume,
+	}
+	volumeMounts := []v1.VolumeMount{
+		{Name: "devices", MountPath: "/dev"},
+		{Name: "udev", MountPath: "/run/udev"},
+		{Name: "bridge", MountPath: devicesBasePath},
+	}
+
+	devices := []string{encryptionBlockDestinationCopy(devicesBasePath, bluestoreBlockName)}
+	if osdProps.metadataPVC.ClaimName != "" {
+		devices = append(devices, encryptionBlockDestinationCopy(devicesBasePath, bluestoreMetadataName))
+	}
+	if osdProps.walPVC.ClaimName != "" {
+		devices = append(devices, encryptionBlockDestinationCopy(devicesBasePath, bluestoreWalName))
+	}
+
+	keyRotationContainer, err := c.getKeyRotationContainer(osdProps, volumeMounts, devices)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate key rotation container")
+	}
+
+	podTemplateSpec := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: keyRotationCronJobAppName,
+			Labels: map[string]string{
+				k8sutil.AppAttr:     keyRotationCronJobAppName,
+				k8sutil.ClusterAttr: c.clusterInfo.Namespace,
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: serviceAccountName,
+			Containers: []v1.Container{
+				keyRotationContainer,
+			},
+			RestartPolicy:     restart,
+			Volumes:           volumes,
+			HostNetwork:       c.spec.Network.IsHost(),
+			PriorityClassName: cephv1.GetOSDPriorityClassName(c.spec.PriorityClassNames),
+			SchedulerName:     osdProps.schedulerName,
+		},
+	}
+	if c.spec.Network.IsHost() {
+		podTemplateSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	} else if c.spec.Network.IsMultus() {
+		if err := k8sutil.ApplyMultus(c.spec.Network, &podTemplateSpec.ObjectMeta); err != nil {
+			return nil, err
+		}
+	}
+
+	cephv1.GetKeyRotationAnnotations(c.spec.Annotations).ApplyToObjectMeta(&podTemplateSpec.ObjectMeta)
+	cephv1.GetKeyRotationLabels(c.spec.Labels).ApplyToObjectMeta(&podTemplateSpec.ObjectMeta)
+
+	c.applyAllPlacementIfNeeded(&podTemplateSpec.Spec)
+	// apply storageClassDeviceSets.Placement
+	osdProps.placement.ApplyToPodSpec(&podTemplateSpec.Spec)
+	applyKeyRotationPlacement(&podTemplateSpec.Spec, c.getOSDLabels(osd, osdProps.crushHostname, osdProps.portable))
+
+	// cryptsetup synchronizes with udev on host through semaphore
+	podTemplateSpec.Spec.HostIPC = true
+
+	k8sutil.RemoveDuplicateEnvVars(&podTemplateSpec.Spec)
+	return &podTemplateSpec, nil
+}
+
+// makeKeyRotationCronJob creates a key rotation cron job for the given OSD.
+func (c *Cluster) makeKeyRotationCronJob(pvcName string, osd OSDInfo, osdProps osdProperties) (*batch.CronJob, error) {
+	podSpec, err := c.getKeyRotationPodTemplateSpec(osdProps, osd, v1.RestartPolicyOnFailure)
+	if err != nil {
+		return nil, err
+	}
+	c.applyResourcesToAllContainers(&podSpec.Spec, cephv1.GetOSDResources(c.spec.Resources, osd.DeviceClass))
+	cronJob := &batch.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        keyRotationCronJobName(osd.ID),
+			Namespace:   c.clusterInfo.Namespace,
+			Labels:      podSpec.Labels,
+			Annotations: podSpec.Annotations,
+		},
+		Spec: batch.CronJobSpec{
+			ConcurrencyPolicy: batch.ForbidConcurrent,
+			Schedule:          c.spec.Security.KeyRotation.Schedule,
+			JobTemplate: batch.JobTemplateSpec{
+				Spec: batch.JobSpec{
+					Template: *podSpec,
+				},
+			},
+		},
+	}
+
+	return cronJob, nil
+}

--- a/pkg/operator/ceph/cluster/osd/key_rotation_test.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_keyRotationCronJobName(t *testing.T) {
+	type args struct {
+		osdID int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "OSD ID 0",
+			args: args{
+				osdID: 0,
+			},
+			want: fmt.Sprintf(keyRotationCronJobAppNameFmt, 0),
+		},
+		{
+			name: "OSD ID 1",
+			args: args{
+				osdID: 1,
+			},
+			want: fmt.Sprintf(keyRotationCronJobAppNameFmt, 1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keyRotationCronJobName(tt.args.osdID); got != tt.want {
+				t.Errorf("keyRotationCronJobName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_applyKeyRotationPlacement(t *testing.T) {
+	type args struct {
+		spec   *v1.PodSpec
+		labels map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test 1",
+			args: args{
+				spec: &v1.PodSpec{
+					Affinity: &v1.Affinity{
+						PodAffinity:     &v1.PodAffinity{},
+						PodAntiAffinity: &v1.PodAntiAffinity{},
+					},
+					TopologySpreadConstraints: []v1.TopologySpreadConstraint{},
+				},
+				labels: map[string]string{
+					"app":    "rook-ceph-osd",
+					"osd-id": "0",
+				},
+			},
+		},
+		{
+			name: "Affinity is nil",
+			args: args{
+				spec: &v1.PodSpec{
+					Affinity:                  nil,
+					TopologySpreadConstraints: []v1.TopologySpreadConstraint{},
+				},
+				labels: map[string]string{
+					"app":    "rook-ceph-osd",
+					"osd-id": "0",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		currentTT := tt
+		t.Run(currentTT.name, func(t *testing.T) {
+			applyKeyRotationPlacement(currentTT.args.spec, currentTT.args.labels)
+			assert.Nil(t, currentTT.args.spec.Affinity.PodAntiAffinity)
+			assert.Nil(t, currentTT.args.spec.TopologySpreadConstraints)
+			assert.Equal(t, currentTT.args.spec.Affinity.PodAffinity, &v1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: currentTT.args.labels},
+						TopologyKey:   v1.LabelHostname,
+					},
+				},
+			})
+		})
+	}
+}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -241,6 +241,11 @@ func (c *Cluster) Start() error {
 	// The following block is used to apply any command(s) required by an upgrade
 	c.applyUpgradeOSDFunctionality()
 
+	err = c.reconcileKeyRotationCronJob()
+	if err != nil {
+		return errors.Wrapf(err, "failed to reconcile key rotation cron jobs")
+	}
+
 	logger.Infof("finished running OSDs in namespace %q", namespace)
 	return nil
 }

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -522,6 +522,17 @@ func CreateDeployment(ctx context.Context, clientset kubernetes.Interface, dep *
 	return clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
 }
 
+// createCronJob creates a cron job with a last applied hash annotation added
+func createCronJob(ctx context.Context, clientset kubernetes.Interface, cj *batchv1.CronJob) (*batchv1.CronJob, error) {
+	// Set hash annotation to the newly generated deployment
+	err := patch.DefaultAnnotator.SetLastAppliedAnnotation(cj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set hash annotation on cron job %q", cj.Name)
+	}
+
+	return clientset.BatchV1().CronJobs(cj.Namespace).Create(ctx, cj, metav1.CreateOptions{})
+}
+
 func CreateOrUpdateDeployment(ctx context.Context, clientset kubernetes.Interface, dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 	newDep, err := CreateDeployment(ctx, clientset, dep)
 	if err != nil {
@@ -534,6 +545,20 @@ func CreateOrUpdateDeployment(ctx context.Context, clientset kubernetes.Interfac
 		}
 	}
 	return newDep, nil
+}
+
+func CreateOrUpdateCronJob(ctx context.Context, clientset kubernetes.Interface, cj *batchv1.CronJob) (*batchv1.CronJob, error) {
+	newCJ, err := createCronJob(ctx, clientset, cj)
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			// annotation was added in CreateCronJob to cj passed by reference
+			newCJ, err = clientset.BatchV1().CronJobs(cj.Namespace).Update(ctx, cj, metav1.UpdateOptions{})
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create or update cronjob %q: %+v", cj.Name, cj)
+		}
+	}
+	return newCJ, nil
 }
 
 func maxInt32Ptr(a, b *int32) *int32 {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This pr implements the following:

- [core: add KeyRotationSpec to cephcluster CR](https://github.com/rook/rook/commit/5dc8f5a688c72fb95dc032d001b8b7ed47e78cae) 

- [osd: add util functions to support encryption key rotation](https://github.com/rook/rook/commit/e3d9a3a13a507842ea252d1c9a7af40fb287c1e9) 

- [ceph: add support for updating secret for default KMS](https://github.com/rook/rook/commit/9f1ea407fb4a384b63e89bcb747f7d19a89428d1) 


- [osd: add rotate-key functionality to rook's key-management cmd](https://github.com/rook/rook/commit/8abba1bbd362ded53ab16446738b3c662e1efef7) 

- [ceph: add util function to create key rotation cron job](https://github.com/rook/rook/commit/20e7b5e453822f6bafb770612e08e763392ec1ec) 

- [ceph: add capability to reconcile key rotation cron jobs](https://github.com/rook/rook/commit/a9659b16e502d32d478faf85de2e8e5ddeeab967)

---

### Cephcluster CR changes

 parameters `enabled: <true|false>` and `schedule: <cron_format, default to @weekly>` are added to
`security.keyRotation` section of cephcluster spec here https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Advanced/key-management-system.md.
```
security:
  kms:
    keyRotation: 
      enabled: "true"
      schedule: "@weekly" 
    connectionDetails:
      KMS_PROVIDER: vault
      ....
      tokenSecretName: rook-vault-token
```

---

### KMS changes

Support for `KMS.UpdateSecret()` is added.
Currently only default type/ k8s secret is supported
It will be extended in future to support other KMS such as vault,ibm hpcs, kmip etc.

---

### KEK Rotation logic would be as follows: 

| Step | Operation                 | Luks Slot 0 | Luks Slot 1 | Key in KMS |
|:---- |:------------------------- |:----------- |:----------- |:---------- |
| 1    | Obtain K1                 | K1          |             | K1         |
| 2    | Add K1 to slot 1          | K1          | K1          | K1         |
| 3    | Create K2 & add to slot 0 | K2          | K1          | K1         |
| 4    | Update K2 in KMS          | K2          | K1          | K2         |
| 5    | Remove K1 from slot 1     | K2          |             | K2         |
 
Note: The above steps will ensure the KEK in kms will be able to open the encrypted device even if the operation is disrupted at any step and all the edge cases from disrupted processes are handled.

`luksAddKey, luksChangeKey, luksKillSlot` commands are being used to achieve this.

Refer: [10 Linux cryptsetup Examples for LUKS Key Management (How to Add, Remove, Change, Reset LUKS encryption Key)](https://www.thegeekstuff.com/2016/03/cryptsetup-lukskey/)

---

### KEK Rotation Cron Job

- One Cron Job per encrypted PVC backed OSD is be created when key rotation is enabled with the given schedule.
- The Cron Job will use OSD pod affinity `requiredDuringScheduling..` using OSD's labels as selector to run on the same node as the OSD.
- The Cron Job will share the host bridge directory with the OSD which contains the enrcypted devices mapped to be able to rotate the KEK.

--- 


**Which issue is resolved by this Pull Request:**
Resolves #7925 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
