### PR TITLE
core: on crash pod ensure rook version label is not set

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/crash.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash.go
@@ -92,13 +92,20 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 
 		deploy.ObjectMeta.Labels = deploymentLabels
 		cephv1.GetCrashCollectorLabels(cephCluster.Spec.Labels).ApplyToObjectMeta(&deploy.ObjectMeta)
-		k8sutil.AddRookVersionLabelToDeployment(deploy)
 		if cephVersion != nil {
 			controller.AddCephVersionLabelToDeployment(*cephVersion, deploy)
 		}
+
+		//  make a copy labels for pod to avoid rook version gets added to pod spec
+		podLabels := map[string]string{}
+		for key, value := range deploymentLabels {
+			podLabels[key] = value
+		}
+		k8sutil.AddRookVersionLabelToDeployment(deploy)
+
 		deploy.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: deploymentLabels,
+				Labels: podLabels,
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: nodeSelector,

--- a/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
@@ -102,4 +102,6 @@ func TestCreateOrUpdateCephCrash(t *testing.T) {
 	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
 	assert.Equal(t, true, podSpec.Spec.HostNetwork)
 	assert.Equal(t, "test-priority-class", podSpec.Spec.PriorityClassName)
+	assert.NotEqual(t, "", deploy.ObjectMeta.Labels["rook-version"])
+	assert.Equal(t, "", podSpec.ObjectMeta.Labels["rook-version"])
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
ceph crash pod gets rook version label added unintentionally, which is only for deployment label.
This fix along with pr 11674 is to stop ceph daemons pod restarting unnecessarily after upgrading rook operator.

**Which issue is resolved by this Pull Request:**
Resolves #11657 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
