### PR TITLE
rgw: Use StatusInfo endpoint for internal communications with server

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -134,14 +134,8 @@ func NewMultisiteContext(context *clusterd.Context, clusterInfo *cephclient.Clus
 
 // UpdateEndpoint updates an object.Context using the latest info from the CephObjectStore spec
 func UpdateEndpoint(objContext *Context, store *cephv1.CephObjectStore) error {
-	nsName := fmt.Sprintf("%s/%s", objContext.clusterInfo.Namespace, objContext.Name)
-
-	port, err := store.Spec.GetPort()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get port for object store %q", nsName)
-	}
-	objContext.Endpoint = BuildDNSEndpoint(GetDomainName(store), port, store.Spec.IsTLSEnabled())
-
+	// Get the latest endpoint from object store info
+	objContext.Endpoint = GetEndpointFromStatus(store)
 	return nil
 }
 

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -500,27 +500,6 @@ func (p *Provisioner) setObjectContext() error {
 	return nil
 }
 
-// setObjectStoreDomainName sets the provisioner.storeDomainName and provisioner.port
-// must be called after setObjectStoreName and setObjectStoreNamespace
-func (p *Provisioner) setObjectStoreDomainName(sc *storagev1.StorageClass) error {
-	// make sure the object store actually exists
-	store, err := p.getObjectStore()
-	if err != nil {
-		return err
-	}
-	p.storeDomainName = object.GetDomainName(store)
-	return nil
-}
-
-func (p *Provisioner) setObjectStorePort() error {
-	store, err := p.getObjectStore()
-	if err != nil {
-		return errors.Wrap(err, "failed to get cephObjectStore")
-	}
-	p.storePort, err = store.Spec.GetPort()
-	return err
-}
-
 func (p *Provisioner) setObjectStoreName(sc *storagev1.StorageClass) {
 	p.objectStoreName = sc.Parameters[ObjectStoreName]
 }
@@ -545,27 +524,25 @@ func (p Provisioner) getObjectStoreEndpoint() string {
 }
 
 func (p *Provisioner) populateDomainAndPort(sc *storagev1.StorageClass) error {
-	endpoint := getObjectStoreEndpoint(sc)
 	// if endpoint is present, let's introspect it
-	if endpoint != "" {
-		p.storeDomainName = cephutil.GetIPFromEndpoint(endpoint)
-		if p.storeDomainName == "" {
-			return errors.New("failed to discover endpoint IP (is empty)")
-		}
-		p.storePort = cephutil.GetPortFromEndpoint(endpoint)
-		if p.storePort == 0 {
-			return errors.New("failed to discover endpoint port (is empty)")
-		}
+	endpoint := getObjectStoreEndpoint(sc)
+	if endpoint == "" {
 		// If no endpoint exists let's see if CephObjectStore exists
-	} else {
-		if err := p.setObjectStoreDomainName(sc); err != nil {
-			return errors.Wrap(err, "failed to set object store domain name")
+		store, err := p.getObjectStore()
+		if err != nil {
+			return err
 		}
-		if err := p.setObjectStorePort(); err != nil {
-			return errors.Wrap(err, "failed to set object store port")
-		}
+		// trim the http(s) prefix from the endpoint
+		endpoint = strings.TrimPrefix(strings.TrimPrefix(object.GetEndpointFromStatus(store), "http://"), "https://")
 	}
-
+	p.storeDomainName = cephutil.GetIPFromEndpoint(endpoint)
+	if p.storeDomainName == "" {
+		return errors.New("failed to discover endpoint IP (is empty)")
+	}
+	p.storePort = cephutil.GetPortFromEndpoint(endpoint)
+	if p.storePort == 0 {
+		return errors.New("failed to discover endpoint port (is empty)")
+	}
 	return nil
 }
 
@@ -688,8 +665,7 @@ func (p *Provisioner) setAdminOpsAPIClient() error {
 	}
 
 	// Build endpoint
-	s3endpoint := object.BuildDNSEndpoint(object.GetDomainName(cephObjectStore), p.storePort, cephObjectStore.Spec.IsTLSEnabled())
-
+	s3endpoint := p.getObjectStoreEndpoint()
 	// If DEBUG level is set we will mutate the HTTP client for printing request and response
 	if logger.LevelAt(capnslog.DEBUG) {
 		p.adminOpsClient, err = admin.New(s3endpoint, accessKey, secretKey, object.NewDebugHTTPClient(httpClient, logger))

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -90,6 +90,12 @@ func TestPopulateDomainAndPort(t *testing.T) {
 				Port: int32(80),
 			},
 		},
+		Status: &cephv1.ObjectStoreStatus{
+			Phase: cephv1.ConditionReady,
+			Info: map[string]string{
+				"endpoint": "http://rook-ceph-rgw-test-store.ns.svc:80",
+			},
+		},
 	}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -347,6 +347,7 @@ func TestCephObjectStoreController(t *testing.T) {
 			},
 			Spec:     cephv1.ObjectStoreSpec{MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}, DataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}},
 			TypeMeta: controllerTypeMeta,
+			Status:  &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://rook-ceph-rgw-my-store.rook-ceph.svc:80"}},
 		}
 		objectStore.Spec.Gateway.Port = 80
 
@@ -646,6 +647,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 			Kind: "CephObjectStore",
 		},
 		Spec: cephv1.ObjectStoreSpec{},
+		Status: &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://rook-ceph-rgw-my-store.rook-ceph.svc:80"}},
 	}
 
 	objectStore.Spec.Zone.Name = zoneName
@@ -839,10 +841,11 @@ func TestCephObjectExternalStoreController(t *testing.T) {
 			Kind: "CephObjectStore",
 		},
 		Spec: cephv1.ObjectStoreSpec{},
+		Status: &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://1.2.3.4:80"}},
 	}
 
 	externalObjectStore.Spec.Gateway.Port = 81
-	externalObjectStore.Spec.Gateway.ExternalRgwEndpoints = []cephv1.EndpointAddress{{IP: ""}}
+	externalObjectStore.Spec.Gateway.ExternalRgwEndpoints = []cephv1.EndpointAddress{{IP: "1.2.3.4"}}
 
 	rgwAdminOpsUserSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -103,3 +103,16 @@ func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string 
 
 	return m
 }
+
+func GetEndpointFromStatus(objectStore *cephv1.CephObjectStore) string {
+	if objectStore.Status == nil {
+		return ""
+	}
+	if len(objectStore.Status.Info["secureEndpoint"]) > 0 {
+		return objectStore.Status.Info["secureEndpoint"]
+	}
+	if len(objectStore.Status.Info["endpoint"]) > 0 {
+		return objectStore.Status.Info["endpoint"]
+	}
+	return ""
+}


### PR DESCRIPTION
The Status.Info stores the endpoint of RGW server, fetch it than building the endpoint for the connecting with RGW server.
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
