### PR TITLE
doc: use kubectl replace instead of apply for crd updates

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -78,7 +78,7 @@ section for instructions on how to change the default namespaces in `common.yaml
 Then apply the latest changes from v1.11 and update the Rook Operator image.
 
 ```console
-kubectl apply --server-side -f common.yaml -f crds.yaml
+kubectl replace -f common.yaml -f crds.yaml
 kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.11.1
 ```
 
@@ -158,7 +158,7 @@ sed -i.bak \
 **Apply the resources.**
 
 ```console
-kubectl apply --server-side -f common.yaml -f crds.yaml
+kubectl replace -f common.yaml -f crds.yaml
 ```
 
 #### **Prometheus Updates**


### PR DESCRIPTION
'kubectl apply --server-side' still doesn't always update CRDs correctly if a CRD is too big to have its last applied annotation. Use 'kubectl replace' instead.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
