### PR TITLE
nfs: network mode can be set separately for cephcluster and nfs

### DIFF
--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -101,6 +101,8 @@ The `server` spec sets configuration for Rook-created NFS-Ganesha server pods.
 * `logLevel`: The log level that NFS-Ganesha servers should output.</br>
   Default value: `NIV_INFO`</br>
   Supported values: `NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL`
+* `hostNetwork`: Whether host networking is enabled for the NFS server pod(s). If not set, the network
+  settings from the CephCluster CR will be applied.
 
 ### Security
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -10964,6 +10964,10 @@ spec:
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    hostNetwork:
+                      description: Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
+                      nullable: true
+                      type: boolean
                     labels:
                       additionalProperties:
                         type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -10958,6 +10958,10 @@ spec:
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    hostNetwork:
+                      description: Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
+                      nullable: true
+                      type: boolean
                     labels:
                       additionalProperties:
                         type: string

--- a/pkg/apis/ceph.rook.io/v1/nfs.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs.go
@@ -43,6 +43,13 @@ func (k *KerberosSpec) GetPrincipalName() string {
 	return k.PrincipalName
 }
 
+func (n *CephNFS) IsHostNetwork(c *ClusterSpec) bool {
+	if n.Spec.Server.HostNetwork != nil {
+		return *n.Spec.Server.HostNetwork
+	}
+	return c.Network.IsHost()
+}
+
 func (n *CephNFS) ValidateCreate() error {
 	return n.Spec.Security.Validate()
 }

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1982,6 +1982,11 @@ type GaneshaServerSpec struct {
 	// LogLevel set logging level
 	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
+
+	// Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
+	// +nullable
+	// +optional
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // NFSSecuritySpec represents security configurations for an NFS server pod


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Based heavily on #10491, Network mode can be set separately for cephcluster and nfs and for the same reasons.

Without this fix it is not possible to use the recommended host network configuration for ceph without also using it for any NFS servers -- and each node can only have one NFS server running on it, including if NFS is enabled on the node itself outside of kubernetes.

**Which issue is resolved by this Pull Request:**
Resolves #10749

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
