### PR TITLE
docs: change old version hint in docs

### DIFF
--- a/.docs/overrides/main.html
+++ b/.docs/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block outdated %}
-  This document is for a development version of Rook.
+  This documentation is not for the latest stable version of Rook.
   <a href="{{ '../' ~ base_url }}/latest-release/">
     <strong>Click here for the latest release documentation.</strong>
   </a>


### PR DESCRIPTION
**Description of your changes:**

Change the "old version" hint on the docs.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook.github.io/issues/144

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.