### PR TITLE
osds: remove deprecated k8s topology label

### DIFF
--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -64,31 +64,17 @@ func extractTopologyFromLabels(labels map[string]string) (map[string]string, str
 	// not including the host name
 	var topologyAffinity string
 
-	// check for the region k8s topology label that was deprecated in 1.17
-	const regionLabel = "region"
-	region, ok := labels[corev1.LabelZoneRegion]
-	if ok {
-		topology[regionLabel] = region
-		topologyAffinity = formatTopologyAffinity(corev1.LabelZoneRegion, region)
-	}
-
 	// check for the region k8s topology label that is GA in 1.17.
-	region, ok = labels[corev1.LabelZoneRegionStable]
+	const regionLabel = "region"
+	region, ok := labels[corev1.LabelZoneRegionStable]
 	if ok {
 		topology[regionLabel] = region
 		topologyAffinity = formatTopologyAffinity(corev1.LabelZoneRegionStable, region)
 	}
 
-	// check for the zone k8s topology label that was deprecated in 1.17
-	const zoneLabel = "zone"
-	zone, ok := labels[corev1.LabelZoneFailureDomain]
-	if ok {
-		topology[zoneLabel] = zone
-		topologyAffinity = formatTopologyAffinity(corev1.LabelZoneFailureDomain, zone)
-	}
-
 	// check for the zone k8s topology label that is GA in 1.17.
-	zone, ok = labels[corev1.LabelZoneFailureDomainStable]
+	const zoneLabel = "zone"
+	zone, ok := labels[corev1.LabelZoneFailureDomainStable]
 	if ok {
 		topology[zoneLabel] = zone
 		topologyAffinity = formatTopologyAffinity(corev1.LabelZoneFailureDomainStable, zone)

--- a/pkg/operator/ceph/cluster/osd/topology/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology_test.go
@@ -103,17 +103,6 @@ func TestTopologyLabels(t *testing.T) {
 	assert.Equal(t, "d1", topology["datacenter"])
 	assert.Equal(t, "topology.rook.io/rack=rack1", affinity)
 
-	// ensure deprecated k8s labels are loaded
-	nodeLabels = map[string]string{
-		corev1.LabelZoneRegion:        "r1",
-		corev1.LabelZoneFailureDomain: "z1",
-	}
-	topology, affinity = extractTopologyFromLabels(nodeLabels)
-	assert.Equal(t, 2, len(topology))
-	assert.Equal(t, "r1", topology["region"])
-	assert.Equal(t, "z1", topology["zone"])
-	assert.Equal(t, "failure-domain.beta.kubernetes.io/zone=z1", affinity)
-
 	// ensure deprecated k8s labels are overridden
 	nodeLabels = map[string]string{
 		corev1.LabelZoneRegionStable:        "r1",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
