### PR TITLE
monitoring: Remove alerts that don't apply to rook

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -524,15 +524,6 @@ groups:
           type: "ceph_default"
   - name: "pools"
     rules:
-      - alert: "CephPoolGrowthWarning"
-        annotations:
-          description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
-          summary: "Pool growth rate may soon exceed capacity"
-        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
-        labels:
-          oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
-          severity: "warning"
-          type: "ceph_default"
       - alert: "CephPoolBackfillFull"
         annotations:
           description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
@@ -583,18 +574,6 @@ groups:
           summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
           description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-  - name: "PrometheusServer"
-    rules:
-      - alert: "PrometheusJobMissing"
-        annotations:
-          description: "The prometheus job that scrapes from Ceph is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
-          summary: "The scrape job for Ceph is missing from Prometheus"
-        expr: "absent(up{job=\"ceph\"})"
-        for: "30s"
-        labels:
-          oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
-          severity: "critical"
-          type: "ceph_default"
   - name: "rados"
     rules:
       - alert: "CephObjectMissing"

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -533,15 +533,6 @@ spec:
             type: "ceph_default"
     - name: "pools"
       rules:
-        - alert: "CephPoolGrowthWarning"
-          annotations:
-            description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
-            summary: "Pool growth rate may soon exceed capacity"
-          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
-          labels:
-            oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
-            severity: "warning"
-            type: "ceph_default"
         - alert: "CephPoolBackfillFull"
           annotations:
             description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
@@ -592,18 +583,6 @@ spec:
             summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
             description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-    - name: "PrometheusServer"
-      rules:
-        - alert: "PrometheusJobMissing"
-          annotations:
-            description: "The prometheus job that scrapes from Ceph is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
-            summary: "The scrape job for Ceph is missing from Prometheus"
-          expr: "absent(up{job=\"ceph\"})"
-          for: "30s"
-          labels:
-            oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
-            severity: "critical"
-            type: "ceph_default"
     - name: "rados"
       rules:
         - alert: "CephObjectMissing"


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the alerts were updated from the ceph repo, the cephadm alerts were removed, now we also remove two other alerts that don't apply to rook clusters. The pool growth warning alert and prometheus job missing alerts need to be removed as also seen in #10109.

**Which issue is resolved by this Pull Request:**
Resolves #11785 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
