### PR TITLE
core: Add env var to exporter for ceph config

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -79,6 +79,15 @@ func TestCreateOrUpdateCephExporter(t *testing.T) {
 	assert.Equal(t, tolerations, podSpec.Spec.Tolerations)
 	assert.Equal(t, false, podSpec.Spec.HostNetwork)
 	assert.Equal(t, "", podSpec.Spec.PriorityClassName)
+	assert.Equal(t, 8, len(podSpec.Spec.Containers[0].Args))
+	assert.Equal(t, "--sock-dir", podSpec.Spec.Containers[0].Args[0])
+	assert.Equal(t, "/run/ceph", podSpec.Spec.Containers[0].Args[1])
+	assert.Equal(t, "--port", podSpec.Spec.Containers[0].Args[2])
+	assert.Equal(t, "9926", podSpec.Spec.Containers[0].Args[3])
+	assert.Equal(t, "--prio-limit", podSpec.Spec.Containers[0].Args[4])
+	assert.Equal(t, "5", podSpec.Spec.Containers[0].Args[5])
+	assert.Equal(t, "--stats-period", podSpec.Spec.Containers[0].Args[6])
+	assert.Equal(t, "5", podSpec.Spec.Containers[0].Args[7])
 
 	cephCluster.Spec.Labels[cephv1.KeyCephExporter] = map[string]string{"foo": "bar"}
 	cephCluster.Spec.Network.HostNetwork = true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The exporter requires the mon config and keyring. Use the CEPH_ARGS env var to specify the config instead of expecting a ceph.conf to be generated by another component on the host path.

Resolves: #11817 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
