### PR TITLE
[WIP]mon: remove condition to use old 6790 mon port

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -271,16 +271,6 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) corev1.Container 
 
 func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container {
 	podIPEnvVar := "ROOK_POD_IP"
-	publicAddr := monConfig.PublicIP
-
-	// Handle the non-default port for host networking. If host networking is not being used,
-	// the service created elsewhere will handle the non-default port redirection to the default port inside the container.
-	if monConfig.UseHostNetwork && monConfig.Port != DefaultMsgr1Port {
-		logger.Warningf("Starting mon %s with host networking on a non-default port %d. The mon must be failed over before enabling msgr2.",
-			monConfig.DaemonName, monConfig.Port)
-		publicAddr = fmt.Sprintf("%s:%d", publicAddr, monConfig.Port)
-	}
-
 	container := corev1.Container{
 		Name: "mon",
 		Command: []string{
@@ -291,7 +281,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 			"--foreground",
 			// If the mon is already in the monmap, when the port is left off of --public-addr,
 			// it will still advertise on the previous port b/c monmap is saved to mon database.
-			config.NewFlag("public-addr", publicAddr),
+			config.NewFlag("public-addr", monConfig.PublicIP),
 			// Set '--setuser-match-path' so that existing directory owned by root won't affect the daemon startup.
 			// For existing data store owned by root, the daemon will continue to run as root
 			//


### PR DESCRIPTION
Check was added in Rook 1.0 to keep using non-default mon port 6790 to support upgrades from 0.9 to 1.0. See #3143 for more details.

Now we can remove this check in Rook 1.11

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #11858

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
