### PR TITLE
docs: add script to help evaluate environments for multus

### DIFF
--- a/tests/scripts/multus-test.sh
+++ b/tests/scripts/multus-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+##
+## This script will install a configurable number of multus-networked daemonsets to test that your
+## multus configuration and network hardware can provide enough IP addresses for Ceph.
+## Configuration options are commented below.
+##
+## TODO: in the future, this test should also check network stability under a reasonable amount of
+##       load to/from daemons.
+##
+
+## A comma-delimited list of multus networks to use for test pods
+: "${MULTUS_NETWORKS:="public-net,cluster-net"}"
+
+## The number of daemons to run per node as a test. This should reflect the maximum number of
+## daemons that could run on a single node for your Ceph install. The default value assumes that one
+## daemon type will run on one node, but that there will be 3 OSDs on said node. As an easy
+## guideline, add one for each additional OSD beyond 3 that might run simultaneously on any node.
+: "${NUM_DAEMONS_PER_NODE:=20}"
+
+## The namespace to install multus test daemons into.
+: "${VALIDATION_NAMESPACE:="rook-ceph"}"
+
+## If you use a command other than 'kubectl' for getting/creating cluster resources, change this.
+: "${KUBECTL:="kubectl"}"
+
+## If you use a command other than 'jq' for json querying, change this.
+: "${JQ:="jq"}"
+
+ALL_DAEMONSETS=() # global for cleanup function
+function main() {
+  trap cleanup EXIT
+
+  ALL_DAEMONSETS=()
+  for i in $(seq "$NUM_DAEMONS_PER_NODE"); do
+    daemonset_name="multus-validator-${i}"
+    ALL_DAEMONSETS+=("${daemonset_name}")
+
+    render_daemonset "${daemonset_name}" | $KUBECTL create -f -
+  done
+
+  echo "Waiting for ${#ALL_DAEMONSETS[@]} daemonsets to have pods scheduled"
+  num_expected_pods=0
+  for ds in "${ALL_DAEMONSETS[@]}"; do
+    echo " └─ waiting for daemonset '${ds}' to have pods scheduled"
+    while true; do
+      num_desired="$($KUBECTL --namespace $VALIDATION_NAMESPACE get daemonset "${ds}" \
+        --output jsonpath='{.status.desiredNumberScheduled}' || true)"
+      if [[ -n "$num_desired" ]] && [[ "$num_desired" -gt 0 ]]; then
+        num_expected_pods=$((num_expected_pods + num_desired))
+        break
+      fi
+      sleep 1
+    done
+  done
+
+  echo "Waiting for ${num_expected_pods} pods from ${#ALL_DAEMONSETS[@]} daemonsets"
+  num_ready_with_multus=0
+  until [[ $num_ready_with_multus -eq $num_expected_pods ]]; do
+    sleep 2
+    pods="$(get_validator_pods_status_and_multus)"
+    num_ready_with_multus="$(echo "${pods}" | grep 'Running' | grep 'multus=true' --count)"
+    echo " └─ ${num_ready_with_multus} of ${num_expected_pods} pods have multus networks"
+  done
+
+  echo "Test successful!"
+}
+
+function cleanup() {
+  echo "Cleaning up daemonsets"
+  set +eE # don't fail out out on errors on cleanup
+  for ds in "${ALL_DAEMONSETS[@]}"; do
+    $KUBECTL --namespace "$VALIDATION_NAMESPACE" delete daemonset "${ds}" &
+  done
+  until [[ "$(number_of_validation_pods)" -eq 0 ]]; do
+    sleep 2
+    echo -n '.'
+  done
+}
+
+function number_of_validation_pods() {
+  $KUBECTL --namespace "$VALIDATION_NAMESPACE" get pod \
+    --selector app=multus-validation --no-headers | wc -l
+}
+
+# Output:
+#    <name> <phase> multus=true  - if multus k8s.v1.cni.cncf.io/network-status annotation is present
+#    <name> <phase> multus=false - if multus k8s.v1.cni.cncf.io/network-status annotation is NOT present
+#
+# Annotation presence is important because if no multus NADs are specified, pod can still be Ready.
+function get_validator_pods_status_and_multus() {
+  $KUBECTL --namespace "$VALIDATION_NAMESPACE" get pods --selector app=multus-validation --output json |
+    jq -r '.items[]
+      | [
+          .metadata.name,
+          .status.phase,
+          (if .metadata.annotations["k8s.v1.cni.cncf.io/network-status"] then "multus=true" else "multus=false" end)
+        ]
+      | @tsv'
+  # @tsv makes the output tab-delimited
+}
+
+function render_daemonset() {
+  local daemonset_name="$1"
+
+  cat <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "${daemonset_name}"
+  namespace: "$VALIDATION_NAMESPACE"
+  labels:
+    app: multus-validation
+spec:
+  selector:
+    matchLabels:
+      name: "${daemonset_name}"
+      app: multus-validation
+  template:
+    metadata:
+      labels:
+        name: "${daemonset_name}"
+        app: multus-validation
+      annotations:
+        k8s.v1.cni.cncf.io/networks: $MULTUS_NETWORKS
+    spec:
+      # TODO: node selectors, tolerations, etc.
+      containers:
+        - name: multus-validator
+          image: quay.io/fedora/fedora:latest
+          command:
+            - sleep
+            - infinity
+          resources: {}
+EOF
+}
+
+main # run main


### PR DESCRIPTION
Add a script to help evaluate environments for running multus.

Sample output
```
❯ ./deploy/tools/multus-test.sh                                                                                                     
daemonset.apps/multus-validator-1 created
daemonset.apps/multus-validator-2 created
daemonset.apps/multus-validator-3 created
daemonset.apps/multus-validator-4 created
daemonset.apps/multus-validator-5 created
daemonset.apps/multus-validator-6 created
daemonset.apps/multus-validator-7 created
daemonset.apps/multus-validator-8 created
daemonset.apps/multus-validator-9 created
daemonset.apps/multus-validator-10 created
daemonset.apps/multus-validator-11 created
daemonset.apps/multus-validator-12 created
daemonset.apps/multus-validator-13 created
daemonset.apps/multus-validator-14 created
daemonset.apps/multus-validator-15 created
Waiting for 15 daemonsets to have pods scheduled
 └─ waiting for daemonset 'multus-validator-1' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-2' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-3' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-4' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-5' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-6' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-7' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-8' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-9' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-10' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-11' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-12' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-13' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-14' to have pods scheduled
 └─ waiting for daemonset 'multus-validator-15' to have pods scheduled
Waiting for 60 pods from 15 daemonsets
 └─ 29 of 60 pods have multus networks
 └─ 41 of 60 pods have multus networks
 └─ 54 of 60 pods have multus networks
 └─ 60 of 60 pods have multus networks
Test successful!
Cleaning up daemonsets
daemonset.apps "multus-validator-4" deleted
daemonset.apps "multus-validator-6" deleted
daemonset.apps "multus-validator-3" deleted
daemonset.apps "multus-validator-12" deleted
daemonset.apps "multus-validator-8" deleted
daemonset.apps "multus-validator-1" deleted
daemonset.apps "multus-validator-5" deleted
daemonset.apps "multus-validator-9" deleted
daemonset.apps "multus-validator-15" deleted
daemonset.apps "multus-validator-2" deleted
daemonset.apps "multus-validator-11" deleted
daemonset.apps "multus-validator-10" deleted
daemonset.apps "multus-validator-14" deleted
daemonset.apps "multus-validator-7" deleted
daemonset.apps "multus-validator-13" deleted
.......................No resources found in rook-ceph namespace.
```

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
