### PR TITLE
ci: update github token in auto-assign bot

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -10,8 +10,7 @@ jobs:
     steps:
       - name: take the issue
         uses: bdougie/take-action@main
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
           message: Thanks for taking this issue! Let us know if you have any questions!
           trigger: /assign
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This Pr updates the behaviour of the token used by the bot
https://github.com/bdougie/take-action/commit/dae661e9a0abfafa2be0c170be1156302f4149e8

Closes: https://github.com/rook/rook/issues/11863

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
