### PR TITLE
external: pool and metadata ec pools were reversed in scripts

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1545,8 +1545,8 @@ class RadosJSON:
                     "name": "ceph-rbd",
                     "kind": "StorageClass",
                     "data": {
-                        "dataPool": self.out_map["RBD_METADATA_EC_POOL_NAME"],
-                        "pool": self.out_map["RBD_POOL_NAME"],
+                        "dataPool": self.out_map["RBD_POOL_NAME"],
+                        "pool": self.out_map["RBD_METADATA_EC_POOL_NAME"],
                         "csi.storage.k8s.io/provisioner-secret-name": "rook-{}".format(
                             self.out_map["CSI_RBD_PROVISIONER_SECRET_NAME"]
                         ),

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -200,8 +200,8 @@ metadata:
 provisioner: $RBD_PROVISIONER
 parameters:
   clusterID: $CLUSTER_ID_RBD
-  pool: $RBD_POOL_NAME
-  dataPool: $RBD_METADATA_EC_POOL_NAME
+  pool: $RBD_METADATA_EC_POOL_NAME
+  dataPool: $RBD_POOL_NAME
   imageFormat: "2"
   imageFeatures: $ROOK_RBD_FEATURES
   csi.storage.k8s.io/provisioner-secret-name: "rook-$CSI_RBD_PROVISIONER_SECRET_NAME"


### PR DESCRIPTION
Pool and Metadata Pool Appear to be reversed causing PVC creation to fail


**Description of your changes:**
It seems the data-pool and EC pool on an external cluster are set the wrong way round in the example code for configuring external clusters

dataPool: needs to contain the EC Data pool
pool: needs to contain the Metadata Pool


**Which issue is resolved by this Pull Request:**
Resolves 
https://github.com/rook/rook/issues/11918


