### PR TITLE
operator: use msgr2 if compression is enabled

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -634,7 +634,7 @@ func (c *cluster) configureMsgr2() error {
 
 		// set default rbd map options to enable msgr2 in the kernel if it's
 		// required even with encryption disabled
-		if c.Spec.Network.Connections != nil && c.Spec.Network.Connections.RequireMsgr2 {
+		if c.Spec.RequireMsgr2() {
 			if err := monStore.SetAll("global", map[string]string{rbdMapOptions: "ms_mode=prefer-crc"}); err != nil {
 				return err
 			}

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -236,7 +236,7 @@ func (m *MonStore) SetAll(clientName string, settings map[string]string) error {
 
 	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
 	if err != nil {
-		logger.Errorf("failed to run command ceph %s", args)
+		logger.Errorf("failed to run command ceph %s: %v", args, err)
 
 		fileContent, err := os.ReadFile(assimilateConfPath.Name() + ".out")
 		if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator will now correctly use the messenger v2 protocol if compression is enabled.

**Which issue is resolved by this Pull Request:**
Resolves #11795

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
