### PR TITLE
osd: handle global or node-local device class configuration correctly

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -531,19 +531,7 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 
 				if matched {
 					matchedDevice = desiredDevice
-					if matchedDevice.DeviceClass == "" {
-						classNotSet := true
-						if agent.pvcBacked {
-							crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-							if crushDeviceClass != "" {
-								matchedDevice.DeviceClass = crushDeviceClass
-								classNotSet = false
-							}
-						}
-						if classNotSet {
-							matchedDevice.DeviceClass = sys.GetDiskDeviceClass(device)
-						}
-					}
+					matchedDevice.UpdateDeviceClass(agent, device)
 					break
 				}
 			}

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -196,3 +196,13 @@ func TestListDevicesChildListDevicesChild(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(child))
 }
+
+func TestGetDiskDeviceClass(t *testing.T) {
+	d := &LocalDisk{}
+	assert.Equal(t, "ssd", GetDiskDeviceClass(d))
+	d.Rotational = true
+	assert.Equal(t, "hdd", GetDiskDeviceClass(d))
+	d.Rotational = false
+	d.RealPath = "nvme"
+	assert.Equal(t, "nvme", GetDiskDeviceClass(d))
+}


### PR DESCRIPTION
**Description of your changes:**

Rook uses global or node-local device class configuration if device-level configuratios doesn't exist. However, after introducing device-class level resource configuration, rook set the default value of device class. So global or node-level device class configuration has never been used after that.

**Which issue is resolved by this Pull Request:**
Resolves #11826 #11871

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
