### PR TITLE
core: support to create pool with assigned pg and can set 'autoscale mode'

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
@@ -210,6 +210,11 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
 * `parameters`: Sets any [parameters](https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values) listed to the given pool
     * `target_size_ratio:` gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool, for more info see the [ceph documentation](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size)
     * `compression_mode`: Sets up the pool for inline compression when using a Bluestore OSD. If left unspecified does not setup any compression mode for the pool. Values supported are the same as Bluestore inline compression [modes](https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression), such as `none`, `passive`, `aggressive`, and `force`.
+    * `pg_num`: Set a custom PG count for the pool. By default, the PGs will be managed by the Ceph PG autoscaler. See the [Ceph documentation](https://docs.ceph.com/en/latest/rados/operations/pools/#create-a-pool) for more info.
+    * `pg_autoscale_mode`: Set pg autoscale mode to pool. See the [ceph documentation](https://docs.ceph.com/en/latest/rados/operations/placement-groups/) for more info.
+      * `off`: Disable autoscaling for this pool. It is up to the administrator to choose an appropriate pgp_num for each pool. Please refer to [Choosing the number of Placement Groups](https://docs.ceph.com/en/latest/rados/operations/placement-groups/#choosing-number-of-placement-groups) for more information.
+      * `on`: Enable automated adjustments of the PG count for the given pool.
+      * `warn`: Raise health alerts when the PG count should be adjusted.
 
 * `mirroring`: Sets up mirroring of the pool
     * `enabled`: whether mirroring is enabled on that pool (default: false)
@@ -231,6 +236,8 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
 
     !!! note
         A value of 0 disables the quota.
+
+
 
 ### Add specific pool properties
 

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -53,6 +53,8 @@ const (
 	CommandProxyInitContainerName = "cmd-proxy"
 	// ProxyAppLabel is the label used to identify the proxy container
 	ProxyAppLabel = "rook-ceph-mgr"
+	// DefaultAutoscaleMode means the default autoscale mode of pg
+	DefaultAutoscaleMode = ""
 )
 
 // CephConfFilePath returns the location to the cluster's config file in the operator container.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
support to create pool with assigned pg and can set 'autoscale mode'

**Which issue is resolved by this Pull Request:**
Resolves #11964 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
