### PR TITLE
build: allow overriding variables from a dot env file

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
   "recommendations": [
     "golang.go",
     "redhat.vscode-yaml",
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "timonwong.shellcheck"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -24,6 +24,13 @@ else
 $(error "please install 'shasum' or 'sha256sum'")
 endif
 
+ifeq ($(origin DOCKERCMD),undefined)
+DOCKERCMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
+ifeq ($(DOCKERCMD),)
+DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
+endif
+endif
+
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)
 GOOS := $(shell go env GOOS)

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -31,7 +31,7 @@ ifneq ($(TAG_WITH_SUFFIX),true)
 override VERSION := $(shell echo "$(VERSION)" | sed -e 's/-alpha.0//' -e 's/-beta.0//' -e 's/-rc.0//')
 endif
 
-DOCS_PREFIX := docs/rook
+DOCS_PREFIX ?= docs/rook
 
 ifeq ($(shell echo $(BRANCH_NAME)),master)
 DOCS_VERSION := latest
@@ -45,15 +45,7 @@ else
 DOCS_VERSION_ALIAS :=
 endif
 
-DOCS_DIR ?= $(ROOT_DIR)/Documentation
-DOCS_WORK_DIR := $(WORK_DIR)/rook.github.io
-DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/docs/rook/$(DOCS_VERSION)
-
-ifdef GIT_API_TOKEN
-DOCS_GIT_REPO := https://$(GIT_API_TOKEN)@github.com/rook/rook.github.io.git
-else
-DOCS_GIT_REPO := git@github.com:rook/rook.github.io.git
-endif
+DOCS_GIT_REPO ?= git@github.com:rook/rook.github.io.git
 
 ifeq ($(origin BRANCH_NAME), undefined)
 BRANCH_NAME := $(shell git branch | grep \* | cut -d ' ' -f2)
@@ -176,22 +168,22 @@ promote.output:
 # 1: registry 2: image, 3: arch
 define repo.targets
 build.image.$(1).$(2).$(3):
-	docker tag $(BUILD_REGISTRY)/$(2)-$(3) $(1)/$(2)-$(3):$(VERSION)
+	$(DOCKERCMD) tag $(BUILD_REGISTRY)/$(2)-$(3) $(1)/$(2)-$(3):$(VERSION)
 	@# Save image as _output/images/linux_<arch>/<image>.tar.gz (no builds for darwin or windows)
 	mkdir -p $(OUTPUT_DIR)/images/linux_$(3)
-	docker save $(BUILD_REGISTRY)/$(2)-$(3) | gzip -c > $(OUTPUT_DIR)/images/linux_$(3)/$(2).tar.gz
+	$(DOCKERCMD) save $(BUILD_REGISTRY)/$(2)-$(3) | gzip -c > $(OUTPUT_DIR)/images/linux_$(3)/$(2).tar.gz
 build.all.images: build.image.$(1).$(2).$(3)
-publish.image.$(1).$(2).$(3): ; @docker push $(1)/$(2)-$(3):$(VERSION)
+publish.image.$(1).$(2).$(3): ; @$(DOCKERCMD) push $(1)/$(2)-$(3):$(VERSION)
 publish.all.images: publish.image.$(1).$(2).$(3)
 # tag the master image, but do not tag the release image with a generic channel tag
 promote.image.$(1).$(2).$(3):
-	docker pull $(1)/$(2)-$(3):$(VERSION)
-	docker tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(CHANNEL)
-	[ "$(CHANNEL)" = "release" ] || docker push $(1)/$(2)-$(3):$(CHANNEL)
+	$(DOCKERCMD) pull $(1)/$(2)-$(3):$(VERSION)
+	$(DOCKERCMD) tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(CHANNEL)
+	[ "$(CHANNEL)" = "release" ] || $(DOCKERCMD) push $(1)/$(2)-$(3):$(CHANNEL)
 promote.all.images: promote.image.$(1).$(2).$(3)
 clean.image.$(1).$(2).$(3):
-	[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(VERSION))" ] || docker rmi $(1)/$(2)-$(3):$(VERSION)
-	[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(CHANNEL))" ] || docker rmi $(1)/$(2)-$(3):$(CHANNEL)
+	[ -z "$$$$($(DOCKERCMD) images -q $(1)/$(2)-$(3):$(VERSION))" ] || $(DOCKERCMD) rmi $(1)/$(2)-$(3):$(VERSION)
+	[ -z "$$$$($(DOCKERCMD) images -q $(1)/$(2)-$(3):$(CHANNEL))" ] || $(DOCKERCMD) rmi $(1)/$(2)-$(3):$(CHANNEL)
 clean.all.images: clean.image.$(1).$(2).$(3)
 endef
 $(foreach r,$(REGISTRIES), $(foreach i,$(IMAGES), $(foreach a,$(IMAGE_ARCHS),$(eval $(call repo.targets,$(r),$(i),$(a))))))

--- a/images/image.mk
+++ b/images/image.mk
@@ -17,13 +17,6 @@
 
 override GOOS=linux
 
-ifeq ($(origin DOCKERCMD),undefined)
-DOCKERCMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
-ifeq ($(DOCKERCMD),)
-DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
-endif
-endif
-
 # include the common make file
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../build/makelib/common.mk

--- a/tests/scripts/build-release.sh
+++ b/tests/scripts/build-release.sh
@@ -31,6 +31,21 @@ function promote() {
 # MAIN      #
 #############
 
+# Load dot env file if available
+if [ -f .env ]; then
+    # shellcheck disable=SC2046
+    export $(grep -v '^#' .env | xargs -d '\n')
+fi
+
+# Use Git access token for accessing the docs repo if set
+# shellcheck disable=SC2034
+DOCS_GIT_REPO="${DOCS_GIT_REPO:-git@github.com:rook/rook.github.io.git}"
+if [ -n "${GIT_API_TOKEN}" ]; then
+    DOCS_GIT_REPO="${DOCS_GIT_REPO//git@/}"
+    DOCS_GIT_REPO="${DOCS_GIT_REPO//:/\/}"
+    DOCS_GIT_REPO="https://${GIT_API_TOKEN}@${DOCS_GIT_REPO}"
+fi
+
 SHOULD_PROMOTE=true
 if [[ ${GITHUB_REF} =~ master ]]; then
     echo "Publishing from master"


### PR DESCRIPTION
**Description of your changes:**

This helps forks build custom rook releases more easily by allowing
certain Makefile vars to be overwriten using a `.env` file.
In addition this introduces the `DOCKERCMD` var to the
`build/release/Makefile`.

Resolved #11701

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
