### PR TITLE
csi: IPv6 compatibility for requiring msgr2

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -108,13 +108,10 @@ func MonEndpoints(mons map[string]*cephclient.MonInfo, requireMsgr2 bool) []stri
 		endpoint := m.Endpoint
 		if requireMsgr2 {
 			logger.Debugf("evaluating mon %q for msgr1 on endpoint %q", m.Name, m.Endpoint)
-			if strings.HasSuffix(m.Endpoint, fmt.Sprintf(":%d", client.Msgr1port)) {
-				parts := strings.Split(m.Endpoint, ":")
-				if len(parts) != 2 {
-					logger.Errorf("endpoint %q does not contain two parts to extract the port", m.Endpoint)
-					continue
-				}
-				endpoint = fmt.Sprintf("%s:%d", parts[0], client.Msgr2port)
+			msgr1Suffix := fmt.Sprintf(":%d", client.Msgr1port)
+			if strings.HasSuffix(m.Endpoint, msgr1Suffix) {
+				address := m.Endpoint[0:strings.LastIndex(m.Endpoint, msgr1Suffix)]
+				endpoint = fmt.Sprintf("%s:%d", address, client.Msgr2port)
 				logger.Debugf("mon %q will use the msgrv2 port: %q", m.Name, endpoint)
 			}
 		}

--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -369,15 +369,20 @@ func TestMonEndpoints(t *testing.T) {
 		verifyEndpointPort(t, endpoints, "3300")
 	})
 
-	t.Run("bad endpoint", func(t *testing.T) {
+	t.Run("ipv6 endpoint conversion", func(t *testing.T) {
 		monInfo := map[string]*cephclient.MonInfo{
-			"a": {Name: "a", Endpoint: "1.2.3.4:5:6789"},
-			"b": {Name: "b", Endpoint: "1.2.3.5:6789"},
-			"c": {Name: "c", Endpoint: "1.2.3.6:6789"},
+			"a": {Name: "a", Endpoint: "[fd07:aaaa:bbbb:cccc::11]:6789"},
+			"b": {Name: "a", Endpoint: "[1234:6789:bbbb:cccc::11]:6789"},
 		}
 		endpoints := MonEndpoints(monInfo, true)
 		assert.Equal(t, 2, len(endpoints))
 		verifyEndpointPort(t, endpoints, "3300")
+		for _, endpoint := range endpoints {
+			// Verify that the v1 port inside the ipv6 address will not be replaced
+			if strings.HasPrefix(endpoint, "[1234") {
+				assert.True(t, strings.HasPrefix(endpoint, "[1234:6789"))
+			}
+		}
 	})
 }
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The msgr2 conversion assumed the endpoints were formatted with a single :, which is not compatible with ipv6. Now if the endpoint ends with the v1 port, it will simply update the prefix to v2.

**Which issue is resolved by this Pull Request:**
Resolves #11977 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
