### PR TITLE
core: fix config format for msgr2 ipv6 monitors

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -261,7 +261,8 @@ func PopulateMonHostMembers(clusterInfo *ClusterInfo) ([]string, []string) {
 		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
 
 		if currentMonPort == Msgr2port {
-			monHosts = append(monHosts, fmt.Sprintf("[v2:%s:%d]", monIP, Msgr2port))
+			msgr2Endpoint := net.JoinHostPort(monIP, strconv.Itoa(int(Msgr2port)))
+			monHosts = append(monHosts, "[v2:"+msgr2Endpoint+"]")
 		} else {
 			msgr2Endpoint := net.JoinHostPort(monIP, strconv.Itoa(int(Msgr2port)))
 			msgr1Endpoint := net.JoinHostPort(monIP, strconv.Itoa(int(currentMonPort)))


### PR DESCRIPTION
**Description of your changes:**
This should correct formatting of IPv6 `mon_hosts` in the config file when `requireMsgr2: true` is set on cluster creation.

**Which issue is resolved by this Pull Request:**
Resolves #11977

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
