### PR TITLE
build: fix publish docs step

### DIFF
--- a/tests/scripts/build-release.sh
+++ b/tests/scripts/build-release.sh
@@ -39,11 +39,11 @@ fi
 
 # Use Git access token for accessing the docs repo if set
 # shellcheck disable=SC2034
-DOCS_GIT_REPO="${DOCS_GIT_REPO:-git@github.com:rook/rook.github.io.git}"
+export DOCS_GIT_REPO="${DOCS_GIT_REPO:-git@github.com:rook/rook.github.io.git}"
 if [ -n "${GIT_API_TOKEN}" ]; then
     DOCS_GIT_REPO="${DOCS_GIT_REPO//git@/}"
     DOCS_GIT_REPO="${DOCS_GIT_REPO//:/\/}"
-    DOCS_GIT_REPO="https://${GIT_API_TOKEN}@${DOCS_GIT_REPO}"
+    export DOCS_GIT_REPO="https://${GIT_API_TOKEN}@${DOCS_GIT_REPO}"
 fi
 
 SHOULD_PROMOTE=true


### PR DESCRIPTION
**Description of your changes:**

The `DOCS_GIT_REPO` var needs to be exported when not set through a `.env` file, as otherwise it is not propagated to commands run in the `build-release.sh` script.

Based on my current investigation this should solve the issue for the `master` release issue introduced by the #11968.

I couldn't test it yet, because the tmate CI debug step doesn't have the CI secrets attached to it. I can do a test run by modifying the CI file to include the secrets but I don't want to accidentally expose any of the secrets.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.