### PR TITLE
external: add alias rbd pool name to support . pools name

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -39,6 +39,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 - `--namespace`: Namespace where CephCluster will run, for example `rook-ceph-external`
 - `--format bash`: The format of the output
 - `--rbd-data-pool-name`: The name of the RBD data pool
+- `--alias-rbd-data-pool-name`: Provides an alias for the  RBD data pool name, necessary if a special character is present in the pool name such as a period or underscore
 - `--rgw-endpoint`: (optional) The RADOS Gateway endpoint in the format `<IP>:<PORT>`
 - `--rgw-pool-prefix`: (optional) The prefix of the RGW pools. If not specified, the default prefix is `default`
 - `--rgw-tls-cert-path`: (optional) RADOS Gateway endpoint TLS certificate file path


### PR DESCRIPTION
if restricted permission was on the . was appended to k8s secret and failed to create the secret so added a alias name is user wan't to suuport pool with . in name

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
