### PR TITLE
external: do not enforce need for monitoring endpoint

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -111,6 +111,11 @@ jobs:
             echo "script failed because wrong subvolumegroup name was passed"
           fi
 
+      - name: dry run test skip monitoring endpoint
+        run: |
+          toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool --dry-run --skip-monitoring-endpoint
+
       - name: test of rados namespace
         run: |
           kubectl create -f deploy/examples/radosnamespace.yaml

--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -46,6 +46,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 - `--rbd-metadata-ec-pool-name`: (optional) Provides the name of erasure coded RBD metadata pool, used for creating ECRBDStorageClass.
 - `--monitoring-endpoint`: (optional) Ceph Manager prometheus exporter endpoints (comma separated list of <IP> entries of active and standby mgrs)
 - `--monitoring-endpoint-port`: (optional) Ceph Manager prometheus exporter port
+- `--skip-monitoring-endpoint`: (optional) Skip prometheus exporter endpoints, even if they are available. Useful if the prometheus module is not enabled
 - `--ceph-conf`: (optional) Provide a Ceph conf file
 - `--cluster-name`: (optional) Ceph cluster name
 - `--output`: (optional) Output will be stored into the provided file

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -400,6 +400,12 @@ class RadosJSON:
             help="Ceph Manager prometheus exporter port",
         )
         output_group.add_argument(
+            "--skip-monitoring-endpoint",
+            default=False,
+            action="store_true",
+            help="Do not check for a monitoring endpoint for the Ceph cluster",
+        )
+        output_group.add_argument(
             "--rbd-metadata-ec-pool-name",
             default="",
             required=False,
@@ -704,9 +710,7 @@ class RadosJSON:
                 json_out.get("mgrmap", {}).get("services", {}).get("prometheus", "")
             )
             if not monitoring_endpoint:
-                raise ExecutionFailureException(
-                    "'prometheus' service not found, is the exporter enabled?.\n"
-                )
+                return "", ""
             # now check the stand-by mgr-s
             standby_arr = json_out.get("mgrmap", {}).get("standbys", [])
             for each_standby in standby_arr:
@@ -1356,10 +1360,13 @@ class RadosJSON:
                 self.out_map["CSI_CEPHFS_PROVISIONER_SECRET_NAME"],
             ) = self.create_cephCSIKeyring_user("client.csi-cephfs-provisioner")
         self.out_map["RGW_TLS_CERT"] = ""
-        (
-            self.out_map["MONITORING_ENDPOINT"],
-            self.out_map["MONITORING_ENDPOINT_PORT"],
-        ) = self.get_active_and_standby_mgrs()
+        self.out_map["MONITORING_ENDPOINT"] = ""
+        self.out_map["MONITORING_ENDPOINT_PORT"] = ""
+        if not self._arg_parser.skip_monitoring_endpoint:
+            (
+                self.out_map["MONITORING_ENDPOINT"],
+                self.out_map["MONITORING_ENDPOINT_PORT"],
+            ) = self.get_active_and_standby_mgrs()
         self.out_map["RBD_POOL_NAME"] = self._arg_parser.rbd_data_pool_name
         self.out_map[
             "RBD_METADATA_EC_POOL_NAME"
@@ -1426,15 +1433,23 @@ class RadosJSON:
                     "userKey": self.out_map["ROOK_EXTERNAL_USER_SECRET"],
                 },
             },
-            {
-                "name": "monitoring-endpoint",
-                "kind": "CephCluster",
-                "data": {
-                    "MonitoringEndpoint": self.out_map["MONITORING_ENDPOINT"],
-                    "MonitoringPort": self.out_map["MONITORING_ENDPOINT_PORT"],
-                },
-            },
         ]
+
+        # if 'MONITORING_ENDPOINT' exists, then only add 'monitoring-endpoint' to Cluster
+        if (
+            self.out_map["MONITORING_ENDPOINT"]
+            and self.out_map["MONITORING_ENDPOINT_PORT"]
+        ):
+            json_out.append(
+                {
+                    "name": "monitoring-endpoint",
+                    "kind": "CephCluster",
+                    "data": {
+                        "MonitoringEndpoint": self.out_map["MONITORING_ENDPOINT"],
+                        "MonitoringPort": self.out_map["MONITORING_ENDPOINT_PORT"],
+                    },
+                }
+            )
 
         # if 'CSI_RBD_NODE_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
         if (


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Add --skip-monitoring-endpoint to create-external-cluster-resources.py to allow the script to work with Ceph clusters without an enabled prometheus module.

**Which issue is resolved by this Pull Request:**

Did not create an issue as this should be a straightforward change, similar to https://github.com/rook/rook/commit/e734911532802451755356b58df9f27b761f477b

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
