### PR TITLE
core: Skip OBC controllers based on env variable

### DIFF
--- a/pkg/operator/ceph/object/bucket/controller.go
+++ b/pkg/operator/ceph/object/bucket/controller.go
@@ -18,6 +18,7 @@ package bucket
 
 import (
 	"context"
+	"os"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +55,10 @@ type ReconcileBucket struct {
 // Add creates a new Ceph CSI Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket controller")
+		return nil
+	}
 	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -53,6 +53,9 @@ import (
 
 const (
 	controllerName = "ceph-object-controller"
+	// DisableOBCEnvVar environment variable, if set to "true", will skip watching Object Bucket and Notification resources.
+	// This variable can be added to container spec of the `rook-ceph-operator` deployment.
+	DisableOBCEnvVar = "ROOK_DISABLE_OBJECT_BUCKET_CLAIM"
 )
 
 var waitForRequeueIfObjectStoreNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}

--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -19,6 +19,7 @@ package notification
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
@@ -28,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 	"github.com/rook/rook/pkg/operator/ceph/object/topic"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
@@ -67,6 +69,11 @@ type ReconcileNotifications struct {
 // Add creates a new CephBucketNotification controller and a new ObjectBucketClaim Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the Manager is started.
 func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext context.Context, opConfig opcontroller.OperatorConfig) error {
+	if os.Getenv(object.DisableOBCEnvVar) == "true" {
+		logger.Info("skip running Object Bucket Notification controller")
+		return nil
+	}
+
 	if err := addNotificationReconciler(mgr, &ReconcileNotifications{
 		client:           mgr.GetClient(),
 		context:          context,


### PR DESCRIPTION
Skip running Object Bucket controllers when the env ROOK_DISABLE_OBJECT_BUCKET_CLAIM is true

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


Tested on single node minikube cluster. Didn't deploy any objectbucket.io group crds.

NAME                                         CREATED AT
cephblockpoolradosnamespaces.ceph.rook.io    2023-04-19T03:52:00Z
cephblockpools.ceph.rook.io                  2023-04-19T03:52:00Z
cephbucketnotifications.ceph.rook.io         2023-04-19T03:52:00Z
cephbuckettopics.ceph.rook.io                2023-04-19T03:52:00Z
cephclients.ceph.rook.io                     2023-04-19T03:52:00Z
cephclusters.ceph.rook.io                    2023-04-19T03:52:00Z
cephfilesystemmirrors.ceph.rook.io           2023-04-19T03:52:00Z
cephfilesystems.ceph.rook.io                 2023-04-19T03:52:00Z
cephfilesystemsubvolumegroups.ceph.rook.io   2023-04-19T03:52:00Z
cephnfses.ceph.rook.io                       2023-04-19T03:52:00Z
cephobjectrealms.ceph.rook.io                2023-04-19T03:52:00Z
cephobjectstores.ceph.rook.io                2023-04-19T03:52:00Z
cephobjectstoreusers.ceph.rook.io            2023-04-19T03:52:00Z
cephobjectzonegroups.ceph.rook.io            2023-04-19T03:52:00Z
cephobjectzones.ceph.rook.io                 2023-04-19T03:52:00Z
cephrbdmirrors.ceph.rook.io                  2023-04-19T03:52:00Z


oc get pods -n rook-ceph
NAME                                                READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-provisioner-84cc595b78-qxmk7       5/5     Running     0          5m36s
csi-cephfsplugin-wvh2l                              2/2     Running     0          5m36s
csi-rbdplugin-provisioner-6f6b6b8cd6-xs7p5          5/5     Running     0          5m36s
csi-rbdplugin-ts8xx                                 2/2     Running     0          5m37s
rook-ceph-crashcollector-minikube-c59574b89-c48bt   1/1     Running     0          3m33s
rook-ceph-mgr-a-765c7cbc-9t9vd                      3/3     Running     0          4m9s
rook-ceph-mgr-b-6898d79b78-x6v9j                    3/3     Running     0          4m9s
rook-ceph-mon-a-84fdf64d78-d58wh                    2/2     Running     0          5m
rook-ceph-mon-b-8d458df7-m9lxc                      2/2     Running     0          4m36s
rook-ceph-mon-c-6c59bd95bb-shz5l                    2/2     Running     0          4m26s
rook-ceph-operator-5cc69b5f7b-xvdg8                 1/1     Running     0          5m45s
rook-ceph-osd-0-f8f4bbd5c-wms45                     2/2     Running     0          3m33s
rook-ceph-osd-prepare-minikube-v7btr                0/1     Completed   0          2m46s
rook-ceph-tools-9b7967b5d-vc4zc                     1/1     Running     0          5m39s


sh-4.4$ ceph status 
  cluster:
    id:     c7b0a9c0-c961-4173-aeca-ec8dbc197c6d
    health: HEALTH_WARN
            OSD count 1 < osd_pool_default_size 3
 
  services:
    mon: 3 daemons, quorum a,b,c (age 3m)
    mgr: a(active, since 90s), standbys: b
    osd: 1 osds: 1 up (since 2m), 1 in (since 2m)
 
  data:
    pools:   0 pools, 0 pgs
    objects: 0 objects, 0 B
    usage:   19 MiB used, 10 GiB / 10 GiB avail
    pgs: 
