### PR TITLE
CephNFS: Some fixes for mounting CephNFS using Kerberos auth

### DIFF
--- a/pkg/operator/ceph/nfs/security.go
+++ b/pkg/operator/ceph/nfs/security.go
@@ -288,8 +288,8 @@ func generateSssdNsswitchConfResources(r *ReconcileCephNFS, nfs *cephv1.CephNFS)
 			"bash", "-c",
 			`set -ex
 cat << EOF > /tmp/etc/nsswitch.conf
-passwd: sss
-group: sss
+passwd: files sss
+group: files sss
 netgroup: sss
 EOF
 chmod 444 /tmp/etc/nsswitch.conf

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -147,11 +147,6 @@ func (r *ReconcileCephNFS) makeDeployment(nfs *cephv1.CephNFS, cfg daemonConfig)
 		// connecting to the krb server. give all ganesha servers the same hostname so they can all
 		// use the same krb credentials to auth
 		Hostname: fmt.Sprintf("%s-%s", nfs.Namespace, nfs.Name),
-		DNSConfig: &v1.PodDNSConfig{
-			// for getaddrinfo() to get the hostname defined above, need to add localhost to
-			// searches in resolv.conf
-			Searches: []string{"localhost"},
-		},
 	}
 	// Replace default unreachable node toleration
 	k8sutil.AddUnreachableNodeToleration(&podSpec)


### PR DESCRIPTION
While testing kerberos mounting of CephNFS resources, I came across a few problems which prevent the use of the CephNFS share being used with kerberos authentication. This  set of changes fix a part of the problems we see with mounting cephNFS shares using kerberos.

**Which issue is resolved by this Pull Request:**
https://github.com/rook/rook/issues/11870
https://github.com/rook/rook/issues/11925

**Checklist:**

- [*] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [*] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [*] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [*] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [*] Documentation has been updated, if necessary.
- [*] Unit tests have been added, if necessary.
- [*] Integration tests have been added, if necessary.
