### PR TITLE
add an ingress for ceph-objectores

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -110,6 +110,12 @@ The `cephObjectStores` array in the values file will define a list of CephObject
 | `storageClass.name` | The name of the storage class | `ceph-bucket` |
 | `storageClass.parameters` | See [Object Store storage class](../Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+| `ingress.enabled` | Enable an ingress for the object store | `false` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.host.name` | Ingress hostname | `""` |
+| `ingress.host.path` | Ingress path prefix | `/` |
+| `ingress.tls` | Ingress tls | `/` |
+| `ingress.ingressClassName` | Ingress tls | `""` |
 
 ### **Existing Clusters**
 

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -137,6 +137,12 @@ The `cephObjectStores` array in the values file will define a list of CephObject
 | `storageClass.name` | The name of the storage class | `ceph-bucket` |
 | `storageClass.parameters` | See [Object Store storage class](../Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+| `ingress.enabled` | Enable an ingress for the object store | `false` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.host.name` | Ingress hostname | `""` |
+| `ingress.host.path` | Ingress path prefix | `/` |
+| `ingress.tls` | Ingress tls | `/` |
+| `ingress.ingressClassName` | Ingress tls | `""` |
 
 ### **Existing Clusters**
 

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -1,0 +1,35 @@
+{{- range .Values.cephObjectStores }}
+{{- if dig "ingress" "enabled" false . }}
+---
+apiVersion: {{ include "capabilities.ingress.apiVersion" $ }}
+kind: Ingress
+metadata:
+  name: {{ .name }}
+  {{- with .ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .ingress.host.name }}
+      http:
+        paths:
+          - path: {{ .ingress.host.path | default "/" }}
+            backend:
+{{- if (eq "networking.k8s.io/v1" (include "capabilities.ingress.apiVersion" $)) }}
+              service:
+                name: rook-ceph-rgw-{{ .name }}
+                port:
+                  number: {{ .spec.gateway.securePort | default .spec.gateway.port }}
+            pathType: Prefix
+{{- else }}
+              serviceName: rook-ceph-rgw-{{ .name }}
+              servicePort: {{ .spec.gateway.securePort | default .spec.gateway.port }}
+{{- end }}
+  {{- with .ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -600,3 +600,15 @@ cephObjectStores:
       parameters:
         # note: objectStoreNamespace and objectStoreName are configured by the chart
         region: us-east-1
+    ingress:
+      # Enable an ingress for the ceph-objectstore
+      enabled: false
+      # annotations: {}
+      # host:
+      #   name: objectstore.example.com
+      #   path: /
+      # tls:
+      # - hosts:
+      #     - objectstore.example.com
+      #   secretName: ceph-objectstore-tls
+      # ingressClassName: nginx


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

in rook-ceph-cluster chart, add the possibility  to generate an ingress for each ceph-objectstore.

**Which issue is resolved by this Pull Request:**

Resolves #

the following values
``` 
    ingress:
      enabled: true
      annotations: 
        foo: bar
      host:
        name: objectstore.example.com
        path: "/ceph-objectstore(/|$)(.*)"
      tls:
        - hosts:
          - objectstore.example.com
         secretName: testsecret-tls
      ingressClassName: nginx
``` 

generate this annotation:
``` 
# Source: rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: cyril-ceph-objectstore
  annotations:
    foo: bar
spec:
  rules:
    - host: objectstore.example.com
      http:
        paths:
          - path: /ceph-objectstore(/|$)(.*)
            backend:
              service:
                name: rook-ceph-rgw-ceph-objectstore
                port:
                  number: 80
            pathType: Prefix
  ingressClassName: nginx
  tls:
    - hosts:
      - objectstore.example.com
      secretName: testsecret-tls
``` 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
