### PR TITLE
core: temporary disable exporter service

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -49,11 +49,15 @@ const (
 	exporterServiceMetricName        = "ceph-exporter-http-metrics"
 )
 
+var (
+	MinVersionForCephExporter = cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
+)
+
 // createOrUpdateCephExporter is a wrapper around controllerutil.CreateOrUpdate
 func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations []corev1.Toleration, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) (controllerutil.OperationResult, error) {
 	// CephVersion change is done temporarily, as some regression was detected in Ceph version 17.2.6 which is summarised here https://github.com/ceph/ceph/pull/50718#issuecomment-1505608312.
 	// Thus, disabling ceph-exporter for now until all the regression are fixed.
-	if !cephVersion.IsAtLeast(cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}) {
+	if !cephVersion.IsAtLeast(MinVersionForCephExporter) {
 		logger.Infof("Skipping exporter reconcile on ceph version %q", cephVersion.String())
 		return controllerutil.OperationResultNone, nil
 	}


### PR DESCRIPTION
The exporter service should only be created if exporter pods are created. Recently the creation was disabled temporarily due to some regression detected in Ceph v17.2.6 https://github.com/rook/rook/pull/12077
Signed-off-by: avanthakkar <avanjohn@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Create the exporter service only if exporter pods are created.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
