### PR TITLE
rgw: use status.info endpoint for internal communications with server

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -134,14 +134,10 @@ func NewMultisiteContext(context *clusterd.Context, clusterInfo *cephclient.Clus
 
 // UpdateEndpoint updates an object.Context using the latest info from the CephObjectStore spec
 func UpdateEndpoint(objContext *Context, store *cephv1.CephObjectStore) error {
-	nsName := fmt.Sprintf("%s/%s", objContext.clusterInfo.Namespace, objContext.Name)
-
-	port, err := store.Spec.GetPort()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get port for object store %q", nsName)
+	// Get the latest endpoint from object store info
+	if objContext.Endpoint == "" {
+		objContext.Endpoint = GetEndpointFromStatus(store)
 	}
-	objContext.Endpoint = BuildDNSEndpoint(GetDomainName(store), port, store.Spec.IsTLSEnabled())
-
 	return nil
 }
 

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -90,6 +90,12 @@ func TestPopulateDomainAndPort(t *testing.T) {
 				Port: int32(80),
 			},
 		},
+		Status: &cephv1.ObjectStoreStatus{
+			Phase: cephv1.ConditionReady,
+			Info: map[string]string{
+				"endpoint": "http://rook-ceph-rgw-test-store.ns.svc:80",
+			},
+		},
 	}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -347,6 +347,7 @@ func TestCephObjectStoreController(t *testing.T) {
 			},
 			Spec:     cephv1.ObjectStoreSpec{MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}, DataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}},
 			TypeMeta: controllerTypeMeta,
+			Status:   &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://rook-ceph-rgw-my-store.rook-ceph.svc:80"}},
 		}
 		objectStore.Spec.Gateway.Port = 80
 
@@ -643,7 +644,8 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephObjectStore",
 		},
-		Spec: cephv1.ObjectStoreSpec{},
+		Spec:   cephv1.ObjectStoreSpec{},
+		Status: &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://rook-ceph-rgw-my-store.rook-ceph.svc:80"}},
 	}
 
 	objectStore.Spec.Zone.Name = zoneName
@@ -836,11 +838,12 @@ func TestCephObjectExternalStoreController(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephObjectStore",
 		},
-		Spec: cephv1.ObjectStoreSpec{},
+		Spec:   cephv1.ObjectStoreSpec{},
+		Status: &cephv1.ObjectStoreStatus{Info: map[string]string{"endpoint": "http://1.2.3.4:80"}},
 	}
 
 	externalObjectStore.Spec.Gateway.Port = 81
-	externalObjectStore.Spec.Gateway.ExternalRgwEndpoints = []cephv1.EndpointAddress{{IP: ""}}
+	externalObjectStore.Spec.Gateway.ExternalRgwEndpoints = []cephv1.EndpointAddress{{IP: "1.2.3.4"}}
 
 	rgwAdminOpsUserSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -103,3 +103,16 @@ func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string 
 
 	return m
 }
+
+func GetEndpointFromStatus(objectStore *cephv1.CephObjectStore) string {
+	if objectStore.Status == nil {
+		return ""
+	}
+	if len(objectStore.Status.Info["secureEndpoint"]) > 0 {
+		return objectStore.Status.Info["secureEndpoint"]
+	}
+	if len(objectStore.Status.Info["endpoint"]) > 0 {
+		return objectStore.Status.Info["endpoint"]
+	}
+	return ""
+}


### PR DESCRIPTION
The Status.Info stores the endpoint of RGW server, fetch it than building the endpoint for the connecting with RGW server.
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
(cherry picked from commit ff56fd0746a6e827627b2b7da0fcfab5cc31d23a)



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
