### PR TITLE
mgr: Default to active mgr label

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -52,6 +52,8 @@ const (
 	balancerModuleName     = "balancer"
 	balancerModuleMode     = "upmap"
 	mgrRoleLabelName       = "mgr_role"
+	activeMgrStatus        = "active"
+	standbyMgrStatus       = "standby"
 	monitoringPath         = "/etc/ceph-monitoring/"
 	serviceMonitorFile     = "service-monitor.yaml"
 	// minimum amount of memory in MB to run the pod
@@ -238,9 +240,9 @@ func (c *Cluster) UpdateActiveMgrLabel(daemonNameToUpdate string, prevActiveMgr 
 
 		labels := pod.GetLabels()
 		cephDaemonId := labels[controller.DaemonIDLabel]
-		newMgrRole := "standby"
+		newMgrRole := standbyMgrStatus
 		if currActiveMgr == cephDaemonId {
-			newMgrRole = "active"
+			newMgrRole = activeMgrStatus
 		}
 
 		currMgrRole, mgrHasLabel := labels[mgrRoleLabelName]
@@ -323,7 +325,7 @@ func (c *Cluster) updateServiceSelectors() {
 		_, hasMgrRoleLabel := service.Spec.Selector[mgrRoleLabelName]
 		if !hasMgrRoleLabel {
 			logger.Infof("adding %s selector label on mgr service %q", mgrRoleLabelName, service.Name)
-			service.Spec.Selector[mgrRoleLabelName] = "active"
+			service.Spec.Selector[mgrRoleLabelName] = activeMgrStatus
 			updateService = true
 		}
 

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -331,6 +331,10 @@ func (c *Cluster) getPodLabels(mgrConfig *mgrConfig, includeNewLabels bool) map[
 	labels := controller.CephDaemonAppLabels(AppName, c.clusterInfo.Namespace, config.MgrType, mgrConfig.DaemonID, c.clusterInfo.NamespacedName().Name, "cephclusters.ceph.rook.io", includeNewLabels)
 	// leave "instance" key for legacy usage
 	labels["instance"] = mgrConfig.DaemonID
+	if includeNewLabels {
+		// default to the active mgr label, and allow the sidecar to update if it's in standby mode
+		labels[mgrRoleLabelName] = activeMgrStatus
+	}
 	return labels
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/Contributing/development-flow/)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The active and standby labels are updated on the mgr pods by the mgr sidecar. In the case of a single mgr, there is not sidecar, so the dashboard and other mgr services were not available when there was a single mgr. Now the mgr pod will default to the active mgr status label so that the single mgr case will succeed. In the case of two mgrs, the sidecar will immediately update the standby mgr to remove the active status label.

This issue was only affecting test deployments from master since #11845 hasn't yet been backported.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
