### PR TITLE
build: run Golang module sync on dependabot PR

### DIFF
--- a/.github/workflows/build_dependabot_bundler_pr.yml
+++ b/.github/workflows/build_dependabot_bundler_pr.yml
@@ -1,0 +1,53 @@
+# This workflow is based on https://github.com/dependabot/dependabot-actions-workflow
+
+name: Build Dependabot Bundler PR
+on:
+  push:
+    branches:
+      - "dependabot/bundler**"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
+      - name: run mod check
+        run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check
+
+      - run: mkdir ./dependabot-pr
+
+      - name: Save branch ref
+        run: echo ${{ github.ref }} | sed 's/refs\/heads\///' > ./dependabot-pr/BRANCH_REF
+
+      - name: Configure git
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      # NOTE: Prefixing/appending commit messages with `[dependabot skip]` allows
+      # dependabot to rebase/update the pull request, force-pushing over any changes
+
+      - name: Commit and copy changes
+        run: |
+          if [[ $(git status | grep -E '(go.mod|go.sum)' ]]; then
+            git add go.mod go.sum pkg/apis/go.mod pkg/apis/go.sum
+            git commit -m "[dependabot skip] Update Golang Modules"
+            git format-patch -n HEAD^ --binary --stdout > ./dependabot-pr/changes.patch
+          else
+            echo "Golang Modules were not changed"
+          fi
+
+      # NOTE: Use actions/upload-artifact instead of actions/cache as the
+      # workflow triggered on the default branch doesn't have access to caches
+      # created on feature branches
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dependabot-pr
+          path: dependabot-pr/

--- a/.github/workflows/update_dependabot_bundler_pr.yml
+++ b/.github/workflows/update_dependabot_bundler_pr.yml
@@ -1,0 +1,67 @@
+# This workflow is based on https://github.com/dependabot/dependabot-actions-workflow
+
+name: Update Dependabot Bundler PR
+on:
+  workflow_run:
+    workflows: ["Build Dependabot Bundler PR"]
+    types:
+      - completed
+
+jobs:
+  update:
+    runs-on: ubuntu-20.04
+    if: >
+      ${{ github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download pr changes
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "dependabot-pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('/home/runner/work/dependabot-pr.zip', Buffer.from(download.data));
+      - run: mkdir -p /home/runner/work/dependabot-pr
+      # NOTE: actions/checkout will delete the contents of the current workspace
+      # so we unpack the changes outside the current workspace
+      - name: Unpack dependabot pr changes
+        run: unzip -o /home/runner/work/dependabot-pr.zip -d /home/runner/work/dependabot-pr
+      - name: Set BRANCH_REF env var
+        run: printf "BRANCH_REF=%q" "$(head -1 '/home/runner/work/dependabot-pr/BRANCH_REF')" >> $GITHUB_ENV
+      - name: Checkout the branch that triggered 'Build Dependabot Bundler PR'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH_REF }}
+      - name: Configure git
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Commit changes
+        run: |
+          CHANGES_PATH=/home/runner/work/dependabot-pr/changes.patch
+          if [ -f "$CHANGES_PATH" ]; then
+            git am --keep-non-patch $CHANGES_PATH
+          else
+            echo "No changes where committed"
+          fi
+      - name: Push changes back to dependabot/bundler branch
+        run: |
+          if [[ "$BRANCH_REF" =~ ^dependabot/bundler* ]]; then
+            git push origin $BRANCH_REF
+          else
+            echo "Branch ref doesn't look like a dependabot/bundler branch: $BRANCH_REF"
+            exit 1
+          fi


### PR DESCRIPTION
Golang module sync on dependabot PR, should force-sync Golang module data from root to API.

This is roughly based on https://github.com/dependabot/dependabot-actions-workflow/blob/main/.github/workflows/update_dependabot_bundler_pr.yml