### PR TITLE
operator: use KUBECONFIG context for cli if present

### DIFF
--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -90,7 +90,7 @@ particularly noticeable with high I/O load or during OSD rebalancing
 )
 
 func init() {
-	validationConfig.Clientset = rook.NewContext().Clientset
+	validationConfig.Clientset = rook.GetInternalOrExternalClient()
 
 	Cmd.AddCommand(runCmd)
 	Cmd.AddCommand(cleanupCmd)


### PR DESCRIPTION
Use contents of KUBECONFIG var for creating Kubernetes client interface if its present. This allows running rook CLI commands locally for quicker development iteration.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
