### PR TITLE
monitoring: Configurable option to disable prometheus metrics

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -45,7 +45,9 @@ If this value is empty, each pod will get an ephemeral directory to store their 
     * `port`: Allows to change the default port where the dashboard is served
     * `ssl`: Whether to serve the dashboard via SSL, ignored on Ceph versions older than `13.2.2`
 * `monitoring`: Settings for monitoring Ceph using Prometheus. To enable monitoring on your cluster see the [monitoring guide](../../Storage-Configuration/Monitoring/ceph-monitoring.md#prometheus-alerts).
-    * `enabled`: Whether to enable prometheus based monitoring for external or internal cluster
+    * `enabled`: Whether to enable the prometheus service monitor for an internal cluster. For an external cluster, whether to create an endpoint port for the metrics. Default is false.
+    * `metricsDisabled`: Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+    If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
     * `externalMgrEndpoints`: external cluster manager endpoints
     * `externalMgrPrometheusPort`: external prometheus manager module port. See [external cluster configuration](#external-cluster) for more details.
     * `rulesNamespace`: Namespace to deploy prometheusRule. If empty, namespace of the cluster will be used.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7272,7 +7272,20 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
-types must exist or the creation will fail.</p>
+types must exist or the creation will fail. Default is false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metricsDisabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.</p>
 </td>
 </tr>
 <tr>
@@ -10921,5 +10934,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7fc93177e</code>.
+on git commit <code>f8f8a3375</code>.
 </em></p>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1814,7 +1814,7 @@ spec:
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail.
+                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail. Default is false.
                       type: boolean
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
@@ -1870,6 +1870,9 @@ spec:
                     interval:
                       description: Interval determines prometheus scrape interval
                       type: string
+                    metricsDisabled:
+                      description: Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled. If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+                      type: boolean
                     port:
                       description: Port is the prometheus server port
                       maximum: 65535

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -74,6 +74,9 @@ spec:
   monitoring:
     # requires Prometheus to be pre-installed
     enabled: false
+    # Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+    # If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+    metricsDisabled: false
   network:
     connections:
       # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1812,7 +1812,7 @@ spec:
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail.
+                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail. Default is false.
                       type: boolean
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
@@ -1868,6 +1868,9 @@ spec:
                     interval:
                       description: Interval determines prometheus scrape interval
                       type: string
+                    metricsDisabled:
+                      description: Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled. If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+                      type: boolean
                     port:
                       description: Port is the prometheus server port
                       maximum: 65535

--- a/design/ceph/ceph-exporter.md
+++ b/design/ceph/ceph-exporter.md
@@ -16,7 +16,7 @@ There will be two main sources of metrics:
 - Prometheus manager module: It is responsible for exposing all metrics other than ceph daemons performance counters.
 - Ceph exporter: It is responsible for exposing only ceph daemons performance counters as prometheus metrics.
 
-Ceph exporter will be deployed in Rook when the `monitoring.enabled: true` setting is applied in the CephCluster CR and the Ceph version later than 17.2.5.
+Ceph exporter will be deployed in Rook when the `monitoring.metricsDisabled: false` setting is applied in the CephCluster CR and the Ceph version later than 17.2.7.
 
 ## Prerequisites
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -323,9 +323,14 @@ type DashboardSpec struct {
 // MonitoringSpec represents the settings for Prometheus based Ceph monitoring
 type MonitoringSpec struct {
 	// Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
-	// types must exist or the creation will fail.
+	// types must exist or the creation will fail. Default is false.
 	// +optional
 	Enabled bool `json:"enabled,omitempty"`
+
+	// Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
+	// If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+	// +optional
+	MetricsDisabled bool `json:"metricsDisabled,omitempty"`
 
 	// ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
 	// +optional

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -363,7 +363,7 @@ func startModuleConfiguration(description string, configureModules func() error)
 
 // Ceph docs about the prometheus module: http://docs.ceph.com/docs/master/mgr/prometheus/
 func (c *Cluster) configurePrometheusModule() error {
-	if c.spec.Monitoring.Enabled {
+	if !c.spec.Monitoring.MetricsDisabled {
 		if err := cephclient.MgrEnableModule(c.context, c.clusterInfo, PrometheusModuleName, true); err != nil {
 			return errors.Wrap(err, "failed to enable mgr prometheus module")
 		}

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -485,7 +485,8 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 		clusterInfo: cephclient.AdminTestClusterInfo("mycluster"),
 		spec: cephv1.ClusterSpec{
 			Monitoring: cephv1.MonitoringSpec{
-				Enabled: false,
+				Enabled:         false,
+				MetricsDisabled: true,
 			},
 		},
 	}
@@ -498,7 +499,7 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 
 	// Enable prometheus module, no changed
 	modulesDisabled = 0
-	c.spec.Monitoring.Enabled = true
+	c.spec.Monitoring.MetricsDisabled = false
 	err = c.configurePrometheusModule()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, modulesEnabled)

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -61,6 +61,10 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 		logger.Infof("Skipping exporter reconcile on ceph version %q", cephVersion.String())
 		return controllerutil.OperationResultNone, nil
 	}
+	if cephCluster.Spec.Monitoring.MetricsDisabled {
+		logger.Info("Skipping exporter reconcile since monitoring.metricsDisabled is true")
+		return controllerutil.OperationResultNone, nil
+	}
 
 	nodeHostnameLabel, ok := node.Labels[corev1.LabelHostname]
 	if !ok {

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -218,7 +218,7 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 			logger.Debugf("crash collector successfully reconciled for node %q. operation: %q", node.Name, op)
 		}
 	}
-	if cephCluster.Spec.Monitoring.Enabled {
+	if !cephCluster.Spec.Monitoring.MetricsDisabled {
 		op, err := r.createOrUpdateCephExporter(node, tolerations, cephCluster, cephVersion)
 		if err != nil {
 			if op == "unchanged" {
@@ -263,11 +263,11 @@ func (r *ReconcileNode) removeDisabledCrashCollectorDaemons(spec cephv1.ClusterS
 
 func (r *ReconcileNode) removeDisabledCephExporterDaemons(spec cephv1.ClusterSpec, namespace string) bool {
 	// If the ceph-exporter daemons are disabled in the spec let's remove them
-	if !spec.Monitoring.Enabled {
+	if spec.Monitoring.MetricsDisabled {
 		r.deleteNodeDaemon(cephExporterAppName, namespace)
 	}
 
-	return !spec.Monitoring.Enabled
+	return spec.Monitoring.MetricsDisabled
 }
 
 func (r *ReconcileNode) listDeploymentAndDelete(appName, nodeName, ns string) error {


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The prometheus mgr module and ceph exporter can now be optionally disabled by the monitoring.metricsDisabled setting in the CephCluster CR. These will not be disabled by default, rather than the mgr module being disabled by default from v1.11.4.

@avanthakkar This means that if we have a ceph version that supports the exporter, the exporter will be enabled by default, so we will need to fix #11831 before enabling the exporter again.

**Which issue is resolved by this Pull Request:**
Resolves #12097 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
