### PR TITLE
core: disable controller runtime metrics server

### DIFF
--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -154,10 +154,11 @@ func (o *Operator) startCRDManager(context context.Context, mgrErrorCh chan erro
 
 	// Set up a manager
 	mgrOpts := manager.Options{
-		LeaderElection: false,
-		Namespace:      o.config.NamespaceToWatch,
-		Scheme:         scheme,
-		CertDir:        certDir,
+		LeaderElection:     false,
+		Namespace:          o.config.NamespaceToWatch,
+		MetricsBindAddress: "0",
+		Scheme:             scheme,
+		CertDir:            certDir,
 	}
 
 	logger.Info("setting up the controller-runtime manager")


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

As we are not using the controller runtime metrics we dont even need to start the server as it just uses extra resources and its not much useful.


* Before disabling the metrics port

```bash
sh-4.4# netstat -plnt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp6       0      0 :::8080                 :::*                    LISTEN      1/rook              
sh-4.4# 
```

* After Disabling the metrics port

```bash
sh-4.4# netstat -plnt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
sh-4.4# 
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
