### PR TITLE
operator: pull multus validation test images before test

### DIFF
--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -183,7 +183,7 @@ For assistance debugging, collect the following into an archive file:
 `)
 
 	// tell them how to cleanup
-	fmt.Printf("\nTo clean up resources when you are done debugging: %s", cleanupCmd.CommandPath())
+	fmt.Printf("\nTo clean up resources when you are done debugging: %s --namespace %s\n", cleanupCmd.CommandPath(), validationConfig.Namespace)
 
 	os.Exit(1)
 }

--- a/pkg/daemon/multus/client-daemonset.yaml
+++ b/pkg/daemon/multus/client-daemonset.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
         {{ range $name, $address := .NetworkNamesAndAddresses }}
         - name: readiness-check-web-server-{{ $name }}-addr
-          # use nginx image because it's already pulled for the nginx pod and has a non-root user
-          image: nginx:stable-alpine
+          # use nginx image because it's already used for the web server pod and has a non-root user
+          image: nginxinc/nginx-unprivileged:stable-alpine
           command:
             - sleep
             - infinity

--- a/pkg/daemon/multus/image-pull-daemonset.yaml
+++ b/pkg/daemon/multus/image-pull-daemonset.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: multus-validation-test-image-pull
+  labels:
+    app: multus-validation-test-image-pull
+    app.kubernetes.io/name: "image-puller"
+    app.kubernetes.io/instance: "image-puller"
+    app.kubernetes.io/component: "image-puller"
+    app.kubernetes.io/part-of: "multus-validation-test"
+    app.kubernetes.io/managed-by: "rook-cli"
+spec:
+  selector:
+    matchLabels:
+      app: multus-validation-test-image-pull
+  template:
+    metadata:
+      labels:
+        app: multus-validation-test-image-pull
+    spec:
+      # TODO: selectors, affinities, tolerations
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sleep
+          # use nginx image because it's already used for the web server pod and has a non-root user
+          image: nginxinc/nginx-unprivileged:stable-alpine
+          command:
+            - sleep
+            - infinity
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            readOnlyRootFilesystem: true

--- a/pkg/daemon/multus/nginx-pod.yaml
+++ b/pkg/daemon/multus/nginx-pod.yaml
@@ -22,7 +22,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: multus-validation-test-web-server
-      image: nginx:stable-alpine
+      image: nginxinc/nginx-unprivileged:stable-alpine
       resources: {}
       ports:
         - containerPort: 8080


### PR DESCRIPTION
Before starting multus validation test clients, pull the client image to all nodes. This will ensure that variations in client readiness timing will not be affected by variations in the time nodes take to pull the image. This is intended to reduce the number of false reports of flaky multus networks.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
