### PR TITLE
monitoring: Skip creating the service monitor for the exporter if monitoring is not enabled

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -240,10 +240,12 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 					return errors.Wrap(err, "failed to create ceph-exporter metrics service")
 				}
 
-				if err := EnableCephExporterServiceMonitor(cephCluster, r.scheme, r.opManagerContext); err != nil {
-					return errors.Wrap(err, "failed to enable service monitor")
+				if cephCluster.Spec.Monitoring.Enabled {
+					if err := EnableCephExporterServiceMonitor(cephCluster, r.scheme, r.opManagerContext); err != nil {
+						return errors.Wrap(err, "failed to enable service monitor")
+					}
+					logger.Debug("service monitor for ceph exporter was enabled successfully")
 				}
-				logger.Debug("service monitor for ceph exporter was enabled successfully")
 			}
 
 		}


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The exporter is enabled by default, but the service monitor can only be enabled if prometheus CRDs are available. The `monitoring.enabled` must be set to true as the flag that prometheus is available and the service monitor should be created.

This is a follow-up to a regression caused by #12193 that I found when testing other exporter changes.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
