### PR TITLE
nfs: Add Spec.Security.Kerberos.DomainName to the CRD to configure /etc/idmapd.conf

### DIFF
--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -55,6 +55,7 @@ spec:
   security:
     kerberos:
       principalName: "nfs"
+      domainName: "DOMAIN1.EXAMPLE.COM"
 
       configFiles:
         volumeSource:
@@ -114,6 +115,11 @@ The `security` spec sets security configuration for the NFS cluster.
     determine the full service principal name: `<principalName>/<namespace>-<name>@<realm>`.
     e.g., nfs/rook-ceph-my-nfs@example.net. For full details, see the
     [NFS security doc](../Storage-Configuration/NFS/nfs-security.md#nfs-service-principals).
+  * `domainName`: this is the domain name used in the kerberos credentials. This is used to
+    configure idmap to map the kerberos credentials to uid/gid. Without this configured, NFS-Ganesha
+    will use the anonuid/anongid configured (default: -2) when accessing the local filesystem.
+    eg., DOMAIN1.EXAMPLE.COM.
+    [NFS security doc](../Storage-Configuration/NFS/nfs-security.md#kerberos-domain-name).
   * `configFiles`: defines where the Kerberos configuration should be sourced from. Config
     files will be placed into the `/etc/krb5.conf.rook/` directory. For advanced usage, see the
     [NFS security doc](../Storage-Configuration/NFS/nfs-security.md#kerberos-configuration).

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -6440,6 +6440,18 @@ See <a href="https://github.com/nfs-ganesha/nfs-ganesha/wiki/RPCSEC_GSS">https:/
 </tr>
 <tr>
 <td>
+<code>domainName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DomainName should be set to the Kerberos Realm.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>configFiles</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.KerberosConfigFiles">
@@ -11042,5 +11054,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f8f8a3375</code>.
+on git commit <code>ff431de56</code>.
 </em></p>

--- a/Documentation/Storage-Configuration/NFS/nfs-security.md
+++ b/Documentation/Storage-Configuration/NFS/nfs-security.md
@@ -102,6 +102,8 @@ authenticate to the Kerberos server (KDC). The requirements are two-parted:
 2. a keytab file that provides credentials for the
    [service principal](#nfs-service-principals) that NFS-Ganesha will use to authenticate with the
    Kerberos server.
+3. a kerberos domain name which will be used to map kerberos credentials to uid/gid
+   [domain name](#kerberos-domain-name) that NFS-Ganesha will use to authenticate with the
 
 Methods of providing the configuration files are documented in the
 [NFS CRD security section](../../CRDs/ceph-nfs-crd.md#security).
@@ -163,3 +165,10 @@ Users must add this service principal to their Kerberos server configuration.
     `spec.security.kerberos.principalName` corresponds directly to NFS-Ganesha's
     NFS_KRB5:PrincipalName config. See the
     [NFS-Ganesha wiki](https://github.com/nfs-ganesha/nfs-ganesha/wiki/RPCSEC_GSS) for more details.
+
+#### Kerberos domain name
+
+The kerberos domain name is used to setup the domain name in /etc/idmapd.conf. This domain name is used
+by idmap to map the kerberos credential to the user uid/gid. Without this configured, NFS-Ganesha will
+be unable to map the Kerberos principal to an uid/gid and will instead use the configured
+anonuid/anongid (default: -2) when accessing the local filesystem.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -7312,6 +7312,9 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        domainName:
+                          description: DomainName should be set to the Kerberos Realm.
+                          type: string
                         keytabFile:
                           description: KeytabFile defines where the Kerberos keytab should be sourced from. The keytab file will be placed into `/etc/krb5.keytab`. If this is left empty, Rook will not add the file. This allows you to manage the `krb5.keytab` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
                           properties:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -7306,6 +7306,9 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        domainName:
+                          description: DomainName should be set to the Kerberos Realm.
+                          type: string
                         keytabFile:
                           description: KeytabFile defines where the Kerberos keytab should be sourced from. The keytab file will be placed into `/etc/krb5.keytab`. If this is left empty, Rook will not add the file. This allows you to manage the `krb5.keytab` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
                           properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2097,6 +2097,10 @@ type KerberosSpec struct {
 	// +kubebuilder:default="nfs"
 	PrincipalName string `json:"principalName"`
 
+	// DomainName should be set to the Kerberos Realm.
+	// +optional
+	DomainName string `json:"domainName"`
+
 	// ConfigFiles defines where the Kerberos configuration should be sourced from. Config files
 	// will be placed into the `/etc/krb5.conf.rook/` directory.
 	//


### PR DESCRIPTION
The file /etc/idmapd.conf is required to be setup for idmapping to work properly with Kerberos authentication. This PR adds a new setting called domainName under Kerberos which requires the user to provide the kerberos realm for users using kerberos authentication. 

The domainName setting is used to configure /etc/idmapd.conf. This is used by the idmapper to map kerberos credentials to uid/gid.

Resolves #11991

**Checklist:**

- [* ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ *] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [* ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.