### PR TITLE
test: allow specifying custom nginx image for multus validation

### DIFF
--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -131,6 +131,8 @@ func init() {
 			"The default value is set to the worst-case value for a Rook Ceph cluster with 3 portable OSDs, 3 portable monitors, "+
 			"and where all optional child resources have been created with 1 daemon such that they all might run on a single node in a failure scenario. "+
 			"If you aren't sure what to choose for this value, add 1 for each additional OSD beyond 3.")
+	runCmd.Flags().StringVar(&validationConfig.NginxImage, "nginx-image", "nginxinc/nginx-unprivileged:stable-alpine",
+		"The Nginx image used for the validation server and clients.")
 
 	// flags for 'validation cleanup'
 	// none
@@ -139,6 +141,11 @@ func init() {
 func runValidation(ctx context.Context) {
 	if validationConfig.PublicNetwork == "" && validationConfig.ClusterNetwork == "" {
 		fmt.Print(`at least one of "--public-network" or "--cluster-network" must be specified`)
+		os.Exit(22 /* EINVAL */)
+	}
+
+	if validationConfig.NginxImage == "" {
+		fmt.Print(`--nginx-image must be specified`)
 		os.Exit(22 /* EINVAL */)
 	}
 

--- a/pkg/daemon/multus/client-daemonset.yaml
+++ b/pkg/daemon/multus/client-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         {{ range $name, $address := .NetworkNamesAndAddresses }}
         - name: readiness-check-web-server-{{ $name }}-addr
           # use nginx image because it's already used for the web server pod and has a non-root user
-          image: nginxinc/nginx-unprivileged:stable-alpine
+          image: "{{ .NginxImage }}"
           command:
             - sleep
             - infinity

--- a/pkg/daemon/multus/image-pull-daemonset.yaml
+++ b/pkg/daemon/multus/image-pull-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: sleep
           # use nginx image because it's already used for the web server pod and has a non-root user
-          image: nginxinc/nginx-unprivileged:stable-alpine
+          image: "{{ .NginxImage }}"
           command:
             - sleep
             - infinity

--- a/pkg/daemon/multus/nginx-pod.yaml
+++ b/pkg/daemon/multus/nginx-pod.yaml
@@ -22,7 +22,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: multus-validation-test-web-server
-      image: nginxinc/nginx-unprivileged:stable-alpine
+      image: "{{ .NginxImage }}"
       resources: {}
       ports:
         - containerPort: 8080

--- a/pkg/daemon/multus/templates.go
+++ b/pkg/daemon/multus/templates.go
@@ -44,14 +44,18 @@ var (
 
 type webServerTemplateConfig struct {
 	NetworksAnnotationValue string
+	NginxImage              string
 }
 
-type imagePullTemplateConfig struct{}
+type imagePullTemplateConfig struct {
+	NginxImage string
+}
 
 type clientTemplateConfig struct {
 	ClientID                 int
 	NetworksAnnotationValue  string
 	NetworkNamesAndAddresses map[string]string
+	NginxImage               string
 }
 
 func webServerPodName() string {
@@ -74,6 +78,7 @@ const clientDaemonSetAppType = "client"
 func (vt *ValidationTest) generateWebServerTemplateConfig() webServerTemplateConfig {
 	return webServerTemplateConfig{
 		NetworksAnnotationValue: vt.generateNetworksAnnotationValue(),
+		NginxImage:              vt.NginxImage,
 	}
 }
 
@@ -89,6 +94,13 @@ func (vt *ValidationTest) generateClientTemplateConfig(clientID int, serverPubli
 		ClientID:                 clientID,
 		NetworksAnnotationValue:  vt.generateNetworksAnnotationValue(),
 		NetworkNamesAndAddresses: netNamesAndAddresses,
+		NginxImage:               vt.NginxImage,
+	}
+}
+
+func (vt *ValidationTest) generateImagePullTemplateConfig() imagePullTemplateConfig {
+	return imagePullTemplateConfig{
+		NginxImage: vt.NginxImage,
 	}
 }
 
@@ -123,7 +135,7 @@ func (vt *ValidationTest) generateWebServerConfigMap() (*core.ConfigMap, error) 
 }
 
 func (vt *ValidationTest) generateImagePullDaemonSet() (*apps.DaemonSet, error) {
-	t, err := loadTemplate("imagePullDaemonSet", imagePullDaemonSet, imagePullTemplateConfig{})
+	t, err := loadTemplate("imagePullDaemonSet", imagePullDaemonSet, vt.generateImagePullTemplateConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image pull daemonset template: %w", err)
 	}

--- a/pkg/daemon/multus/validation.go
+++ b/pkg/daemon/multus/validation.go
@@ -71,8 +71,8 @@ type ValidationTest struct {
 	// Logger an instance of the basic log implementation used by this library.
 	Logger Logger
 
-	// TODO: allow overriding the nginx server image from CLI, and set from default var that can be
-	// overridden at build time
+	//NginxImage is the Nginx image which will be used for the web server and clients.
+	NginxImage string
 }
 
 // ValidationTestResults contains results from a validation test.
@@ -361,9 +361,14 @@ func (vt *ValidationTest) Run(ctx context.Context) (*ValidationTestResults, erro
 	vt.Logger.Infof("  cluster network: %q", vt.ClusterNetwork)
 	vt.Logger.Infof("  daemons per node: %d", vt.DaemonsPerNode)
 	vt.Logger.Infof("  resource timeout: %v", vt.ResourceTimeout)
+	vt.Logger.Infof("  nginx image: %q", vt.NginxImage)
 
 	if vt.PublicNetwork == "" && vt.ClusterNetwork == "" {
 		return nil, fmt.Errorf("at least one of 'public network' and 'cluster network' must be specified")
+	}
+
+	if vt.NginxImage == "" {
+		return nil, fmt.Errorf("'nginx-image' must be specified")
 	}
 
 	testResults := &ValidationTestResults{


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
- allow overriding the nginx server image for multus-validation-test-web-server from CLI using `--nginx-image` flag
- default image will be **nginxinc/nginx-unprivileged:stable-alpine**

**Which issue is resolved by this Pull Request:**
Resolves #12175 
CC @BlaineEXE 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
