### PR TITLE
helm: add exporter resource entry to ceph cluster

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -530,6 +530,7 @@ It scrapes for Ceph daemon core dumps and sends them to the Ceph manager crash m
 You can read more about the [Ceph Crash module](https://docs.ceph.com/docs/master/mgr/crash/).
 * `logcollector`: Set resource requests/limits for the log collector. When enabled, this container runs as side-car to each Ceph daemons.
 * `cleanup`: Set resource requests/limits for cleanup job, responsible for wiping cluster's data after uninstall
+* `exporter`: Set resource requests/limits for Ceph exporter.
 
 In order to provide the best possible experience running Ceph in containers, Rook internally recommends minimum memory limits if resource limits are passed.
 If a user configures a limit or request value that is too low, Rook will still run the pod(s) and print a warning to the operator log.
@@ -540,6 +541,7 @@ If a user configures a limit or request value that is too low, Rook will still r
 * `crashcollector`: 60MB
 * `mgr-sidecar`: 100MB limit, 40MB requests
 * `prepareosd`: no limits (see the note)
+* `exporter`: 128MB limit, 50MB requests
 
 !!! note
     We recommend not setting memory limits on the OSD prepare job to prevent OSD provisioning failure due to memory constraints.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -331,6 +331,13 @@ cephClusterSpec:
       requests:
         cpu: "500m"
         memory: "100Mi"
+    exporter:
+      limits:
+        cpu: "250m"
+        memory: "128Mi"
+      requests:
+        cpu: "50m"
+        memory: "50Mi"
 
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -227,6 +227,7 @@ spec:
   #   crashcollector:
   #   logcollector:
   #   cleanup:
+  #   exporter:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
   priorityClassNames:


### PR DESCRIPTION
**Description of your changes:**

This adds the new `exporter:` resource key to the Ceph cluster example yaml. It also set some sane resource requests and limits for it in the CephCluster section of the rook-ceph Helm chart.

**Which issue is resolved by this Pull Request:**
Closes #11914

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
