### PR TITLE
test: add tmate pod manifest

### DIFF
--- a/tests/scripts/tmate-pod.yaml
+++ b/tests/scripts/tmate-pod.yaml
@@ -1,0 +1,79 @@
+# Apply this manifest to CI clusters to allow debugging complex failures during CI runs
+#
+# Usage:
+#   kubectl apply -f tests/scripts/tmate-pod.yaml
+#   kubectl -n tmate wait --for=condition=ready -l app=tmate pod --timeout=300
+#   sleep 1 # just in case tmate hasn't output its web/ssh links yet
+#   kubectl -n tmate logs deploy/tmate
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tmate
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tmate
+  namespace: tmate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-all
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - nonResourceURLs:
+      - "*"
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tmate-allow-all
+subjects:
+  - kind: ServiceAccount
+    name: tmate
+    namespace: tmate
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-all
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tmate
+  namespace: tmate
+spec:
+  selector:
+    matchLabels:
+      app: tmate
+  template:
+    metadata:
+      labels:
+        app: tmate
+    spec:
+      serviceAccountName: tmate
+      containers:
+        - name: tmate
+          image: quay.io/fedora/fedora:39
+          command:
+            - sh
+            - -c
+            - |
+              dnf install -y tmate kubernetes-client bash vim
+              tmate -F -S /var/tmp/tmate.sock
+          resources: {}
+          readinessProbe:
+            exec:
+              # return ready only when the tmate socket exists -- when tmate is officially running
+              command:
+                - ls
+                - /var/tmp/tmate.sock


### PR DESCRIPTION
Add a tmate manifest that can be added to CI tests to allow manually debugging them in real-time while the test is ongoing.

I found this method to be working for another repo I was trying to debug. I quickly added the manifest and usage here with the intent that we can decide when and how often to use it at a later point. And we can always enable it manually and temporarily for any PR we are struggling with.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
