### PR TITLE
monitoring: Service monitor should not use mgr_role label

### DIFF
--- a/deploy/examples/monitoring/service-monitor.yaml
+++ b/deploy/examples/monitoring/service-monitor.yaml
@@ -11,10 +11,9 @@ spec:
       - rook-ceph
   selector:
     matchLabels:
-      mgr_role: active
       app: rook-ceph-mgr
       rook_cluster: rook-ceph
   endpoints:
-  - port: http-metrics
-    path: /metrics
-    interval: 5s
+    - port: http-metrics
+      path: /metrics
+      interval: 5s


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The service monitor selectors need to match the mgr service labels. Since the mgr service labels don't use the mgr_role (only the mgr service selectors use the mgr_role), the mgr_role should be removed from the service monitor.

**Which issue is resolved by this Pull Request:**
Related to #12249 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
