### PR TITLE
core: cleanup exporter resources

### DIFF
--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -23,6 +23,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,4 +101,19 @@ func CreateOrUpdateServiceMonitor(ctx context.Context, serviceMonitorDefinition 
 		return nil, fmt.Errorf("failed to update servicemonitor. %v", err)
 	}
 	return sm, nil
+}
+
+// DeleteServiceMonitor deletes a ServiceMonitor and returns the error if any
+func DeleteServiceMonitor(ctx context.Context, ns string, name string) error {
+	client, err := getMonitoringClient()
+	if err != nil {
+		return fmt.Errorf("failed to get monitoring client. %v", err)
+	}
+	err = client.MonitoringV1().ServiceMonitors(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if kerror.IsNotFound(err) {
+			return nil
+		}
+	}
+	return err
 }


### PR DESCRIPTION
Signed-off-by: avanthakkar <avanjohn@gmail.com>

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Cleanup exporter daemon even if ceph version is not supported along with other resources like metrics service and service monitor.

**Which issue is resolved by this Pull Request:**
Resolves #12249

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
