### PR TITLE
object: add missing cephcluster spec addition in object controller

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -38,15 +38,14 @@ import (
 
 // Context holds the context for the object store.
 type Context struct {
-	Context         *clusterd.Context
-	clusterInfo     *cephclient.ClusterInfo
-	CephClusterSpec cephv1.ClusterSpec
-	Name            string
-	UID             string
-	Endpoint        string
-	Realm           string
-	ZoneGroup       string
-	Zone            string
+	Context     *clusterd.Context
+	clusterInfo *cephclient.ClusterInfo
+	Name        string
+	UID         string
+	Endpoint    string
+	Realm       string
+	ZoneGroup   string
+	Zone        string
 }
 
 // AdminOpsContext holds the object store context as well as information for connecting to the admin
@@ -214,7 +213,7 @@ func RunAdminCommandNoMultisite(c *Context, expectJSON bool, args ...string) (st
 	var err error
 
 	// If Multus is enabled we proxy all the command to the mgr sidecar
-	if c.CephClusterSpec.Network.IsMultus() {
+	if c.clusterInfo.NetworkSpec.IsMultus() {
 		output, stderr, err = c.Context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, cephclient.ProxyAppLabel, cephclient.CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{"radosgw-admin"}, args...)...)
 	} else {
 		command, args := cephclient.FinalizeCephCommandArgs("radosgw-admin", c.clusterInfo, args, c.Context.ConfigDir)

--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -151,7 +151,7 @@ func TestRunAdminCommandNoMultisite(t *testing.T) {
 	})
 
 	t.Run("with multus - we use the remote executor", func(t *testing.T) {
-		objContext.CephClusterSpec = v1.ClusterSpec{Network: v1.NetworkSpec{Provider: "multus"}}
+		objContext.clusterInfo.NetworkSpec = v1.NetworkSpec{Provider: "multus"}
 		_, err := RunAdminCommandNoMultisite(objContext, true, []string{"zone", "get"}...)
 		assert.Error(t, err)
 

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -674,16 +674,6 @@ func (p *Provisioner) setAdminOpsAPIClient() error {
 		return errors.Wrapf(err, "failed to get ceph object store %q", p.objectStoreName)
 	}
 
-	cephCluster, err := p.getCephCluster()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get ceph cluster in namespace %q", p.clusterInfo.Namespace)
-	}
-	if cephCluster == nil {
-		return errors.Errorf("failed to read ceph cluster in namespace %q, it's nil", p.clusterInfo.Namespace)
-	}
-	// Set the Ceph Cluster Spec so that we can fetch the admin ops key properly when multus is enabled
-	p.objectContext.CephClusterSpec = cephCluster.Spec
-
 	// Fetch the object store admin ops user
 	accessKey, secretKey, err := object.GetAdminOPSUserCredentials(p.objectContext, &cephObjectStore.Spec)
 	if err != nil {

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -85,19 +85,6 @@ func (p *Provisioner) getObjectStore() (*cephv1.CephObjectStore, error) {
 	return store, err
 }
 
-func (p *Provisioner) getCephCluster() (*cephv1.CephCluster, error) {
-	cephCluster, err := p.context.RookClientset.CephV1().CephClusters(p.clusterInfo.Namespace).List(p.clusterInfo.Context, metav1.ListOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list ceph clusters in namespace %q", p.clusterInfo.Namespace)
-	}
-	if len(cephCluster.Items) == 0 {
-		return nil, errors.Errorf("failed to find ceph cluster in namespace %q", p.clusterInfo.Namespace)
-	}
-
-	// This is a bit weak, but there will always be a single cluster per namespace anyway
-	return &cephCluster.Items[0], err
-}
-
 func MaxObjectQuota(AdditionalConfig map[string]string) string {
 	return AdditionalConfig["maxObjects"]
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -368,7 +368,6 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 	if err != nil {
 		return r.setFailedStatus(k8sutil.ObservedGenerationNotAvailable, namespacedName, "failed to setup object store context", err)
 	}
-	objContext.CephClusterSpec = cluster
 
 	if cephObjectStore.Spec.IsExternal() {
 		logger.Info("reconciling external object store")

--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -72,8 +72,6 @@ func newS3Agent(p provisioner) (*object.S3Agent, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get object context for CephObjectStore %v", p.objectStoreName)
 	}
-	// CephClusterSpec is needed for GetAdminOPSUserCredentials()
-	objContext.CephClusterSpec = *p.clusterSpec
 
 	adminOpsCtx, err := object.NewMultisiteAdminOpsContext(objContext, &objStore.Spec)
 	if err != nil {

--- a/pkg/operator/ceph/object/topic/provisioner.go
+++ b/pkg/operator/ceph/object/topic/provisioner.go
@@ -69,8 +69,6 @@ func createSNSClient(p provisioner, objectStoreName types.NamespacedName) (*sns.
 		return nil, errors.Wrapf(err, "failed to get object context for CephObjectStore %v", objectStoreName)
 	}
 
-	// CephClusterSpec is needed for GetAdminOPSUserCredentials()
-	objContext.CephClusterSpec = *p.clusterSpec
 	accessKey, secretKey, err := object.GetAdminOPSUserCredentials(objContext, &objStore.Spec)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get Ceph RGW admin ops user credentials")

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -378,10 +378,6 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 		return errors.Wrapf(err, "Multisite failed to set on object context for object store user")
 	}
 
-	// The object store context needs the CephCluster spec to read networkinfo
-	// Otherwise GetAdminOPSUserCredentials() will fail detecting the network provider when running RunAdminCommandNoMultisite()
-	objContext.CephClusterSpec = *r.cephClusterSpec
-
 	opsContext, err := newMultisiteAdminOpsCtxFunc(objContext, &store.Spec)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialized rgw admin ops client api")


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The ceph cluster spec need to set on object context for executing radosgw-admin commands if multus is enabled.
The radosgw-admin command uses the network spec from ceph cluster spec
in object context but it is not filled properly in the object package.
But with PR 10898, network spec is available in clusterinfo which can
be used directly. Also removed cluserspec from object context.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
