### PR TITLE
ci: adding path ignore to documentations

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -1,6 +1,9 @@
 name: Integration test CephMgrSuite
 on:
   pull_request:
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
 
 defaults:
   run:


### PR DESCRIPTION
**Description of your changes:**
Updating GitHub Actions Workflows so it ignores the documentations changes.

**Which issue is resolved by this Pull Request:**
Resolves #12287 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
