### PR TITLE
mgr: update default rook_cluster of ServiceMonitor

### DIFF
--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -18,21 +18,19 @@ limitations under the License.
 package k8sutil
 
 import (
-	"path"
 	"testing"
 
-	"github.com/rook/rook/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetServiceMonitor(t *testing.T) {
-	projectRoot := util.PathToProjectRoot()
-	filePath := path.Join(projectRoot, "/deploy/examples/monitoring/service-monitor.yaml")
-	servicemonitor, err := GetServiceMonitor(filePath)
-	assert.Nil(t, err)
-	assert.Equal(t, "rook-ceph-mgr", servicemonitor.GetName())
-	assert.Equal(t, "rook-ceph", servicemonitor.GetNamespace())
+	name := "rook-ceph-mgr"
+	namespace := "rook-ceph"
+	servicemonitor := GetServiceMonitor(name, namespace)
+	assert.Equal(t, name, servicemonitor.GetName())
+	assert.Equal(t, namespace, servicemonitor.GetNamespace())
 	assert.NotNil(t, servicemonitor.GetLabels())
 	assert.NotNil(t, servicemonitor.Spec.NamespaceSelector.MatchNames)
+	assert.NotNil(t, servicemonitor.Spec.Selector.MatchLabels)
 	assert.NotNil(t, servicemonitor.Spec.Endpoints)
 }


### PR DESCRIPTION
When deploying a cluster with Helm Chart, if the namespace is not the default value `rook-ceph`, and if the monitoring feature is enabled, then the generated ServiceMonitor's `rook_cluster` selector now follows the namespace, not the hard-coded value `rook-ceph`.

## Example Scenario

1. Deploy a rook-ceph cluster (rook-ceph, rook-ceph-cluster) with Helm Chart.
    - With modifying the namespace to `my-rook-ceph`
    - With enabling the feature `monitoring`
1. Command `kubectl -n csi-rook-ceph get servicemonitor rook-ceph-mgr -o jsonpath --template '{.spec.selector.matchLabels.rook_cluster}'`
1. Before patch, the command output should be `rook-ceph`.
    - After patch, it should be `my-rook-ceph`.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
