### PR TITLE
security: remove default scc privileges

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -21,7 +21,8 @@ priority:
 allowedCapabilities: ["MKNOD"]
 allowHostIPC: true
 readOnlyRootFilesystem: false
-requiredDropCapabilities: []
+# drop all default privileges
+requiredDropCapabilities: ["All"]
 defaultAddCapabilities: []
 runAsUser:
   type: RunAsAny

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -566,6 +566,9 @@ spec:
             runAsNonRoot: true
             runAsUser: 2016
             runAsGroup: 2016
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - mountPath: /var/lib/rook
               name: rook-config

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -567,8 +567,7 @@ spec:
             runAsUser: 2016
             runAsGroup: 2016
             capabilities:
-              drop:
-                - ALL
+              drop: ["ALL"]
           volumeMounts:
             - mountPath: /var/lib/rook
               name: rook-config

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -91,6 +91,8 @@ spec:
             runAsNonRoot: true
             runAsUser: 2016
             runAsGroup: 2016
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: ROOK_CEPH_USERNAME
               valueFrom:

--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -43,7 +43,7 @@ func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContex
 		AllowHostNetwork:         false,
 		AllowHostPorts:           false,
 		AllowedCapabilities:      []corev1.Capability{"MKNOD"},
-		RequiredDropCapabilities: []corev1.Capability{},
+		RequiredDropCapabilities: []corev1.Capability{"ALL"},
 		DefaultAddCapabilities:   []corev1.Capability{},
 		RunAsUser: secv1.RunAsUserStrategyOptions{
 			Type: secv1.RunAsUserStrategyRunAsAny,

--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -33,6 +33,8 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .RegistrarImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
@@ -54,6 +56,7 @@ spec:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
+              drop: ["ALL"]
             allowPrivilegeEscalation: true
           image: {{ .CSIPluginImage }}
           args:
@@ -123,6 +126,8 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIPluginImage }}
           args:
             - "--type=liveness"

--- a/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin.yaml
+++ b/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin.yaml
@@ -31,6 +31,8 @@ spec:
           # non-privileged sidecar containers cannot access unix domain socket
           # created by privileged CSI driver container.
           securityContext:
+            capabilities:
+              drop: ["ALL"]
             privileged: true
           image: {{ .RegistrarImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
@@ -54,6 +56,7 @@ spec:
             capabilities:
               add:
               - SYS_ADMIN
+              drop: ["ALL"]
             privileged: true
           args:
             - "--nodeid=$(NODE_ID)"

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -38,6 +38,8 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .RegistrarImage }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
@@ -59,6 +61,7 @@ spec:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
+              drop: ["ALL"]
             allowPrivilegeEscalation: true
           image: {{ .CSIPluginImage }}
           args :
@@ -148,6 +151,8 @@ spec:
         - name: csi-addons
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIAddonsImage }}
           args :
             - "--node-id=$(NODE_ID)"
@@ -188,6 +193,8 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            capabilities:
+              drop: ["ALL"]
           image: {{ .CSIPluginImage }}
           args:
             - "--type=liveness"


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
security: remove default scc privileges

with `requiredDropCapabilities: ["All"]` we can
drop all the default privileges and we can add the
privileges required `allowedCapabilities:` here.

security: drop all capabilities to op container

adding drop `ALL` capabilities in rook operator container
as this is not required and will remove the warning in ocp cluster.

Signed-off-by: subhamkrai <srai@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
