### PR TITLE
osd: removing ceph_args from the osd env

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -230,6 +230,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   raw-disk:
     runs-on: ubuntu-20.04
@@ -284,6 +285,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   two-osds-in-device:
     runs-on: ubuntu-20.04
@@ -332,6 +334,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   osd-with-metadata-device:
     runs-on: ubuntu-20.04
@@ -386,6 +389,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption:
     runs-on: ubuntu-20.04
@@ -485,6 +489,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   pvc:
     runs-on: ubuntu-20.04
@@ -559,6 +564,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   pvc-db:
     runs-on: ubuntu-20.04
@@ -609,6 +615,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   pvc-db-wal:
     runs-on: ubuntu-20.04
@@ -662,6 +669,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc:
     runs-on: ubuntu-20.04
@@ -727,6 +735,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc-db:
     runs-on: ubuntu-20.04
@@ -779,6 +788,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc-db-wal:
     runs-on: ubuntu-20.04
@@ -841,6 +851,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc-kms-vault-token-auth:
     runs-on: ubuntu-20.04
@@ -922,6 +933,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc-kms-vault-k8s-auth:
     runs-on: ubuntu-20.04
@@ -985,6 +997,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   lvm-pvc:
     runs-on: ubuntu-20.04
@@ -1040,6 +1053,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   multi-cluster-mirroring:
     runs-on: ubuntu-20.04
@@ -1296,6 +1310,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   rgw-multisite-testing:
     runs-on: ubuntu-20.04
@@ -1325,6 +1340,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   encryption-pvc-kms-ibm-kp:
     runs-on: ubuntu-20.04
@@ -1357,6 +1373,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   multus-cluster-network:
     runs-on: ubuntu-20.04
@@ -1436,6 +1453,7 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true
 
   csi-hostnetwork-disabled:
     runs-on: ubuntu-20.04
@@ -1489,3 +1507,4 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
+          limit-access-to-actor: true

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -357,7 +357,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 				SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
 					Name: "rook-ceph-config"},
 					Key: "mon_host"}}},
-		{Name: "CEPH_ARGS", Value: "-m $(ROOK_CEPH_MON_HOST)"},
 		blockPathEnvVariable(osd.BlockPath),
 		cvModeEnvVariable(osd.CVMode),
 		dataDeviceClassEnvVar(osd.DeviceClass),


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The osd perf dump doesn't work and just output empty array ceph daemon /var/run/ceph/ceph-osd.1.asok perf dump

Currently the ceph_args
sh-5.1# echo $CEPH_ARGS
-m [v2:172.30.212.221:3300],[v2:172.30.247.36:3300],[v2:172.30.7.251:3300]

If we update the ceph_args to empty
sh-5.1# CEPH_ARGS=
sh-5.1# echo $CEPH_ARGS

sh-5.1#
or

sh-5.1# export CEPH_ARGS='-c /var/lib/rook/openshift-storage/openshift-storage.config' sh-5.1#

The perf dump works fine

Even I noticed the `perf schema` cmd outputs err

sh-5.1# ceph daemon /var/run/ceph/ceph-osd.0.asok perf schema Invalid command: unused arguments: ['-m', '[v2:172.30.212.221:3300],[v2:172.30.247.36:3300],[v2:172.30.7.251:3300]'] perf schema :  dump non-labeled counters schemas
admin_socket: invalid command

And works fine if we update it


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
