### PR TITLE
ci: Daily rgw tests to run against ceph main

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -347,7 +347,7 @@ jobs:
     strategy:
       matrix:
         ceph-image-tag:
-          ["latest-master-devel", "latest-quincy-devel", "latest-pacific-devel"]
+          ["latest-main-devel", "latest-quincy-devel", "latest-pacific-devel"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The daily rgw tests were mistakenly running against an old latest-master-devel ceph tag instead of the newer
latest-main-devel ceph tag. Now the daily rgw tests will be run against the latest and greatest as expected.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
