### PR TITLE
rgw: restart object bucket reconcile if rgw objectstore is updated

### DIFF
--- a/pkg/operator/ceph/object/bucket/controller.go
+++ b/pkg/operator/ceph/object/bucket/controller.go
@@ -97,6 +97,20 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 		return err
 	}
 
+	// Watch for CephObjectStore spec change
+	eventHandler := handler.EnqueueRequestsFromMapFunc(handler.MapFunc(func(context context.Context, obj client.Object) []reconcile.Request {
+		objectStore, _ := obj.(*cephv1.CephObjectStore)
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: objectStore.Namespace}}
+		return []reconcile.Request{req}
+	}),
+	)
+	objectStoreKind := source.Kind(mgr.GetCache(),
+		&cephv1.CephObjectStore{TypeMeta: metav1.TypeMeta{Kind: "CephObjectStore", APIVersion: v1.SchemeGroupVersion.String()}})
+	err = c.Watch(objectStoreKind, eventHandler, predicateController(ctx, mgr.GetClient()))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -115,8 +129,8 @@ func (r *ReconcileBucket) Reconcile(context context.Context, request reconcile.R
 
 func (r *ReconcileBucket) reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// See if there is a CephCluster
-	cephCluster := &cephv1.CephCluster{}
-	err := r.client.Get(r.opManagerContext, request.NamespacedName, cephCluster)
+	cephClusters := &cephv1.CephClusterList{}
+	err := r.client.List(r.opManagerContext, cephClusters, &client.ListOptions{Namespace: request.Namespace})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.Infof("no ceph cluster found in %+v. not deploying the bucket provisioner", request.NamespacedName)
@@ -125,6 +139,14 @@ func (r *ReconcileBucket) reconcile(request reconcile.Request) (reconcile.Result
 		// Error reading the object - requeue the request.
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to get the ceph cluster")
 	}
+
+	//Do not nothing if no ceph cluster is present
+	if len(cephClusters.Items) == 0 {
+		logger.Debug("no ceph cluster found not provisioning buckets")
+		return reconcile.Result{}, nil
+	}
+	// there will be only one cephcluster per namespace
+	cephCluster := cephClusters.Items[0]
 
 	if !cephCluster.DeletionTimestamp.IsZero() {
 		logger.Debug("ceph cluster is being deleted, no need to reconcile the bucket provisioner")


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
For  clusters, 
If the Objecstore CR is updated with new  endpoints the existing object buckets were not updated with the updated endpoint

So adding a watcher so to object bucket so it reconcile with change of objectstore

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
