### PR TITLE
pool: Add .mgr pool to the stretch cluster examples

### DIFF
--- a/deploy/examples/cluster-stretched-aws.yaml
+++ b/deploy/examples/cluster-stretched-aws.yaml
@@ -25,11 +25,11 @@ spec:
       # https://rook.io/docs/rook/latest/CRDs/ceph-cluster-crd/#osd-topology.
       failureDomainLabel: topology.kubernetes.io/zone
       # The sub failure domain is the secondary level at which the data will be placed to maintain data durability and availability.
-      # The default is "host", which means that each OSD must be on a different node and you would need at least two nodes per zone.
-      # If the subFailureDomain is set to "osd", the OSDs would be allowed anywhere in the same zone including on the same node.
+      # Since OSDs are portable, the default is "osd", which means that you would need at least two nodes per zone.
+      # If the subFailureDomain is set to "host", the OSDs should not be portable.
       # If set to "rack" or some other intermediate failure domain, those labels would also need to be set on the nodes where
       # the osds are started.
-      subFailureDomain: host
+      subFailureDomain: osd
       zones:
         - name: us-east-2a
           arbiter: true
@@ -141,3 +141,17 @@ spec:
     mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  name: .mgr
+  failureDomain: zone
+  replicated:
+    size: 4
+    requireSafeReplicaSize: true
+    replicasPerFailureDomain: 2
+    subFailureDomain: osd

--- a/deploy/examples/cluster-stretched.yaml
+++ b/deploy/examples/cluster-stretched.yaml
@@ -79,3 +79,17 @@ spec:
     mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  name: .mgr
+  failureDomain: zone
+  replicated:
+    size: 4
+    requireSafeReplicaSize: true
+    replicasPerFailureDomain: 2
+    subFailureDomain: host


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The stretch clusters must create pools with a pool spec that is valid for the stretch scenario, with 4 replicas and failure domain and sub failure domain as needed to match the topology. Otherwise, ceph will create a default .mgr pool which will have replica 3 which is invalid for the stretch scenario.

**Which issue is resolved by this Pull Request:**
Resolves #12356

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
