### PR TITLE
mon: allow changing hostNetwork settings

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -8420,7 +8420,8 @@ NetworkProviderType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Provider is what provides network connectivity to the cluster e.g. &ldquo;host&rdquo; or &ldquo;multus&rdquo;</p>
+<p>Provider is what provides network connectivity to the cluster e.g. &ldquo;host&rdquo; or &ldquo;multus&rdquo;.
+If the Provider is updated from being empty to &ldquo;host&rdquo; on a running cluster, then the operator will automatically fail over all the mons to apply the &ldquo;host&rdquo; network settings.</p>
 </td>
 </tr>
 <tr>
@@ -8492,7 +8493,9 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>HostNetwork to enable host network</p>
+<p>HostNetwork to enable host network.
+If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to
+apply the new network settings.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/Storage-Configuration/Advanced/ceph-mon-health.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-mon-health.md
@@ -115,3 +115,10 @@ $ ceph -s
     osd: 3 osds: 3 up (since 10m), 3 in (since 10m)
 [...]
 ```
+
+## Automatic Monitor Failover
+
+Rook will automatically fail over the mons when the following settings are updated in the CephCluster CR:
+- `spec.network.hostNetwork`: When enabled or disabled, Rook fails over all monitors, configuring them to enable or disable host networking.
+- `spec.network.Provider` : When updated from being empty to "host", Rook fails over all monitors, configuring them to enable or disable host networking.
+- `spec.network.multiClusterService`: When enabled or disabled, Rook fails over all monitors, configuring them to start (or stop) using service IPs compatible with the multi-cluster service.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2232,7 +2232,7 @@ spec:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network
+                      description: HostNetwork to enable host network. If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to apply the new network settings.
                       type: boolean
                     ipFamily:
                       description: IPFamily is the single stack IPv6 or IPv4 protocol
@@ -2252,7 +2252,7 @@ spec:
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus"
+                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus". If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.
                       enum:
                         - ""
                         - host

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2230,7 +2230,7 @@ spec:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network
+                      description: HostNetwork to enable host network. If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to apply the new network settings.
                       type: boolean
                     ipFamily:
                       description: IPFamily is the single stack IPv6 or IPv4 protocol
@@ -2250,7 +2250,7 @@ spec:
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus"
+                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus". If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.
                       enum:
                         - ""
                         - host

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2317,7 +2317,8 @@ type SSSDSidecarAdditionalFile struct {
 // NetworkSpec for Ceph includes backward compatibility code
 // +kubebuilder:validation:XValidation:message="at least one network selector must be specified when using multus",rule="!has(self.provider) || (self.provider != 'multus' || (self.provider == 'multus' && size(self.selectors) > 0))"
 type NetworkSpec struct {
-	// Provider is what provides network connectivity to the cluster e.g. "host" or "multus"
+	// Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
+	// If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.
 	// +kubebuilder:validation:XValidation:message="network provider must be disabled (reverted to empty string) before a new provider is enabled",rule="self == '' || self == oldSelf"
 	// +nullable
 	// +optional
@@ -2363,7 +2364,9 @@ type NetworkSpec struct {
 	// +optional
 	Connections *ConnectionsSpec `json:"connections,omitempty"`
 
-	// HostNetwork to enable host network
+	// HostNetwork to enable host network.
+	// If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to
+	// apply the new network settings.
 	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 


### PR DESCRIPTION
Allow changing `spec.network.hostNetwork/spec.network.provider:host` settings on a running cluster by failing over mons

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
If `spec.Network.HostNetwork/spec.network.provider:host` settings are changed on a running cluster, then user needs to manually failover the mons because they are using service network. This PR allows to failover mons automatically during the health check if the user has toggled the HostNetwork settings. 

**Which issue is resolved by this Pull Request:**
Resolves #11748

Tested on Local multi node minikube cluster:
Without host network:

```

❯ oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-fr8ml                                   2/2     Running     0          18m
csi-cephfsplugin-klz56                                   2/2     Running     0          18m
csi-cephfsplugin-provisioner-84cc595b78-25h5g            5/5     Running     0          18m
csi-cephfsplugin-provisioner-84cc595b78-cztrz            5/5     Running     0          18m
csi-cephfsplugin-s2nlr                                   2/2     Running     0          18m
csi-cephfsplugin-x6xd9                                   2/2     Running     0          18m
csi-rbdplugin-2wv7d                                      2/2     Running     0          18m
csi-rbdplugin-d8gkn                                      2/2     Running     0          18m
csi-rbdplugin-ftzl9                                      2/2     Running     0          18m
csi-rbdplugin-provisioner-6f6b6b8cd6-p5hn2               5/5     Running     0          18m
csi-rbdplugin-provisioner-6f6b6b8cd6-z5l64               5/5     Running     0          18m
csi-rbdplugin-sx7lf                                      2/2     Running     0          18m
rook-ceph-crashcollector-minikube-c59574b89-cjdmw        1/1     Running     0          16m
rook-ceph-crashcollector-minikube-m02-d479f7977-sbzx7    1/1     Running     0          16m
rook-ceph-crashcollector-minikube-m03-85f7494b46-nqzsm   1/1     Running     0          16m
rook-ceph-crashcollector-minikube-m04-5bd75b99f5-ztdkg   1/1     Running     0          16m
rook-ceph-mgr-a-c54c8c4b4-7rjpv                          3/3     Running     0          17m
rook-ceph-mgr-b-ccd5df64c-6qcxj                          3/3     Running     0          17m
rook-ceph-mon-a-66fb84c656-tg745                         2/2     Running     0          18m
rook-ceph-mon-b-7b695cdd5f-5qb44                         2/2     Running     0          17m
rook-ceph-mon-c-7847b5679f-pkddb                         2/2     Running     0          17m
rook-ceph-operator-f46fcbc97-cxl9z                       1/1     Running     0          18m
rook-ceph-osd-0-68fd99c57d-cm9ll                         2/2     Running     0          16m
rook-ceph-osd-1-655f8cf46d-k6262                         2/2     Running     0          16m
rook-ceph-osd-2-758d57dd9b-6zzlf                         2/2     Running     0          16m
rook-ceph-osd-3-6cc8c86b4-cft9r                          2/2     Running     0          16m
rook-ceph-osd-prepare-minikube-d2mq6                     0/1     Completed   0          15m
rook-ceph-osd-prepare-minikube-m02-z4ztc                 0/1     Completed   0          15m
rook-ceph-osd-prepare-minikube-m03-f8s26                 0/1     Completed   0          15m
rook-ceph-osd-prepare-minikube-m04-cllll                 0/1     Completed   0          15m
rook-ceph-tools-9b7967b5d-kwncx                          1/1     Running     0          18m


sh-4.4$ ceph status 
  cluster:
    id:     a59b8e0a-949b-49f4-ad72-6ec1268c0bf8
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 18m)
    mgr: a(active, since 15m), standbys: b
    osd: 4 osds: 4 up (since 16m), 4 in (since 17m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 26 objects, 19 MiB
    usage:   113 MiB used, 40 GiB / 40 GiB avail
    pgs:     33 active+clean
 
  io:
    client:   9.3 KiB/s wr, 0 op/s rd, 1 op/s wr
 
sh-4.4$ 

Ceph Mon Endpoints:

apiVersion: v1
data:
  csi-cluster-config-json: '[{"clusterID":"rook-ceph","monitors":["10.103.227.236:6789","10.111.148.197:6789","10.104.239.146:6789"],"namespace":""}]'
  data: a=10.111.148.197:6789,b=10.104.239.146:6789,c=10.103.227.236:6789
  mapping: '{"node":{"a":{"Name":"minikube-m04","Hostname":"minikube-m04","Address":"192.168.39.54"},"b":{"Name":"minikube-m02","Hostname":"minikube-m02","Address":"192.168.39.174"},"c":{"Name":"minikube-m03","Hostname":"minikube-m03","Address":"192.168.39.221"}}}'
  maxMonId: "2"
  outOfQuorum: ""
kind: ConfigMap


❯ oc get service -n rook-ceph | grep mon
rook-ceph-mon-a           ClusterIP   10.111.148.197   <none>        6789/TCP,3300/TCP   20m
rook-ceph-mon-b           ClusterIP   10.104.239.146   <none>        6789/TCP,3300/TCP   19m
rook-ceph-mon-c           ClusterIP   10.103.227.236   <none>        6789/TCP,3300/TCP   19m

```


Enabled hostnetwork on a running cluster:

```
❯ oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS        AGE
csi-cephfsplugin-fr8ml                                   2/2     Running     0               33m
csi-cephfsplugin-klz56                                   2/2     Running     0               33m
csi-cephfsplugin-provisioner-84cc595b78-25h5g            5/5     Running     0               33m
csi-cephfsplugin-provisioner-84cc595b78-cztrz            5/5     Running     0               33m
csi-cephfsplugin-s2nlr                                   2/2     Running     0               33m
csi-cephfsplugin-x6xd9                                   2/2     Running     0               33m
csi-rbdplugin-2wv7d                                      2/2     Running     0               33m
csi-rbdplugin-d8gkn                                      2/2     Running     0               33m
csi-rbdplugin-ftzl9                                      2/2     Running     0               33m
csi-rbdplugin-provisioner-6f6b6b8cd6-p5hn2               5/5     Running     0               33m
csi-rbdplugin-provisioner-6f6b6b8cd6-z5l64               5/5     Running     0               33m
csi-rbdplugin-sx7lf                                      2/2     Running     0               33m
rook-ceph-crashcollector-minikube-dc65f5b84-k2mhg        1/1     Running     0               8m10s
rook-ceph-crashcollector-minikube-m02-b669d59bd-8sw59    1/1     Running     0               9m58s
rook-ceph-crashcollector-minikube-m03-77484b9649-ndspl   1/1     Running     0               9m59s
rook-ceph-crashcollector-minikube-m04-8f6486b5d-9928t    1/1     Running     0               9m56s
rook-ceph-mgr-a-778fdfccc9-6pd7v                         3/3     Running     1 (2m21s ago)   9m32s
rook-ceph-mgr-b-d8dc988-g5pdw                            3/3     Running     1 (2m25s ago)   9m7s
rook-ceph-mon-d-6647ccfcb9-ghtzz                         2/2     Running     0               5m41s
rook-ceph-mon-e-794b476fc5-v5tf5                         2/2     Running     0               4m19s
rook-ceph-mon-f-d995d6db9-9bz4b                          2/2     Running     0               2m55s
rook-ceph-operator-f46fcbc97-cxl9z                       1/1     Running     0               34m
rook-ceph-osd-0-f685f9857-4jmwj                          2/2     Running     0               6m55s
rook-ceph-osd-1-84c947598f-8wxgn                         2/2     Running     0               8m10s
rook-ceph-osd-2-55467bd9f7-fk2sr                         2/2     Running     0               7m46s
rook-ceph-osd-3-f7f499dd9-h8j5z                          2/2     Running     0               7m21s
rook-ceph-osd-prepare-minikube-m02-t76vv                 0/1     Completed   0               94s
rook-ceph-osd-prepare-minikube-m03-6qxq2                 0/1     Completed   0               91s
rook-ceph-osd-prepare-minikube-m04-jtt47                 0/1     Completed   0               88s
rook-ceph-osd-prepare-minikube-qw5ht                     0/1     Completed   0               97s
rook-ceph-tools-9b7967b5d-kwncx                          1/1     Running     0               33m



oc exec -it -n rook-ceph rook-ceph-tools-9b7967b5d-kwncx sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
sh-4.4$ ceph status 
  cluster:
    id:     a59b8e0a-949b-49f4-ad72-6ec1268c0bf8
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum d,e,f (age 11s)
    mgr: a(active, since 103s), standbys: b
    osd: 4 osds: 4 up (since 4m), 4 in (since 30m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 27 objects, 22 MiB
    usage:   136 MiB used, 40 GiB / 40 GiB avail
    pgs:     33 active+clean
 
  io:
    client:   18 KiB/s wr, 0 op/s rd, 1 op/s wr
 
sh-4.4$ 


Configmap got updated to use correct IPs:
 oc get cm rook-ceph-mon-endpoints -n rook-ceph -o yaml
apiVersion: v1
data:
  csi-cluster-config-json: '[{"clusterID":"rook-ceph","monitors":["192.168.39.133:6789","192.168.39.221:6789","192.168.39.54:6789"],"namespace":""}]'
  data: d=192.168.39.133:6789,e=192.168.39.221:6789,f=192.168.39.54:6789
  mapping: '{"node":{"d":{"Name":"minikube","Hostname":"minikube","Address":"192.168.39.133"},"e":{"Name":"minikube-m03","Hostname":"minikube-m03","Address":"192.168.39.221"},"f":{"Name":"minikube-m04","Hostname":"minikube-m04","Address":"192.168.39.54"}}}'
  maxMonId: "5"
  outOfQuorum: ""
kind: ConfigMap


No mon services are available:
❯ oc get service -n rook-ceph | grep mon

```
------------------------------------------------

Hostnetwork disabled again:

```
oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS      AGE
csi-cephfsplugin-fr8ml                                   2/2     Running     0             63m
csi-cephfsplugin-klz56                                   2/2     Running     0             63m
csi-cephfsplugin-provisioner-84cc595b78-25h5g            5/5     Running     4 (21m ago)   63m
csi-cephfsplugin-provisioner-84cc595b78-cztrz            5/5     Running     0             63m
csi-cephfsplugin-s2nlr                                   2/2     Running     0             63m
csi-cephfsplugin-x6xd9                                   2/2     Running     0             63m
csi-rbdplugin-2wv7d                                      2/2     Running     0             63m
csi-rbdplugin-d8gkn                                      2/2     Running     0             63m
csi-rbdplugin-ftzl9                                      2/2     Running     0             63m
csi-rbdplugin-provisioner-6f6b6b8cd6-p5hn2               5/5     Running     0             63m
csi-rbdplugin-provisioner-6f6b6b8cd6-z5l64               5/5     Running     4 (21m ago)   63m
csi-rbdplugin-sx7lf                                      2/2     Running     0             63m
rook-ceph-crashcollector-minikube-c59574b89-h9k9f        1/1     Running     1 (21m ago)   28m
rook-ceph-crashcollector-minikube-m02-d479f7977-cgmxj    1/1     Running     0             28m
rook-ceph-crashcollector-minikube-m03-85f7494b46-45wpx   1/1     Running     0             28m
rook-ceph-crashcollector-minikube-m04-5bd75b99f5-2pnkw   1/1     Running     0             27m
rook-ceph-mgr-a-c54c8c4b4-g222p                          3/3     Running     1 (13m ago)   27m
rook-ceph-mgr-b-ccd5df64c-rgghm                          3/3     Running     1 (14m ago)   27m
rook-ceph-mon-g-ffd5f8844-ppldc                          2/2     Running     0             17m
rook-ceph-mon-h-786bbd75c4-z22pn                         2/2     Running     0             15m
rook-ceph-mon-i-6d6d599986-hpkcr                         2/2     Running     0             14m
rook-ceph-operator-f46fcbc97-cxl9z                       1/1     Running     0             63m
rook-ceph-osd-0-68fd99c57d-5fjv2                         2/2     Running     0             25m
rook-ceph-osd-1-655f8cf46d-ltgpj                         2/2     Running     0             26m
rook-ceph-osd-2-758d57dd9b-tgcgb                         2/2     Running     0             25m
rook-ceph-osd-3-6cc8c86b4-qjxf7                          2/2     Running     0             25m
rook-ceph-osd-prepare-minikube-dhzw2                     0/1     Completed   0             13m
rook-ceph-osd-prepare-minikube-m02-l2s9b                 0/1     Completed   0             12m
rook-ceph-osd-prepare-minikube-m03-drc5p                 0/1     Completed   0             12m
rook-ceph-osd-prepare-minikube-m04-k2m2p                 0/1     Completed   0             12m
rook-ceph-tools-9b7967b5d-kwncx                          1/1     Running     0             63m


❯ oc exec -it -n rook-ceph rook-ceph-tools-9b7967b5d-kwncx sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
sh-4.4$ ceph status 
  cluster:
    id:     a59b8e0a-949b-49f4-ad72-6ec1268c0bf8
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum g,h,i (age 14m)
    mgr: a(active, since 12m), standbys: b
    osd: 4 osds: 4 up (since 18m), 4 in (since 62m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 29 objects, 31 MiB
    usage:   226 MiB used, 40 GiB / 40 GiB avail
    pgs:     33 active+clean
 
  io:
    client:   7.0 KiB/s wr, 0 op/s rd, 0 op/s wr
 
sh-4.4$ 


 oc get cm rook-ceph-mon-endpoints -n rook-ceph -o yaml
apiVersion: v1
data:
  csi-cluster-config-json: '[{"clusterID":"rook-ceph","monitors":["10.109.126.217:6789","10.99.149.128:6789","10.96.165.167:6789"],"namespace":""}]'
  data: h=10.109.126.217:6789,i=10.99.149.128:6789,g=10.96.165.167:6789
  mapping: '{"node":{"g":{"Name":"minikube-m02","Hostname":"minikube-m02","Address":"192.168.39.174"},"h":{"Name":"minikube-m03","Hostname":"minikube-m03","Address":"192.168.39.221"},"i":{"Name":"minikube","Hostname":"minikube","Address":"192.168.39.133"}}}'
  maxMonId: "8"
  outOfQuorum: ""


❯ oc get service -n rook-ceph | grep mon
rook-ceph-mon-g           ClusterIP   10.96.165.167    <none>        6789/TCP,3300/TCP   18m
rook-ceph-mon-h           ClusterIP   10.109.126.217   <none>        6789/TCP,3300/TCP   16m
rook-ceph-mon-i           ClusterIP   10.99.149.128    <none>        6789/TCP,3300/TCP   15m
```








**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
