### PR TITLE
operator:Add ceph image version label to PVC

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -83,6 +83,14 @@ func testPrepareDeviceSets(t *testing.T, setTemplateName bool) {
 	}
 	assert.Equal(t, fmt.Sprintf("mydata-%s-0", expectedName), pvcs.Items[0].GenerateName)
 	assert.Equal(t, cluster.clusterInfo.Namespace, pvcs.Items[0].Namespace)
+
+	//Verify that the PVC has correct Image Version Label
+	cephImageVersion := createValidImageVersionLabel(cluster.spec.CephVersion.Image)
+	for _, item := range pvcs.Items {
+		val, exist := item.Labels[CephImageLabelKey]
+		assert.Equal(t, true, exist)
+		assert.Equal(t, cephImageVersion, val)
+	}
 }
 
 func TestPrepareDeviceSetWithHolesInPVCs(t *testing.T) {
@@ -283,4 +291,13 @@ func TestPVCName(t *testing.T) {
 
 	id = deviceSetPVCID("device.set.with.dots", "b", 10)
 	assert.Equal(t, "device-set-with-dots-b-10", id)
+}
+
+func TestCreateValidImageVersionLabel(t *testing.T) {
+	image := "ceph/ceph:v17.2.6"
+	assert.Equal(t, "ceph_ceph_v17.2.6", createValidImageVersionLabel(image))
+	image = "rook/ceph:master"
+	assert.Equal(t, "rook_ceph_master", createValidImageVersionLabel(image))
+	image = ".invalid_label"
+	assert.Equal(t, "", createValidImageVersionLabel(image))
 }

--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -36,13 +36,19 @@ const (
 	OSDOverPVCLabelKey = "ceph.rook.io/pvc"
 	// TopologyLocationLabel is the crush location label added to OSD deployments
 	TopologyLocationLabel = "topology-location-%s"
+	// CephImageLabelKey is the ceph image version label added to PVC
+	CephImageLabelKey = "ceph.rook.io/cephImageAtCreation"
+	// RookImageLabelKey is the rook image version label added to PVC
+	RookImageLabelKey = "ceph.rook.io/rookImageAtCreation"
 )
 
-func makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId string, setIndex int) map[string]string {
+func makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId string, setIndex int, cephImage string, rookImage string) map[string]string {
 	return map[string]string{
 		CephDeviceSetLabelKey:      storageClassDeviceSetName,
 		CephSetIndexLabelKey:       fmt.Sprintf("%d", setIndex),
 		CephDeviceSetPVCIDLabelKey: pvcStorageClassDeviceSetPVCId,
+		CephImageLabelKey:          cephImage,
+		RookImageLabelKey:          rookImage,
 	}
 }
 


### PR DESCRIPTION
**Description of your changes:**

This PR makes it possible to know the Ceph image version from PVC for OSD. 

It's useful to know whether users are affected by OSD bugs that only exist in specific versions. Although ceph has a similar function introduced in [ceph/ceph#48298](https://github.com/ceph/ceph/pull/48298), we need to get this information by executing the ceph osd metadata command. In addition, it's better to store not ceph binary version than the container image version.


**Which issue is resolved by this Pull Request:**

Similar Issue
https://github.com/rook/rook/issues/11059

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
