### PR TITLE
ci: add missing closing bracket in the script

### DIFF
--- a/.github/workflows/build_dependabot_bundler_pr.yml
+++ b/.github/workflows/build_dependabot_bundler_pr.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Commit and copy changes
         run: |
-          if [[ $(git status | grep -E '(go.mod|go.sum)' ]]; then
+          if [[ $(git status | grep -E '(go.mod|go.sum)') ]]; then
             git add go.mod go.sum pkg/apis/go.mod pkg/apis/go.sum
             git commit -m "[dependabot skip] Update Golang Modules"
             git format-patch -n HEAD^ --binary --stdout > ./dependabot-pr/changes.patch


### PR DESCRIPTION
there is error in the script to check if there
is any changes on go.mod or go.sum line.

```
/home/runner/work/_temp/dc877811-e494-4d57-ab19-a37942eac23d.sh: line 1: unexpected EOF while looking for matching `)'
```

instead of this `if [[ $(git status | grep -E '(go.mod|go.sum)' ]]; then` it will be `if [[ $(git status | grep -E '(go.mod|go.sum)') ]]; then`

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
