### PR TITLE
ci: update the minimum kubernetes version supported

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.27.1
+        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.27.3
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.27.1"]
+        kubernetes-versions: ["v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.27.1"]
+        kubernetes-versions: ["v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.23.15", "v1.24.10", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.23.10", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.21.14", "v1.27.1"]
+        kubernetes-versions: ["v1.22.17", "v1.27.2"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -7,7 +7,7 @@ and Rook is granted the required privileges (see below for more information).
 
 ## Minimum Version
 
-Kubernetes **v1.21** or higher is supported.
+Kubernetes **v1.22** or higher is supported.
 
 ## CPU Architecture
 

--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -12,7 +12,7 @@ This guide will walk through the basic setup of a Ceph cluster and enable K8s ap
 
 ## Minimum Version
 
-Kubernetes **v1.21** or higher is supported by Rook.
+Kubernetes **v1.22** or higher is supported by Rook.
 
 ## CPU Architecture
 

--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -13,7 +13,7 @@ This chart is a simple packaging of templates that will optionally create Rook r
 
 ## Prerequisites
 
-* Kubernetes 1.19+
+* Kubernetes 1.22+
 * Helm 3.x
 * Install the [Rook Operator chart](operator-chart.md)
 

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -16,7 +16,7 @@ This chart is a simple packaging of templates that will optionally create Rook r
 
 ## Prerequisites
 
-* Kubernetes 1.19+
+* Kubernetes 1.22+
 * Helm 3.x
 * Install the [Rook Operator chart](operator-chart.md)
 

--- a/Documentation/Helm-Charts/operator-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/operator-chart.gotmpl.md
@@ -11,7 +11,7 @@ This chart bootstraps a [rook-ceph-operator](https://github.com/rook/rook) deplo
 
 ## Prerequisites
 
-* Kubernetes 1.19+
+* Kubernetes 1.22+
 * Helm 3.x
 
 See the [Helm support matrix](https://helm.sh/docs/topics/version_skew/) for more details.

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -14,7 +14,7 @@ This chart bootstraps a [rook-ceph-operator](https://github.com/rook/rook) deplo
 
 ## Prerequisites
 
-* Kubernetes 1.19+
+* Kubernetes 1.22+
 * Helm 3.x
 
 See the [Helm support matrix](https://helm.sh/docs/topics/version_skew/) for more details.

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -48,7 +48,7 @@ those releases.
 
 ## Breaking changes in v1.12
 
-* The minimum supported version of Kubernetes is v1.21.0.
+* The minimum supported version of Kubernetes is v1.22.
 
 ## Considerations
 


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
For v1.12 update the minimum K8s version supported to v1.22, to continue running CI against the most recent six K8s versions for the latest release.

**Which issue is resolved by this Pull Request:**
Resolves #12365 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
