### PR TITLE
Fix confusing successful message when reconciling CephObjectStoreUser

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		logger.Debugf("ObjectStore resource not ready in namespace %q, retrying in %q. %v",
 			request.NamespacedName.Namespace, opcontroller.WaitForRequeueIfCephClusterNotReady.RequeueAfter.String(), err)
 		r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, k8sutil.ReconcileFailedStatus)
-		return opcontroller.WaitForRequeueIfCephClusterNotReady, *cephObjectStoreUser, nil
+		return opcontroller.WaitForRequeueIfCephClusterNotReady, *cephObjectStoreUser, err
 	}
 
 	// Generate user config


### PR DESCRIPTION
**Description of your changes:**

When creating a CephObjectStoreUser with a value spec.store that refers to an unexisting CephObjectStore, after the reconciliation loop the CephObjectStoreUser is in the ReconcileFailed state. However, a ReconcileSucceeded event is created with this message:

"successfully configured CephObjectStoreUser"

The success message results of the return value for the error which is currently `nil`. Let's replace it with the error message.

After the change, the event created is:

```txt
Status:
  Phase:  ReconcileFailed
Events:
  Type     Reason           Age              From                                    Message
  ----     ------           ----             ----                                    -------
  Warning  ReconcileFailed  2s (x2 over 4s)  rook-ceph-object-store-user-controller  failed to reconcile CephObjectStoreUser "rook-ceph/username". failed to detect if object store "this-objectstore-does-not-exist" is initialized: CephObjectStore "this-objectstore-does-not-exist" could not be found
```

**Which issue is resolved by this Pull Request:**
Resolves #12395

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
