### PR TITLE
core: fix deletion of exporter service monitor

### DIFF
--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -109,11 +109,16 @@ func DeleteServiceMonitor(ctx context.Context, ns string, name string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get monitoring client. %v", err)
 	}
-	err = client.MonitoringV1().ServiceMonitors(ns).Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil {
-		if kerror.IsNotFound(err) {
-			return nil
+	existingSvcMonitor, err := client.MonitoringV1().ServiceMonitors(ns).Get(ctx, name, metav1.GetOptions{})
+	if existingSvcMonitor != nil {
+		err = client.MonitoringV1().ServiceMonitors(ns).Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil {
+			if kerror.IsNotFound(err) {
+				return nil
+			}
 		}
+	} else {
+		return fmt.Errorf("failed to get non-existing service monitor %q. %v", name, err)
 	}
 	return err
 }


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Delete the service monitor for ceph exporter only if there's an existing ServiceMonitor with the given name

**Which issue is resolved by this Pull Request:**
Resolves #12335

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
