### PR TITLE
exporter: Ignore failed deletion of service monitor

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -15,6 +15,7 @@
         "core",
         "csi",
         "docs",
+        "exporter",
         "external",
         "file",
         "helm",

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -515,7 +515,7 @@ func (c *Cluster) EnableServiceMonitor() error {
 
 	applyMonitoringLabels(c, serviceMonitor)
 
-	if _, err = k8sutil.CreateOrUpdateServiceMonitor(c.clusterInfo.Context, serviceMonitor); err != nil {
+	if _, err = k8sutil.CreateOrUpdateServiceMonitor(c.context, c.clusterInfo.Context, serviceMonitor); err != nil {
 		return errors.Wrap(err, "service monitor could not be enabled")
 	}
 	return nil

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
@@ -219,7 +220,7 @@ func MakeCephExporterMetricsService(cephCluster cephv1.CephCluster, servicePortM
 }
 
 // EnableCephExporterServiceMonitor add a servicemonitor that allows prometheus to scrape from the monitoring endpoint of the exporter
-func EnableCephExporterServiceMonitor(cephCluster cephv1.CephCluster, scheme *runtime.Scheme, opManagerContext context.Context) error {
+func EnableCephExporterServiceMonitor(context *clusterd.Context, cephCluster cephv1.CephCluster, scheme *runtime.Scheme, opManagerContext context.Context) error {
 	serviceMonitor := k8sutil.GetServiceMonitor(cephExporterAppName, cephCluster.Namespace)
 	cephv1.GetCephExporterLabels(cephCluster.Spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 
@@ -230,7 +231,7 @@ func EnableCephExporterServiceMonitor(cephCluster cephv1.CephCluster, scheme *ru
 	serviceMonitor.Spec.Selector.MatchLabels = controller.AppLabels(cephExporterAppName, cephCluster.Namespace)
 	applyCephExporterLabels(cephCluster, serviceMonitor)
 
-	if _, err = k8sutil.CreateOrUpdateServiceMonitor(opManagerContext, serviceMonitor); err != nil {
+	if _, err = k8sutil.CreateOrUpdateServiceMonitor(context, opManagerContext, serviceMonitor); err != nil {
 		return errors.Wrap(err, "service monitor could not be enabled")
 	}
 	return nil

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -86,9 +86,9 @@ func (r *ReconcileNode) Reconcile(context context.Context, request reconcile.Req
 }
 
 func (r *ReconcileNode) cleanupExporterResources(clusterNamespace string, ns string, nodeName string) (reconcile.Result, error) {
-	err := k8sutil.DeleteServiceMonitor(r.opManagerContext, ns, cephExporterAppName)
+	err := k8sutil.DeleteServiceMonitor(r.context, r.opManagerContext, ns, cephExporterAppName)
 	if err != nil {
-		logger.Debugf("failed to delete service monitor for ceph exporter in namespace %q on node %q", ns, nodeName)
+		logger.Debugf("failed to delete service monitor for ceph exporter in namespace %q on node %q. %v", ns, nodeName, err)
 	}
 	err = k8sutil.DeleteService(r.opManagerContext, r.context.Clientset, r.opConfig.OperatorNamespace, cephExporterAppName)
 	if err != nil {
@@ -271,7 +271,7 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 				}
 
 				if cephCluster.Spec.Monitoring.Enabled {
-					if err := EnableCephExporterServiceMonitor(cephCluster, r.scheme, r.opManagerContext); err != nil {
+					if err := EnableCephExporterServiceMonitor(r.context, cephCluster, r.scheme, r.opManagerContext); err != nil {
 						return errors.Wrap(err, "failed to enable service monitor")
 					}
 					logger.Debug("service monitor for ceph exporter was enabled successfully")

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -21,20 +21,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"github.com/rook/rook/pkg/clusterd"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-func getMonitoringClient() (*monitoringclient.Clientset, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to build config. %v", err)
-	}
-	client, err := monitoringclient.NewForConfig(cfg)
+func getMonitoringClient(context *clusterd.Context) (*monitoringclient.Clientset, error) {
+	client, err := monitoringclient.NewForConfig(context.KubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get monitoring client. %v", err)
 	}
@@ -75,11 +72,11 @@ func GetServiceMonitor(name string, namespace string) *monitoringv1.ServiceMonit
 }
 
 // CreateOrUpdateServiceMonitor creates serviceMonitor object or an error
-func CreateOrUpdateServiceMonitor(ctx context.Context, serviceMonitorDefinition *monitoringv1.ServiceMonitor) (*monitoringv1.ServiceMonitor, error) {
+func CreateOrUpdateServiceMonitor(context *clusterd.Context, ctx context.Context, serviceMonitorDefinition *monitoringv1.ServiceMonitor) (*monitoringv1.ServiceMonitor, error) {
 	name := serviceMonitorDefinition.GetName()
 	namespace := serviceMonitorDefinition.GetNamespace()
 	logger.Debugf("creating servicemonitor %s", name)
-	client, err := getMonitoringClient()
+	client, err := getMonitoringClient(context)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get monitoring client. %v", err)
 	}
@@ -104,16 +101,23 @@ func CreateOrUpdateServiceMonitor(ctx context.Context, serviceMonitorDefinition 
 }
 
 // DeleteServiceMonitor deletes a ServiceMonitor and returns the error if any
-func DeleteServiceMonitor(ctx context.Context, ns string, name string) error {
-	client, err := getMonitoringClient()
+func DeleteServiceMonitor(context *clusterd.Context, ctx context.Context, ns string, name string) error {
+	client, err := getMonitoringClient(context)
 	if err != nil {
 		return fmt.Errorf("failed to get monitoring client. %v", err)
+	}
+	_, err = client.MonitoringV1().ServiceMonitors(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		// Either the service monitor does not exist or there are not privileges to detect it
+		// so we ignore any errors
+		return nil
 	}
 	err = client.MonitoringV1().ServiceMonitors(ns).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if kerror.IsNotFound(err) {
 			return nil
 		}
+		return errors.Wrapf(err, "failed to delete service monitor %q", name)
 	}
-	return err
+	return nil
 }

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -108,7 +108,7 @@ func DeleteServiceMonitor(context *clusterd.Context, ctx context.Context, ns str
 	}
 	_, err = client.MonitoringV1().ServiceMonitors(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		// Either the service monitor does not exist or there are not privileges to detect it
+		// Either the service monitor does not exist or there are no privileges to detect it
 		// so we ignore any errors
 		return nil
 	}


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
If the ceph version does not suppport the exporter, the operator will attempt to delete the service monitor related to the exporter to ensure it does not exist for a node. If the expected rbac does not exist, this will cause unnecessary errors since there would anyway be no service monitor to delete. So we ignore the error of deleting the service monitor for the exporter.

The context is also passed to the exporter so a new kubeconfig does not need to be initiated and cause unnecessary logging about invalid options for the config. The invalid context error was causing many of these errors in the log:
```
W0626 18:00:17.526858       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
```

**Which issue is resolved by this Pull Request:**
Resolves #12335

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
