### PR TITLE
csi: update cephcsi to v3.9.0 and k8s-sidecar to v0.7.0

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.cephFSFSGroupPolicy` | Policy for modifying a volume's ownership or permissions when the CephFS PVC is being mounted. supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html | `"File"` |
 | `csi.cephFSKernelMountOptions` | Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options. Set to "ms_mode=secure" when connections.encrypted is enabled in CephCluster CR | `nil` |
 | `csi.cephFSPluginUpdateStrategy` | CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
-| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.8.0` |
+| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.9.0` |
 | `csi.cephfsGrpcMetricsPort` | CSI CephFS driver GRPC metrics port | `9091` |
 | `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port | `9081` |
 | `csi.cephfsPodLabels` | Labels to add to the CSI CephFS Deployments and DaemonSets Pods | `nil` |

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.cephfsPodLabels` | Labels to add to the CSI CephFS Deployments and DaemonSets Pods | `nil` |
 | `csi.clusterName` | Cluster name identifier to set as metadata on the CephFS subvolume and RBD images. This will be useful in cases like for example, when two container orchestrator clusters (Kubernetes/OCP) are using a single ceph cluster | `nil` |
 | `csi.csiAddons.enabled` | Enable CSIAddons | `false` |
-| `csi.csiAddons.image` | CSIAddons Sidecar image | `"quay.io/csiaddons/k8s-sidecar:v0.5.0"` |
+| `csi.csiAddons.image` | CSIAddons Sidecar image | `"quay.io/csiaddons/k8s-sidecar:v0.7.0"` |
 | `csi.csiAddonsPort` | CSI Addons server port | `9070` |
 | `csi.csiCephFSPluginResource` | CEPH CSI CephFS plugin resource requirement list | see values.yaml |
 | `csi.csiCephFSPluginVolume` | The volume of the CephCSI CephFS plugin DaemonSet | `nil` |

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
@@ -123,9 +123,9 @@ The CSI-Addons Controller handles the requests from users to initiate an operati
 Users can deploy the controller by running the following commands:
 
 ```console
-kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.5.0/deploy/controller/crds.yaml
-kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.5.0/deploy/controller/rbac.yaml
-kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.5.0/deploy/controller/setup-controller.yaml
+kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.7.0/deploy/controller/crds.yaml
+kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.7.0/deploy/controller/rbac.yaml
+kubectl create -f https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.7.0/deploy/controller/setup-controller.yaml
 ```
 
 This creates the required crds and configure permissions.
@@ -157,14 +157,15 @@ kubectl patch cm rook-ceph-operator-config -nrook-ceph -p $'data:\n "CSI_ENABLE_
 CSI-Addons supports the following operations:
 
 * Reclaim Space
-  * [Creating a ReclaimSpaceJob](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/reclaimspace.md#reclaimspacejob)
-  * [Creating a ReclaimSpaceCronJob](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/reclaimspace.md#reclaimspacecronjob)
-  * [Annotating PersistentVolumeClaims](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/reclaimspace.md#annotating-perstentvolumeclaims)
+  * [Creating a ReclaimSpaceJob](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/reclaimspace.md#reclaimspacejob)
+  * [Creating a ReclaimSpaceCronJob](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/reclaimspace.md#reclaimspacecronjob)
+  * [Annotating PersistentVolumeClaims](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/reclaimspace.md#annotating-perstentvolumeclaims)
+  * [Annotating Namespace](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/reclaimspace.md#annotating-namespace)
 * Network Fencing
-  * [Creating a NetworkFence](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/networkfence.md)
+  * [Creating a NetworkFence](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/networkfence.md)
 * Volume Replication
-  * [Creating VolumeReplicationClass](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/volumereplicationclass.md)
-  * [Creating VolumeReplication CR](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.5.0/docs/volumereplication.md)
+  * [Creating VolumeReplicationClass](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/volumereplicationclass.md)
+  * [Creating VolumeReplication CR](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.7.0/docs/volumereplication.md)
 
 ## Enable RBD Encryption Support
 

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -18,7 +18,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-ceph-operator-config
 The default upstream images are included below, which you can change to your desired images.
 
 ```yaml
-ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
+ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
 ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
 ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"
 ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"
@@ -32,7 +32,7 @@ ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.5.0"
 If image version is not passed along with the image name in any of the variables above,
 Rook will add the corresponding default version to that image.
 Example: if `ROOK_CSI_CEPH_IMAGE: "quay.io/private-repo/cephcsi"` is passed,
-Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.8.0"`.
+Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.9.0"`.
 
 ### **Use default images**
 

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -24,7 +24,7 @@ ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"
 ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"
 ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
 ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1"
-ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.5.0"
+ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.7.0"
 ```
 
 ### **Use private repository**

--- a/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
+++ b/Documentation/Storage-Configuration/NFS/nfs-csi-driver.md
@@ -5,9 +5,6 @@ title: CSI provisioner and driver
 !!! attention
     This feature is experimental and will not support upgrades to future versions.
 
-In version 1.9.1, Rook is able to deploy the experimental NFS Ceph CSI driver. This requires Ceph
-CSI version 3.7.0 or above. We recommend Ceph v16.2.7 or above.
-
 For this section, we will refer to Rook's deployment examples in the
 [deploy/examples](https://github.com/rook/rook/tree/master/deploy/examples) directory.
 

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -189,7 +189,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-cep
     If have not customized the CSI image versions, this is automatically updated.
 
 !!! important
-    The minimum supported version of Ceph-CSI is v3.7.0.
+    The minimum supported version of Ceph-CSI is v3.8.0.
 
 If you have specified custom CSI images, we recommended you update to the latest Ceph-CSI drivers.
 See the [CSI Custom Images](../Storage-Configuration/Ceph-CSI/custom-images.md) documentation.

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -514,7 +514,7 @@ csi:
     # -- Enable CSIAddons
     enabled: false
     # -- CSIAddons Sidecar image
-    image: "quay.io/csiaddons/k8s-sidecar:v0.5.0"
+    image: "quay.io/csiaddons/k8s-sidecar:v0.7.0"
 
   nfs:
     # -- Enable the nfs csi driver

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -470,7 +470,7 @@ csi:
 
   cephcsi:
     # -- Ceph CSI image
-    # @default -- `quay.io/cephcsi/cephcsi:v3.8.0`
+    # @default -- `quay.io/cephcsi/cephcsi:v3.9.0`
     image:
 
   registrar:

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,5 +1,5 @@
  quay.io/ceph/ceph:v17.2.6
- quay.io/cephcsi/cephcsi:v3.8.0
+ quay.io/cephcsi/cephcsi:v3.9.0
  quay.io/csiaddons/k8s-sidecar:v0.5.0
  registry.k8s.io/sig-storage/csi-attacher:v4.1.0
  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,6 +1,6 @@
  quay.io/ceph/ceph:v17.2.6
  quay.io/cephcsi/cephcsi:v3.9.0
- quay.io/csiaddons/k8s-sidecar:v0.5.0
+ quay.io/csiaddons/k8s-sidecar:v0.7.0
  registry.k8s.io/sig-storage/csi-attacher:v4.1.0
  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
  registry.k8s.io/sig-storage/csi-provisioner:v3.4.0

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -190,7 +190,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -497,7 +497,7 @@ data:
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: "15"
   # Enable the csi addons sidecar.
   CSI_ENABLE_CSIADDONS: "false"
-  # ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.5.0"
+  # ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.7.0"
   # The CSI GRPC timeout value (in seconds). It should be >= 120. If this variable is not set or is an invalid value, it's default to 150.
   CSI_GRPC_TIMEOUT_SECONDS: "150"
 

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -107,7 +107,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.8.0"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"

--- a/pkg/operator/ceph/csi/betav1csidriver.go
+++ b/pkg/operator/ceph/csi/betav1csidriver.go
@@ -39,7 +39,11 @@ type beta1CsiDriver struct {
 }
 
 // createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
-func (d beta1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kubernetes.Interface, name, fsGroupPolicy string, attachRequired bool) error {
+func (d beta1CsiDriver) createCSIDriverInfo(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	name, fsGroupPolicy string,
+	attachRequired, seLinuxMountRequired bool) error {
 	mountInfo := false
 	// Create CSIDriver object
 	csiDriver := &betav1k8scsi.CSIDriver{

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -157,8 +157,13 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 
 	// SA token projection is stable only from kubernetes version 1.20.
 	CSIParam.EnableOIDCTokenProjection = false
-	if ver.Major == KubeMinMajor && ver.Minor >= KubeMinVerForOIDCTokenProjection {
+	if ver.Major == kubeMinMajor && ver.Minor >= kubeMinVerForOIDCTokenProjection {
 		CSIParam.EnableOIDCTokenProjection = true
+	}
+
+	// CSIDriver SeLinuxMount option is only available from kubernetes version 1.25.
+	if ver.Major == kubeMinMajor && ver.Minor >= kubeMinVerForCSIDriverSeLinuxMount {
+		CSIParam.EnableCSIDriverSeLinuxMount = true
 	}
 
 	CSIParam.EnableRBDSnapshotter = true

--- a/pkg/operator/ceph/csi/csidriver.go
+++ b/pkg/operator/ceph/csi/csidriver.go
@@ -28,7 +28,7 @@ import (
 )
 
 type csiDriver interface {
-	createCSIDriverInfo(ctx context.Context, clientset kubernetes.Interface, name, fsGroupPolicy string, attachRequired bool) error
+	createCSIDriverInfo(ctx context.Context, clientset kubernetes.Interface, name, fsGroupPolicy string, attachRequired, seLinuxMountRequired bool) error
 	reCreateCSIDriverInfo(ctx context.Context) error
 	deleteCSIDriverInfo(ctx context.Context, clientset kubernetes.Interface, name string) error
 }
@@ -39,7 +39,11 @@ type v1CsiDriver struct {
 }
 
 // createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
-func (d v1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kubernetes.Interface, name, fsGroupPolicy string, attachRequired bool) error {
+func (d v1CsiDriver) createCSIDriverInfo(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	name, fsGroupPolicy string,
+	attachRequired, seLinuxMountRequired bool) error {
 	mountInfo := false
 	// Create CSIDriver object
 	csiDriver := &v1k8scsi.CSIDriver{
@@ -50,6 +54,10 @@ func (d v1CsiDriver) createCSIDriverInfo(ctx context.Context, clientset kubernet
 			AttachRequired: &attachRequired,
 			PodInfoOnMount: &mountInfo,
 		},
+	}
+	if seLinuxMountRequired {
+		selinuxMount := true
+		csiDriver.Spec.SELinuxMount = &selinuxMount
 	}
 	if fsGroupPolicy != "" {
 		policy := v1k8scsi.FSGroupPolicy(fsGroupPolicy)

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -144,7 +144,7 @@ var (
 	DefaultAttacherImage    = "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"
 	DefaultSnapshotterImage = "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1"
 	DefaultResizerImage     = "registry.k8s.io/sig-storage/csi-resizer:v1.7.0"
-	DefaultCSIAddonsImage   = "quay.io/csiaddons/k8s-sidecar:v0.5.0"
+	DefaultCSIAddonsImage   = "quay.io/csiaddons/k8s-sidecar:v0.7.0"
 
 	// image pull policy
 	DefaultCSIImagePullPolicy = string(v1.PullIfNotPresent)

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -138,7 +138,7 @@ var (
 // manually challenging.
 var (
 	// image names
-	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.8.0"
+	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.9.0"
 	DefaultRegistrarImage   = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0"
 	DefaultProvisionerImage = "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0"
 	DefaultAttacherImage    = "registry.k8s.io/sig-storage/csi-attacher:v4.1.0"
@@ -311,9 +311,7 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 	RBDDriverName = tp.DriverNamePrefix + rbdDriverSuffix
 	NFSDriverName = tp.DriverNamePrefix + "nfs.csi.ceph.com"
 
-	if CustomCSICephConfigExists {
-		tp.Param.MountCustomCephConf = v.SupportsCustomCephConf()
-	}
+	tp.Param.MountCustomCephConf = CustomCSICephConfigExists
 
 	csiDriverobj = v1CsiDriver{}
 	// In case of an k8s version upgrade, delete the beta CSIDriver object;
@@ -425,10 +423,6 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 	// get common plugin tolerations and node affinity
 	pluginTolerations := getToleration(r.opConfig.Parameters, pluginTolerationsEnv, []corev1.Toleration{})
 	pluginNodeAffinity := getNodeAffinity(r.opConfig.Parameters, pluginNodeAffinityEnv, &corev1.NodeAffinity{})
-
-	if holderEnabled && !v.SupportsNsenter() {
-		return errors.Errorf("multus/csi pod networking is applied but the csi version %q does not support it, need at least %q", v.String(), nsenterSupportedVersion.String())
-	}
 
 	// Deploy the CSI Holder DaemonSet if Multus is enabled or
 	// EnableCSIHostNetwork is disabled.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -74,6 +74,7 @@ type Param struct {
 	EnableCSIAddonsSideCar                bool
 	MountCustomCephConf                   bool
 	EnableOIDCTokenProjection             bool
+	EnableCSIDriverSeLinuxMount           bool
 	EnableCSIEncryption                   bool
 	EnableCSITopology                     bool
 	EnableLiveness                        bool
@@ -178,9 +179,10 @@ var (
 )
 
 const (
-	KubeMinMajor                     = "1"
-	KubeMinVerForOIDCTokenProjection = "20"
-	kubeMaxVerForBeta1csiDriver      = "21"
+	kubeMinMajor                       = "1"
+	kubeMinVerForOIDCTokenProjection   = "20"
+	kubeMaxVerForBeta1csiDriver        = "21"
+	kubeMinVerForCSIDriverSeLinuxMount = "25"
 
 	// common tolerations and node affinity
 	provisionerTolerationsEnv  = "CSI_PROVISIONER_TOLERATIONS"
@@ -647,19 +649,27 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 	}
 
 	if EnableRBD {
-		err = csiDriverobj.createCSIDriverInfo(r.opManagerContext, r.context.Clientset, RBDDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_RBD_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)), tp.Param.RBDAttachRequired)
+		err = csiDriverobj.createCSIDriverInfo(
+			r.opManagerContext, r.context.Clientset,
+			RBDDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_RBD_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)),
+			tp.Param.RBDAttachRequired, CSIParam.EnableCSIDriverSeLinuxMount)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create CSI driver object for %q", RBDDriverName)
 		}
 	}
 	if EnableCephFS {
-		err = csiDriverobj.createCSIDriverInfo(r.opManagerContext, r.context.Clientset, CephFSDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_CEPHFS_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)), tp.Param.CephFSAttachRequired)
+		err = csiDriverobj.createCSIDriverInfo(
+			r.opManagerContext, r.context.Clientset,
+			CephFSDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_CEPHFS_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)),
+			tp.Param.CephFSAttachRequired, CSIParam.EnableCSIDriverSeLinuxMount)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create CSI driver object for %q", CephFSDriverName)
 		}
 	}
 	if EnableNFS {
-		err = csiDriverobj.createCSIDriverInfo(r.opManagerContext, r.context.Clientset, NFSDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_NFS_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)), tp.Param.NFSAttachRequired)
+		err = csiDriverobj.createCSIDriverInfo(r.opManagerContext, r.context.Clientset,
+			NFSDriverName, k8sutil.GetValue(r.opConfig.Parameters, "CSI_NFS_FSGROUPPOLICY", string(k8scsi.FileFSGroupPolicy)),
+			tp.Param.NFSAttachRequired, CSIParam.EnableCSIDriverSeLinuxMount)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create CSI driver object for %q", NFSDriverName)
 		}

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -268,7 +268,7 @@ func Test_getImage(t *testing.T) {
 			args: args{
 				data:         map[string]string{},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
 			},
 			want: DefaultCSIPluginImage,
 		},
@@ -279,7 +279,7 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi:v8",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
 			},
 			want: "registry.io/private/cephcsi:v8",
 		},
@@ -290,9 +290,9 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.8.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
 			},
-			want: "registry.io/private/cephcsi:v3.8.0",
+			want: "registry.io/private/cephcsi:v3.9.0",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -25,21 +25,15 @@ import (
 )
 
 var (
-	//minimum supported version is 3.7.0
-	minimum = CephCSIVersion{3, 7, 0}
+	//minimum supported version is 3.8.0
+	minimum = CephCSIVersion{3, 8, 0}
 	//supportedCSIVersions are versions that rook supports
-	releasev380 = CephCSIVersion{3, 8, 0}
+	releasev390 = CephCSIVersion{3, 9, 0}
 
 	supportedCSIVersions = []CephCSIVersion{
 		minimum,
-		releasev380,
+		releasev390,
 	}
-
-	// custom ceph.conf is supported in v3.5.0+
-	cephConfSupportedVersion = CephCSIVersion{3, 5, 0}
-
-	// pod networking fix with the extra holder pod is supported with at least v3.6.1
-	nsenterSupportedVersion = CephCSIVersion{3, 6, 1}
 
 	// for parsing the output of `cephcsi`
 	versionCSIPattern = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
@@ -117,25 +111,4 @@ func extractCephCSIVersion(src string) (*CephCSIVersion, error) {
 	}
 
 	return &CephCSIVersion{major, minor, bugfix}, nil
-}
-
-// SupportsCustomCephConf checks if the detected version supports custom ceph.conf
-func (v *CephCSIVersion) SupportsCustomCephConf() bool {
-	// if AllowUnsupported is set also a csi-image greater than the supported ones are allowed
-	if AllowUnsupported {
-		return true
-	}
-
-	return v.isAtLeast(&cephConfSupportedVersion)
-}
-
-// SupportsNsenter checks if the csi image has support for calling "nsenter" while executing
-// mount/map commands. This is needed for Multus scenarios.
-func (v *CephCSIVersion) SupportsNsenter() bool {
-	// if AllowUnsupported is set also a csi-image greater than the supported ones are allowed
-	if AllowUnsupported {
-		return true
-	}
-
-	return v.isAtLeast(&nsenterSupportedVersion)
 }

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -23,14 +23,13 @@ import (
 )
 
 var (
-	testMinVersion  = CephCSIVersion{3, 7, 0}
-	testReleaseV350 = CephCSIVersion{3, 5, 0}
-	testReleaseV360 = CephCSIVersion{3, 6, 0}
-	testReleaseV361 = CephCSIVersion{3, 6, 1}
+	testMinVersion  = CephCSIVersion{3, 8, 0}
 	testReleaseV370 = CephCSIVersion{3, 7, 0}
 	testReleaseV371 = CephCSIVersion{3, 7, 1}
 	testReleaseV380 = CephCSIVersion{3, 8, 0}
 	testReleaseV381 = CephCSIVersion{3, 8, 1}
+	testReleaseV390 = CephCSIVersion{3, 9, 0}
+	testReleaseV391 = CephCSIVersion{3, 9, 1}
 
 	testVersionUnsupported = CephCSIVersion{4, 0, 0}
 )
@@ -45,25 +44,22 @@ func TestIsAtLeast(t *testing.T) {
 	ret = testMinVersion.isAtLeast(&testMinVersion)
 	assert.Equal(t, true, ret)
 
-	// Test for 3.6.0
-	ret = testReleaseV360.isAtLeast(&testReleaseV360)
-	assert.Equal(t, true, ret)
-
 	// Test for 3.7.0
-	ret = testReleaseV370.isAtLeast(&testReleaseV360)
-	assert.Equal(t, true, ret)
+	ret = testReleaseV370.isAtLeast(&testMinVersion)
+	assert.Equal(t, false, ret)
 
 	// Test for 3.7.1
-	ret = testReleaseV371.isAtLeast(&testReleaseV360)
+	ret = testReleaseV371.isAtLeast(&testMinVersion)
+	assert.Equal(t, false, ret)
+
+	// Test for 3.9.0
+	ret = testReleaseV390.isAtLeast(&testReleaseV380)
 	assert.Equal(t, true, ret)
 
-	// Test for 3.8.0
-	ret = testReleaseV380.isAtLeast(&testReleaseV370)
+	// Test for 3.9.1
+	ret = testReleaseV391.isAtLeast(&testReleaseV381)
 	assert.Equal(t, true, ret)
 
-	// Test for 3.8.1
-	ret = testReleaseV381.isAtLeast(&testReleaseV371)
-	assert.Equal(t, true, ret)
 }
 
 func TestSupported(t *testing.T) {
@@ -74,20 +70,23 @@ func TestSupported(t *testing.T) {
 	ret = testVersionUnsupported.Supported()
 	assert.Equal(t, false, ret)
 
-	// 3.6 is not supported after 3.8.0 release
-	ret = testReleaseV360.Supported()
+	// 3.7.x is not supported after 3.9.0 release
+	ret = testReleaseV370.Supported()
 	assert.Equal(t, false, ret)
 
-	ret = testReleaseV370.Supported()
-	assert.Equal(t, true, ret)
-
 	ret = testReleaseV371.Supported()
-	assert.Equal(t, true, ret)
+	assert.Equal(t, false, ret)
 
 	ret = testReleaseV380.Supported()
 	assert.Equal(t, true, ret)
 
 	ret = testReleaseV381.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testReleaseV390.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testReleaseV391.Supported()
 	assert.Equal(t, true, ret)
 }
 
@@ -114,43 +113,4 @@ func Test_extractCephCSIVersion(t *testing.T) {
 
 	assert.Nil(t, version)
 	assert.Contains(t, err.Error(), "failed to parse version from")
-}
-
-func TestSupportsCustomCephConf(t *testing.T) {
-	AllowUnsupported = true
-	ret := testMinVersion.SupportsCustomCephConf()
-	assert.True(t, ret)
-
-	AllowUnsupported = false
-	ret = testMinVersion.SupportsCustomCephConf()
-	assert.True(t, ret)
-
-	ret = testReleaseV360.SupportsCustomCephConf()
-	assert.True(t, ret)
-
-	ret = testReleaseV370.SupportsCustomCephConf()
-	assert.True(t, ret)
-
-	ret = testReleaseV371.SupportsCustomCephConf()
-	assert.True(t, ret)
-}
-
-func TestSupportsNsenter(t *testing.T) {
-	t.Run("AllowUnsupported=true regardless of the version", func(t *testing.T) {
-		AllowUnsupported = true
-		ret := testMinVersion.SupportsNsenter()
-		assert.True(t, ret)
-	})
-
-	t.Run("AllowUnsupported=false and version 3.5 is too old", func(t *testing.T) {
-		AllowUnsupported = false
-		ret := testReleaseV350.SupportsNsenter()
-		assert.False(t, ret)
-	})
-
-	t.Run("AllowUnsupported=false and version 3.6.1 is fine", func(t *testing.T) {
-		AllowUnsupported = false
-		ret := testReleaseV361.SupportsNsenter()
-		assert.True(t, ret)
-	})
 }


### PR DESCRIPTION
**Description of your changes:**

This pr:
- csi: update cephcsi to v3.9.0

  This commit updates cephcsi image to
v3.9.0 release and also removes support
for v3.7.x.

  refer: https://github.com/ceph/ceph-csi/releases/tag/v3.8.0

- csi: update csiaddons k8s-sidecar to v0.7.0

  This commit updates k8s-sidecar to v0.7.0
and all links now point to v0.7.0 tag.

  refer: https://github.com/csi-addons/kubernetes-csi-addons/releases/tag/v0.7.0

- csi: add SeLinuxMount: true Option to csidriver obj

  This feature is alpha and available from k8s 1.25.
This enabled faster mounting of volumes using
RWOP access pod.

  refer: https://kubernetes.io/blog/2023/04/18/kubernetes-1-27-/efficient-selinux-relabeling-beta/

  The csidriver object's selinuxmount option will be set to true and visible only if required feature gates are turned on.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
