### PR TITLE
external: Fix import script for idempotent

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -140,12 +140,12 @@ To install with Helm, the rook cluster helm chart will configure the necessary r
 
 ```console
     clusterNamespace=rook-ceph
-    operatorNamesapce=rook-ceph
+    operatorNamespace=rook-ceph
     cd deploy/examples/charts/rook-ceph-cluster
     helm repo add rook-release https://charts.rook.io/release
     helm install --create-namespace --namespace $clusterNamespace rook-ceph rook-release/rook-ceph -f values.yaml
     helm install --create-namespace --namespace $clusterNamespace rook-ceph-cluster \
-    --set operatorNamespace=$operatorNamesapce rook-release/rook-ceph-cluster -f values-external.yaml
+    --set operatorNamespace=$operatorNamespace rook-release/rook-ceph-cluster -f values-external.yaml
 ```
 
 Skip the manifest installation section and continue with [Cluster Verification](#cluster-verification).

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -76,8 +76,7 @@ function importClusterID() {
 }
 
 function importSecret() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "$MON_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "$MON_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -91,13 +90,12 @@ function importSecret() {
       --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
       --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
   else
-    echo "secret $secret already exists"
+    echo "secret $MON_SECRET_NAME already exists"
   fi
 }
 
 function importConfigMap() {
-  configmap=$(kubectl -n "$NAMESPACE" get configmap "$MON_ENDPOINT_CONFIGMAP_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get configmap "$MON_ENDPOINT_CONFIGMAP_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       configmap \
@@ -106,13 +104,12 @@ function importConfigMap() {
       --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
       --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
   else
-    echo "configmap $configmap already exists"
+    echo "configmap $MON_ENDPOINT_CONFIGMAP_NAME already exists"
   fi
 }
 
 function importCsiRBDNodeSecret() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "rook-""$CSI_RBD_NODE_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "rook-$CSI_RBD_NODE_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -122,13 +119,12 @@ function importCsiRBDNodeSecret() {
       --from-literal=userID="$CSI_RBD_NODE_SECRET_NAME" \
       --from-literal=userKey="$CSI_RBD_NODE_SECRET"
   else
-    echo "secret $secret already exists"
+    echo "secret rook-$CSI_RBD_NODE_SECRET_NAME already exists"
   fi
 }
 
 function importCsiRBDProvisionerSecret() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "rook-""$CSI_RBD_PROVISIONER_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "rook-$CSI_RBD_PROVISIONER_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -138,13 +134,12 @@ function importCsiRBDProvisionerSecret() {
       --from-literal=userID="$CSI_RBD_PROVISIONER_SECRET_NAME" \
       --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
   else
-    echo "secret $secret already exists"
+    echo "secret $CSI_RBD_PROVISIONER_SECRET_NAME already exists"
   fi
 }
 
 function importCsiCephFSNodeSecret() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "rook-""$CSI_CEPHFS_NODE_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "rook-$CSI_CEPHFS_NODE_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -154,13 +149,12 @@ function importCsiCephFSNodeSecret() {
       --from-literal=adminID="$CSI_CEPHFS_NODE_SECRET_NAME" \
       --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
   else
-    echo "secret $secret already exists"
+    echo "secret $CSI_CEPHFS_NODE_SECRET_NAME already exists"
   fi
 }
 
 function importCsiCephFSProvisionerSecret() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "rook-$CSI_CEPHFS_PROVISIONER_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -170,13 +164,12 @@ function importCsiCephFSProvisionerSecret() {
       --from-literal=adminID="$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
       --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
   else
-    echo "secret $secret already exists"
+    echo "secret $CSI_CEPHFS_PROVISIONER_SECRET_NAME already exists"
   fi
 }
 
 function importRGWAdminOpsUser() {
-  secret=$(kubectl -n "$NAMESPACE" get secret "$RGW_ADMIN_OPS_USER_SECRET_NAME")
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get secret "$RGW_ADMIN_OPS_USER_SECRET_NAME" &>/dev/null; then
     kubectl -n "$NAMESPACE" \
       create \
       secret \
@@ -186,13 +179,12 @@ function importRGWAdminOpsUser() {
       --from-literal=accessKey="$RGW_ADMIN_OPS_USER_ACCESS_KEY" \
       --from-literal=secretKey="$RGW_ADMIN_OPS_USER_SECRET_KEY"
   else
-    echo "secret $secret already exists"
+    echo "secret $RGW_ADMIN_OPS_USER_SECRET_NAME already exists"
   fi
 }
 
 function createECRBDStorageClass() {
-  storageclass=$(kubectl -n "$NAMESPACE" get storageclass $RBD_STORAGE_CLASS_NAME)
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get storageclass $RBD_STORAGE_CLASS_NAME &>/dev/null; then
     cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -216,13 +208,12 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 eof
   else
-    echo "storageclass $storageclass already exists"
+    echo "storageclass $RBD_STORAGE_CLASS_NAME already exists"
   fi
 }
 
 function createRBDStorageClass() {
-  storageclass=$(kubectl -n "$NAMESPACE" get storageclass $RBD_STORAGE_CLASS_NAME)
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get storageclass $RBD_STORAGE_CLASS_NAME &>/dev/null; then
     cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -245,13 +236,12 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 eof
   else
-    echo "storageclass $storageclass already exists"
+    echo "storageclass $RBD_STORAGE_CLASS_NAME already exists"
   fi
 }
 
 function createCephFSStorageClass() {
-  storageclass=$(kubectl -n "$NAMESPACE" get storageclass $CEPHFS_STORAGE_CLASS_NAME)
-  if [ $? != 0 ]; then
+  if ! kubectl -n "$NAMESPACE" get storageclass $CEPHFS_STORAGE_CLASS_NAME &>/dev/null; then
     cat <<eof | kubectl create -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -272,7 +262,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 eof
   else
-    echo "storageclass $storageclass already exists"
+    echo "storageclass $CEPHFS_STORAGE_CLASS_NAME already exists"
   fi
 }
 


### PR DESCRIPTION
Correct command to check if object already exist

Thank you for contributing to Rook! -->

**Description of your changes:**

Fix PR https://github.com/rook/rook/pull/12417 than exit when check command fail. 

**Which issue is resolved by this Pull Request:**

[Resolves #](https://github.com/rook/rook/issues/12412)

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


** Run proof ***

External export file : `cat ceph_export_create_cluster_external`

```
export NAMESPACE=rook-ceph
export ROOK_EXTERNAL_FSID=XXX
export ROOK_EXTERNAL_USERNAME=client.healthchecker
export ROOK_EXTERNAL_CEPH_MON_DATA=XXX
export ROOK_EXTERNAL_USER_SECRET=XXX
export CSI_RBD_NODE_SECRET=XXX
export CSI_RBD_NODE_SECRET_NAME=csi-rbd-node
export CSI_RBD_PROVISIONER_SECRET=XXX
export CSI_RBD_PROVISIONER_SECRET_NAME=csi-rbd-provisioner
export CEPHFS_POOL_NAME=cephfs_data
export CEPHFS_METADATA_POOL_NAME=cephfs_metadata
export CEPHFS_FS_NAME=cephFS
export CSI_CEPHFS_NODE_SECRET=XXX
export CSI_CEPHFS_PROVISIONER_SECRET=XXX
export CSI_CEPHFS_NODE_SECRET_NAME=csi-cephfs-node
export CSI_CEPHFS_PROVISIONER_SECRET_NAME=csi-cephfs-provisioner
export MONITORING_ENDPOINT=1.2.3.1
export MONITORING_ENDPOINT_PORT=9283
export RBD_POOL_NAME=cephrbd_data
export RGW_POOL_PREFIX=default
export ROOK_RBD_FEATURES=fast-diff,object-map,deep-flatten,exclusive-lock,layering
```


First run 

```
. ceph_export_create_cluster_external && ./import-external-cluster.sh
secret rook-ceph-mon already exists
configmap/rook-ceph-mon-endpoints created
secret/rook-csi-rbd-node created
secret/rook-csi-rbd-provisioner created
secret/rook-csi-cephfs-node created
secret/rook-csi-cephfs-provisioner created
storageclass.storage.k8s.io/ceph-rbd created
storageclass.storage.k8s.io/cephfs created
```

Second run

```
. ceph_export_create_cluster_external && ./import-external-cluster.sh
secret rook-ceph-mon already exists
configmap rook-ceph-mon-endpoints already exists
secret rook-csi-rbd-node already exists
secret csi-rbd-provisioner already exists
secret csi-cephfs-node already exists
secret csi-cephfs-provisioner already exists
storageclass ceph-rbd already exists
storageclass cephfs already exists
```

Third run 

```
. ceph_export_create_cluster_external && ./import-external-cluster.sh
secret rook-ceph-mon already exists
configmap rook-ceph-mon-endpoints already exists
secret rook-csi-rbd-node already exists
secret csi-rbd-provisioner already exists
secret csi-cephfs-node already exists
secret csi-cephfs-provisioner already exists
storageclass ceph-rbd already exists
storageclass cephfs already exists
```

