### PR TITLE
ci: Enable mergify for the 1.12 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,39 +15,6 @@ pull_request_rules:
       comment:
         message: Hi @{{author}}, this pull request was opened against a release branch, is it expected? Normally patches should go in the master branch first and then be backported to release branches.
 
-  # release-1.7 branch
-  - name: automerge backport release-1.7
-    conditions:
-      - author=mergify[bot]
-      - base=release-1.7
-      - label!=do-not-merge
-      - "status-success=DCO"
-      - "check-success=canary"
-      - "check-success=unittests"
-      - "check-success=golangci-lint"
-      - "check-success=codegen"
-      - "check-success=lint"
-      - "check-success=modcheck"
-      - "check-success=pvc"
-      - "check-success=pvc-db"
-      - "check-success=pvc-db-wal"
-      - "check-success=encryption-pvc"
-      - "check-success=encryption-pvc-db"
-      - "check-success=encryption-pvc-db-wal"
-      - "check-success=encryption-pvc-kms-vault-token-auth"
-      - "check-success=TestCephSmokeSuite (v1.15.12)"
-      - "check-success=TestCephSmokeSuite (v1.21.0)"
-      - "check-success=TestCephHelmSuite (v1.15.12)"
-      - "check-success=TestCephHelmSuite (v1.21.0)"
-      - "check-success=TestCephMultiClusterDeploySuite (v1.21.0)"
-      - "check-success=TestCephUpgradeSuite (v1.15.12)"
-      - "check-success=TestCephUpgradeSuite (v1.21.0)"
-    actions:
-      merge:
-        method: merge
-      dismiss_reviews: {}
-      delete_head_branch: {}
-
   # release-1.8 branch
   - name: automerge backport release-1.8
     conditions:
@@ -223,14 +190,58 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
-  # release-1.7 branch
-  - actions:
-      backport:
-        branches:
-          - release-1.7
+  # release-1.12 branch
+  - name: automerge backport release-1.12
     conditions:
-      - label=backport-release-1.7
-    name: backport release-1.7
+      - author=mergify[bot]
+      - base=release-1.12
+      - label!=do-not-merge
+      - "status-success=DCO"
+      - "check-success=linux-build-all (1.20)"
+      - "check-success=unittests"
+      - "check-success=golangci-lint"
+      - "check-success=codegen"
+      - "check-success=codespell"
+      - "check-success=lint"
+      - "check-success=modcheck"
+      - "check-success=Shellcheck"
+      - "check-success=yaml-linter"
+      - "check-success=lint-test"
+      - "check-success=gen-rbac"
+      - "check-success=crds-gen"
+      - "check-success=docs-check"
+      - "check-success=pylint"
+      - "check-success=canary"
+      - "check-success=raw-disk"
+      - "check-success=two-osds-in-device"
+      - "check-success=osd-with-metadata-device"
+      - "check-success=encryption"
+      - "check-success=lvm"
+      - "check-success=pvc"
+      - "check-success=pvc-db"
+      - "check-success=pvc-db-wal"
+      - "check-success=encryption-pvc"
+      - "check-success=encryption-pvc-db"
+      - "check-success=encryption-pvc-db-wal"
+      - "check-success=encryption-pvc-kms-vault-token-auth"
+      - "check-success=encryption-pvc-kms-vault-k8s-auth"
+      - "check-success=lvm-pvc"
+      - "check-success=rgw-multisite-testing"
+      - "check-success=TestCephSmokeSuite (v1.22.17)"
+      - "check-success=TestCephSmokeSuite (v1.27.2)"
+      - "check-success=TestCephHelmSuite (v1.22.17)"
+      - "check-success=TestCephHelmSuite (v1.27.2)"
+      - "check-success=TestCephMultiClusterDeploySuite (v1.27.2)"
+      - "check-success=TestCephObjectSuite (v1.27.2)"
+      - "check-success=TestCephUpgradeSuite (v1.22.17)"
+      - "check-success=TestCephUpgradeSuite (v1.27.2)"
+      - "check-success=TestHelmUpgradeSuite (v1.22.17)"
+      - "check-success=TestHelmUpgradeSuite (v1.27.2)"
+    actions:
+      merge:
+        method: merge
+      dismiss_reviews: {}
+      delete_head_branch: {}
 
   # release-1.8 branch
   - actions:
@@ -267,3 +278,12 @@ pull_request_rules:
     conditions:
       - label=backport-release-1.11
     name: backport release-1.11
+
+  # release-1.12 branch
+  - actions:
+      backport:
+        branches:
+          - release-1.12
+    conditions:
+      - label=backport-release-1.12
+    name: backport release-1.12


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
For the new release-1.12 branch, mergify rules are added for automatically opening PRs and merging backports when approved.

Also remove 1.7 from the mergify rules since it's so old.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
