### PR TITLE
core: add check for pv access modes' multinode support

### DIFF
--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -358,3 +358,77 @@ func TestOnDeviceCMUpdate(t *testing.T) {
 	b = clientCluster.onDeviceCMUpdate(oldCM, newCM)
 	assert.True(t, b)
 }
+
+func Test_pvSupportMultiNodeAccess(t *testing.T) {
+	type args struct {
+		accessModes []corev1.PersistentVolumeAccessMode
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "single access mode, contains RWX",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteMany,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "single access mode, contains ROX",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadOnlyMany,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "single access mode, contains only RWO",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "single access mode, contains only RWOP",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOncePod,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple access mode, contains RWX",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+					corev1.ReadWriteMany,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple access mode, contains RWX and ROX",
+			args: args{
+				accessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteMany,
+					corev1.ReadOnlyMany,
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pvSupportsMultiNodeAccess(tt.args.accessModes)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

During faster node loss recovery,
Rook needs to check and blocklist only rbd pvs
that do not support multinode access modes such as
ReadOnlyMany(ROX) and ReadWriteMany(RWX).
This commit adds check for the same.

We may end up blocklisting the wrong node if the rbd pvc is mounted on multiple nodes.
+ pvc with accessmodes that support multinode do need blocklisting to be able to mount on new nodes.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---
Discussed this addition with @subhamkrai (he is on leave for today and tomorrow).

