### PR TITLE
external: support custom ceph keyring file

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -44,6 +44,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 - `--monitoring-endpoint-port`: (optional) Ceph Manager prometheus exporter port
 - `--skip-monitoring-endpoint`: (optional) Skip prometheus exporter endpoints, even if they are available. Useful if the prometheus module is not enabled
 - `--ceph-conf`: (optional) Provide a Ceph conf file
+- `--keyring`: (optional) Path to Ceph keyring file, to be used with `--ceph-conf`
 - `--cluster-name`: (optional) Ceph cluster name
 - `--output`: (optional) Output will be stored into the provided file
 - `--dry-run`: (optional) Prints the executed commands without running them

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -309,6 +309,9 @@ class RadosJSON:
             "--ceph-conf", "-c", help="Provide a ceph conf file.", type=str
         )
         common_group.add_argument(
+            "--keyring", "-k", help="Path to ceph keyring file.", type=str
+        )
+        common_group.add_argument(
             "--run-as-user",
             "-u",
             default="",
@@ -617,6 +620,7 @@ class RadosJSON:
         self.run_as_user = self._arg_parser.run_as_user
         self.output_file = self._arg_parser.output
         self.ceph_conf = self._arg_parser.ceph_conf
+        self.ceph_keyring = self._arg_parser.keyring
         self.MIN_USER_CAP_PERMISSIONS = {
             "mgr": "allow command config",
             "mon": "allow r, allow command quorum_status, allow command version",
@@ -632,7 +636,10 @@ class RadosJSON:
         if not self._arg_parser.rgw_pool_prefix and not self._arg_parser.upgrade:
             self._arg_parser.rgw_pool_prefix = self.DEFAULT_RGW_POOL_PREFIX
         if self.ceph_conf:
-            self.cluster = rados.Rados(conffile=self.ceph_conf)
+            kwargs = {}
+            if self.ceph_keyring:
+                kwargs["conf"] = {"keyring": self.ceph_keyring}
+            self.cluster = rados.Rados(conffile=self.ceph_conf, **kwargs)
         else:
             self.cluster = rados.Rados()
             self.cluster.conf_read_file()


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

Allow setting a custom keyring file when creating external ceph cluster resources. See https://docs.ceph.com/en/latest/rados/api/python/#configure-a-cluster-handle

**Which issue is resolved by this Pull Request:**
Resolves:

If using a ceph.conf and a keyring from a non-standard location, the keyring might not be found by default.

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
