### PR TITLE
external: create ceph cluster namespace

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -319,7 +319,9 @@ class RadosJSON:
             "--cluster-name", default="", help="Ceph cluster name"
         )
         common_group.add_argument(
-            "--namespace", default="", help="Namespace where CephCluster is running"
+            "--namespace",
+            default="",
+            help="Namespace where CephCluster is running",
         )
         common_group.add_argument(
             "--rgw-pool-prefix", default="", help="RGW Pool prefix"

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -4,6 +4,7 @@ set -e
 ##############
 # VARIABLES #
 #############
+NAMESPACE=${NAMESPACE:="rook-ceph-external"}
 MON_SECRET_NAME=rook-ceph-mon
 RGW_ADMIN_OPS_USER_SECRET_NAME=rgw-admin-ops-user
 MON_SECRET_CLUSTER_NAME_KEYNAME=cluster-name
@@ -63,6 +64,17 @@ function checkEnvVars() {
   if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ]; then
     echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
     exit 1
+  fi
+}
+
+function createClusterNamespace() {
+  if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+    kubectl \
+      create \
+      namespace \
+      "$NAMESPACE"
+  else
+    echo "cluster namespace $NAMESPACE already exists"
   fi
 }
 
@@ -270,6 +282,7 @@ eof
 # MAIN #
 ########
 checkEnvVars
+createClusterNamespace
 importClusterID
 importSecret
 importConfigMap


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

We need to create the namespace with the import script, https://rook.io/docs/rook/v1.11/CRDs/Cluster/external-cluster/#commands-on-the-k8s-consumer-cluster
The import script creates the secrets and cm which is later used by the operator for cluster creation.

Also in the future, we are looking at how to remove the import script or to minimize the creation process.

PS: didn't change the namespace as it not needed, it is just it more clarifies that we were talking about cluster_namesapce

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
