### PR TITLE
external: added an optional flag for enabling v2 mon port

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -207,6 +207,11 @@ jobs:
             echo "script failed because wrong realm was passed"
           fi
 
+      - name: test enable v2 mon port
+        run: |
+          toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --v2-port-enable
+
       - name: check-ownerreferences
         run: tests/scripts/github-action-helper.sh check_ownerreferences
 
@@ -1307,7 +1312,6 @@ jobs:
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
 
-
   rgw-multisite-testing:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -1336,7 +1340,6 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
-
 
   encryption-pvc-kms-ibm-kp:
     runs-on: ubuntu-20.04
@@ -1369,7 +1372,6 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
-
 
   multus-cluster-network:
     runs-on: ubuntu-20.04
@@ -1449,7 +1451,6 @@ jobs:
         uses: ./.github/workflows/tmate_debug
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
-
 
   csi-hostnetwork-disabled:
     runs-on: ubuntu-20.04

--- a/Documentation/CRDs/Cluster/external-cluster.md
+++ b/Documentation/CRDs/Cluster/external-cluster.md
@@ -58,6 +58,7 @@ python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --
 - `--rgw-zonegroup-name`: (optional) Provides the name of the rgw-zone-group
 - `--upgrade`: (optional) Upgrades the 'Ceph CSI keyrings (For example: client.csi-cephfs-provisioner) with new permissions needed for the new cluster version and older permission will still be applied.
 - `--restricted-auth-permission`: (optional) Restrict cephCSIKeyrings auth permissions to specific pools, and cluster. Mandatory flags that need to be set are `--rbd-data-pool-name`, and `--cluster-name`. `--cephfs-filesystem-name` flag can also be passed in case of CephFS user restriction, so it can restrict users to particular CephFS filesystem.
+- `--v2-port-enable`: (optional) Enables the v2 mon port (3300) for mons.
 
 ### Multi-tenancy
 
@@ -197,8 +198,8 @@ Create the object store resources:
 
 ### Connect to v2 mon port
 
-If encryption or compression on the wire is needed, specify the v2 port.
-Check if the v2 port is available in `ceph quorum_status`, then you can update the `export ROOK_EXTERNAL_CEPH_MON_DATA` to use the v2 port `3300`.
+If encryption or compression on the wire is needed, specify the `--v2-port-enable` flag.
+If the v2 address type is present in the `ceph quorum_status`, then the output of 'ceph mon data' i.e, `ROOK_EXTERNAL_CEPH_MON_DATA` will use the v2 port(`3300`).
 
 ##  Exporting Rook to another cluster
 

--- a/deploy/examples/create-external-cluster-resources-tests.py
+++ b/deploy/examples/create-external-cluster-resources-tests.py
@@ -260,3 +260,16 @@ class TestRadosJSON(unittest.TestCase):
 
         if self.rjObj.out_map["MONITORING_ENDPOINT_PORT"] != "":
             self.fail("MONITORING_ENDPOINT_PORT should be empty")
+
+    def test_v2_port_enable(self):
+        self.rjObj = ext.RadosJSON(
+            ["--rbd-data-pool-name=abc", "--v2-port-enable", "--format=json"]
+        )
+        self.rjObj.cluster = ext.DummyRados.Rados()
+        # for testing, we are using 'DummyRados' object
+        mon_data = self.rjObj.get_ceph_external_mon_data()
+        mon_ip = mon_data.split("=")[1]
+        mon_port = mon_ip.split(":")[-1]
+        if mon_port != "3300":
+            self.fail(f"Expected Port: 3300, Returned Port: {mon_port}")
+        print(f"MonPort: {mon_port}")

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -334,6 +334,12 @@ class RadosJSON:
             + "Note: Restricting the csi-users per pool, and per cluster will require creating new csi-users and new secrets for that csi-users."
             + "So apply these secrets only to new `Consumer cluster` deployment while using the same `Source cluster`.",
         )
+        common_group.add_argument(
+            "--v2-port-enable",
+            action="store_true",
+            default=False,
+            help="Enable v2 mon port(3300) for mons",
+        )
 
         output_group = argP.add_argument_group("output")
         output_group.add_argument(
@@ -692,8 +698,20 @@ class RadosJSON:
             raise ExecutionFailureException(
                 "Only 'v2' address type is enabled, user should also enable 'v1' type as well"
             )
-        ip_port = str(q_leader_details["public_addr"].split("/")[0])
-        return f"{str(q_leader_name)}={ip_port}"
+        ip_addr = str(q_leader_details["public_addr"].split("/")[0])
+
+        if self._arg_parser.v2_port_enable:
+            if len(q_leader_addrvec) > 1:
+                if q_leader_addrvec[0]["type"] == "v2":
+                    ip_addr = q_leader_addrvec[0]["addr"]
+                elif q_leader_addrvec[1]["type"] == "v2":
+                    ip_addr = q_leader_addrvec[1]["addr"]
+            else:
+                sys.stderr.write(
+                    "'v2' address type not present, and 'v2-port-enable' flag is provided"
+                )
+
+        return f"{str(q_leader_name)}={ip_addr}"
 
     def _convert_hostname_to_ip(self, host_name, port, ip_type):
         # if 'cluster' instance is a dummy type,


### PR DESCRIPTION
**Description of your changes:**
Added a new flag `--v2-port-enable` to enable the v2 mon port.

**Which issue is resolved by this Pull Request:**
Resolves #12297 

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
