### PR TITLE
cosi: The COSI driver should be disabled by default

### DIFF
--- a/pkg/operator/ceph/object/cosi/controller.go
+++ b/pkg/operator/ceph/object/cosi/controller.go
@@ -134,9 +134,13 @@ func (r *ReconcileCephCOSIDriver) reconcile(request reconcile.Request) (reconcil
 	}
 
 	if cosiDeploymentStrategy == cephv1.COSIDeploymentStrategyNever {
-		logger.Info("Ceph COSI Driver is disabled, delete if exists")
+		logger.Debug("Ceph COSI Driver is disabled, delete if exists")
 		cephCOSIDriverDeployment := &appsv1.Deployment{}
 		err = r.client.Get(r.opManagerContext, request.NamespacedName, cephCOSIDriverDeployment)
+		if kerrors.IsNotFound(err) {
+			// nothing to delete
+			return reconcile.Result{}, *cephCOSIDriver, nil
+		}
 		if err != nil && client.IgnoreNotFound(err) != nil {
 			return reconcile.Result{}, *cephCOSIDriver, errors.Wrap(err, "failed to get Ceph COSI Driver Deployment")
 		}

--- a/pkg/operator/ceph/object/cosi/controller.go
+++ b/pkg/operator/ceph/object/cosi/controller.go
@@ -125,10 +125,14 @@ func (r *ReconcileCephCOSIDriver) reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, *cephCOSIDriver, errors.Wrapf(err, "failed to get Ceph COSI Driver %s", request.NamespacedName)
 	}
 
-	cosiDeploymentStrategy := cephv1.COSIDeploymentStrategyAuto
+	// While in experimental mode, the COSI driver is not enabled by default
+	cosiDeploymentStrategy := cephv1.COSIDeploymentStrategyNever
+
+	// Get the setting from the CephCOSIDriver CR if exists
 	if !reflect.DeepEqual(cephCOSIDriver.Spec, cephv1.CephCOSIDriverSpec{}) && cephCOSIDriver.Spec.DeploymentStrategy != "" {
 		cosiDeploymentStrategy = cephCOSIDriver.Spec.DeploymentStrategy
 	}
+
 	if cosiDeploymentStrategy == cephv1.COSIDeploymentStrategyNever {
 		logger.Info("Ceph COSI Driver is disabled, delete if exists")
 		cephCOSIDriverDeployment := &appsv1.Deployment{}


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
- Change the default deployment strategy to never. While experimental, the cosi driver should not be enabled by default.
- Add steps for enabling the cosi driver that is disabled by default. Also add an introduction to the COSI driver and a section for prerequisites.

Also a fix for when the driver is disabled:
- The controller was attempting to delete the cosi driver again and again, always failing the reconcile when the driver did not exist. Since the desired state is for the driver not to exist when disabled, return a successful reconcile.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
