### PR TITLE
mon: delete ParseMonEndpoints from mon package

### DIFF
--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -74,7 +74,7 @@ func runMgrSidecar(cmd *cobra.Command, args []string) error {
 	}
 
 	context := createContext()
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
+	clusterInfo.Monitors = opcontroller.ParseMonEndpoints(cfg.monEndpoints)
 	rook.LogStartupInfo(mgrSidecarCmd.Flags())
 
 	ownerRef := opcontroller.ClusterOwnerRef(clusterName, ownerRefID)

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -323,7 +323,7 @@ func commonOSDInit(cmd *cobra.Command) {
 	rook.SetLogLevel()
 	rook.LogStartupInfo(cmd.Flags())
 
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
+	clusterInfo.Monitors = opcontroller.ParseMonEndpoints(cfg.monEndpoints)
 }
 
 // use zone/region/hostname labels in the crushmap

--- a/pkg/operator/ceph/cluster/mon/endpoint.go
+++ b/pkg/operator/ceph/cluster/mon/endpoint.go
@@ -25,27 +25,10 @@ import (
 
 // FlattenMonEndpoints returns a comma-delimited string of all mons and endpoints in the form
 // <mon-name>=<mon-endpoint>
-func FlattenMonEndpoints(mons map[string]*cephclient.MonInfo) string {
+func flattenMonEndpoints(mons map[string]*cephclient.MonInfo) string {
 	endpoints := []string{}
 	for _, m := range mons {
 		endpoints = append(endpoints, fmt.Sprintf("%s=%s", m.Name, m.Endpoint))
 	}
 	return strings.Join(endpoints, ",")
-}
-
-// ParseMonEndpoints parses a flattened representation of mons and endpoints in the form
-// <mon-name>=<mon-endpoint> and returns a list of Ceph mon configs.
-func ParseMonEndpoints(input string) map[string]*cephclient.MonInfo {
-	logger.Infof("parsing mon endpoints: %s", input)
-	mons := map[string]*cephclient.MonInfo{}
-	rawMons := strings.Split(input, ",")
-	for _, rawMon := range rawMons {
-		parts := strings.Split(rawMon, "=")
-		if len(parts) != 2 {
-			logger.Warningf("ignoring invalid monitor %s", rawMon)
-			continue
-		}
-		mons[parts[0]] = &cephclient.MonInfo{Name: parts[0], Endpoint: parts[1]}
-	}
-	return mons
 }

--- a/pkg/operator/ceph/cluster/mon/endpoint_test.go
+++ b/pkg/operator/ceph/cluster/mon/endpoint_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,17 +30,17 @@ func TestMonFlattening(t *testing.T) {
 	mons := map[string]*cephclient.MonInfo{
 		"foo": {Name: "foo", Endpoint: "1.2.3.4:5000"},
 	}
-	flattened := FlattenMonEndpoints(mons)
+	flattened := flattenMonEndpoints(mons)
 	assert.Equal(t, "foo=1.2.3.4:5000", flattened)
-	parsed := ParseMonEndpoints(flattened)
+	parsed := controller.ParseMonEndpoints(flattened)
 	assert.Equal(t, 1, len(parsed))
 	assert.Equal(t, "foo", parsed["foo"].Name)
 	assert.Equal(t, "1.2.3.4:5000", parsed["foo"].Endpoint)
 
 	// multiple endpoints
 	mons["bar"] = &cephclient.MonInfo{Name: "bar", Endpoint: "2.3.4.5:6000"}
-	flattened = FlattenMonEndpoints(mons)
-	parsed = ParseMonEndpoints(flattened)
+	flattened = flattenMonEndpoints(mons)
+	parsed = controller.ParseMonEndpoints(flattened)
 	assert.Equal(t, 2, len(parsed))
 	assert.Equal(t, "foo", parsed["foo"].Name)
 	assert.Equal(t, "1.2.3.4:5000", parsed["foo"].Endpoint)

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -293,7 +293,7 @@ func (c *Cluster) startMons(targetCount int) error {
 		}
 	}
 
-	logger.Debugf("mon endpoints used are: %s", FlattenMonEndpoints(c.ClusterInfo.Monitors))
+	logger.Debugf("mon endpoints used are: %s", flattenMonEndpoints(c.ClusterInfo.Monitors))
 
 	// reconcile mon PDB
 	if err := c.reconcileMonPDB(); err != nil {
@@ -1125,7 +1125,7 @@ func (c *Cluster) persistExpectedMonDaemons() error {
 	}
 
 	configMap.Data = map[string]string{
-		EndpointDataKey: FlattenMonEndpoints(c.ClusterInfo.Monitors),
+		EndpointDataKey: flattenMonEndpoints(c.ClusterInfo.Monitors),
 		// persist the maxMonID that was previously stored in the configmap. We are likely saving info
 		// about scheduling of the mons, but we only want to update the maxMonID once a new mon has
 		// actually been started. If the operator is restarted or the reconcile is otherwise restarted,


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

The function ParseMonEndpoints existed twice, once in the mon package and once in the controller package. It has now been deleted from the mon package. Usages in the mon package now reference the function in the controller package.

**Which issue is resolved by this Pull Request:**
Resolves #12536

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
