### PR TITLE
mon: update the rook-ceph-mon-endpoints with the csi-config-map

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -118,6 +118,10 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	if err != nil {
 		return errors.Wrap(err, "failed to update csi cluster config")
 	}
+	err = csi.UpdateMonEndpointConfig(c.context.Clientset, c.namespacedName.Namespace, monEndpoints)
+	if err != nil {
+		return errors.Wrap(err, "failed to update mon endpoint config")
+	}
 	logger.Info("successfully updated csi config map")
 
 	// Create Crash Collector Secret

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1082,7 +1082,9 @@ func (c *Cluster) saveMonConfig() error {
 	if err := csi.SaveClusterConfig(c.context.Clientset, c.Namespace, c.ClusterInfo, &csi.CsiClusterConfigEntry{Namespace: c.ClusterInfo.Namespace, Monitors: monEndpoints}); err != nil {
 		return errors.Wrap(err, "failed to update csi cluster config")
 	}
-
+	if err := csi.UpdateMonEndpointConfig(c.context.Clientset, c.Namespace, monEndpoints); err != nil {
+		return errors.Wrap(err, "failed to update mon endpoint config")
+	}
 	return nil
 }
 


### PR DESCRIPTION
    This is where where we update the cluster-info and that clusterinfo is used by csi-config
https://github.com/rook/rook/blob/cb44c7b88fb346f3b120e8bda769ac808ec60880/pkg/operator/ceph/controller/cluster_info.go#L277 So strongly believe now we should definitely update the rook-ceph-mon-endpoints with the csi-config-map whenever we do v2 port updation, https://github.com/rook/rook/blob/cb44c7b88fb346f3b120e8bda769ac808ec60880/pkg/operator/ceph/csi/cluster_config.go#L105

Closes: https://github.com/rook/rook/issues/12595

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
