### PR TITLE
docs: add note in upgrade guide about cephfs driver's breaking change

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -49,6 +49,10 @@ those releases.
 ## Breaking changes in v1.12
 
 * The minimum supported version of Kubernetes is v1.22.
+* CephCSI CephFS driver introduced a breaking change in v3.9.0. If any existing CephFS storageclass in
+  the cluster has `MountOptions` parameter set, follow the steps mentioned in the
+  [CephCSI upgrade guide](https://github.com/ceph/ceph-csi/blob/v3.9.0/docs/ceph-csi-upgrade.md/#upgrading-cephfs)
+  to ensure a smooth upgrade.
 
 ## Considerations
 


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

CephCSI CephFS introduced a breaking change in v3.9.0. This commit adds a note in upgrade guide regarding the same.

refer: https://github.com/ceph/ceph-csi/blob/v3.9.0/docs/ceph-csi-upgrade.md/#upgrading-cephfs

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
