### PR TITLE
nfs: fix null pointer deref in generateSssdSidecarResources()

### DIFF
--- a/pkg/operator/ceph/nfs/security.go
+++ b/pkg/operator/ceph/nfs/security.go
@@ -164,15 +164,16 @@ func generateSssdSidecarResources(nfs *cephv1.CephNFS, sidecarCfg *cephv1.SSSDSi
 			SubPath:   "krb5.conf",
 		}
 		sssdMounts = append(sssdMounts, krb5ConfD, krbConfMount)
-	}
-	if nfs.Spec.Security.Kerberos.KeytabFile.VolumeSource != nil {
-		volName := "krb5-keytab"
-		keytabMount := v1.VolumeMount{
-			Name:      volName,
-			MountPath: "/etc/krb5.keytab",
-			SubPath:   "krb5.keytab",
+
+		if nfs.Spec.Security.Kerberos.KeytabFile.VolumeSource != nil {
+			volName := "krb5-keytab"
+			keytabMount := v1.VolumeMount{
+				Name:      volName,
+				MountPath: "/etc/krb5.keytab",
+				SubPath:   "krb5.keytab",
+			}
+			sssdMounts = append(sssdMounts, keytabMount)
 		}
-		sssdMounts = append(sssdMounts, keytabMount)
 	}
 
 	// the init container is needed to copy the starting content from the /var/lib/sss/pipes


### PR DESCRIPTION
0a151e913 results in a bug which causes null pointer dereference when Kerberos is not setup. This causes a failure in Unit test TestReconcileCephNFS_addSecurityConfigsToPod


<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ *] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ *] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
