### PR TITLE
object: fix s5cmd for s3 endpoint verification

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -242,7 +242,6 @@ jobs:
         with:
           name: canary
 
-
   raw-disk:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -286,6 +285,12 @@ jobs:
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
 
+      - name: test toolbox-operator-image pod
+        run: |
+          tests/scripts/github-action-helper.sh create_operator_toolbox
+          toolbox=$(kubectl get pod -l app=rook-ceph-tools-operator-image -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          timeout 120 sh -c "while kubectl get pod $toolbox -nrook-ceph -o jsonpath='{.items[*].status.phase}'|grep -qE 'Running'; do echo 'waiting for operator toolbox pod to start'; sleep 5; done"
+
       - name: check-ownerreferences
         run: tests/scripts/github-action-helper.sh check_ownerreferences
 
@@ -294,7 +299,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: canary
-
 
   two-osds-in-device:
     runs-on: ubuntu-20.04
@@ -340,7 +344,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: canary
-
 
   osd-with-metadata-device:
     runs-on: ubuntu-20.04
@@ -393,7 +396,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: canary
-
 
   encryption:
     runs-on: ubuntu-20.04
@@ -492,7 +494,6 @@ jobs:
         with:
           name: canary
 
-
   pvc:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -565,7 +566,6 @@ jobs:
         with:
           name: pvc
 
-
   pvc-db:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -613,7 +613,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: pvc-db
-
 
   pvc-db-wal:
     runs-on: ubuntu-20.04
@@ -665,7 +664,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: pvc-db-wal
-
 
   encryption-pvc:
     runs-on: ubuntu-20.04
@@ -730,7 +728,6 @@ jobs:
         with:
           name: encryption-pvc
 
-
   encryption-pvc-db:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -780,7 +777,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: encryption-pvc-db
-
 
   encryption-pvc-db-wal:
     runs-on: ubuntu-20.04
@@ -841,7 +837,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: encryption-pvc-db-wal
-
 
   encryption-pvc-kms-vault-token-auth:
     runs-on: ubuntu-20.04
@@ -924,7 +919,6 @@ jobs:
         with:
           name: encryption-pvc-kms-vault-token-auth
 
-
   encryption-pvc-kms-vault-k8s-auth:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -986,7 +980,6 @@ jobs:
         with:
           name: encryption-pvc-kms-vault-k8s-auth
 
-
   lvm-pvc:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -1039,7 +1032,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: lvm-pvc
-
 
   multi-cluster-mirroring:
     runs-on: ubuntu-20.04
@@ -1295,7 +1287,6 @@ jobs:
         with:
           name: multi-cluster-mirroring
 
-
   rgw-multisite-testing:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
@@ -1323,7 +1314,6 @@ jobs:
         with:
           name: rgw-multisite-testing
           path: test
-
 
   encryption-pvc-kms-ibm-kp:
     runs-on: ubuntu-20.04
@@ -1355,7 +1345,6 @@ jobs:
         with:
           name: encryption-pvc-kms-ibm-kp
           path: test
-
 
   multus-cluster-network:
     runs-on: ubuntu-20.04
@@ -1434,7 +1423,6 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: canary-multus
-
 
   csi-hostnetwork-disabled:
     runs-on: ubuntu-20.04

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -219,9 +219,13 @@ below in the section [creating a user](#create-a-user) if you are not creating t
 
 ### Configure s5cmd
 
-To test the `CephObjectStore`, set the object store credentials in the toolbox pod for the `s5cmd` tool.
+To test the `CephObjectStore`, set the object store credentials in the toolbox pod that contains the `s5cmd` tool.
+
+!!! important
+    The default toolbox.yaml does not contain the s5cmd. The toolbox must be started with the rook operator image (toolbox-operator-image), which does contain s5cmd.
 
 ```console
+kubectl create -f deploy/examples/toolbox-operator-image.yaml
 mkdir ~/.aws
 cat > ~/.aws/credentials << EOF
 [default]

--- a/deploy/examples/toolbox-operator-image.yaml
+++ b/deploy/examples/toolbox-operator-image.yaml
@@ -1,0 +1,136 @@
+#################################################################################################################
+# Define the toolbox that will run with the Rook operator image.
+
+# For example
+#   kubectl create -f toolbox-operator-image.yaml
+#################################################################################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools-operator-image
+  namespace: rook-ceph # namespace:cluster
+  labels:
+    app: rook-ceph-tools-operator-image
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools-operator-image
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools-operator-image
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: rook-ceph-tools-operator-image
+          image: rook/ceph:master
+          command:
+            - /bin/bash
+            - -c
+            - |
+              # Replicate the script from toolbox.sh inline so the ceph image
+              # can be run directly, instead of requiring the rook toolbox
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+
+              # create a ceph config file in its default location so ceph/rados tools can be used
+              # without specifying any arguments
+              write_endpoints() {
+                endpoints=$(cat ${MON_CONFIG})
+
+                # filter out the mon names
+                # external cluster can have numbers or hyphens in mon names, handling them in regex
+                # shellcheck disable=SC2001
+                mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$(date)
+                echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
+                  cat <<EOF > ${CEPH_CONFIG}
+              [global]
+              mon_host = ${mon_endpoints}
+
+              [client.admin]
+              keyring = ${KEYRING_FILE}
+              EOF
+              }
+
+              # watch the endpoints config file and update if the mon endpoints ever change
+              watch_endpoints() {
+                # get the timestamp for the target of the soft link
+                real_path=$(realpath ${MON_CONFIG})
+                initial_time=$(stat -c %Z "${real_path}")
+                while true; do
+                  real_path=$(realpath ${MON_CONFIG})
+                  latest_time=$(stat -c %Z "${real_path}")
+
+                  if [[ "${latest_time}" != "${initial_time}" ]]; then
+                    write_endpoints
+                    initial_time=${latest_time}
+                  fi
+
+                  sleep 10
+                done
+              }
+
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=${ROOK_CEPH_SECRET}
+              if [[ "$ceph_secret" == "" ]]; then
+                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > ${KEYRING_FILE}
+              [${ROOK_CEPH_USERNAME}]
+              key = ${ceph_secret}
+              EOF
+
+              # write the initial config file
+              write_endpoints
+
+              # continuously update the mon endpoints if they fail over
+              watch_endpoints
+          imagePullPolicy: IfNotPresent
+          tty: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2016
+            runAsGroup: 2016
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
+      volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 5

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -597,6 +597,11 @@ function deploy_multus_cluster() {
   kubectl create -f nfs-test.yaml
 }
 
+function create_operator_toolbox() {
+  cd deploy/examples
+  kubectl create -f toolbox-operator-image.yaml
+}
+
 function wait_for_ceph_csi_configmap_to_be_updated {
   timeout 60 bash <<EOF
 until [[ $(kubectl -n rook-ceph get configmap rook-ceph-csi-config -o jsonpath="{.data.csi-cluster-config-json}" | jq .[0].rbd.netNamespaceFilePath) != "null" ]]; do


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
add a new toolbox yaml manifest which will use the rook image instead of ceph image
for running s5 cmd container needs to run with rook image

**Which issue is resolved by this Pull Request:**
Resolves # closes: https://github.com/rook/rook/issues/12227

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
