### PR TITLE
tests: Toolbox to use same ceph image as the test

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -15,6 +15,7 @@
         "core",
         "cosi",
         "csi",
+        "doc",
         "docs",
         "exporter",
         "external",
@@ -37,6 +38,7 @@
         "subvolumegroup",
         "namespace",
         "test",
+        "tests",
         "webhook"
       ]
     ],

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -18,6 +18,7 @@ package installer
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -112,7 +113,12 @@ func (m *CephManifestsMaster) GetToolbox() string {
 		manifest = strings.ReplaceAll(manifest, "name: rook-direct-mount", "name: rook-ceph-tools")
 		return strings.ReplaceAll(manifest, "app: rook-direct-mount", "app: rook-ceph-tools")
 	}
-	return m.settings.readManifest("toolbox.yaml")
+	manifest := m.settings.readManifest("toolbox.yaml")
+	// The toolbox uses the ceph image, so replace the version that is being tested
+	// The regex allows for any character in the tag ("\S" --> non-whitespace character)
+	versionRegex := regexp.MustCompile(`image: quay.io/ceph/ceph:\S+`)
+	manifest = versionRegex.ReplaceAllString(manifest, "image: "+m.settings.CephVersion.Image)
+	return manifest
 }
 
 //**********************************************************************************


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The test is currently only using the ceph version that is included with toolbox.yaml, which may be different from the version of the ceph cluster being tested. Now the version will be replaced to match the desired ceph test version.

This seems to affect the stability of the CI, for example in [this daily run](https://github.com/rook/rook/actions/runs/5697351936/job/15443927251) where the toolbox would not start. Perhaps the host ran out of space to pull the different image.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
