### PR TITLE
operator: fix formatting of some logger methods

### DIFF
--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -269,7 +269,7 @@ func atomicPrependToConfigObject(
 		if err != nil {
 			logger.Infof("failed to unlock rados object %q, but since the lock has a timeout, we will continue. %v", objInfoString, err)
 		}
-		logger.Info("successfully unlocked rados object %q", objInfoString)
+		logger.Infof("successfully unlocked rados object %q", objInfoString)
 	}()
 
 	cmd := cephclient.NewRadosCommand(context, clusterInfo,

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -131,7 +131,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	err := r.client.Get(r.opManagerContext, request.NamespacedName, cephObjectRealm)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Debug("CephObjectRealm %q resource not found. Ignoring since object must be deleted", request.NamespacedName.String())
+			logger.Debugf("CephObjectRealm %q resource not found. Ignoring since object must be deleted", request.NamespacedName.String())
 			return reconcile.Result{}, *cephObjectRealm, nil
 		}
 		// Error reading the object - requeue the request.
@@ -185,7 +185,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 
 	// Create/Pull Ceph Realm
 	if cephObjectRealm.Spec.IsPullRealm() {
-		logger.Debug("pull section in realm %q spec found", request.NamespacedName)
+		logger.Debugf("pull section in realm %q spec found", request.NamespacedName)
 		_, err = r.pullCephRealm(cephObjectRealm)
 		if err != nil {
 			return reconcile.Result{}, *cephObjectRealm, err
@@ -207,14 +207,14 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	r.updateStatus(observedGeneration, request.NamespacedName, k8sutil.ReadyStatus)
 
 	// Return and do not requeue
-	logger.Debug("realm %q done reconciling", request.NamespacedName)
+	logger.Debugf("realm %q done reconciling", request.NamespacedName)
 	return reconcile.Result{}, *cephObjectRealm, nil
 }
 
 func (r *ReconcileObjectRealm) pullCephRealm(realm *cephv1.CephObjectRealm) (reconcile.Result, error) {
 	realmArg := fmt.Sprintf("--rgw-realm=%s", realm.Name)
 	urlArg := fmt.Sprintf("--url=%s", realm.Spec.Pull.Endpoint)
-	logger.Debug("getting keys to pull realm for CephObjectRealm %q", realm.Name)
+	logger.Debugf("getting keys to pull realm for CephObjectRealm %q", realm.Name)
 	accessKeyArg, secretKeyArg, err := object.GetRealmKeyArgs(r.opManagerContext, r.context, realm.Name, realm.Namespace)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
@@ -336,7 +336,7 @@ func (r *ReconcileObjectRealm) updateStatus(observedGeneration int64, name types
 	objectRealm := &cephv1.CephObjectRealm{}
 	if err := r.client.Get(r.opManagerContext, name, objectRealm); err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Debug("CephObjectRealm %q resource not found. Ignoring since object must be deleted", name)
+			logger.Debugf("CephObjectRealm %q resource not found. Ignoring since object must be deleted", name)
 			return
 		}
 		logger.Warningf("failed to retrieve object realm %q to update status to %q. %v", name, status, err)

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -249,7 +249,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 
 	r.updateStatus(r.client, namespacedName, cephv1.ConditionReady)
 	// Return and do not requeue
-	logger.Debug("done reconciling cephBlockPoolRadosNamespace %q", namespacedName)
+	logger.Debugf("done reconciling cephBlockPoolRadosNamespace %q", namespacedName)
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Some logging instructions use formatting syntax `%q`, but the logging method is `Info` or `Debug` instead of `Debugf` and `Infof`. As a result, the arguments of the method were concatenated instead of formatted properly.

**Which issue is resolved by this Pull Request:**

No issue.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
