### PR TITLE
csi: add mode csi pods to the list to force delete pod

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -319,6 +319,8 @@ func (c *cephStatusChecker) getRookPodsOnNode(node string) ([]v1.Pod, error) {
 		"csi-cephfsplugin-provisioner",
 		"csi-cephfsplugin",
 		"csi-nfsplugin-holder",
+		"csi-nfsplugin-provisioner",
+		"csi-nfsplugin",
 		"rook-ceph-operator",
 		"rook-ceph-mon",
 		"rook-ceph-osd",

--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -314,8 +314,11 @@ func (c *cephStatusChecker) getRookPodsOnNode(node string) ([]v1.Pod, error) {
 	appLabels := []string{
 		"csi-rbdplugin-provisioner",
 		"csi-rbdplugin",
+		"csi-rbdplugin-holder",
+		"csi-cephfsplugin-holder",
 		"csi-cephfsplugin-provisioner",
 		"csi-cephfsplugin",
+		"csi-nfsplugin-holder",
 		"rook-ceph-operator",
 		"rook-ceph-mon",
 		"rook-ceph-osd",

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -326,8 +326,11 @@ func TestGetRookPodsOnNode(t *testing.T) {
 		{"app": "rook-ceph-osd"},
 		{"app": "csi-rbdplugin-provisioner"},
 		{"app": "csi-rbdplugin"},
+		{"app": "csi-rbdplugin-holder"},
 		{"app": "csi-cephfsplugin-provisioner"},
 		{"app": "csi-cephfsplugin"},
+		{"app": "csi-cephfsplugin-holder"},
+		{"app": "csi-nfsplugin-holder"},
 		{"app": "rook-ceph-operator"},
 		{"app": "rook-ceph-crashcollector"},
 		{"app": "rook-ceph-mgr"},
@@ -363,7 +366,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 	pods, err := c.getRookPodsOnNode("node0")
 	assert.NoError(t, err)
 	// A pod is having two matching labels and its returned only once
-	assert.Equal(t, 12, len(pods))
+	assert.Equal(t, 15, len(pods))
 
 	podNames := []string{}
 	for _, pod := range pods {

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -330,6 +330,8 @@ func TestGetRookPodsOnNode(t *testing.T) {
 		{"app": "csi-cephfsplugin-provisioner"},
 		{"app": "csi-cephfsplugin"},
 		{"app": "csi-cephfsplugin-holder"},
+		{"app": "csi-nfsplugin-provisioner"},
+		{"app": "csi-nfsplugin"},
 		{"app": "csi-nfsplugin-holder"},
 		{"app": "rook-ceph-operator"},
 		{"app": "rook-ceph-crashcollector"},
@@ -366,7 +368,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 	pods, err := c.getRookPodsOnNode("node0")
 	assert.NoError(t, err)
 	// A pod is having two matching labels and its returned only once
-	assert.Equal(t, 15, len(pods))
+	assert.Equal(t, 17, len(pods))
 
 	podNames := []string{}
 	for _, pod := range pods {


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

Add holder pods label to the list so that Rook can get all the pods on the failed node and force delete the pods stuck in the terminating state.

Add nfs pods label to the list so that Rook can get all the pods on the failed node and force delete the pods stuck in the terminating state.


**Which issue is resolved by this Pull Request:**
Updates #12645 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
