### PR TITLE
nfs: run dbus-daemon sidecar as dbus user instead of root

### DIFF
--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -252,6 +252,9 @@ func (r *ReconcileCephNFS) daemonContainer(nfs *cephv1.CephNFS, cfg daemonConfig
 func (r *ReconcileCephNFS) dbusContainer(nfs *cephv1.CephNFS) v1.Container {
 	_, dbusMount := dbusVolumeAndMount()
 
+	// uid of the "dbus" user in most (all?) Linux distributions
+	dbusUID := int64(81)
+
 	return v1.Container{
 		Name: "dbus-daemon",
 		Command: []string{
@@ -270,6 +273,9 @@ func (r *ReconcileCephNFS) dbusContainer(nfs *cephv1.CephNFS) v1.Container {
 		},
 		Env:       k8sutil.ClusterDaemonEnvVars(r.cephClusterSpec.CephVersion.Image), // do not need access to Ceph env vars b/c not a Ceph daemon
 		Resources: nfs.Spec.Server.Resources,
+		SecurityContext: &v1.SecurityContext{
+			RunAsUser: &dbusUID,
+		},
 	}
 }
 


### PR DESCRIPTION
**Description of your changes:**

When the dbus-daemon in the sidecar is started as "root" user, it fails with the following log entry:

    Failed to start message bus: Failed to drop capabilities: Operation not permitted

By starting the sidecar as "dbus" user (uid=81), the executable does not try to drop capabilities, and starts successfully.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
