### PR TITLE
csi: set ceph cluster as ControllerRef for holder ds

### DIFF
--- a/pkg/operator/ceph/csi/controller_test.go
+++ b/pkg/operator/ceph/csi/controller_test.go
@@ -215,6 +215,7 @@ func TestCephCSIController(t *testing.T) {
 		c.Client = cl
 		// // Create a ReconcileCSI object with the scheme and fake client.
 		r := &ReconcileCSI{
+			scheme:  s,
 			client:  cl,
 			context: c,
 			opConfig: controller.OperatorConfig{

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -24,6 +24,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -73,7 +74,9 @@ func TestReconcileCSI_configureHolders(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph", Name: "my-cluster"},
 					Spec:       cephv1.ClusterSpec{},
 				},
-				clusterInfo: &cephclient.ClusterInfo{Monitors: map[string]*cephclient.MonInfo{"a": {Name: "a", Endpoint: "10.0.0.1:6789"}}},
+				clusterInfo: &cephclient.ClusterInfo{
+					Monitors:  map[string]*cephclient.MonInfo{"a": {Name: "a", Endpoint: "10.0.0.1:6789"}},
+					OwnerInfo: client.NewMinimumOwnerInfoWithOwnerRef()},
 			},
 		}
 


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

Setting the ceph cluster as the ControllerRef for the holder daemonset set so that when a ceph cluster is deleted the holder daemoset will also get deleted.

**Which issue is resolved by this Pull Request:**
Resolves #12645

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
