### PR TITLE
object: Allow creating an object user in different namespace

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -82,7 +82,13 @@ When the `zone` section is set pools with the object stores name will not be cre
 
 * `metadataPool`: The settings used to create all of the object store metadata pools. Must use replication.
 * `dataPool`: The settings to create the object store data pool. Can use replication or erasure coding.
-* `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the object store will remain when the object store will be deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'.
+* `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the object store will remain when the object store
+  will be deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified
+  is also deemed as 'false'.
+* `allowUsersInNamespaces`: If a CephObjectStoreUser is created in a namespace other than the Rook cluster namespace,
+  the namespace must be added to this list of allowed namespaces, or specify "*" to allow all namespaces.
+  This is useful for applications that need object store credentials to be created in their own namespace,
+  where neither OBCs nor COSI is being used to create buckets. The default is empty.
 
 ## Gateway Settings
 

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -36,6 +36,9 @@ spec:
 
 * `store`: The object store in which the user will be created. This matches the name of the objectstore CRD.
 * `displayName`: The display name which will be passed to the `radosgw-admin user create` command.
+* `clusterNamespace`: The namespace where the parent CephCluster and CephObjectStore are found. If not specified,
+  the user must be in the same namespace as the cluster and object store.
+  To enable this feature, the CephObjectStore allowUsersInNamespaces must include the namespace of this user.
 * `quotas`: This represents quota limitation can be set on the user. Please refer [here](https://docs.ceph.com/en/latest/radosgw/admin/#quota-management) for details.
     * `maxBuckets`: The maximum bucket limit for the user.
     * `maxSize`: Maximum size limit of all objects across all the user's buckets.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1872,6 +1872,23 @@ ObjectStoreSecuritySpec
 <p>Security represents security settings</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>allowUsersInNamespaces</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The list of allowed namespaces in addition to the object store namespace
+where ceph object store users may be created. Specify &ldquo;*&rdquo; to allow all
+namespaces, otherwise list individual namespaces that are to be allowed.
+This is useful for applications that need object store credentials
+to be created in their own namespace, where neither OBCs nor COSI
+is being used to create buckets. The default is empty.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1994,6 +2011,18 @@ ObjectUserQuotaSpec
 </td>
 <td>
 <em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
 </table>
@@ -8616,6 +8645,23 @@ ObjectStoreSecuritySpec
 <p>Security represents security settings</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>allowUsersInNamespaces</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The list of allowed namespaces in addition to the object store namespace
+where ceph object store users may be created. Specify &ldquo;*&rdquo; to allow all
+namespaces, otherwise list individual namespaces that are to be allowed.
+This is useful for applications that need object store credentials
+to be created in their own namespace, where neither OBCs nor COSI
+is being used to create buckets. The default is empty.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ObjectStoreStatus">ObjectStoreStatus
@@ -8772,6 +8818,18 @@ ObjectUserQuotaSpec
 </td>
 <td>
 <em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -9907,6 +9907,11 @@ spec:
             spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
+                allowUsersInNamespaces:
+                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store users may be created. Specify "*" to allow all namespaces, otherwise list individual namespaces that are to be allowed. This is useful for applications that need object store credentials to be created in their own namespace, where neither OBCs nor COSI is being used to create buckets. The default is empty.
+                  items:
+                    type: string
+                  type: array
                 dataPool:
                   description: The data pool settings
                   nullable: true
@@ -11442,6 +11447,9 @@ spec:
                         - read, write
                       type: string
                   type: object
+                clusterNamespace:
+                  description: The namespace where the parent CephCluster and CephObjectStore are found
+                  type: string
                 displayName:
                   description: The display name for the ceph users
                   type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -9898,6 +9898,11 @@ spec:
             spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
+                allowUsersInNamespaces:
+                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store users may be created. Specify "*" to allow all namespaces, otherwise list individual namespaces that are to be allowed. This is useful for applications that need object store credentials to be created in their own namespace, where neither OBCs nor COSI is being used to create buckets. The default is empty.
+                  items:
+                    type: string
+                  type: array
                 dataPool:
                   description: The data pool settings
                   nullable: true
@@ -11432,6 +11437,9 @@ spec:
                         - read, write
                       type: string
                   type: object
+                clusterNamespace:
+                  description: The namespace where the parent CephCluster and CephObjectStore are found
+                  type: string
                 displayName:
                   description: The display name for the ceph users
                   type: string

--- a/deploy/examples/object-user.yaml
+++ b/deploy/examples/object-user.yaml
@@ -13,13 +13,17 @@ spec:
   displayName: "my display name"
   # Quotas set on the user
   # quotas:
-     # maxBuckets: 100
-     # maxSize: 10G
-     # maxObjects: 10000
+  #   maxBuckets: 100
+  #   maxSize: 10G
+  #   maxObjects: 10000
   # Additional permissions given to the user
   # capabilities:
-     # user: "*"
-     # bucket: "*"
-     # metadata: "*"
-     # usage: "*"
-     # zone: "*"
+  #   user: "*"
+  #   bucket: "*"
+  #   metadata: "*"
+  #   usage: "*"
+  #   zone: "*"
+  # If the CephObjectStoreUser is created in a namespace other than the Rook cluster namespace,
+  # specify the namespace where the cluster and object store are found.
+  # "allowUsersInNamespaces" must include this namespace to enable this feature.
+  # clusterNamespace: rook-ceph

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -109,6 +109,10 @@ spec:
       disabled: false
     readinessProbe:
       disabled: false
+  # If a CephObjectStoreUser is created in a namespace other than the Rook cluster namespace,
+  # the namespace must be added to the list of allowed namespaces, or specify "*" to allow all namespaces.
+  # allowUsersInNamespaces:
+  #   - other-namespace
   # security oriented settings
   # security:
   # To enable the Server Side Encryption configuration properly don't forget to uncomment the Secret at the end of the file

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1387,6 +1387,15 @@ type ObjectStoreSpec struct {
 	// +optional
 	// +nullable
 	Security *ObjectStoreSecuritySpec `json:"security,omitempty"`
+
+	// The list of allowed namespaces in addition to the object store namespace
+	// where ceph object store users may be created. Specify "*" to allow all
+	// namespaces, otherwise list individual namespaces that are to be allowed.
+	// This is useful for applications that need object store credentials
+	// to be created in their own namespace, where neither OBCs nor COSI
+	// is being used to create buckets. The default is empty.
+	// +optional
+	AllowUsersInNamespaces []string `json:"allowUsersInNamespaces,omitempty"`
 }
 
 // ObjectHealthCheckSpec represents the health check of an object store
@@ -1597,6 +1606,9 @@ type ObjectStoreUserSpec struct {
 	// +optional
 	// +nullable
 	Quotas *ObjectUserQuotaSpec `json:"quotas,omitempty"`
+	// The namespace where the parent CephCluster and CephObjectStore are found
+	// +optional
+	ClusterNamespace string `json:"clusterNamespace,omitempty"`
 }
 
 // Additional admin-level capabilities for the Ceph object store user


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The object user was previously required to be created in the same namespace as the object store and the cluster. Now, the object user can be reconciled even in a different namespace from the cluster and object store. The namespace would be specified in the object user CR.

**Which issue is resolved by this Pull Request:**
Resolves #12716

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
