### PR TITLE
monitoring: add "for" to CephOSDDownHigh alert

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -89,6 +89,7 @@ groups:
           description: "{{ $value | humanize }}% or {{ with query \"count(ceph_osd_up == 0)\" }}{{ . | first | value }}{{ end }} of {{ with query \"count(ceph_osd_up)\" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
           summary: "More than 10% of OSDs are down"
         expr: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
+        for: "5m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
           severity: "critical"


### PR DESCRIPTION
As part of a normal restart, an OSD can go down just as prometheus tries to scrape it, causing this alert to fire. Alerts shouldn't fire as part of normal operations. This change requires the OSD to be down for 5 consecutive minutes before the alert will fire.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
