### PR TITLE
tests: Start toolbox earlier in tests

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -230,13 +230,12 @@ func (h *CephInstaller) WaitForToolbox(namespace string) error {
 // CreateRookToolbox creates rook-ceph-tools via kubectl
 func (h *CephInstaller) CreateRookToolbox(manifests CephManifests) (err error) {
 	logger.Infof("Starting Rook toolbox")
-
 	_, err = h.k8shelper.KubectlWithStdin(manifests.GetToolbox(), createFromStdinArgs...)
 	if err != nil {
 		return errors.Wrap(err, "failed to create rook-toolbox pod")
 	}
 
-	return h.WaitForToolbox(manifests.Settings().Namespace)
+	return nil
 }
 
 // Execute a command in the ceph toolbox
@@ -372,6 +371,9 @@ func (h *CephInstaller) CreateRookExternalCluster(externalManifests CephManifest
 	logger.Infof("Running toolbox on external namespace %q", externalSettings.Namespace)
 	if err := h.CreateRookToolbox(externalManifests); err != nil {
 		return errors.Wrap(err, "failed to start toolbox on external cluster")
+	}
+	if err := h.WaitForToolbox(externalManifests.Settings().Namespace); err != nil {
+		return errors.Wrap(err, "failed to wait for toolbox on external cluster")
 	}
 
 	var clusterStatus cephv1.ClusterStatus
@@ -579,6 +581,10 @@ func (h *CephInstaller) InstallRook() (bool, error) {
 			logger.Errorf("Cluster %q install failed. %v", h.settings.Namespace, err)
 			return false, err
 		}
+		err = h.CreateRookToolbox(h.Manifests)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to install toolbox in cluster %s", h.settings.Namespace)
+		}
 	}
 
 	logger.Info("Waiting for Rook Cluster")
@@ -586,16 +592,9 @@ func (h *CephInstaller) InstallRook() (bool, error) {
 		return false, err
 	}
 
-	if h.settings.UseHelm {
-		err := h.WaitForToolbox(h.settings.Namespace)
-		if err != nil {
-			return false, err
-		}
-	} else {
-		err = h.CreateRookToolbox(h.Manifests)
-		if err != nil {
-			return false, errors.Wrapf(err, "failed to install toolbox in cluster %s", h.settings.Namespace)
-		}
+	err = h.WaitForToolbox(h.settings.Namespace)
+	if err != nil {
+		return false, err
 	}
 
 	const loopCount = 20

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -92,6 +92,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		Namespace:         "multi-external",
 		OperatorNamespace: s.settings.OperatorNamespace,
 		RookVersion:       s.settings.RookVersion,
+		CephVersion:       installer.PacificVersion,
 	}
 	externalSettings.ApplyEnvVars()
 	s.externalManifests = installer.NewCephManifests(externalSettings)


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The toolbox sometimes times out when the tests are waiting for it to start. Now we create the toolbox spec sooner in the tests so we won't need to wait so long for it to start or increase the wait timeout in the tests.

This is similar to #12736 that starts the toolbox earlier in other tests.

**Which issue is resolved by this Pull Request:**
Resolves #12733

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
