### PR TITLE
ci: upgrade the kubernetes versions for ci

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.27.3
+        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.28.0
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -121,7 +121,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -156,7 +156,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -191,7 +191,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -227,7 +227,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -262,7 +262,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -297,7 +297,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -332,7 +332,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -367,7 +367,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.25.0"
+          kubernetes-version: "1.28.0"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.27.2"]
+        kubernetes-versions: ["v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.27.2"]
+        kubernetes-versions: ["v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.26.5", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.14", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.25.12", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -254,7 +254,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.22.17", "v1.28.0"]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -672,21 +672,33 @@ function test_csi_nfs_workload {
 }
 
 function install_minikube_with_none_driver() {
-  CRICTL_VERSION="v1.26.0"
-  MINIKUBE_VERSION="v1.29.0"
+  CRICTL_VERSION="v1.28.0"
+  MINIKUBE_VERSION="v1.31.2"
 
   sudo apt update
   sudo apt install -y conntrack socat
   curl -LO https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_amd64.deb
   sudo dpkg -i minikube_latest_amd64.deb
   rm -f minikube_latest_amd64.deb
-  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.0/cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
-  sudo dpkg -i cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
-  rm -f cri-dockerd_0.3.0.3-0.ubuntu-focal_amd64.deb
+
+  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.4/cri-dockerd_0.3.4.3-0.ubuntu-focal_amd64.deb
+  sudo dpkg -i cri-dockerd_0.3.4.3-0.ubuntu-focal_amd64.deb
+  rm -f cri-dockerd_0.3.4.3-0.ubuntu-focal_amd64.deb
+
   wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
   sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
   rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
   sudo sysctl fs.protected_regular=0
+
+  CNI_PLUGIN_VERSION="v1.3.0"
+  CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz" # change arch if not on amd64
+  CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
+
+  curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
+  sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
+  sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
+  rm "$CNI_PLUGIN_TAR"
+
   export MINIKUBE_HOME=$HOME CHANGE_MINIKUBE_NONE_USER=true KUBECONFIG=$HOME/.kube/config
   sudo -E minikube start --kubernetes-version="$1" --driver=none --memory 6g --cpus=2 --addons ingress --cni=calico
 }


### PR DESCRIPTION
since, kubernetes v1.28.0 release upgrading the
latest k8s version to v.1.28.0 and minimum version to v1.23.17

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
