### PR TITLE
osd: replace existing OSDs to use new store

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -19,7 +19,6 @@ package ceph
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 	"strconv"
@@ -30,9 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/clusterd"
-	cleanup "github.com/rook/rook/pkg/daemon/ceph/cleanup"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	osddaemon "github.com/rook/rook/pkg/daemon/ceph/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -263,11 +259,11 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	// destroy the OSD using the OSD ID
 	var replaceOSD *osd.OSDReplaceInfo
 	if replaceOSDID != -1 {
-		osdInfo, err := destroyOSD(context, &clusterInfo, replaceOSDID)
+		logger.Infof("destroying osd.%d and cleaning its backing device", replaceOSDID)
+		replaceOSD, err = osddaemon.DestroyOSD(context, &clusterInfo, replaceOSDID, cfg.pvcBacked, cfg.storeConfig.EncryptedDevice)
 		if err != nil {
-			rook.TerminateFatal(errors.Wrapf(err, "failed to destroy OSD %d.", osdInfo.ID))
+			rook.TerminateFatal(errors.Wrapf(err, "failed to destroy OSD %d.", replaceOSDID))
 		}
-		replaceOSD = &oposd.OSDReplaceInfo{ID: osdInfo.ID, Path: osdInfo.BlockPath}
 	}
 
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, forceFormat,
@@ -416,37 +412,4 @@ func readCephSecret(path string) error {
 		return errors.New("ceph admin secret not found")
 	}
 	return nil
-}
-
-func destroyOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID int) (*oposd.OSDInfo, error) {
-	osdInfo, err := osddaemon.GetOSDInfoById(context, clusterInfo, osdID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get OSD info for OSD.%d", osdID)
-	}
-
-	// destroy the osd
-	logger.Infof("destroying OSD %d on path %q in %q mode", osdInfo.ID, osdInfo.BlockPath, osdInfo.CVMode)
-	destroyOSDArgs := []string{"osd", "destroy", fmt.Sprintf("osd.%d", osdInfo.ID), "--yes-i-really-mean-it"}
-	_, err = client.NewCephCommand(context, clusterInfo, destroyOSDArgs).Run()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to destroy osd.%d.", osdInfo.ID)
-	}
-
-	// Sanitize OSD disk
-	s := cleanup.NewDiskSanitizer(context, clusterInfo,
-		&cephv1.SanitizeDisksSpec{
-			Method:     cephv1.SanitizeMethodProperty(cephv1.SanitizeMethodComplete),
-			DataSource: cephv1.SanitizeDataSourceProperty(cephv1.SanitizeDataSourceZero),
-			Iteration:  1,
-		},
-	)
-
-	// TODO: handle disk sanitization errors
-	if osdInfo.CVMode == "raw" {
-		s.SanitizeRawDisk([]oposd.OSDInfo{osdInfo})
-	} else if osdInfo.CVMode == "lvm" {
-		s.SanitizeLVMDisk([]oposd.OSDInfo{osdInfo})
-	}
-
-	return &osdInfo, nil
 }

--- a/pkg/daemon/ceph/client/deviceclass.go
+++ b/pkg/daemon/ceph/client/deviceclass.go
@@ -34,7 +34,7 @@ func GetDeviceClasses(context *clusterd.Context, clusterInfo *ClusterInfo) ([]st
 
 	var deviceclass []string
 	if err := json.Unmarshal(buf, &deviceclass); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal osd crush class list response")
+		return nil, errors.Wrapf(err, "failed to unmarshal osd crush class list response %q", string(buf))
 	}
 
 	return deviceclass, nil

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1129,9 +1129,11 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 			}
 
 			// Close encrypted device
-			err = CloseEncryptedDevice(context, block)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to close encrypted device %q for osd %d", block, osdID)
+			if block != "" {
+				err = CloseEncryptedDevice(context, block)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to close encrypted device %q for osd %d", block, osdID)
+				}
 			}
 
 			// If there is a metadata block

--- a/pkg/operator/ceph/cluster/osd/replace.go
+++ b/pkg/operator/ceph/cluster/osd/replace.go
@@ -134,7 +134,13 @@ func (c *Cluster) getOSDWithNonMatchingStore() ([]OSDReplaceInfo, error) {
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to details about the OSD %q", deployments.Items[i].Name)
 				}
-				osdReplaceList = append(osdReplaceList, OSDReplaceInfo{ID: osdInfo.ID, Path: osdInfo.BlockPath, Node: osdInfo.NodeName})
+				var path string
+				if osdInfo.PVCName != "" {
+					path = osdInfo.PVCName
+				} else {
+					path = osdInfo.BlockPath
+				}
+				osdReplaceList = append(osdReplaceList, OSDReplaceInfo{ID: osdInfo.ID, Path: path, Node: osdInfo.NodeName})
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -160,7 +160,7 @@ func TestGetOSDWithNonMatchingStoreOnPVCs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(osdList))
 		assert.Equal(t, 0, osdList[0].ID)
-		assert.Equal(t, "/some/path", osdList[0].Path)
+		assert.Equal(t, "pvc0", osdList[0].Path)
 	})
 }
 


### PR DESCRIPTION
This is a follow up for #12507
- fixes replacing of encrypted OSDs.
- Updates OSD status at the end of main reconcile, rather than every 60 seconds via the OSDhealthChecker

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #


Tests:

- [x] Encrypted OSDs
- [x] Encrypted OSDs with KMS

osd prepare pod logs for cleaning encrypted OSDs and preparing it again:
[osd-0-prepare.txt](https://github.com/rook/rook/files/12415543/osd-0-prepare.txt)



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
