### PR TITLE
pool: add subFailureDomain property to erasureCoded pools

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5164,6 +5164,18 @@ string
 <p>The algorithm for erasure coding</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>subFailureDomain</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubFailureDomain is the failure domain within a zone</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ExternalSpec">ExternalSpec

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -135,6 +135,9 @@ spec:
                       description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                       minimum: 0
                       type: integer
+                    subFailureDomain:
+                      description: SubFailureDomain is the failure domain within a zone
+                      type: string
                   required:
                     - codingChunks
                     - dataChunks
@@ -6204,6 +6207,9 @@ spec:
                             description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                             minimum: 0
                             type: integer
+                          subFailureDomain:
+                            description: SubFailureDomain is the failure domain within a zone
+                            type: string
                         required:
                           - codingChunks
                           - dataChunks
@@ -6372,6 +6378,9 @@ spec:
                           description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
+                        subFailureDomain:
+                          description: SubFailureDomain is the failure domain within a zone
+                          type: string
                       required:
                         - codingChunks
                         - dataChunks
@@ -9690,6 +9699,9 @@ spec:
                           description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
+                        subFailureDomain:
+                          description: SubFailureDomain is the failure domain within a zone
+                          type: string
                       required:
                         - codingChunks
                         - dataChunks
@@ -10765,6 +10777,9 @@ spec:
                           description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
+                        subFailureDomain:
+                          description: SubFailureDomain is the failure domain within a zone
+                          type: string
                       required:
                         - codingChunks
                         - dataChunks
@@ -11404,6 +11419,9 @@ spec:
                           description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
+                        subFailureDomain:
+                          description: SubFailureDomain is the failure domain within a zone
+                          type: string
                       required:
                         - codingChunks
                         - dataChunks
@@ -11567,6 +11585,9 @@ spec:
                           description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
+                        subFailureDomain:
+                          description: SubFailureDomain is the failure domain within a zone
+                          type: string
                       required:
                         - codingChunks
                         - dataChunks

--- a/deploy/examples/pool-ec.yaml
+++ b/deploy/examples/pool-ec.yaml
@@ -16,6 +16,8 @@ spec:
   erasureCoded:
     dataChunks: 2
     codingChunks: 1
+    # The name of the failure domain to place further down replicas
+    # subFailureDomain: host
   # Set any property on a given pool
   # see https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values
   parameters:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1016,6 +1016,10 @@ type ErasureCodedSpec struct {
 	// The algorithm for erasure coding
 	// +optional
 	Algorithm string `json:"algorithm,omitempty"`
+
+	// SubFailureDomain is the failure domain within a zone
+	// +optional
+	SubFailureDomain string `json:"subFailureDomain,omitempty"`
 }
 
 // +genclient

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -88,7 +88,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterInfo *ClusterInf
 	if pool.DeviceClass != "" {
 		profilePairs = append(profilePairs, fmt.Sprintf("crush-device-class=%s", pool.DeviceClass))
 	}
-
+	if pool.ErasureCoded.SubFailureDomain != "" {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-sub-failure-domain=%s", pool.FailureDomain))
+	}
 	args := []string{"osd", "erasure-code-profile", "set", profileName, "--force"}
 	args = append(args, profilePairs...)
 	_, err = NewCephCommand(context, clusterInfo, args).Run()


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

ec pools would benefit with having a subFailureDomain as the number of nodes is always less than the OSDs So to provide balanced replication it is a great add on


**Which issue is resolved by this Pull Request:**
Resolves # Closes: https://github.com/rook/rook/issues/7198


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
