### PR TITLE
ceph: return valid CIDR ip

### DIFF
--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -350,8 +350,9 @@ func rbdStatusUnMarshal(output []byte) ([]string, error) {
 }
 
 func concatenateWatcherIp(address string) string {
-	// split with separation '/' to remove nounce and concatenating `/32` to define a network with only one IP address
-	watcherIP := strings.Split(address, "/")[0] + "/32"
+	// address is in format `10.63.0.5:0/1254753579`
+	// split with separation ':0/' to remove nounce and concatenating `/32` to define a network with only one IP address
+	watcherIP := strings.Split(address, ":0/")[0] + "/32"
 	return watcherIP
 }
 

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -348,12 +348,12 @@ func TestRBDStatusUnMarshal(t *testing.T) {
 
 	listIP, err := rbdStatusUnMarshal([]byte(output))
 	assert.NoError(t, err)
-	assert.Equal(t, listIP[0], "192.168.39.137:0/32")
+	assert.Equal(t, listIP[0], "192.168.39.137/32")
 }
 
 func TestConcatenateWatcherIp(t *testing.T) {
 	WatcherIP := concatenateWatcherIp("192.168.39.137:0/3762982934")
-	assert.Equal(t, WatcherIP, "192.168.39.137:0/32")
+	assert.Equal(t, WatcherIP, "192.168.39.137/32")
 }
 
 func TestOnDeviceCMUpdate(t *testing.T) {


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

we need to return a valid CIDR IP to get it fenced properly, the previously returned one was like `10.63.0.5:0/32` which
is not a valid CIDR, removing `:0` to look like the proper IP CIDR.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
