### PR TITLE
mon: typo in json tag of struct MonMap

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -70,7 +70,7 @@ type Summary struct {
 
 type MonMap struct {
 	Epoch        int           `json:"epoch"`
-	NumMons      int           `josn:"num_mons"`
+	NumMons      int           `json:"num_mons"`
 	FSID         string        `json:"fsid"`
 	CreatedTime  string        `json:"created"`
 	ModifiedTime string        `json:"modified"`


### PR DESCRIPTION
The json tag in struct MonMap had a spelling error where "json" was incorrectly splled as "josn". This commit corrects the spelling to "json".

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
