### PR TITLE
docs: use better example in disaster recover docs

### DIFF
--- a/Documentation/Troubleshooting/disaster-recovery.md
+++ b/Documentation/Troubleshooting/disaster-recovery.md
@@ -37,7 +37,7 @@ Since Kubernetes does not allow undeleting resources, the following procedure wi
 the CRs to their prior state without even necessarily suffering cluster downtime.
 
 !!! note
-    In the following commands, the affected `CephCluster` resource is called `rook-ceph`. If yours is named differently, the
+    In the following commands, the affected `CephCluster` resource is called `my-cluster`. If yours is named differently, the
     commands will need to be adjusted.
 
 1.  Scale down the operator.
@@ -50,7 +50,7 @@ the CRs to their prior state without even necessarily suffering cluster downtime
 
     ```console
     # Store the `CephCluster` CR settings. Also, save other Rook CRs that are in terminating state.
-    kubectl -n rook-ceph get cephcluster rook-ceph -o yaml > cluster.yaml
+    kubectl -n rook-ceph get cephcluster my-cluster -o yaml > cluster.yaml
 
     # Backup critical secrets and configmaps in case something goes wrong later in the procedure
     kubectl -n rook-ceph get secret -o yaml > secrets.yaml
@@ -71,7 +71,7 @@ the CRs to their prior state without even necessarily suffering cluster downtime
     1.  Programmatically determine all such resources, using this command:
         ```console
         # Determine the `CephCluster` UID
-        ROOK_UID=$(kubectl -n rook-ceph get cephcluster rook-ceph -o 'jsonpath={.metadata.uid}')
+        ROOK_UID=$(kubectl -n rook-ceph get cephcluster my-cluster -o 'jsonpath={.metadata.uid}')
         # List all secrets, configmaps, services, deployments, and PVCs with that ownership UID.
         RESOURCES=$(kubectl -n rook-ceph get secret,configmap,service,deployment,pvc -o jsonpath='{range .items[?(@.metadata.ownerReferences[*].uid=="'"$ROOK_UID"'")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}')
         # Show the collected resources.
@@ -102,8 +102,8 @@ the CRs to their prior state without even necessarily suffering cluster downtime
         - apiVersion: ceph.rook.io/v1
            blockOwnerDeletion: true
            controller: true
-           kind: `CephCluster`
-           name: rook-ceph
+           kind: CephCluster
+           name: my-cluster
            uid: <uid>
         ```
 
@@ -116,7 +116,7 @@ the CRs to their prior state without even necessarily suffering cluster downtime
     Remove the finalizer from the `CephCluster` resource. This will cause the resource to be immediately deleted by Kubernetes.
 
     ```console
-    kubectl -n rook-ceph patch cephcluster/rook-ceph --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
+    kubectl -n rook-ceph patch cephcluster/my-cluster --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
     ```
 
     After the finalizer is removed, the `CephCluster` will be immediately deleted. If all owner references were properly removed,


### PR DESCRIPTION
In section to restore crd for cephCluster, the name of the cephCluster used is `rook-ceph` which is very much same as namespace which makes it very much
confusion. Now, changin to `my-cluster` which is also the default cephCluster name in test yaml file.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
