### PR TITLE
ci: update mergify to have latest k8s version

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -197,7 +197,7 @@ pull_request_rules:
       - base=release-1.12
       - label!=do-not-merge
       - "status-success=DCO"
-      - "check-success=linux-build-all (1.20)"
+      - "check-success=linux-build-all (1.21)"
       - "check-success=unittests"
       - "check-success=golangci-lint"
       - "check-success=codegen"
@@ -228,15 +228,15 @@ pull_request_rules:
       - "check-success=lvm-pvc"
       - "check-success=rgw-multisite-testing"
       - "check-success=TestCephSmokeSuite (v1.22.17)"
-      - "check-success=TestCephSmokeSuite (v1.27.2)"
+      - "check-success=TestCephSmokeSuite (v1.28.0)"
       - "check-success=TestCephHelmSuite (v1.22.17)"
-      - "check-success=TestCephHelmSuite (v1.27.2)"
-      - "check-success=TestCephMultiClusterDeploySuite (v1.27.2)"
+      - "check-success=TestCephHelmSuite (v1.28.0)"
+      - "check-success=TestCephMultiClusterDeploySuite (v1.28.0)"
       - "check-success=TestCephObjectSuite (v1.27.2)"
       - "check-success=TestCephUpgradeSuite (v1.22.17)"
-      - "check-success=TestCephUpgradeSuite (v1.27.2)"
+      - "check-success=TestCephUpgradeSuite (v1.28.0)"
       - "check-success=TestHelmUpgradeSuite (v1.22.17)"
-      - "check-success=TestHelmUpgradeSuite (v1.27.2)"
+      - "check-success=TestHelmUpgradeSuite (v1.28.0)"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
updating .mergify backport for 1.12 branch
to include latest version of k8s v1.28.0 and
latest golang version v1.21.0

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
