### PR TITLE
monitoring: set port for servicemonitor for ceph-exporter

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -55,6 +55,7 @@ const (
 	standbyMgrStatus       = "standby"
 	monitoringPath         = "/etc/ceph-monitoring/"
 	serviceMonitorFile     = "service-monitor.yaml"
+	serviceMonitorPort     = "http-metrics"
 	// minimum amount of memory in MB to run the pod
 	cephMgrPodMinimumMemory uint64 = 512
 	// DefaultMetricsPort prometheus exporter port
@@ -502,7 +503,7 @@ func wellKnownModule(name string) bool {
 
 // EnableServiceMonitor add a servicemonitor that allows prometheus to scrape from the monitoring endpoint of the cluster
 func (c *Cluster) EnableServiceMonitor() error {
-	serviceMonitor := k8sutil.GetServiceMonitor(AppName, c.clusterInfo.Namespace)
+	serviceMonitor := k8sutil.GetServiceMonitor(AppName, c.clusterInfo.Namespace, serviceMonitorPort)
 	cephv1.GetMonitoringLabels(c.spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 
 	if c.spec.External.Enable {

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -220,8 +220,9 @@ func MakeCephExporterMetricsService(cephCluster cephv1.CephCluster, servicePortM
 }
 
 // EnableCephExporterServiceMonitor add a servicemonitor that allows prometheus to scrape from the monitoring endpoint of the exporter
-func EnableCephExporterServiceMonitor(context *clusterd.Context, cephCluster cephv1.CephCluster, scheme *runtime.Scheme, opManagerContext context.Context) error {
-	serviceMonitor := k8sutil.GetServiceMonitor(cephExporterAppName, cephCluster.Namespace)
+func EnableCephExporterServiceMonitor(context *clusterd.Context, cephCluster cephv1.CephCluster, scheme *runtime.Scheme, opManagerContext context.Context, servicePortMetricName string) error {
+	serviceMonitor := k8sutil.GetServiceMonitor(cephExporterAppName, cephCluster.Namespace, servicePortMetricName)
+
 	cephv1.GetCephExporterLabels(cephCluster.Spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 
 	err := controllerutil.SetControllerReference(&cephCluster, serviceMonitor, scheme)

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -271,7 +271,7 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 				}
 
 				if cephCluster.Spec.Monitoring.Enabled {
-					if err := EnableCephExporterServiceMonitor(r.context, cephCluster, r.scheme, r.opManagerContext); err != nil {
+					if err := EnableCephExporterServiceMonitor(r.context, cephCluster, r.scheme, r.opManagerContext, exporterServiceMetricName); err != nil {
 						return errors.Wrap(err, "failed to enable service monitor")
 					}
 					logger.Debug("service monitor for ceph exporter was enabled successfully")

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -39,7 +39,7 @@ func getMonitoringClient(context *clusterd.Context) (*monitoringclient.Clientset
 }
 
 // GetServiceMonitor creates serviceMonitor object template
-func GetServiceMonitor(name string, namespace string) *monitoringv1.ServiceMonitor {
+func GetServiceMonitor(name string, namespace string, portName string) *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -62,7 +62,7 @@ func GetServiceMonitor(name string, namespace string) *monitoringv1.ServiceMonit
 			},
 			Endpoints: []monitoringv1.Endpoint{
 				{
-					Port:     "http-metrics",
+					Port:     portName,
 					Path:     "/metrics",
 					Interval: "5s",
 				},

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -26,9 +26,11 @@ import (
 func TestGetServiceMonitor(t *testing.T) {
 	name := "rook-ceph-mgr"
 	namespace := "rook-ceph"
-	servicemonitor := GetServiceMonitor(name, namespace)
+	port := "http-metrics"
+	servicemonitor := GetServiceMonitor(name, namespace, port)
 	assert.Equal(t, name, servicemonitor.GetName())
 	assert.Equal(t, namespace, servicemonitor.GetNamespace())
+	assert.Equal(t, port, servicemonitor.Spec.Endpoints[0].Port)
 	assert.NotNil(t, servicemonitor.GetLabels())
 	assert.NotNil(t, servicemonitor.Spec.NamespaceSelector.MatchNames)
 	assert.NotNil(t, servicemonitor.Spec.Selector.MatchLabels)


### PR DESCRIPTION
ceph-exporter's ServiceMonitor and Service CRD contain different port
name, which results in no metrics being collected by prometheus.

this commit makes GetCephMonitor configurable, which we use to set
consistent port names in ServiceMonitor and Service for ceph-exporter.
