### PR TITLE
operator: populate user provided labels on mon PVC resource 

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -58,6 +58,13 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 		if monConfig.Zone != "" {
 			labels["zone"] = monConfig.Zone
 		}
+		// Populate provided labels if they do not exist already
+		for k, v := range monVolumeClaimTemplate.ObjectMeta.Labels {
+			_, ok := labels[k]
+			if !ok {
+				labels[k] = v
+			}
+		}
 	}
 
 	return labels


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Add Labels provided via CR to Monitor PVC**

**Which issue is resolved by this Pull Request:**
Rook operator currently ignores labels provided to volumeClaimTemplate of ceph monitors if passed like below
```
apiVersion: ceph.rook.io/v1
kind: CephCluster
...
spec:
...
  mon:
    volumeClaimTemplate:
      metadata:
        labels:
          velero.io/exclude-from-backup: "true"
      spec:
...
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
