### PR TITLE
helm: move discovery daemon settings into the configmap

### DIFF
--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -10,6 +10,10 @@ data:
   ROOK_OBC_WATCH_OPERATOR_NAMESPACE: {{ .Values.enableOBCWatchOperatorNamespace | quote }}
   ROOK_CEPH_ALLOW_LOOP_DEVICES: {{ .Values.allowLoopDevices | quote }}
   ROOK_DISABLE_ADMISSION_CONTROLLER: {{ .Values.disableAdmissionController | quote }}
+  ROOK_ENABLE_DISCOVERY_DAEMON: {{ .Values.enableDiscoveryDaemon | quote }}
+{{- if .Values.discoverDaemonUdev }}
+  DISCOVER_DAEMON_UDEV_BLACKLIST: {{ .Values.discoverDaemonUdev | quote }}
+{{- end }}
 {{- if .Values.csi }}
   ROOK_CSI_ENABLE_RBD: {{ .Values.csi.enableRbdDriver | quote }}
   ROOK_CSI_ENABLE_CEPHFS: {{ .Values.csi.enableCephfsDriver | quote }}

--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -85,10 +85,6 @@ spec:
 {{- end }}
         - name: ROOK_DISABLE_DEVICE_HOTPLUG
           value: "{{ .Values.disableDeviceHotplug }}"
-        - name: DISCOVER_DAEMON_UDEV_BLACKLIST
-          value: "{{ .Values.discoverDaemonUdev }}"
-        - name: ROOK_ENABLE_DISCOVERY_DAEMON
-          value: "{{ .Values.enableDiscoveryDaemon }}"
 
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
**Description of your changes:**

This allows the rook mgr module to check if the discovery daemon is enabled here: https://github.com/ceph/ceph/blob/6dda3e2b432bf9b55dd0db004b3ea6793333d66f/src/pybind/mgr/rook/rook_cluster.py#L763C49-L763C49. The udev blacklist setting was also moved just to keep similar settings in the same place.

**Which issue is resolved by this Pull Request:**
None

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [N/A]] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [N/A]] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [N/A] Documentation has been updated, if necessary.
- [N/A] Unit tests have been added, if necessary.
- [N/A] Integration tests have been added, if necessary.
