### PR TITLE
Fix discover daemonset default value for discovery interval

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -136,6 +136,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `discover.tolerationKey` | The specific key of the taint to tolerate | `nil` |
 | `discover.tolerations` | Array of tolerations in YAML format which will be added to discover deployment | `nil` |
 | `discoverDaemonUdev` | Blacklist certain disks according to the regex provided. | `nil` |
+| `discoveryDaemonInterval` | Set the discovery daemon device discovery interval (default to 60m) | `"60m"` |
 | `enableDiscoveryDaemon` | Enable discovery daemon | `false` |
 | `enableOBCWatchOperatorNamespace` | Whether the OBC provisioner should watch on the operator namespace or not, if not the namespace of the cluster will be used | `true` |
 | `hostpathRequiresPrivileged` | Runs Ceph Pods as privileged to be able to write to `hostPaths` in OpenShift with SELinux restrictions. | `false` |

--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -85,7 +85,8 @@ spec:
 {{- end }}
         - name: ROOK_DISABLE_DEVICE_HOTPLUG
           value: "{{ .Values.disableDeviceHotplug }}"
-
+        - name: ROOK_DISCOVER_DEVICES_INTERVAL
+          value: "{{ .Values.discoveryDaemonInterval }}"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -579,6 +579,8 @@ csi:
 
 # -- Enable discovery daemon
 enableDiscoveryDaemon: false
+# -- Set the discovery daemon device discovery interval (default to 60m)
+discoveryDaemonInterval: 60m
 
 # -- The timeout for ceph commands in seconds
 cephCommandsTimeoutSeconds: "15"

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -81,10 +81,7 @@ func (d *Discover) Start(ctx context.Context, namespace, discoverImage, security
 }
 
 func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, discoverImage, securityAccount string, data map[string]string, useCephVolume bool) error {
-	discoveryInterval := k8sutil.GetValue(data, discoverIntervalEnv, "")
-	if discoverImage == "" {
-		discoveryInterval = defaultDiscoverInterval
-	}
+	discoveryInterval := k8sutil.GetValue(data, discoverIntervalEnv, defaultDiscoverInterval)
 
 	discoveryParameters := []string{"discover",
 		"--discover-interval", discoveryInterval}


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Fix the default value passed to the discovery deamonset by the operator and add a configuration variable `discoveryDaemonInterval` to the Helm chart

Currently the daemonset pods crash with the error below, this is due to the operator not properly setting a default value when the `ROOK_DISCOVER_DEVICES_INTERVAL` env variable is not set.

```
Error: invalid argument "" for "--discover-interval" flag: time: invalid duration ""
   Usage:  rook discover [flags]

Flags:
rook error: invalid argument "" for "--discover-interval" flag: time: invalid duration ""
        --discover-interval duration   interval between discovering devices (default 60m) (default 1h0m0s)  
  -h, --help                                      help for discover      
        --use-ceph-volume                 Use ceph-volume inventory to extend storage devices information (default false)
Global Flags:      
       --log-level string   logging level for logging/tracing output (valid values: ERROR,WARNING,INFO,DEBUG) (default "INFO")
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [] Documentation has been updated, if necessary.
- [] Unit tests have been added, if necessary.
- [] Integration tests have been added, if necessary.
