### PR TITLE
helm: Add ServiceMonitor namespace override

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -122,6 +122,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.serviceMonitor.enabled` | Enable ServiceMonitor for Ceph CSI drivers | `false` |
 | `csi.serviceMonitor.interval` | Service monitor scrape interval | `"5s"` |
 | `csi.serviceMonitor.labels` | ServiceMonitor additional labels | `{}` |
+| `csi.serviceMonitor.namespace` | Use a different namespace for the ServiceMonitor | `nil` |
 | `csi.sidecarLogLevel` | Set logging level for Kubernetes-csi sidecar containers. Supported values from 0 to 5. 0 for general useful logs (the default), 5 for trace level verbosity. | `0` |
 | `csi.snapshotter.image` | Kubernetes CSI snapshotter image | `registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2` |
 | `csi.topology.domainLabels` | domainLabels define which node labels to use as domains for CSI nodeplugins to advertise their domains | `nil` |

--- a/deploy/charts/rook-ceph/templates/servicemonitor.yaml
+++ b/deploy/charts/rook-ceph/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: csi-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.csi.serviceMonitor.namespace | default .Release.Namespace }}
   labels: {{- include "library.rook-ceph.labels" . | nindent 4 }}
     {{- with .Values.csi.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -476,6 +476,8 @@ csi:
     interval: 5s
     # -- ServiceMonitor additional labels
     labels: {}
+    # -- Use a different namespace for the ServiceMonitor
+    namespace:
 
   # -- Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)
   # @default -- `/var/lib/kubelet`


### PR DESCRIPTION
**Description of your changes:**

The prometheus helm chart (kube-prometheus-stack) allows you to restrict which namespaces prometheus will check for ServiceMonitor objects, because of this it is typical to be able to configure the namespace of your ServiceMonitors in helm charts, which is the functionality I have added here.

**Which issue is resolved by this Pull Request:**
Resolves # n/a

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
