### PR TITLE
ci: use minikube action for creating cluster

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -13,10 +13,18 @@ runs:
       with:
         go-version: "1.21"
 
-    - name: Setup Minikube
-      shell: bash --noprofile --norc -eo pipefail -x {0}
-      run: |
-        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.28.0
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.9.0
+      with:
+        minikube version: "v1.31.2"
+        kubernetes version: "v1.28.0"
+        start args: --memory 6g --cpus=2
+        github token: ${{ inputs.github-token }}
+
+    # - name: Setup Minikube
+    #   shell: bash --noprofile --norc -eo pipefail -x {0}
+    #   run: |
+    #     tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.28.0
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}


### PR DESCRIPTION
There is a new release of minikube action which
mention support none driver let's try that.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
