### PR TITLE
mgr: Allow more than two mgrs

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7218,7 +7218,7 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Count is the number of manager to run</p>
+<p>Count is the number of manager daemons to run</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1323,8 +1323,8 @@ spec:
                       description: AllowMultiplePerNode allows to run multiple managers on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of manager to run
-                      maximum: 2
+                      description: Count is the number of manager daemons to run
+                      maximum: 5
                       minimum: 0
                       type: integer
                     modules:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1321,8 +1321,8 @@ spec:
                       description: AllowMultiplePerNode allows to run multiple managers on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of manager to run
-                      maximum: 2
+                      description: Count is the number of manager daemons to run
+                      maximum: 5
                       minimum: 0
                       type: integer
                     modules:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -581,9 +581,9 @@ type MonZoneSpec struct {
 
 // MgrSpec represents options to configure a ceph mgr
 type MgrSpec struct {
-	// Count is the number of manager to run
+	// Count is the number of manager daemons to run
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=2
+	// +kubebuilder:validation:Maximum=5
 	// +optional
 	Count int `json:"count,omitempty"`
 	// AllowMultiplePerNode allows to run multiple managers on the same node (not recommended)


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
While two mgrs is considered sufficient, more mgr daemons are now allowed in case the admin wants even more fault tolerance to the active mgr going down, in case multiple mgrs go down. Up to five mgr pods will be allowed. All mgrs will be in standby mode except one active mgr. All mgr pods have a sidecar that will update their respective pod specs with the active or passive label.

**Which issue is resolved by this Pull Request:**
Resolves #12812 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
