### PR TITLE
build: update s5cmd to version v2.2.1

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -305,6 +305,15 @@ jobs:
           # waiting for toolbox operator image pod to get ready
           kubectl -n rook-ceph wait --for=condition=ready pod -l app=rook-ceph-tools-operator-image  --timeout=180s
 
+      - name: check s5cmd version in the toolbox image
+        run: |
+          toolbox=$(kubectl get pod -l app=rook-ceph-tools-operator-image -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          s5cmd_version="$(kubectl -n rook-ceph exec ${toolbox} -- /usr/local/bin/s5cmd version)"
+          echo ${s5cmd_version} | grep -q "^v2.2.1"  || {
+             echo " Error: the version of s5cmd version in the  toolbox is not the expected v2.2.1 but ${s5cmd_version}"
+             exit 1
+          } 
+
       - name: check-ownerreferences
         run: tests/scripts/github-action-helper.sh check_ownerreferences
 

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -57,7 +57,7 @@ $(info )
 endif
 
 # s5cmd's version
-S5CMD_VERSION = 2.0.0
+S5CMD_VERSION = 2.2.1
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
 YQv3 := $(TOOLS_HOST_DIR)/yq-$(YQv3_VERSION)


### PR DESCRIPTION
This is the latest available version.
The previously used version v2.0.0 was very outdated.

Fixes: #12883

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

This updates the version of s5cmd built into the  container(s) to the latest available version  v2.2.1 

**Which issue is resolved by this Pull Request:**
Resolves #12883 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
