### PR TITLE
build: Avoid CRD edits when building on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,10 @@ build.version:
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
 # Change how CRDs are generated for CSVs
+ifneq ($(REAL_HOST_PLATFORM),darwin_arm64)
 build.common: export NO_OB_OBC_VOL_GEN=true
 build.common: export MAX_DESC_LEN=0
+endif
 build.common: export SKIP_GEN_CRD_DOCS=true
 build.common: build.version helm.build mod.check crds gen-rbac
 	@$(MAKE) go.init


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
On mac development machines, the crds are being left in a state of change with the description removed and the OBC CRDs removed from crds.yaml and resources.yaml. By skipping the related env vars, these resources
are no longer left unexpectedly modified.

**Which issue is resolved by this Pull Request:**
Resolves #12765

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
