### PR TITLE
ci: Skip encryption pvc kms test if needed

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -312,7 +312,7 @@ jobs:
           echo ${s5cmd_version} | grep -q "^v2.2.1"  || {
              echo " Error: the version of s5cmd version in the  toolbox is not the expected v2.2.1 but ${s5cmd_version}"
              exit 1
-          } 
+          }
 
       - name: check-ownerreferences
         run: tests/scripts/github-action-helper.sh check_ownerreferences
@@ -1445,6 +1445,7 @@ jobs:
 
   encryption-pvc-kms-ibm-kp:
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The skip_ci label was not being respected by the encryption-pvc-kms-ibm-kp canary test.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
