### PR TITLE
mon: failover mons from hostpath to persistent volumes

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -366,7 +366,30 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 		}
 	}
 
+	// failover mons running on host path to use persistent volumes if VolumeClaimTemplate is set and vice versa
+	for _, mon := range c.ClusterInfo.Monitors {
+		if c.HasMonPathChanged(mon.Name) {
+			logger.Infof("fail over mon %q due to change in mon path", mon.Name)
+			c.failMon(len(c.ClusterInfo.Monitors), desiredMonCount, mon.Name)
+			return nil
+		}
+	}
+
 	return nil
+}
+
+// HasMonPathChanged checks if the mon storage path has changed from host path to persistent volume or vice versa
+func (c *Cluster) HasMonPathChanged(mon string) bool {
+	var monPathChanged bool
+	if c.mapping.Schedule[mon] != nil && c.spec.Mon.VolumeClaimTemplate != nil {
+		logger.Infof("mon %q path has changed from host path to persistent volumes", mon)
+		monPathChanged = true
+	} else if c.mapping.Schedule[mon] == nil && c.spec.Mon.VolumeClaimTemplate == nil {
+		logger.Infof("mon %q path has changed from persistent volumes to host path", mon)
+		monPathChanged = true
+	}
+
+	return monPathChanged
 }
 
 func (c *Cluster) trackMonInOrOutOfQuorum(monName string, inQuorum bool) (bool, error) {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -645,3 +645,37 @@ func TestUpdateMonInterval(t *testing.T) {
 		assert.Equal(t, time.Minute, h.interval)
 	})
 }
+
+func TestHasMonPathChanged(t *testing.T) {
+	t.Run("mon path changed from pv to hostpath", func(t *testing.T) {
+		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
+		c.mapping.Schedule["a"] = nil
+		result := c.HasMonPathChanged("a")
+		assert.True(t, result)
+	})
+
+	t.Run("mon path has not changed from pv to hostpath", func(t *testing.T) {
+		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
+		c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{}}
+		c.mapping.Schedule["b"] = nil
+		result := c.HasMonPathChanged("b")
+		c.spec.Mon.VolumeClaimTemplate = nil
+		assert.False(t, result)
+	})
+
+	t.Run("mon path changed from hostpath to pv", func(t *testing.T) {
+		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
+		c.mapping.Schedule["c"] = &opcontroller.MonScheduleInfo{}
+		c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{}}
+		result := c.HasMonPathChanged("c")
+		assert.True(t, result)
+	})
+
+	t.Run("mon path has not changed from host path to pv", func(t *testing.T) {
+		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
+		c.mapping.Schedule["d"] = &opcontroller.MonScheduleInfo{}
+		result := c.HasMonPathChanged("d")
+		c.spec.Mon.VolumeClaimTemplate = nil
+		assert.False(t, result)
+	})
+}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1229,6 +1229,12 @@ func (c *Cluster) commitMaxMonIDRequireIncrementing(desiredMaxMonID int, require
 var updateDeploymentAndWait = UpdateCephDeploymentAndWait
 
 func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
+
+	if c.HasMonPathChanged(m.DaemonName) {
+		logger.Infof("path has changed for mon %q. Skip updating mon deployment %q in order to failover the mon", m.DaemonName, d.Name)
+		return nil
+	}
+
 	// Expand mon PVC if storage request for mon has increased in cephcluster crd
 	if c.monVolumeClaimTemplate(m) != nil {
 		desiredPvc, err := c.makeDeploymentPVC(m, false)


### PR DESCRIPTION
This PR fails over mon pods running on hostpath to use persistent volumes

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #12376

Testing:

Tested the changes locally on singe node minikube

Mons on HostPath

```
❯ oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-5b7vv                                   2/2     Running     0          23m
csi-cephfsplugin-h9rqc                                   2/2     Running     0          23m
csi-cephfsplugin-provisioner-86788ff996-4p9cz            5/5     Running     0          23m
csi-cephfsplugin-provisioner-86788ff996-99n8p            5/5     Running     0          23m
csi-cephfsplugin-vx4b2                                   2/2     Running     0          23m
csi-rbdplugin-67lts                                      2/2     Running     0          23m
csi-rbdplugin-nzh57                                      2/2     Running     0          23m
csi-rbdplugin-provisioner-7b5494c7fd-2z7cz               5/5     Running     0          23m
csi-rbdplugin-provisioner-7b5494c7fd-r5vss               5/5     Running     0          23m
csi-rbdplugin-vwhp6                                      2/2     Running     0          23m
rook-ceph-crashcollector-minikube-94f6bdb4c-5d2qs        1/1     Running     0          21m
rook-ceph-crashcollector-minikube-m02-5c5864465f-gkqpw   1/1     Running     0          20m
rook-ceph-crashcollector-minikube-m03-6fbdb9b884-4qng6   1/1     Running     0          21m
rook-ceph-mgr-a-84fc6bb8d-s5fnk                          2/2     Running     0          22m
rook-ceph-mgr-b-5b7cf98c9b-6cxwt                         2/2     Running     0          22m
rook-ceph-mon-a-866df56bc5-62s9d                         1/1     Running     0          22m
rook-ceph-mon-b-55847fb696-22fwc                         1/1     Running     0          22m
rook-ceph-mon-c-584fd654fd-v46mv                         1/1     Running     0          22m
rook-ceph-operator-9574ccfdb-v7kwc                       1/1     Running     0          23m
rook-ceph-osd-0-76fd48f66b-hckfz                         1/1     Running     0          21m
rook-ceph-osd-1-577bc5f56c-hsbtb                         1/1     Running     0          21m
rook-ceph-osd-2-7468fdd6d-w4dzx                          1/1     Running     0          21m
rook-ceph-osd-prepare-set1-data-0vhpbl-bs9g4             0/1     Completed   0          21m
rook-ceph-osd-prepare-set1-data-1w95zs-rbprb             0/1     Completed   0          21m
rook-ceph-osd-prepare-set1-data-245k5d-g7ht2             0/1     Completed   0          21m
rook-ceph-tools-757999d6c7-hhkpm                         1/1     Running     0          23m

```

```
❯ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                        STORAGECLASS      REASON   AGE
local0-0                                   10Gi       RWO            Retain           Available                                local-storage              23m
local0-1                                   10Gi       RWO            Retain           Bound       rook-ceph/set1-data-1w95zs   local-storage              23m
local1-0                                   10Gi       RWO            Retain           Available                                local-storage              23m
local1-1                                   10Gi       RWO            Retain           Bound       rook-ceph/set1-data-245k5d   local-storage              23m
local2-0                                   10Gi       RWO            Retain           Available                                local-storage              23m
local2-1                                   10Gi       RWO            Retain           Bound       rook-ceph/set1-data-0vhpbl   local-storage              23m
pvc-687537df-548b-4df9-9916-9b6bbc1c00e5   20Gi       RWO            Delete           Bound       default/wp-pv-claim          rook-ceph-block            49s
pvc-bc6de1d3-406e-46bf-9764-6b7c6fbec012   20Gi       RWO            Delete           Bound       default/mysql-pv-claim       rook-ceph-block            61s

```

```
sh-4.4$ ceph status 
  cluster:
    id:     699acdf8-19d2-4a93-b8d4-f068a3ff5cc9
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 23m)
    mgr: a(active, since 20m), standbys: b
    osd: 3 osds: 3 up (since 21m), 3 in (since 22m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 92 objects, 220 MiB
    usage:   732 MiB used, 29 GiB / 30 GiB avail
    pgs:     33 active+clean
 
  io:
    client:   38 KiB/s rd, 6.3 MiB/s wr, 9 op/s rd, 59 op/s wr
 
```

```
❯ oc get pods
NAME                               READY   STATUS    RESTARTS   AGE
wordpress-86bc5bb8d6-jgwdc         1/1     Running   0          2m10s
wordpress-mysql-6b49db8c4c-rkp4g   1/1     Running   0          2m21s

```



Failover mons from HostPath to PV

```
❯ oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-5b7vv                                   2/2     Running     0          30m
csi-cephfsplugin-h9rqc                                   2/2     Running     0          30m
csi-cephfsplugin-provisioner-86788ff996-4p9cz            5/5     Running     0          30m
csi-cephfsplugin-provisioner-86788ff996-99n8p            5/5     Running     0          30m
csi-cephfsplugin-vx4b2                                   2/2     Running     0          30m
csi-rbdplugin-67lts                                      2/2     Running     0          30m
csi-rbdplugin-nzh57                                      2/2     Running     0          30m
csi-rbdplugin-provisioner-7b5494c7fd-2z7cz               5/5     Running     0          30m
csi-rbdplugin-provisioner-7b5494c7fd-r5vss               5/5     Running     0          30m
csi-rbdplugin-vwhp6                                      2/2     Running     0          30m
rook-ceph-crashcollector-minikube-94f6bdb4c-5d2qs        1/1     Running     0          29m
rook-ceph-crashcollector-minikube-m02-5c5864465f-gkqpw   1/1     Running     0          28m
rook-ceph-crashcollector-minikube-m03-6fbdb9b884-4qng6   1/1     Running     0          29m
rook-ceph-mgr-a-84fc6bb8d-s5fnk                          2/2     Running     0          29m
rook-ceph-mgr-b-5b7cf98c9b-6cxwt                         2/2     Running     0          29m
rook-ceph-mon-d-6d5584dcbb-p5vfs                         1/1     Running     0          3m44s
rook-ceph-mon-e-b9d5577cf-pcqmb                          1/1     Running     0          2m25s
rook-ceph-mon-f-74c6f94db8-jhm5j                         1/1     Running     0          64s
rook-ceph-operator-9574ccfdb-v7kwc                       1/1     Running     0          30m
rook-ceph-osd-0-76fd48f66b-hckfz                         1/1     Running     0          29m
rook-ceph-osd-1-577bc5f56c-hsbtb                         1/1     Running     0          28m
rook-ceph-osd-2-7468fdd6d-w4dzx                          1/1     Running     0          29m
rook-ceph-osd-prepare-set1-data-0vhpbl-bs9g4             0/1     Completed   0          29m
rook-ceph-osd-prepare-set1-data-1w95zs-rbprb             0/1     Completed   0          29m
rook-ceph-osd-prepare-set1-data-245k5d-g7ht2             0/1     Completed   0          29m
rook-ceph-tools-757999d6c7-hhkpm                         1/1     Running     0          30m
```

```
❯ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS      REASON   AGE
local0-0                                   10Gi       RWO            Retain           Bound    rook-ceph/rook-ceph-mon-d    local-storage              31m
local0-1                                   10Gi       RWO            Retain           Bound    rook-ceph/set1-data-1w95zs   local-storage              31m
local1-0                                   10Gi       RWO            Retain           Bound    rook-ceph/rook-ceph-mon-e    local-storage              31m
local1-1                                   10Gi       RWO            Retain           Bound    rook-ceph/set1-data-245k5d   local-storage              31m
local2-0                                   10Gi       RWO            Retain           Bound    rook-ceph/rook-ceph-mon-f    local-storage              31m
local2-1                                   10Gi       RWO            Retain           Bound    rook-ceph/set1-data-0vhpbl   local-storage              31m
pvc-687537df-548b-4df9-9916-9b6bbc1c00e5   20Gi       RWO            Delete           Bound    default/wp-pv-claim          rook-ceph-block            8m45s
pvc-bc6de1d3-406e-46bf-9764-6b7c6fbec012   20Gi       RWO            Delete           Bound    default/mysql-pv-claim       rook-ceph-block            8m57s

```


```
sh-4.4$ ceph status 
  cluster:
    id:     699acdf8-19d2-4a93-b8d4-f068a3ff5cc9
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum d,e,f (age 103s)
    mgr: a(active, since 16s), standbys: b
    osd: 3 osds: 3 up (since 29m), 3 in (since 30m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 98 objects, 251 MiB
    usage:   907 MiB used, 29 GiB / 30 GiB avail
    pgs:     33 active+clean
 
sh-4.4$ 

```


```
❯ oc get pods
NAME                               READY   STATUS    RESTARTS   AGE
wordpress-86bc5bb8d6-jgwdc         1/1     Running   0          10m
wordpress-mysql-6b49db8c4c-rkp4g   1/1     Running   0          10m
```


Failing over from PV to hostpath again
```
❯ oc get pods -n rook-ceph
NAME                                                     READY   STATUS      RESTARTS      AGE
csi-cephfsplugin-5b7vv                                   2/2     Running     0             43m
csi-cephfsplugin-h9rqc                                   2/2     Running     0             43m
csi-cephfsplugin-provisioner-86788ff996-4p9cz            5/5     Running     0             43m
csi-cephfsplugin-provisioner-86788ff996-99n8p            5/5     Running     0             43m
csi-cephfsplugin-vx4b2                                   2/2     Running     0             43m
csi-rbdplugin-67lts                                      2/2     Running     0             43m
csi-rbdplugin-nzh57                                      2/2     Running     0             43m
csi-rbdplugin-provisioner-7b5494c7fd-2z7cz               5/5     Running     0             43m
csi-rbdplugin-provisioner-7b5494c7fd-r5vss               5/5     Running     0             43m
csi-rbdplugin-vwhp6                                      2/2     Running     0             43m
rook-ceph-crashcollector-minikube-94f6bdb4c-5d2qs        1/1     Running     0             42m
rook-ceph-crashcollector-minikube-m02-5c5864465f-gkqpw   1/1     Running     0             41m
rook-ceph-crashcollector-minikube-m03-6fbdb9b884-4qng6   1/1     Running     0             41m
rook-ceph-mgr-a-84fc6bb8d-s5fnk                          1/2     Running     2 (12s ago)   42m
rook-ceph-mgr-b-5b7cf98c9b-6cxwt                         1/2     Running     2 (12s ago)   42m
rook-ceph-mon-g-c7dfd476-w76pb                           1/1     Running     0             4m53s
rook-ceph-mon-h-69465966d4-v4gsm                         1/1     Running     0             3m11s
rook-ceph-mon-i-9bf7657c5-9jjdj                          1/1     Running     0             109s
rook-ceph-operator-9574ccfdb-v7kwc                       1/1     Running     0             43m
rook-ceph-osd-0-76fd48f66b-hckfz                         1/1     Running     0             41m
rook-ceph-osd-1-577bc5f56c-hsbtb                         1/1     Running     0             41m
rook-ceph-osd-2-7468fdd6d-w4dzx                          1/1     Running     0             41m
rook-ceph-osd-prepare-set1-data-0vhpbl-bs9g4             0/1     Completed   0             42m
rook-ceph-osd-prepare-set1-data-1w95zs-rbprb             0/1     Completed   0             41m
rook-ceph-osd-prepare-set1-data-245k5d-g7ht2             0/1     Completed   0             41m
rook-ceph-tools-757999d6c7-hhkpm                         1/1     Running     0             43m
```

```
❯ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS     CLAIM                        STORAGECLASS      REASON   AGE
local0-0                                   10Gi       RWO            Retain           Released   rook-ceph/rook-ceph-mon-d    local-storage              43m
local0-1                                   10Gi       RWO            Retain           Bound      rook-ceph/set1-data-1w95zs   local-storage              43m
local1-0                                   10Gi       RWO            Retain           Released   rook-ceph/rook-ceph-mon-e    local-storage              43m
local1-1                                   10Gi       RWO            Retain           Bound      rook-ceph/set1-data-245k5d   local-storage              43m
local2-0                                   10Gi       RWO            Retain           Released   rook-ceph/rook-ceph-mon-f    local-storage              43m
local2-1                                   10Gi       RWO            Retain           Bound      rook-ceph/set1-data-0vhpbl   local-storage              43m
pvc-687537df-548b-4df9-9916-9b6bbc1c00e5   20Gi       RWO            Delete           Bound      default/wp-pv-claim          rook-ceph-block            21m
pvc-bc6de1d3-406e-46bf-9764-6b7c6fbec012   20Gi       RWO            Delete           Bound      default/mysql-pv-claim       rook-ceph-block            21m
```

```
sh-4.4$ ceph status 
  cluster:
    id:     699acdf8-19d2-4a93-b8d4-f068a3ff5cc9
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum g,h,i (age 2m)
    mgr: a(active, since 45s), standbys: b
    osd: 3 osds: 3 up (since 41m), 3 in (since 42m)
 
  data:
    pools:   2 pools, 33 pgs
    objects: 98 objects, 251 MiB
    usage:   909 MiB used, 29 GiB / 30 GiB avail
    pgs:     33 active+clean
 
sh-4.4$ 
```

```
❯ oc get pods
NAME                               READY   STATUS    RESTARTS   AGE
wordpress-86bc5bb8d6-jgwdc         1/1     Running   0          21m
wordpress-mysql-6b49db8c4c-rkp4g   1/1     Running   0          22m
```







**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
