### PR TITLE
ci: fix the  snyk policy to  correctly  ignore the  MPL  license issue.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,3 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 ignore:
-  MPL-2.0:
-    - reason: "Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license"
+  'snyk:lic:npm:symbol:MPL-2.0':
+    - '*':
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+version: v1.25.0
+patch: {}


### PR DESCRIPTION
**Description of your changes:**

after  https://github.com/rook/rook/pull/12932 has been merged, we continue to see MPL issues reported by the snyk CI runs:

https://github.com/rook/rook/actions/runs/6302663608/job/17110310884

This updates to the `.snyk` policy file to correctly ignore the MPL license issue by using the  the proper snyk ID for this issue

According to the doc
https://docs.snyk.io/manage-risk/policies/the-.snyk-file,

the correct ID is `snyk:lic:npm:symbol:MPL-2.0`

The update to the file has been performed with the `snyk ignore` command to ensure validity of the policy file.




**Which issue is resolved by this Pull Request:**
Resolves #12930 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
