### PR TITLE
ci: Suppress mpl-2.0 warnings in Snyk scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,49 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 ignore:
-  'snyk:lic:npm:symbol:MPL-2.0':
-    - '*':
+  "snyk:lic:golang:github.com:hashicorp:vault:sdk:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:vault:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:vault:api:auth:approle:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:vault:api:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:golang-lru:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-sockaddr:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-secure-stdlib:strutil:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-secure-stdlib:parseutil:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-rootcerts:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-retryablehttp:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-immutable-radix:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:go-cleanhttp:MPL-2.0":
+    - "*":
+        reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
+  "snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0":
+    - "*":
         reason: Mozilla Public License 2.0 is compatible with Rook's Apache 2.0 license
 version: v1.25.0
 patch: {}


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
 The Snyk scan was failing on a warning with the MPL 2.0 license, which is compatible with Rook. This is another attempt at testing the suppression...

**Which issue is resolved by this Pull Request:**
Resolves #12930 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
