### PR TITLE
docs: krew is wrong word use kubectl instead

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,11 +33,11 @@ labels: bug
 
 **Cluster Status to submit**:
 
-* Output of krew commands, if necessary
+* Output of kubectl commands, if necessary
 
   To get the health of the cluster, use `kubectl rook-ceph health`
   To get the status of the cluster, use `kubectl rook-ceph ceph status`
-  For more details, see the [Rook Krew Plugin](https://rook.io/docs/rook/latest-release/Troubleshooting/krew-plugin)
+  For more details, see the [Rook kubectl Plugin](https://rook.io/docs/rook/latest-release/Troubleshooting/kubectl-plugin)
 
 **Environment**:
 * OS (e.g. from /etc/os-release):

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -337,7 +337,7 @@ kubectl exec -n rook-ceph --stdin --tty $(kubectl get pod -n rook-ceph -l ceph_d
 
 1. Restart the modified manager module to test the modifications:
 
-Example for restarting the rook manager module with the [krew plugin](https://github.com/rook/kubectl-rook-ceph):
+Example for restarting the rook manager module with the [kubectl plugin](https://github.com/rook/kubectl-rook-ceph):
 
 ```console
 kubectl rook-ceph ceph mgr module disable rook

--- a/Documentation/Getting-Started/glossary.md
+++ b/Documentation/Getting-Started/glossary.md
@@ -70,9 +70,9 @@ An [external cluster](../CRDs/Cluster/external-cluster.md) is a Ceph configurati
 
 A [host storage cluster](../CRDs/Cluster/host-cluster.md) is where Rook configures Ceph to store data directly on the host devices.
 
-### Krew Plugin
+### kubectl Plugin
 
-The [Rook Krew plugin](../Troubleshooting/krew-plugin.md) is a tool to help troubleshoot your Rook cluster.
+The [Rook kubectl plugin](../Troubleshooting/kubectl-plugin.md) is a tool to help troubleshoot your Rook cluster.
 
 ### Object Bucket Claim (OBC)
 

--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -170,7 +170,7 @@ Ceph has a dashboard to view the status of the cluster. See the [dashboard guide
 
 Create a toolbox pod for full access to a ceph admin client for debugging and troubleshooting the Rook cluster. See the [toolbox documentation](../Troubleshooting/ceph-toolbox.md) for setup and usage information.
 
-The [Rook Krew plugin](https://github.com/rook/kubectl-rook-ceph) provides commands to view status and troubleshoot issues.
+The [Rook kubectl plugin](https://github.com/rook/kubectl-rook-ceph) provides commands to view status and troubleshoot issues.
 
 See the [advanced configuration](../Storage-Configuration/Advanced/ceph-configuration.md) document for helpful maintenance and tuning examples.
 

--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -112,10 +112,10 @@ $ kubectl -n rook-ceph scale deployment rook-ceph-osd-<ID> --replicas=0
 $ ceph osd down osd.<ID>
 ```
 
-### Purge the OSD with Krew
+### Purge the OSD with kubectl
 
 !!! note
-    The `rook-ceph` Krew plugin must be [installed](https://github.com/rook/kubectl-rook-ceph#install)
+    The `rook-ceph` kubectl plugin must be [installed](https://github.com/rook/kubectl-rook-ceph#install)
 
 ```bash
 kubectl rook-ceph rook purge-osd 0 --force

--- a/Documentation/Troubleshooting/.pages
+++ b/Documentation/Troubleshooting/.pages
@@ -1,5 +1,5 @@
 nav:
-    - krew-plugin.md
+    - kubectl-plugin.md
     - ceph-toolbox.md
     - common-issues.md
     - ceph-common-issues.md

--- a/Documentation/Troubleshooting/ceph-toolbox.md
+++ b/Documentation/Troubleshooting/ceph-toolbox.md
@@ -14,7 +14,7 @@ The toolbox can be run in two modes:
     Before running the toolbox you should have a running Rook cluster deployed (see the [Quickstart Guide](../Getting-Started/quickstart.md)).
 
 !!! note
-    The toolbox is not necessary if you are using [Krew plugin](krew-plugin.md) to execute Ceph commands.
+    The toolbox is not necessary if you are using [kubectl plugin](kubectl-plugin.md) to execute Ceph commands.
 
 ## Interactive Toolbox
 

--- a/Documentation/Troubleshooting/disaster-recovery.md
+++ b/Documentation/Troubleshooting/disaster-recovery.md
@@ -11,7 +11,7 @@ there is a manual procedure to get the quorum going again. The only requirement 
 is still healthy. The following steps will remove the unhealthy
 mons from quorum and allow you to form a quorum again with a single mon, then grow the quorum back to the original size.
 
-The [Rook Krew Plugin](https://github.com/rook/kubectl-rook-ceph/) has a command `restore-quorum` that will
+The [Rook kubectl Plugin](https://github.com/rook/kubectl-rook-ceph/) has a command `restore-quorum` that will
 walk you through the mon quorum automated restoration process.
 
 If the name of the healthy mon is `c`, you would run the command:

--- a/Documentation/Troubleshooting/kubectl-plugin.md
+++ b/Documentation/Troubleshooting/kubectl-plugin.md
@@ -1,8 +1,9 @@
 ---
-title: Krew Plugin
+title: kubectl Plugin
 ---
 
-The Rook Krew plugin is a tool to help troubleshoot your Rook cluster. Here are a few of the operations that the plugin will assist with:
+The Rook kubectl plugin is a tool to help troubleshoot your Rook cluster. Here are a few of the operations that the plugin will assist with:
+
 - Health of the Rook pods
 - Health of the Ceph cluster
 - Create "debug" pods for mons and OSDs that are in need of special Ceph maintenance operations
@@ -14,20 +15,23 @@ See the [kubectl-rook-ceph documentation](https://github.com/rook/kubectl-rook-c
 
 ## Installation
 
-* Install [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)
-* Install Rook plugin
+- Install [krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)
+- Install Rook plugin
+
   ```console
-    kubectl krew install rook-ceph
+    kubectl kubectl install rook-ceph
   ```
 
 ## Ceph Commands
 
-* Run any `ceph` command with `kubectl rook-ceph ceph <args>`. For example, get the Ceph status:
+- Run any `ceph` command with `kubectl rook-ceph ceph <args>`. For example, get the Ceph status:
+
   ```console
     kubectl rook-ceph ceph status
   ```
 
   Output:
+
   ```console
     cluster:
     id:     a1ac6554-4cc8-4c3b-a8a3-f17f5ec6f529
@@ -56,12 +60,14 @@ Reference: [Ceph Status](https://github.com/rook/kubectl-rook-ceph/blob/master/R
 
 Debug mode can be useful when a MON or OSD needs advanced maintenance operations that require the daemon to be stopped. Ceph tools such as `ceph-objectstore-tool`, `ceph-bluestore-tool`, or `ceph-monstore-tool` are commonly used in these scenarios. Debug mode will set up the MON or OSD so that these commands can be run.
 
-* Start the debug pod for mon b
+- Start the debug pod for mon b
+
   ```console
     kubectl rook-ceph debug start rook-ceph-mon-b
   ```
 
-* Stop the debug pod for mon b
+- Stop the debug pod for mon b
+
   ```console
     kubectl rook-ceph debug stop rook-ceph-mon-b
   ```

--- a/design/common/multi-net-multus.md
+++ b/design/common/multi-net-multus.md
@@ -90,13 +90,13 @@ It is important that the web server be only **a single** instance. If clients co
 node with the web server can make successful HTTP(S) requests but clients on other nodes are not,
 that is an important indicator of inter-node traffic being blocked.
 
-The validation test routine will run in the Rook operator container. Rook's kubectl [Krew plugin]
+The validation test routine will run in the Rook operator container. Rook's kubectl [kubectl plugin]
 may facilitate running the test, but it is useful to have the option of executing a long-running
 validation routine running in the Kubernetes cluster instead of on an administrator's log-in
 session. Additionally, the results of the validation tester may become important for users wanting
 to get help with Multus configuration, and having a tool that is present in the Rook container image
 will allow users to run the routine for bug reports more readily than if they needed to install the
-Krew plugin.
+kubectl plugin.
 
 
 <!--
@@ -106,4 +106,4 @@ LINKS
 [multi-net spec]: https://github.com/k8snetworkplumbingwg/multi-net-spec
 [cni-genie]: https://github.com/cni-genie/CNI-Genie/
 [knitter]: https://github.com/ZTE/Knitter
-[krew plugin]: https://github.com/rook/kubectl-rook-ceph
+[kubectl plugin]: https://github.com/rook/kubectl-rook-ceph


### PR DESCRIPTION
krew is itself a plugin and it is wrong wording
to use krew plugin intead it should be kubectl
pluging.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
