### PR TITLE
core: use crash profile in crash daemon keyring

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -34,7 +34,7 @@ const (
 [client.crash]
 	key = %s
 	caps mon = "allow profile crash"
-	caps mgr = "allow rw"
+	caps mgr = "allow profile crash"
 `
 )
 
@@ -59,7 +59,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.C
 func cephCrashCollectorKeyringCaps() []string {
 	return []string{
 		"mon", "allow profile crash",
-		"mgr", "allow rw",
+		"mgr", "allow profile crash",
 	}
 }
 

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
@@ -24,5 +24,5 @@ import (
 
 func TestCephCrashCollectorKeyringCaps(t *testing.T) {
 	caps := cephCrashCollectorKeyringCaps()
-	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
+	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow profile crash"})
 }


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The ceph documentation indicates to use the crash profile instead of specifying rw for the mgr access.

This is tested with pacific, quincy, and reef with the profile change. In each case, a crash dump was able to be reported successfully and displayed in the dashboard.

See the crash keyring recommendation in [ceph docs](https://docs.ceph.com/en/quincy/mgr/crash/#enabling).

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
