### PR TITLE
Add toleration of 5 seconds to rook-ceph operator deployment to override default toleration seconds of 300 seconds

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 5
       containers:
       - name: rook-ceph-operator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -669,6 +669,11 @@ spec:
       labels:
         app: rook-ceph-operator
     spec:
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 5
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -595,6 +595,11 @@ spec:
       labels:
         app: rook-ceph-operator
     spec:
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 5
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator


### PR DESCRIPTION


**Description of your changes:**

-   Add toleration to rook-ceph operator deployment
-   Toleration seconds is set to 5 seconds for immediate redeployment in-case of zone failures

**Which issue is resolved by this Pull Request:**
Resolves #12660

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
