### PR TITLE
ci: fixing linter error (using variable 'urllib' before assignment)

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -58,9 +58,11 @@ except ModuleNotFoundError:
 try:
     # for 2.7.x
     from urlparse import urlparse
+    from urllib import urlencode as urlencode
 except ModuleNotFoundError:
     # for 3.x
     from urllib.parse import urlparse
+    from urllib.parse import urlencode as urlencode
 
 try:
     from base64 import encodestring
@@ -1363,7 +1365,7 @@ class RadosJSON:
         rgw_endpoint = self._arg_parser.rgw_endpoint
         base_url = base_url + "://" + rgw_endpoint + "/admin/info?"
         params = {"format": "json"}
-        request_url = base_url + urllib.parse.urlencode(params)
+        request_url = base_url + urlencode(params)
 
         try:
             r = requests.get(


### PR DESCRIPTION
This change is to fix the following ci error:

```
Run pylint $(git ls-files '*.py') -E
************* Module create-external-cluster-resources
deploy/examples/create-external-cluster-resources.py:1366:33: E0601: Using variable 'urllib' before assignment (used-before-assignment)
Error: Process completed with exit code 2.
```
In fact the error (from the ci output) seems to be firing for python 3.9 however, analyzing the code I can only see a possible issue with python2.7 (as `urlencode` is part of `urllib` and not `urllib.parse`). The fix consists in adding logic to properly import urlencode depending on python version.

Closes: https://github.com/rook/rook/issues/12985

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
