### PR TITLE
ci: make use of caching in actions/setup-go

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-
       - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
 
       - name: run codegen
         run: GOPATH=$(go env GOPATH) make codegen

--- a/.github/workflows/crds-gen.yml
+++ b/.github/workflows/crds-gen.yml
@@ -28,14 +28,14 @@ jobs:
   crds-gen:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-
       - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
 
       - name: run crds-gen
         run: GOPATH=$(go env GOPATH) make crds

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,13 +24,12 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-          cache: false
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/multus.yaml
+++ b/.github/workflows/multus.yaml
@@ -31,15 +31,15 @@ jobs:
     env:
       NUMBER_OF_COMPUTE_NODES: 5
     steps:
-      - name: Set up Go version
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-
       - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set up Go version
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
 
       - name: Create KinD Cluster
         uses: helm/kind-action@v1.8.0

--- a/.github/workflows/rbac-gen.yaml
+++ b/.github/workflows/rbac-gen.yaml
@@ -28,14 +28,14 @@ jobs:
   gen-rbac:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-
       - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
 
       - name: run gen-rbac
         run: GOPATH=$(go env GOPATH) make gen-rbac


### PR DESCRIPTION
The GH action to set up Golang (actions/setup-go) has cache functionality. For cache hits, this saves ~2 minutes for each run. In order for the cache to hit, caching must not be disabled, and the code must be checked out before setting up Golang.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
