### PR TITLE
core: remove redundant `len` check

### DIFF
--- a/pkg/operator/ceph/cluster/dependents.go
+++ b/pkg/operator/ceph/cluster/dependents.go
@@ -71,10 +71,8 @@ func CephClusterDependents(c *clusterd.Context, namespace string) (*dependents.D
 			errs = append(errs, errors.Wrapf(err, "failed to get %s", listKind))
 			continue
 		}
-		if len(list.Items) > 0 {
-			for _, obj := range list.Items {
-				dependents.Add(listKindToSingularKind(listKind), obj.GetName())
-			}
+		for _, obj := range list.Items {
+			dependents.Add(listKindToSingularKind(listKind), obj.GetName())
 		}
 	}
 	// returns a nil error if there are no errors in the list

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -86,12 +86,11 @@ func templateToDeployment(name, templateData string, p templateParam) (*apps.Dep
 
 func applyResourcesToContainers(opConfig map[string]string, key string, podspec *corev1.PodSpec) {
 	resource := getComputeResource(opConfig, key)
-	if len(resource) > 0 {
+
+	for _, r := range resource {
 		for i, c := range podspec.Containers {
-			for _, r := range resource {
-				if c.Name == r.Name {
-					podspec.Containers[i].Resources = r.Resource
-				}
+			if c.Name == r.Name {
+				podspec.Containers[i].Resources = r.Resource
 			}
 		}
 	}
@@ -200,21 +199,19 @@ func applyVolumeToPodSpec(opConfig map[string]string, configName string, podspec
 		logger.Warningf("failed to parse %q for %q. %v", volumesRaw, configName, err)
 		return
 	}
-	if len(volumes) > 0 {
-		for i := range volumes {
-			found := false
-			for j := range podspec.Volumes {
-				// check do we need to override any existing volumes
-				if volumes[i].Name == podspec.Volumes[j].Name {
-					podspec.Volumes[j] = volumes[i]
-					found = true
-					break
-				}
+	for i := range volumes {
+		found := false
+		for j := range podspec.Volumes {
+			// check do we need to override any existing volumes
+			if volumes[i].Name == podspec.Volumes[j].Name {
+				podspec.Volumes[j] = volumes[i]
+				found = true
+				break
 			}
-			if !found {
-				// if not found add volume to volumes list
-				podspec.Volumes = append(podspec.Volumes, volumes[i])
-			}
+		}
+		if !found {
+			// if not found add volume to volumes list
+			podspec.Volumes = append(podspec.Volumes, volumes[i])
 		}
 	}
 }

--- a/pkg/operator/ceph/test/container.go
+++ b/pkg/operator/ceph/test/container.go
@@ -64,7 +64,6 @@ func (d *ContainerTestDefinition) TestContainer(
 	cont *v1.Container,
 	logger *capnslog.PackageLogger,
 ) {
-
 	if d.Image != nil {
 		assert.Equal(t, *d.Image, cont.Image)
 	}
@@ -76,27 +75,26 @@ func (d *ContainerTestDefinition) TestContainer(
 	if d.Args != nil {
 		assert.Nil(t, optest.ArgumentsMatchExpected(cont.Args, d.Args))
 	}
-	if d.InOrderArgs != nil {
-		for argNum, arg := range d.InOrderArgs {
-			assert.Equal(t, cont.Args[argNum], arg)
-		}
+
+	for argNum, arg := range d.InOrderArgs {
+		assert.Equal(t, cont.Args[argNum], arg)
 	}
-	if d.VolumeMountNames != nil {
-		assert.Equal(t, len(d.VolumeMountNames), len(cont.VolumeMounts))
-		for _, n := range d.VolumeMountNames {
-			assert.Nil(t, optest.VolumeMountExists(n, cont.VolumeMounts))
-		}
+
+	assert.Equal(t, len(d.VolumeMountNames), len(cont.VolumeMounts))
+	for _, n := range d.VolumeMountNames {
+		assert.Nil(t, optest.VolumeMountExists(n, cont.VolumeMounts))
 	}
+
 	if d.EnvCount != nil {
 		assert.Equal(t, *d.EnvCount, len(cont.Env))
 	}
-	if d.Ports != nil {
-		assert.Equal(t, len(d.Ports), len(cont.Ports))
-		for i, p := range d.Ports {
-			assert.Equal(t, p.ContainerPort, cont.Ports[i].ContainerPort)
-			assert.Equal(t, p.Protocol, cont.Ports[i].Protocol)
-		}
+
+	assert.Equal(t, len(d.Ports), len(cont.Ports))
+	for i, p := range d.Ports {
+		assert.Equal(t, p.ContainerPort, cont.Ports[i].ContainerPort)
+		assert.Equal(t, p.Protocol, cont.Ports[i].Protocol)
 	}
+
 	if d.IsPrivileged != nil {
 		assert.Equal(t, *d.IsPrivileged, *cont.SecurityContext.Privileged)
 	}

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1054,11 +1054,9 @@ func (k8sh *K8sHelper) IsPodInExpectedState(podNamePattern string, namespace str
 	for i := 0; i < RetryLoop; i++ {
 		podList, err := k8sh.Clientset.CoreV1().Pods(namespace).List(ctx, listOpts)
 		if err == nil {
-			if len(podList.Items) >= 1 {
-				for _, pod := range podList.Items {
-					if pod.Status.Phase == v1.PodPhase(state) {
-						return true
-					}
+			for _, pod := range podList.Items {
+				if pod.Status.Phase == v1.PodPhase(state) {
+					return true
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

This pull request is a minor code cleanup.

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the slice or map is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

**Which issue is resolved by this Pull Request:**

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
