### PR TITLE
csi: add mountinfo path for cephfs daemonset

### DIFF
--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -97,6 +97,8 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+            - name: ceph-csi-mountinfo
+              mountPath: /csi/mountinfo
             - name: csi-plugins-dir
               mountPath: "{{ .KubeletDirPath }}/plugins"
               mountPropagation: "Bidirectional"
@@ -153,6 +155,10 @@ spec:
           imagePullPolicy: {{ .ImagePullPolicy }}
         {{ end }}
       volumes:
+        - name: ceph-csi-mountinfo
+          hostPath:
+          path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/mountinfo"
+          type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/"


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
If mountinfo path is available cephcsi will try to recover the fuse client. adding the support for the same in Rook.

**Which issue is resolved by this Pull Request:**
Resolves #13009

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
