### PR TITLE
mon: Write the assimilate-conf config to a valid operator working directory

### DIFF
--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -212,7 +212,9 @@ func TestMonStore_SetAll(t *testing.T) {
 	}
 
 	// commands w/ no error
-	e := monStore.SetAll("osd.0", cfgOverrides)
+	keys, e := monStore.setAll("osd.0", cfgOverrides)
+	// no keys written since it's mocked
+	assert.Equal(t, 0, len(keys))
 	assert.NoError(t, e)
 	assert.True(t, appliedSettings)
 }


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
The /tmp dir is not always available in some environments. The only directories the operator should rely on are the directories that are in its pod spec. For assimilate-conf now we use the /var/lib/rook directory to generate files since we know it is a valid emptydir mounted into the operator pod.

**Which issue is resolved by this Pull Request:**
Resolves #13029

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
