### PR TITLE
Enhance SCC Function to Support Multiple Namespaces

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -26,15 +26,14 @@ import (
 
 // NewSecurityContextConstraints returns a new SecurityContextConstraints for Rook-Ceph to run on
 // OpenShift.
-func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContextConstraints {
+func NewSecurityContextConstraints(name string, namespaces ...string) *secv1.SecurityContextConstraints {
 	return &secv1.SecurityContextConstraints{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "security.openshift.io/v1",
 			Kind:       "SecurityContextConstraints",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 		AllowPrivilegedContainer: true,
 		AllowHostDirVolumePlugin: true,
@@ -66,12 +65,17 @@ func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContex
 			secv1.FSProjected,
 			secv1.FSTypeSecret,
 		},
-		Users: []string{
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-system", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:default", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-mgr", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-osd", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-rgw", namespace),
-		},
+		Users: func() (users []string) {
+			for _, ns := range namespaces {
+				users = append(users, []string{
+					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-system", ns),
+					fmt.Sprintf("system:serviceaccount:%s:default", ns),
+					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-mgr", ns),
+					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-osd", ns),
+					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-rgw", ns),
+				}...)
+			}
+			return
+		}(),
 	}
 }


### PR DESCRIPTION
**Description of your changes:**

Currently, the function receives a single namespace string and appends it to the users. This approach is insufficient when dealing with multiple CephClusters running in different namespaces, as there will be only one SCC. This update modifies the function to create users for all specified namespaces, ensuring compatibility with multiple namespaces.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
