### PR TITLE
osd: print warning message if no matching node found for osd

### DIFF
--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -281,11 +281,17 @@ func GetKubernetesNodesMatchingRookNodes(ctx context.Context, rookNodes []cephv1
 	if err != nil {
 		return nodes, fmt.Errorf("failed to list kubernetes nodes. %+v", err)
 	}
-	for _, kn := range k8sNodes.Items {
-		for _, rn := range rookNodes {
+	for _, rn := range rookNodes {
+		nodeFound := false
+		for _, kn := range k8sNodes.Items {
 			if rookNodeMatchesKubernetesNode(rn, kn) {
 				nodes = append(nodes, kn)
+				nodeFound = true
+				break
 			}
+		}
+		if !nodeFound {
+			logger.Warningf("failed to find matching kubernetes node for %q. Check the CephCluster's config and confirm each 'name' field in spec.storage.nodes matches their 'kubernetes.io/hostname' label", rn.Name)
 		}
 	}
 	return nodes, nil


### PR DESCRIPTION


<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

As seen in https://github.com/rook/rook/issues/1988, it's a common mistake to configure rook nodes with names that don't match Kubernetes's node label. This PR prints more detailed message to help debugging problem.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
