### PR TITLE
external: automatically init the rbd pool

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1299,6 +1299,14 @@ class RadosJSON:
                 f"The provided pool, '{self._arg_parser.rbd_data_pool_name}', does not exist"
             )
 
+    def init_rbd_pool(self):
+        if isinstance(self.cluster, DummyRados):
+            return
+        rbd_pool_name = self._arg_parser.rbd_data_pool_name
+        ioctx = self.cluster.open_ioctx(rbd_pool_name)
+        rbd_inst = rbd.RBD()
+        rbd_inst.pool_init(ioctx, True)
+
     def validate_rados_namespace(self):
         rbd_pool_name = self._arg_parser.rbd_data_pool_name
         rados_namespace = self._arg_parser.rados_namespace
@@ -1467,6 +1475,7 @@ class RadosJSON:
             self._arg_parser.k8s_cluster_name.lower()
         )  # always convert cluster name to lowercase characters
         self.validate_rbd_pool()
+        self.init_rbd_pool()
         self.validate_rados_namespace()
         self._excluded_keys.add("K8S_CLUSTER_NAME")
         self.get_cephfs_data_pool_details()


### PR DESCRIPTION
**Description of your changes:**

Sometimes the pool is not enabled and the ceph cluster shows health warning, so automatically initalize the pool from the script

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
