### PR TITLE
docs: fix typo in command for krew plugin

### DIFF
--- a/Documentation/Troubleshooting/kubectl-plugin.md
+++ b/Documentation/Troubleshooting/kubectl-plugin.md
@@ -19,7 +19,7 @@ See the [kubectl-rook-ceph documentation](https://github.com/rook/kubectl-rook-c
 - Install Rook plugin
 
   ```console
-    kubectl kubectl install rook-ceph
+    kubectl krew install rook-ceph
   ```
 
 ## Ceph Commands


### PR DESCRIPTION
A typo was in the command for installing the krew plugin

