### PR TITLE
core: Update operator base image to reef

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION ?= v17.2.6-20230410
+CEPH_VERSION ?= v18.2.0-20231018
 else
-CEPH_VERSION ?= v17.2.6-20230410
+CEPH_VERSION ?= v18.2.0-20231018
 endif
 REGISTRY_NAME = quay.io
 BASEIMAGE = $(REGISTRY_NAME)/ceph/ceph-$(GOARCH):$(CEPH_VERSION)

--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -406,7 +406,7 @@ const firstPeriodUpdate = `{
                 "id": "1580fd1d-a065-4484-82ff-329e9a779999",
                 "name": "my-store",
                 "api_name": "my-store",
-                "is_master": "true",
+                "is_master": true,
                 "endpoints": [
                     "http://10.105.59.166:80"
                 ],
@@ -489,7 +489,7 @@ const secondPeriodGet = `{
                 "id": "1580fd1d-a065-4484-82ff-329e9a779999",
                 "name": "my-store",
                 "api_name": "my-store",
-                "is_master": "true",
+                "is_master": true,
                 "endpoints": [
                     "http://10.105.59.166:80"
                 ],
@@ -575,7 +575,7 @@ const secondPeriodUpdateWithoutChanges = `{
                 "id": "1580fd1d-a065-4484-82ff-329e9a779999",
                 "name": "my-store",
                 "api_name": "my-store",
-                "is_master": "true",
+                "is_master": true,
                 "endpoints": [
                     "http://10.105.59.166:80"
                 ],
@@ -659,7 +659,7 @@ const secondPeriodUpdateWithChanges = `{
                 "id": "1580fd1d-a065-4484-82ff-329e9a779999",
                 "name": "my-store",
                 "api_name": "my-store",
-                "is_master": "true",
+                "is_master": true,
                 "endpoints": [
                     "http://10.105.59.166:80",
                     "https://10.105.59.166:443"

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -71,7 +71,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "my-store",
 		"api_name": "my-store",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			"http://rook-ceph-rgw-my-store.rook-ceph.svc:80"
 		],
@@ -206,7 +206,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [],
 		"hostnames": [],
 		"hostnames_s3website": [],
@@ -242,7 +242,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			"http://rook-ceph-rgw-my-store.rook-ceph.svc:80"
         ],

--- a/pkg/operator/ceph/object/dependents_test.go
+++ b/pkg/operator/ceph/object/dependents_test.go
@@ -46,7 +46,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			"http://rook-ceph-rgw-store-a.rook-ceph.svc:80"
         ],
@@ -86,7 +86,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			"http://rook-ceph-rgw-store-a.rook-ceph.svc:80"
         ],

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -81,7 +81,7 @@ type idType struct {
 
 type zoneGroupType struct {
 	MasterZoneID string     `json:"master_zone"`
-	IsMaster     string     `json:"is_master"`
+	IsMaster     bool       `json:"is_master"`
 	Zones        []zoneType `json:"zones"`
 	Endpoints    []string   `json:"endpoints"`
 }
@@ -302,12 +302,7 @@ func checkZoneGroupIsMaster(objContext *Context) (bool, error) {
 		return false, errors.Wrap(err, "failed to parse master zone id")
 	}
 
-	zoneGroupIsMaster, err := strconv.ParseBool(zoneGroupJson.IsMaster)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to parse is_master from zone group json into bool")
-	}
-
-	return zoneGroupIsMaster, nil
+	return zoneGroupJson.IsMaster, nil
 }
 
 func DecodeSecret(secret *v1.Secret, keyName string) (string, error) {

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -47,7 +47,7 @@ const (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			":80"
 		],

--- a/pkg/operator/ceph/object/zonegroup/controller_test.go
+++ b/pkg/operator/ceph/object/zonegroup/controller_test.go
@@ -87,7 +87,7 @@ var (
 		"id": "fd8ff110-d3fd-49b4-b24f-f6cd3dddfedf",
 		"name": "zonegroup-a",
 		"api_name": "zonegroup-a",
-		"is_master": "true",
+		"is_master": true,
 		"endpoints": [
 			":80"
 		],


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Reef object store configuration may have issues due to the operator base image being Quincy, while trying to deploy a Reef cluster. There appear to be forward compatibility issues with the radosgw-admin command. Now the base image is updated to v18.2.0 to better handle the compatibility across ceph versions.

**Which issue is resolved by this Pull Request:**
Resolves #13010

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
