### PR TITLE
core: Crash collector keyring requires rw access for the mgr profile

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -34,7 +34,7 @@ const (
 [client.crash]
 	key = %s
 	caps mon = "allow profile crash"
-	caps mgr = "allow profile crash"
+	caps mgr = "allow rw"
 `
 )
 
@@ -59,7 +59,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.C
 func cephCrashCollectorKeyringCaps() []string {
 	return []string{
 		"mon", "allow profile crash",
-		"mgr", "allow profile crash",
+		"mgr", "allow rw",
 	}
 }
 

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
@@ -24,5 +24,5 @@ import (
 
 func TestCephCrashCollectorKeyringCaps(t *testing.T) {
 	caps := cephCrashCollectorKeyringCaps()
-	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow profile crash"})
+	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
 }


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
This reverts #12970. The mgr does require rw access for the cron job that collects the crashes, which was added in #6417.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
