### PR TITLE
docs: unifying namespaces handling for the second cluster creation

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
@@ -47,12 +47,23 @@ kubectl apply -f common.yaml -f operator.yaml -f cluster.yaml # add other files 
 
 ## Deploying a second cluster
 
-If you wish to create a new CephCluster in a different namespace than `rook-ceph` while using a single operator to manage both clusters execute the following:
+If you wish to create a new CephCluster in a separate namespace, you can easily do so
+by modifying the `ROOK_OPERATOR_NAMESPACE` and `SECOND_ROOK_CLUSTER_NAMESPACE` values in the
+below instructions. The default configuration in `common-second-cluster.yaml` is already
+set up to utilize `rook-ceph` for the operator and `rook-ceph-secondary` for the cluster.
+There's no need to run the `sed` command if you prefer to use these default values.
 
 ```console
 cd deploy/examples
+export ROOK_OPERATOR_NAMESPACE="rook-ceph"
+export SECOND_ROOK_CLUSTER_NAMESPACE="rook-ceph-secondary"
 
-NAMESPACE=rook-ceph-secondary envsubst < common-second-cluster.yaml | kubectl create -f -
+sed -i.bak \
+    -e "s/\(.*\):.*# namespace:operator/\1: $ROOK_OPERATOR_NAMESPACE # namespace:operator/g" \
+    -e "s/\(.*\):.*# namespace:cluster/\1: $SECOND_ROOK_CLUSTER_NAMESPACE # namespace:cluster/g" \
+  common-second-cluster.yaml
+
+kubectl create -f common-second-cluster.yaml
 ```
 
 This will create all the necessary RBACs as well as the new namespace. The script assumes that `common.yaml` was already created.

--- a/deploy/examples/common-second-cluster.yaml
+++ b/deploy/examples/common-second-cluster.yaml
@@ -7,13 +7,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: $NAMESPACE
+  name: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cluster-mgmt
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -21,13 +21,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -35,13 +35,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -49,13 +49,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -63,13 +63,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-mgr
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -77,13 +77,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-mgr
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-osd-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -91,13 +91,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-osd
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-purge-osd-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,13 +105,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-purge-osd
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-rgw-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -119,13 +119,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-rgw
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-default-psp
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -133,19 +133,19 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 rules:
   - apiGroups:
       - ""
@@ -164,7 +164,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-osd
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 rules:
   # this is needed for rook's "key-management" CLI to fetch the vault token from the secret when
   # validating the connection details and for key rotation operations.
@@ -202,13 +202,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-osd
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-osd-external
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -216,26 +216,26 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-osd
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 ---
 # Aspects of ceph osd purge job that require access to the operator/cluster namespace
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-purge-osd
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -255,7 +255,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-purge-osd
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -263,16 +263,16 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-purge-osd
-    namespace: $NAMESPACE
+    namespace: rook-ceph-secondary # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-purge-osd
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-rgw
-  namespace: $NAMESPACE
+  namespace: rook-ceph-secondary # namespace:cluster


### PR DESCRIPTION

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

Let's use the same technique based on 'sed' while employing two different namespaces for the cluster and the operator when creating the second cluster.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
