### PR TITLE
manifest: fixing rook-ceph-mgr-system namespace

### DIFF
--- a/deploy/charts/library/templates/_cluster-rolebinding.tpl
+++ b/deploy/charts/library/templates/_cluster-rolebinding.tpl
@@ -67,7 +67,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-system{{ template "library.suffix-cluster-namespace" . }}
-  namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:operator
+  namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -1056,7 +1056,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: rook-ceph # namespace:operator
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**
Setting rook-ceph-mgr-system to cluster instead of operator

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
