### PR TITLE
pool: rbd cmd shouldn't use admin in external mode

### DIFF
--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -219,7 +219,10 @@ func (c *clientCluster) fenceNode(ctx context.Context, node *corev1.Node, cluste
 		return nil
 	}
 
-	clusterInfo := cephclient.AdminClusterInfo(ctx, cluster.Namespace, cluster.Name)
+	clusterInfo, _, _, err := opcontroller.LoadClusterInfo(c.context, ctx, cluster.Namespace, &cluster.Spec)
+	if err != nil {
+		return pkgerror.Wrapf(err, "Failed to load cluster info.")
+	}
 
 	for i := range rbdPVList {
 		err = c.fenceRbdImage(ctx, node, cluster, clusterInfo, rbdPVList[i])

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -271,7 +271,24 @@ func TestHandleNodeFailure(t *testing.T) {
 		},
 	}
 
-	_, err := c.context.Clientset.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+	// Mock clusterInfo
+	secrets := map[string][]byte{
+		"fsid":         []byte("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: ns,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+	_, err := c.context.Clientset.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	_, err = c.context.Clientset.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	_, err = c.context.ApiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, &v1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "networkfences.csiaddons.openshift.io"}}, metav1.CreateOptions{})


### PR DESCRIPTION
when creating networkFence, rbd command was loading admin config and hence running rbd command use client.admin in case of external cluster also. With this commit instead of client.admin user it will use what is being passed to config.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
