### PR TITLE
docs: add namespace on delete webhook command

### DIFF
--- a/Documentation/Troubleshooting/disaster-recovery.md
+++ b/Documentation/Troubleshooting/disaster-recovery.md
@@ -63,7 +63,7 @@ the CRs to their prior state without even necessarily suffering cluster downtime
     the valdiating webhook in order to make changes.
 
         ```console
-        kubectl delete ValidatingWebhookConfiguration rook-ceph-webhook
+        kubectl -n rook-ceph delete ValidatingWebhookConfiguration rook-ceph-webhook
         ```
 
 4.  Remove the owner references from all critical Rook resources that were referencing the `CephCluster` CR.


### PR DESCRIPTION
The only command on the page that did not have a namespace directly set was this one.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

I had some issues when running this step-by-step because this command was missing the namespace part, and I only saw this later. It can be useful for future users that passes by this page to already have this pre-set for them, just like the other commands.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
