### PR TITLE
multus: use rook image for ip range detection

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -19,6 +19,9 @@ FROM BASEIMAGE
 ARG S5CMD_VERSION
 ARG S5CMD_ARCH
 
+# install 'ip' tool for Multus
+RUN dnf install -y --setopt=install_weak_deps=False iproute && dnf clean all
+
 # Install the s5cmd package to interact with s3 gateway
 RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \
     mkdir /s5cmd && \


### PR DESCRIPTION
Use the Rook image (defined by the operator pod) to detect the Multus network address ranges. It is reasonable for users to want to have a minimal Ceph image that does not have the `ip` utility installed, which is used for detecting the address ranges of multus interfaces. Instead, use the Rook image, which Rook can ensure has the `ip` tool if Ceph ever removes it from their image.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
