### PR TITLE
Improve the create-dev-cluster script

### DIFF
--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -1,21 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 The Rook Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 KUBECTL="minikube kubectl --"
-ROOK_EXAMPLES_DIR="../../deploy/examples/"
+ROOK_EXAMPLES_DIR="${SCRIPT_ROOT}/../../deploy/examples/"
 
 wait_for_ceph_cluster() {
     echo "Waiting for ceph cluster"


### PR DESCRIPTION
<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

In testing the recently added `create-dev-cluster` script, I encountered a few minor usability glitches that this  PR aims to improve:

* the script did not find the `deploy/examples` directory in the code tree. This change fixes that problem by making the path relative to the directory containing the script.
* The script errored out if a minikube cluster already existed. This changes the script's behavior to instead use the existing environment. The `-f` switch can still be used to enforce minikube creation.  This part of the PR has been superseded by PR #13158  and removed from this PR

**Which issue is resolved by this Pull Request:**
none 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
