### PR TITLE
Revert "osd: support encrypted OSD on partiton"

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -446,6 +446,11 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 		}
 		logger.Infof("device %q is available.", device.Name)
 
+		if device.Type == sys.PartType && agent.storeConfig.EncryptedDevice {
+			logger.Infof("partition %q is not picked because encrypted OSD on partition is not allowed", device.Name)
+			continue
+		}
+
 		var deviceInfo *DeviceOsdIDEntry
 		if agent.metadataDevice != "" && agent.metadataDevice == device.Name {
 			// current device is desired as the metadata device

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -415,6 +415,12 @@ func (a *OsdAgent) allowRawMode(context *clusterd.Context) (bool, error) {
 	// by default assume raw mode
 	allowRawMode := true
 
+	// ceph-volume raw mode does not support encryption yet
+	if a.storeConfig.EncryptedDevice {
+		logger.Debug("won't use raw mode since encryption is enabled")
+		allowRawMode = false
+	}
+
 	// ceph-volume raw mode does not support more than one OSD per disk
 	osdsPerDeviceCountString := sanitizeOSDsPerDevice(a.storeConfig.OSDsPerDevice)
 	osdsPerDeviceCount, err := strconv.Atoi(osdsPerDeviceCountString)

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1599,7 +1599,7 @@ func TestAllowRawMode(t *testing.T) {
 		wantErr bool
 	}{
 		{"raw simple scenario supported", fields{"", config.StoreConfig{}}, args{&clusterd.Context{}, false}, true, false},
-		{"raw encrypted scenario supported", fields{"", config.StoreConfig{EncryptedDevice: true}}, args{&clusterd.Context{}, false}, true, false},
+		{"lvm complex scenario not supported: encrypted", fields{"", config.StoreConfig{EncryptedDevice: true}}, args{&clusterd.Context{}, false}, false, false},
 		{"lvm complex scenario not supported: osd per device > 1", fields{"", config.StoreConfig{OSDsPerDevice: 2}}, args{&clusterd.Context{}, false}, false, false},
 		{"lvm complex scenario not supported: metadata dev", fields{"/dev/sdb", config.StoreConfig{}}, args{&clusterd.Context{}, false}, false, false},
 		{"lvm complex scenario not supported: metadata dev", fields{"/dev/sdb", config.StoreConfig{}}, args{&clusterd.Context{}, false}, false, false},


### PR DESCRIPTION
This reverts commit 093125904b373382212c958e0fff90ea9acd2b10.

Once we introduced encrypted OSD on partition in #12924. However, even though `encryptedDevice` field is `true`, an non-encrypted OSD is created. To prevent the creation of misconfigured OSD, it's better to revert #12924 for now.

Initially, I intended to correct this problem. However, I found it will take a long time because we need to change the KMS-related code, init containers of both OSD pod and OSD prepare pod.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
