### PR TITLE
test: adding support for multi-rook clusters creation

### DIFF
--- a/Documentation/Contributing/development-environment.md
+++ b/Documentation/Contributing/development-environment.md
@@ -95,4 +95,6 @@ To accelerate the development process, users have the option to employ the scrip
 at `tests/scripts/create-dev-cluster.sh`. This script is designed to rapidly set
 up a new minikube environment, apply the CRDs and the common file, and then utilize the
 `cluster-test.yaml` script to create the Rook cluster. Once setup, users can use the different `*-test.yaml`
-files from the `deploy/examples/` directory to configure their clusters.
+files from the `deploy/examples/` directory to configure their clusters. This script supports
+the possibility of creating multiple rook clusters running on the same machine by using the option
+`-p <profile-name>`.


### PR DESCRIPTION
This change introduce a new argument `-p <profile-name>` to specify the minikube profile for the new cluster. This way we can have multiple rook clusters running on the same machine.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
