### PR TITLE
More improvements to create dev cluster

### DIFF
--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -59,7 +59,7 @@ show_info() {
     echo "    > " alias kubectl=\"$KUBECTL\"
 }
 
-check_minikube_exists() {
+check_minikube_profile_exists() {
     if minikube profile list | grep -q $ROOK_PROFILE_NAME; then
         echo "A minikube profile '$ROOK_PROFILE_NAME' already exists, please use -f to force the cluster creation."
 	exit 1
@@ -165,7 +165,7 @@ cd "$ROOK_EXAMPLES_DIR" || exit
 check_examples_dir
 
 if [ -z "$force_minikube" ]; then
-    check_minikube_exists
+    check_minikube_profile_exists
 fi
 
 setup_minikube_env

--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -60,9 +60,19 @@ show_info() {
 }
 
 check_minikube_profile_exists() {
-    if minikube profile list | grep -q $ROOK_PROFILE_NAME; then
-        echo "A minikube profile '$ROOK_PROFILE_NAME' already exists, please use -f to force the minikube  cluster creation."
-	exit 1
+    
+	minikube profile list | grep -q $ROOK_PROFILE_NAME
+	local retcode=$?
+	if [ $retcode -eq 0 ]; then
+        echo "A minikube profile '$ROOK_PROFILE_NAME' already exists."
+	echo "Using the existing minikube environment."
+	echo " please use -f to force the minikube  cluster creation."
+	return  1
+    else
+	echo " A minikube environment does not exist yet."
+	echo " please use -f to force the minikube  cluster creation."
+
+
     fi
 }
 
@@ -164,11 +174,16 @@ echo "Using '$ROOK_EXAMPLES_DIR' as examples directory.."
 cd "$ROOK_EXAMPLES_DIR" || exit
 check_examples_dir
 
-if [ -z "$force_minikube" ]; then
     check_minikube_profile_exists
+    local exists=$?
+    if [$exists -eq 0 ]; then
+	if [[ -n "${force_minikube}" ]]; then
+    	setup_minikube_env
+fi
 fi
 
-setup_minikube_env
+fi
+
 create_rook_cluster
 wait_for_rook_operator
 wait_for_ceph_cluster

--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -133,6 +133,7 @@ show_usage() {
     echo " Usage: $(basename "$0") [-r] [-d /path/to/rook-examples/dir]"
     echo "  -r        Enable rook orchestrator"
     echo "  -m        Enable monitoring"
+    echo "  -f        enforce creation of the minikube environment "
     echo "  -d value  Path to Rook examples directory (i.e github.com/rook/rook/deploy/examples)"
 }
 

--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -61,7 +61,7 @@ show_info() {
 
 check_minikube_profile_exists() {
     if minikube profile list | grep -q $ROOK_PROFILE_NAME; then
-        echo "A minikube profile '$ROOK_PROFILE_NAME' already exists, please use -f to force the cluster creation."
+        echo "A minikube profile '$ROOK_PROFILE_NAME' already exists, please use -f to force the minikube  cluster creation."
 	exit 1
     fi
 }

--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -18,23 +18,34 @@ wait_for_ceph_cluster() {
 }
 
 get_minikube_driver() {
+	if [[ -n "${minikube_driver}" ]];  then
+		echo "${minikube_driver}"
+		return
+	fi
+	
+
+
     os=$(uname)
     architecture=$(uname -m)
     if [[ "$os" == "Darwin" ]]; then
         if [[ "$architecture" == "x86_64" ]]; then
             echo "hyperkit"
+	    return
         elif [[ "$architecture" == "arm64" ]]; then
             echo "qemu"
+	    return
         else
             echo "Unknown Architecture on Apple OS"
 	    exit 1
         fi
     elif [[ "$os" == "Linux" ]]; then
         echo "kvm2"
+	return
     else
         echo "Unknown/Unsupported OS"
 	exit 1
     fi
+
 }
 
 show_info() {
@@ -135,12 +146,13 @@ show_usage() {
     echo "  -m        Enable monitoring"
     echo "  -f        enforce creation of the minikube environment "
     echo "  -d value  Path to Rook examples directory (i.e github.com/rook/rook/deploy/examples)"
+    echo "  -y value  Specify minikube driver (hypervisor)"
 }
 
 ####################################################################
 ################# MAIN #############################################
 
-while getopts ":hrmfd:" opt; do
+while getopts ":hrmfd:y:" opt; do
     case $opt in
 	h)
 	    show_usage
@@ -158,13 +170,15 @@ while getopts ":hrmfd:" opt; do
 	d)
 	    ROOK_EXAMPLES_DIR="$OPTARG"
 	    ;;
+    y)
+	    minikube_driver="$OPTARG"
 	\?)
-	    echo  "Invalid option: -$OPTARG" >&2
+	    echo  "Invalid option: -$opt" >&2
 	    show_usage
 	    exit 1
 	    ;;
 	:)
-	    echo "Option -$OPTARG requires an argument." >&2
+	    echo "Option -$opt requires an argument." >&2
 	    exit 1
 	    ;;
     esac
@@ -179,6 +193,7 @@ check_examples_dir
     local exists=$?
     if [$exists -eq 0 ]; then
 	if [[ -n "${force_minikube}" ]]; then
+    if [${exists} -eq 0 ]; then
     	setup_minikube_env
 fi
 fi


### PR DESCRIPTION
This PR is a follow-up to several recent PRs that added and improved a `create-dev-cluster` script. 
This adds a few enhancements
* Allow for using an existing minikube environment
* add description of `-f` to the usage text
* add an option `-y` to specify the qemu driver


Additionally, this PR fixes a number of syntax errors, some of which were introduced with this PR while others existed before.

The PR is currently  split  into  multiple commits to separate logical changes , but these  could easily be squashed if desired.





**Which issue is resolved by this Pull Request:**

none 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
