### PR TITLE
mgr: set interval of serviceMonitor to the value from MonitoringSpec

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -530,6 +530,10 @@ func (c *Cluster) EnableServiceMonitor() error {
 	if c.spec.External.Enable {
 		serviceMonitor.Spec.Endpoints[0].Port = controller.ServiceExternalMetricName
 	}
+	if c.spec.Monitoring.Interval != nil {
+		duration := c.spec.Monitoring.Interval.Duration.String()
+		serviceMonitor.Spec.Endpoints[0].Interval = monitoringv1.Duration(duration)
+	}
 	err := c.clusterInfo.OwnerInfo.SetControllerReference(serviceMonitor)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set owner reference to service monitor %q", serviceMonitor.Name)

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -18,19 +18,21 @@ limitations under the License.
 package k8sutil
 
 import (
-	"testing"
-
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestGetServiceMonitor(t *testing.T) {
 	name := "rook-ceph-mgr"
 	namespace := "rook-ceph"
 	port := "http-metrics"
+	interval := monitoringv1.Duration("5s")
 	servicemonitor := GetServiceMonitor(name, namespace, port)
 	assert.Equal(t, name, servicemonitor.GetName())
 	assert.Equal(t, namespace, servicemonitor.GetNamespace())
 	assert.Equal(t, port, servicemonitor.Spec.Endpoints[0].Port)
+	assert.Equal(t, interval, servicemonitor.Spec.Endpoints[0].Interval)
 	assert.NotNil(t, servicemonitor.GetLabels())
 	assert.NotNil(t, servicemonitor.Spec.NamespaceSelector.MatchNames)
 	assert.NotNil(t, servicemonitor.Spec.Selector.MatchLabels)


### PR DESCRIPTION
This change updates the serviceMonitor interval field with the value from the MonitoringSpec.

**Testing:**

Setup a cluster with monitoring enabled, change the interval and make sure its value is propagated to the `servicemonitor`:

```
grep -A 2 monitoring deploy/examples/cluster-test.yaml
  monitoring:
    enabled: true
    interval: 3m10s
```

check the `servicemonitor` object:

```
kubectl get servicemonitors rook-ceph-mgr -o yaml | grep -i "interval:" -A 3 -B 3
  uid: b45044cc-c07d-46b5-bfa3-d7146a6347c3
spec:
  endpoints:
  - interval: 3m10s
    path: /metrics
    port: http-metrics
  namespaceSelector:

```




<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #13159

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
