### PR TITLE
unify treatment of invocation errors in the create-dev-cluster script

### DIFF
--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -138,8 +138,16 @@ show_usage() {
     echo "  -d value          Path to Rook examples directory (i.e github.com/rook/rook/deploy/examples)"
 }
 
+invocation_error() {
+    printf "%s\n" "$*" > /dev/stderr
+    show_usage
+    exit 1
+}
+
 ####################################################################
 ################# MAIN #############################################
+
+
 
 while getopts ":hrmfd:p:" opt; do
     case $opt in
@@ -163,13 +171,10 @@ while getopts ":hrmfd:p:" opt; do
 	    minikube_profile_name="$OPTARG"
 	    ;;
 	\?)
-	    echo  "Invalid option: -$OPTARG" >&2
-	    show_usage
-	    exit 1
+	    invocation_error "Invalid option: -$OPTARG"
 	    ;;
 	:)
-	    echo "Option -$OPTARG requires an argument." >&2
-	    exit 1
+	    invocation_error "Option -$OPTARG requires an argument."
 	    ;;
     esac
 done


### PR DESCRIPTION
The treatment of invocation errors in the  create-dev-cluster script  was not very uniform and contained a lot of code duplication.

 This change to the create-dev-cluster script is intended to make the
    handling of invalid invocations more uniform
    examples are unknown options and options requiring an argument specified
    without one.


 This change to the create-dev-cluster script is intended to make the
    handling of invalid invocations more uniform    
    The unification is achieved by encapsulating the corresponding code in a
    function.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.