### PR TITLE
csi: add CSIDriverOptions section in cephCluster CR

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1099,6 +1099,20 @@ LogCollectorSpec
 <p>Logging represents loggings settings</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>csi</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CSIDriverSpec">
+CSIDriverSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CSI Driver Options applied per cluster.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2794,6 +2808,94 @@ case where the range spec is forgotten (e.g., /24). Rook does in-depth validatio
 </td>
 </tr></tbody>
 </table>
+<h3 id="ceph.rook.io/v1.CSICephFSSpec">CSICephFSSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.CSIDriverSpec">CSIDriverSpec</a>)
+</p>
+<div>
+<p>CSICephFSSpec defines the settings for CephFS CSI driver.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>kernelMountOptions</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KernelMountOptions defines the mount options for kernel mounter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fuseMountOptions</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FuseMountOptions defines the mount options for ceph fuse mounter.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.CSIDriverSpec">CSIDriverSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ClusterSpec">ClusterSpec</a>)
+</p>
+<div>
+<p>CSIDriverSpec defines CSI Driver settings applied per cluster.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>readAffinity</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ReadAffinitySpec">
+ReadAffinitySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReadAffinity defines the read affinity settings for CSI driver.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cephfs</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CSICephFSSpec">
+CSICephFSSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CephFS defines CSI Driver settings for CephFS driver.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.Capacity">Capacity
 </h3>
 <p>
@@ -4247,6 +4349,20 @@ LogCollectorSpec
 <td>
 <em>(Optional)</em>
 <p>Logging represents loggings settings</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>csi</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CSIDriverSpec">
+CSIDriverSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CSI Driver Options applied per cluster.</p>
 </td>
 </tr>
 </tbody>
@@ -10305,6 +10421,50 @@ Annotations
 <p>The annotations-related configuration to add/set on each rgw service.
 nullable
 optional</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.ReadAffinitySpec">ReadAffinitySpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.CSIDriverSpec">CSIDriverSpec</a>)
+</p>
+<div>
+<p>ReadAffinitySpec defines the read affinity settings for CSI driver.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enables read affinity for CSI driver.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>crushLocationLabels</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CrushLocationLabels defines which node labels to use
+as CRUSH location. This should correspond to the values set in
+the CRUSH map.</p>
 </td>
 </tr>
 </tbody>

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
@@ -249,21 +249,22 @@ OSD locations defined in the CRUSH map and topology labels on nodes.
 Refer to the [krbd-options](https://docs.ceph.com/en/latest/man/8/rbd/#kernel-rbd-krbd-options)
 for more details.
 
-Execute the following steps:
+Execute the following step to enable read affinity for a specific ceph cluster:
 
-* Patch the `rook-ceph-operator-config` configmap using the following
-command.
+* Patch the ceph cluster CR to enable read affinity:
 
 ```console
-kubectl patch cm rook-ceph-operator-config -nrook-ceph -p $'data:\n "CSI_ENABLE_READ_AFFINITY": "true"'
+kubectl patch cephclusters.ceph.rook.io <cluster-name> -n rook-ceph -p '{"spec":{"csi":{"readAffinity":{"enabled": true}}}}'
+```
+
+```yaml
+  csi:
+    readAffinity:
+      enabled: true
 ```
 
 * Add topology labels to the Kubernetes nodes. The same labels may be used as mentioned in the
 [OSD topology](../../CRDs/Cluster/ceph-cluster-crd.md#osd-topology) topic.
-
-* (optional) Rook will pass the labels mentioned in [osd-topology](../../CRDs/Cluster/ceph-cluster-crd.md#osd-topology)
-as the default set of labels. This can overridden to supply custom labels by updating the
-`CSI_CRUSH_LOCATION_LABELS` value in the `rook-ceph-operator-config` configmap.
 
 Ceph CSI will extract the CRUSH location from the topology labels found on the node
 and pass it though krbd options during mapping RBD volumes.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -962,6 +962,32 @@ spec:
                       description: Disable determines whether we should enable the crash collector
                       type: boolean
                   type: object
+                csi:
+                  description: CSI Driver Options applied per cluster.
+                  properties:
+                    cephfs:
+                      description: CephFS defines CSI Driver settings for CephFS driver.
+                      properties:
+                        fuseMountOptions:
+                          description: FuseMountOptions defines the mount options for ceph fuse mounter.
+                          type: string
+                        kernelMountOptions:
+                          description: KernelMountOptions defines the mount options for kernel mounter.
+                          type: string
+                      type: object
+                    readAffinity:
+                      description: ReadAffinity defines the read affinity settings for CSI driver.
+                      properties:
+                        crushLocationLabels:
+                          description: CrushLocationLabels defines which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map.
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enables read affinity for CSI driver.
+                          type: boolean
+                      type: object
+                  type: object
                 dashboard:
                   description: Dashboard settings
                   nullable: true

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -281,6 +281,22 @@ spec:
     # No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
     pgHealthCheckTimeout: 0
 
+  # csi defines CSI Driver settings applied per cluster.
+  csi:
+    readAffinity:
+      # Enable read affinity to enable clients to optimize reads from an OSD in the same topology.
+      # Enabling the read affinity may cause the OSDs to consume some extra memory.
+      # For more details see this doc:
+      # https://rook.io/docs/rook/latest/Storage-Configuration/Ceph-CSI/ceph-csi-drivers/#enable-read-affinity-for-rbd-volumes
+      enabled: false
+
+    # cephfs driver specific settings.
+    cephfs:
+      # Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options.
+      # kernelMountOptions: ""
+      # Set CephFS Fuse mount options to use https://docs.ceph.com/en/quincy/man/8/ceph-fuse/#options.
+      # fuseMountOptions: ""
+
   # healthChecks
   # Valid values for daemons are 'mon', 'osd', 'status'
   healthCheck:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -960,6 +960,32 @@ spec:
                       description: Disable determines whether we should enable the crash collector
                       type: boolean
                   type: object
+                csi:
+                  description: CSI Driver Options applied per cluster.
+                  properties:
+                    cephfs:
+                      description: CephFS defines CSI Driver settings for CephFS driver.
+                      properties:
+                        fuseMountOptions:
+                          description: FuseMountOptions defines the mount options for ceph fuse mounter.
+                          type: string
+                        kernelMountOptions:
+                          description: KernelMountOptions defines the mount options for kernel mounter.
+                          type: string
+                      type: object
+                    readAffinity:
+                      description: ReadAffinity defines the read affinity settings for CSI driver.
+                      properties:
+                        crushLocationLabels:
+                          description: CrushLocationLabels defines which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map.
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enables read affinity for CSI driver.
+                          type: boolean
+                      type: object
+                  type: object
                 dashboard:
                   description: Dashboard settings
                   nullable: true

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -221,6 +221,42 @@ type ClusterSpec struct {
 	// +optional
 	// +nullable
 	LogCollector LogCollectorSpec `json:"logCollector,omitempty"`
+
+	// CSI Driver Options applied per cluster.
+	// +optional
+	CSI CSIDriverSpec `json:"csi,omitempty"`
+}
+
+// CSIDriverSpec defines CSI Driver settings applied per cluster.
+type CSIDriverSpec struct {
+	// ReadAffinity defines the read affinity settings for CSI driver.
+	// +optional
+	ReadAffinity ReadAffinitySpec `json:"readAffinity"`
+	// CephFS defines CSI Driver settings for CephFS driver.
+	// +optional
+	CephFS CSICephFSSpec `json:"cephfs,omitempty"`
+}
+
+// CSICephFSSpec defines the settings for CephFS CSI driver.
+type CSICephFSSpec struct {
+	// KernelMountOptions defines the mount options for kernel mounter.
+	// +optional
+	KernelMountOptions string `json:"kernelMountOptions,omitempty"`
+	// FuseMountOptions defines the mount options for ceph fuse mounter.
+	// +optional
+	FuseMountOptions string `json:"fuseMountOptions,omitempty"`
+}
+
+// ReadAffinitySpec defines the read affinity settings for CSI driver.
+type ReadAffinitySpec struct {
+	// Enables read affinity for CSI driver.
+	// +optional
+	Enabled bool `json:"enabled"`
+	// CrushLocationLabels defines which node labels to use
+	// as CRUSH location. This should correspond to the values set in
+	// the CRUSH map.
+	// +optional
+	CrushLocationLabels []string `json:"crushLocationLabels,omitempty"`
 }
 
 // LogCollectorSpec is the logging spec

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -48,6 +48,7 @@ type ClusterInfo struct {
 	name              string
 	OsdUpgradeTimeout time.Duration
 	NetworkSpec       cephv1.NetworkSpec
+	CSIDriverSpec     cephv1.CSIDriverSpec
 	// A context to cancel the context it is used to determine whether the reconcile loop should
 	// exist (if the context has been cancelled). This cannot be in main clusterd context since this
 	// is a pointer passed through the entire life cycle or the operator. If the context is

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -220,6 +220,11 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 		go cluster.reportTelemetry()
 	}
 
+	err := csi.SaveCSIDriverOptions(c.context.Clientset, cluster.Namespace, cluster.ClusterInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to save CSI driver options")
+	}
+
 	// Populate ClusterInfo with the last value
 	cluster.mons.ClusterInfo = cluster.ClusterInfo
 	cluster.mons.ClusterInfo.SetName(c.namespacedName.Name)

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -32,6 +32,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
@@ -153,6 +154,12 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 	// it will also update if Multus is enabled, so ceph cmds
 	// can run on remote executor
 	clusterInfo.NetworkSpec = cephClusterSpec.Network
+
+	// update clusterInfo with cephClusterSpec.CSI.
+	clusterInfo.CSIDriverSpec = cephClusterSpec.CSI
+	if len(clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels) == 0 {
+		clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels = strings.Split(topology.GetDefaultTopologyLabels(), ",")
+	}
 
 	// If an admin key was provided we don't need to load the other resources
 	// Some people might want to give the admin key

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -868,8 +868,12 @@ func (r *ReconcileCSI) configureHolder(driver driverDetails, c ClusterDetail, tp
 	clusterConfigEntry := &CsiClusterConfigEntry{
 		Monitors: MonEndpoints(c.clusterInfo.Monitors, c.cluster.Spec.RequireMsgr2()),
 		RBD:      &CsiRBDSpec{},
-		CephFS:   &CsiCephFSSpec{},
-		NFS:      &CsiNFSSpec{},
+		CephFS: &CsiCephFSSpec{
+			FuseMountOptions:   c.clusterInfo.CSIDriverSpec.CephFS.FuseMountOptions,
+			KernelMountOptions: c.clusterInfo.CSIDriverSpec.CephFS.KernelMountOptions,
+		},
+		NFS:          &CsiNFSSpec{},
+		ReadAffinity: &c.clusterInfo.CSIDriverSpec.ReadAffinity,
 	}
 	netNamespaceFilePath := generateNetNamespaceFilePath(CSIParam.KubeletDirPath, driver.fullName, c.cluster.Namespace)
 	if driver.name == RBDDriverShortName {

--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -269,8 +269,11 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) updateClusterConfig(cephFilesyst
 		Namespace: r.clusterInfo.Namespace,
 		Monitors:  csi.MonEndpoints(r.clusterInfo.Monitors, cephCluster.Spec.RequireMsgr2()),
 		CephFS: &csi.CsiCephFSSpec{
-			SubvolumeGroup: cephFilesystemSubVolumeGroup.Name,
+			SubvolumeGroup:     cephFilesystemSubVolumeGroup.Name,
+			KernelMountOptions: r.clusterInfo.CSIDriverSpec.CephFS.KernelMountOptions,
+			FuseMountOptions:   r.clusterInfo.CSIDriverSpec.CephFS.FuseMountOptions,
 		},
+		ReadAffinity: &r.clusterInfo.CSIDriverSpec.ReadAffinity,
 	}
 
 	// If the cluster has Multus enabled we need to append the network namespace of the driver's

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -264,6 +264,11 @@ func (r *ReconcileCephBlockPoolRadosNamespace) updateClusterConfig(cephBlockPool
 			RadosNamespace: cephBlockPoolRadosNamespace.Name,
 		},
 		RadosNamespace: cephBlockPoolRadosNamespace.Name,
+		CephFS: &csi.CsiCephFSSpec{
+			KernelMountOptions: r.clusterInfo.CSIDriverSpec.CephFS.KernelMountOptions,
+			FuseMountOptions:   r.clusterInfo.CSIDriverSpec.CephFS.FuseMountOptions,
+		},
+		ReadAffinity: &r.clusterInfo.CSIDriverSpec.ReadAffinity,
 	}
 
 	if cephCluster.Spec.Network.IsMultus() {


### PR DESCRIPTION
This commit adds new CSIDriverOptions section in
cephCluster CR. This section contains settings
for read affinity and kernel+fuse Mount options
These settings will be injected directly into
rook-ceph-csi-config cm to be applicable per
ceph cluster.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
