### PR TITLE
multus: fix placement error for net addr detect job

### DIFF
--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -266,7 +266,7 @@ func discoverAddressRanges(
 	}
 
 	// use osd placement for net canaries b/c osd pods are present on both public and cluster nets
-	clusterSpec.Placement[cephv1.KeyOSD].ApplyToPodSpec(&job.Spec.Template.Spec)
+	cephv1.GetOSDPlacement(clusterSpec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)
 
 	// set up net status vol from downward api, plus init container to wait for net status to be available
 	netStatusVol, netStatusMount := networkStatusVolumeAndMount()


### PR DESCRIPTION
Fix an issue in the network address detection job where placement was only retreived from osd and not merged with all.

**Which issue is resolved by this Pull Request:**
Resolves #13138

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
