### PR TITLE
ci: upgrade min k8s support to 1.23.17

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.28.0
+        tests/scripts/github-action-helper.sh install_minikube_with_none_driver v1.28.4
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -121,7 +121,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephSmokeSuite
         run: |
@@ -156,7 +156,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephSmokeSuite
         run: |
@@ -191,7 +191,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephSmokeSuite
         run: |
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephObjectSuite
         run: |
@@ -261,7 +261,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephObjectSuite
         run: |
@@ -296,7 +296,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -331,7 +331,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.0"
+          kubernetes-version: "1.28.4"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.28.0"]
+        kubernetes-versions: ["v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.28.0"]
+        kubernetes-versions: ["v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.27.2"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.24.17", "v1.26.11", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.24.17", "v1.26.11", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.24.17", "v1.26.11", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.24.16", "v1.26.7", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.24.17", "v1.26.11", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.25.12", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.25.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.22.17", "v1.28.0"]
+        kubernetes-versions: ["v1.23.17", "v1.28.4"]
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Upgrade minimum kubernetes support to 1.23.17 from 1.22.17. Also, upgrade kubernetes version latest minor release.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
