### PR TITLE
mgr: honor the ContinueUpgradeAfterChecksEvenIfNotHealthy flag

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -21,6 +21,7 @@
         "external",
         "file",
         "helm",
+	"k8sutil",
         "manifest",
         "mds",
         "mgr",


### PR DESCRIPTION
Resolves: #13167

Previously, the mgr did not honor the flag
ContinueUpgradeAfterChecksEvenIfNotHealthy
from the cluster spec. Only osd, mds, and rgw did.

To render the update behavior correct and complete across the daemons, this change implements the honoring of the flag for the mgr.


**Which issue is resolved by this Pull Request:**
Resolves: #13167

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
