### PR TITLE
build: use /usr/bin/env to look up script interpreters

### DIFF
--- a/.docs/macros/includes/main.py
+++ b/.docs/macros/includes/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from pygit2 import Repository
 import re

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # set the shell to bash in case some environments use sh
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Can be used or additional go build flags
 BUILDFLAGS ?=

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # Copyright 2018 The Rook Authors. All rights reserved.
 #

--- a/build/common.sh
+++ b/build/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 set -u
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -15,7 +15,7 @@
 # remove default suffixes as we dont use them
 .SUFFIXES:
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 ifneq (, $(shell command -v shasum))
 SHA256CMD := shasum -a 256
 else ifneq (, $(shell command -v sha256sum))

--- a/build/reset
+++ b/build/reset
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash
 set -e
 
 ##############

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/usr/bin/env -S bash +e
 
 temp="/tmp/rook-tests-scripts-helm"
 

--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/usr/bin/env -S bash +e
 
 KUBE_VERSION=${1:-"v1.15.12"}
 null_str=

--- a/tests/scripts/multus/setup-multus.sh
+++ b/tests/scripts/multus/setup-multus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash
 set -xeo pipefail
 
 # initially copied from https://github.com/k8snetworkplumbingwg/whereabouts

--- a/tests/scripts/validate_modified_files.sh
+++ b/tests/scripts/validate_modified_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash
 set -ex
 
 #############


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

For users that have their `/bin/bash` at a "abnormal" place (e.g., NixOS) this makes the scripts and shell vars use `/usr/bin/env` to find the "right" one.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
