### PR TITLE
rgw: correctly handle mgr-proxied rgw cli commands in multus scenarios

### DIFF
--- a/pkg/util/exec/error.go
+++ b/pkg/util/exec/error.go
@@ -19,6 +19,7 @@ package exec
 
 import (
 	"fmt"
+	kexec "k8s.io/client-go/util/exec"
 	"os/exec"
 	"syscall"
 )
@@ -41,12 +42,12 @@ func ExitStatus(err error) (int, bool) {
 		if ok {
 			return waitStatus.ExitStatus(), true
 		}
-
+	case kexec.CodeExitError:
+		return int(e.ExitStatus()), true
 	case *CephCLIError:
 		return ExitStatus(e.err)
 	case syscall.Errno:
 		return int(e), true
-
 	}
 	return 0, false
 }


### PR DESCRIPTION
Due to multi-site Ceph object resources (realms, zonegroups, zones) reconciliation CLI commands being proxied through CephCluster's Mgr pods in Multus-based scenarios, return codes were being additionally wrapped by K8S' command streams and weren't adequately handled in-code, causing reconciliation of CephObject(Realm|ZoneGroup|Zone) resources to fail, as an exit code of 0, instead of the expected syscall.ENOENT (2) was returned.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #12833

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
