### PR TITLE
operator: allow setting ceph config options via ceph cluster crd

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -92,6 +92,7 @@ For more details on the mons and when to choose a number other than `3`, see the
 * `removeOSDsIfOutAndSafeToRemove`: If `true` the operator will remove the OSDs that are down and whose data has been restored to other OSDs. In Ceph terms, the OSDs are `out` and `safe-to-destroy` when they are removed.
 * `cleanupPolicy`: [cleanup policy settings](#cleanup-policy)
 * `security`: [security page for key management configuration](../../Storage-Configuration/Advanced/key-management-system.md)
+* `cephConfig`: [Set Ceph config options using the Ceph Mon config store](#ceph-config)
 
 ### Ceph container images
 
@@ -937,3 +938,31 @@ However, all new configuration by the operator will be blocked with this cleanup
 Rook waits for the deletion of PVs provisioned using the cephCluster before proceeding to delete the
 cephCluster. To force deletion of the cephCluster without waiting for the PVs to be deleted, you can
 set the `allowUninstallWithVolumes` to true under `spec.CleanupPolicy`.
+
+## Ceph Config
+
+!!! attention
+    This feature is experimental.
+
+The Ceph config options are applied after the MONs are all in quorum and running. To set Ceph config options, you can add them to your `CephCluster` spec like this:
+
+```yaml
+spec:
+  # [...]
+  cephConfig:
+    # Who's the target for these config options?
+    global:
+      # All values must be quoted so they are considered a string in YAML
+      osd_pool_default_size: "3"
+      mon_warn_on_pool_no_redundancy: "false"
+      osd_crush_update_on_start: "false"
+    # Make sure to quote special characters
+    "osd.*":
+      osd_max_scrubs: "10"
+```
+
+!!! warning
+    Rook performs no direct validation on these config options, so the validity of the settings is the
+    user's responsibility.
+
+The operator does not unset any removed config options, it is the user's responsibility to unset or set the default value for each removed option manually using the Ceph CLI.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1113,6 +1113,18 @@ CSIDriverSpec
 <p>CSI Driver Options applied per cluster.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>cephConfig</code><br/>
+<em>
+map[string]map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ceph Config options</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -4363,6 +4375,18 @@ CSIDriverSpec
 <td>
 <em>(Optional)</em>
 <p>CSI Driver Options applied per cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cephConfig</code><br/>
+<em>
+map[string]map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ceph Config options</p>
 </td>
 </tr>
 </tbody>

--- a/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
@@ -206,11 +206,13 @@ ceph osd pool set rbd pg_num 512
 ## Custom `ceph.conf` Settings
 
 !!! warning
-    The advised method for controlling Ceph configuration is to manually use the Ceph CLI
-    or the Ceph dashboard because this offers the most flexibility. It is highly recommended that this
-    only be used when absolutely necessary and that the `config` be reset to an empty string if/when the
-    configurations are no longer necessary. Configurations in the config file will make the Ceph cluster
-    less configurable from the CLI and dashboard and may make future tuning or debugging difficult.
+    The advised method for controlling Ceph configuration is to use the [`cephConfig:` structure](../../CRDs/Cluster/ceph-cluster-crd.md#ceph-config)
+    in the `CephCluster` CRD.
+
+    It is highly recommended that this only be used when absolutely necessary and that the `config` be
+    reset to an empty string if/when the configurations are no longer necessary. Configurations in the
+    config file will make the Ceph cluster less configurable from the CLI and dashboard and may make
+    future tuning or debugging difficult.
 
 Setting configs via Ceph's CLI requires that at least one mon be available for the configs to be
 set, and setting configs via dashboard requires at least one mgr to be available. Ceph also has

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,3 +5,5 @@
 - Removed support for Ceph Pacific (v16)
 
 ## Features
+
+- Added `cephConfig:` to CephCluster to allow setting Ceph config options in the Ceph MON config store via the CRD

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -895,6 +895,14 @@ spec:
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                cephConfig:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Ceph Config options
+                  nullable: true
+                  type: object
                 cephVersion:
                   description: The version information that instructs Rook to orchestrate a particular version of Ceph.
                   nullable: true

--- a/deploy/examples/cluster-multus-test.yaml
+++ b/deploy/examples/cluster-multus-test.yaml
@@ -7,19 +7,6 @@
 #   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
 #   kubectl create -f cluster-test.yaml
 #################################################################################################################
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: rook-config-override
-  namespace: rook-ceph # namespace:cluster
-data:
-  config: |
-    [global]
-    osd_pool_default_size = 1
-    mon_warn_on_pool_no_redundancy = false
-    bdev_flock_retry = 20
-    bluefs_buffered_io = false
----
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -47,3 +34,10 @@ spec:
     useAllNodes: true
     useAllDevices: true
     #deviceFilter:
+  cephConfig:
+    global:
+      osd_pool_default_size: "1"
+      mon_warn_on_pool_no_redundancy: "false"
+      bdev_flock_retry: "20"
+      bluefs_buffered_io: "false"
+      mon_data_avail_warn: "10"

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -7,20 +7,6 @@
 #   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
 #   kubectl create -f cluster-test.yaml
 #################################################################################################################
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: rook-config-override
-  namespace: rook-ceph # namespace:cluster
-data:
-  config: |
-    [global]
-    osd_pool_default_size = 1
-    mon_warn_on_pool_no_redundancy = false
-    bdev_flock_retry = 20
-    bluefs_buffered_io = false
-    mon_data_avail_warn = 10
----
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -57,6 +43,13 @@ spec:
     mgr: system-cluster-critical
   disruptionManagement:
     managePodBudgets: true
+  cephConfig:
+    global:
+      osd_pool_default_size: "1"
+      mon_warn_on_pool_no_redundancy: "false"
+      bdev_flock_retry: "20"
+      bluefs_buffered_io: "false"
+      mon_data_avail_warn: "10"
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -893,6 +893,14 @@ spec:
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                cephConfig:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: Ceph Config options
+                  nullable: true
+                  type: object
                 cephVersion:
                   description: The version information that instructs Rook to orchestrate a particular version of Ceph.
                   nullable: true

--- a/design/ceph/ceph-config-via-cluster-crd.md
+++ b/design/ceph/ceph-config-via-cluster-crd.md
@@ -51,3 +51,5 @@ The operator will use the Ceph config store (that is accessed via `ceph config a
 ### Limitations
 
 The operator won't be unsetting any previously set config options or restore config options to their default value.
+
+The operator will ignore a few vital config options, such as `fsid`, `keyring` and `mon_host`.

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/sykesm/zap-logfmt v0.0.4
 	go.uber.org/zap v1.26.0
+	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/sync v0.5.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -117,7 +118,6 @@ require (
 	go.starlark.net v0.0.0-20230814145427-12f4cb8177e4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -225,6 +225,11 @@ type ClusterSpec struct {
 	// CSI Driver Options applied per cluster.
 	// +optional
 	CSI CSIDriverSpec `json:"csi,omitempty"`
+
+	// Ceph Config options
+	// +optional
+	// +nullable
+	CephConfig map[string]map[string]string `json:"cephConfig,omitempty"`
 }
 
 // CSIDriverSpec defines CSI Driver settings applied per cluster.

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -214,7 +216,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 				assert.Equal(t, failureDomain, args[6])
 			}
 			if deviceClass == "" {
-				assert.False(t, testIsStringInSlice("hdd", args))
+				assert.False(t, slices.Contains(args, "hdd"))
 			} else {
 				assert.Equal(t, deviceClass, args[7])
 			}
@@ -334,15 +336,6 @@ func TestExtractPoolDetails(t *testing.T) {
 		assert.Equal(t, "zone", failureDomain)
 		assert.Equal(t, "ssd", deviceClass)
 	})
-}
-
-func testIsStringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }
 
 func TestGetPoolStatistics(t *testing.T) {

--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -218,3 +218,46 @@ func TestMonStore_SetAll(t *testing.T) {
 	assert.NoError(t, e)
 	assert.True(t, appliedSettings)
 }
+
+func TestFilterSettingsMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    CephConfigOptionsMap
+		expected CephConfigOptionsMap
+	}{
+		{
+			name: "no filtered config options",
+			input: map[string]map[string]string{
+				"global": {
+					"osd_pool_default_size": "1",
+				},
+			},
+			expected: map[string]map[string]string{
+				"global": {
+					"osd_pool_default_size": "1",
+				},
+			},
+		},
+		{
+			name: "filtered config options",
+			input: map[string]map[string]string{
+				"global": {
+					"mon_host":              "192.168.1.100:687",
+					"osd_pool_default_size": "1",
+					"bluefs_buffered_io":    "false",
+				},
+			},
+			expected: map[string]map[string]string{
+				"global": {
+					"osd_pool_default_size": "1",
+					"bluefs_buffered_io":    "false",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, filterSettingsMap(tt.input))
+		})
+	}
+}

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -273,7 +273,7 @@ function deploy_cluster() {
     exit 1
   fi
   # enable monitoring
-  yq w -i -d1 cluster-test.yaml spec.monitoring.enabled true
+  yq w -i -d0 cluster-test.yaml spec.monitoring.enabled true
   kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.40.0/bundle.yaml
   kubectl create -f monitoring/rbac.yaml
 
@@ -401,9 +401,9 @@ function deploy_first_rook_cluster() {
   cd deploy/examples/
 
   deploy_manifest_with_local_build operator.yaml
-  yq w -i -d1 cluster-test.yaml spec.dashboard.enabled false
-  yq w -i -d1 cluster-test.yaml spec.storage.useAllDevices false
-  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"1
+  yq w -i -d0 cluster-test.yaml spec.dashboard.enabled false
+  yq w -i -d0 cluster-test.yaml spec.storage.useAllDevices false
+  yq w -i -d0 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"1
   kubectl create -f cluster-test.yaml
   deploy_toolbox
 }
@@ -413,8 +413,8 @@ function deploy_second_rook_cluster() {
   cd deploy/examples/
   NAMESPACE=rook-ceph-secondary envsubst <common-second-cluster.yaml | kubectl create -f -
   sed -i 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g' cluster-test.yaml
-  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"2
-  yq w -i -d1 cluster-test.yaml spec.dataDirHostPath "/var/lib/rook-external"
+  yq w -i -d0 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"2
+  yq w -i -d0 cluster-test.yaml spec.dataDirHostPath "/var/lib/rook-external"
   kubectl create -f cluster-test.yaml
   yq w -i toolbox.yaml metadata.namespace rook-ceph-secondary
   deploy_toolbox


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

This implements the "Ceph Config via Ceph Cluster CRD" design document as a `cephConfig:` structure on the CRD.

**Notes**:

I'm unsure if I should add a  test for the `SetAllMultiple` function. I feel that it is covered well enough by the `SetAll` tests.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.