### PR TITLE
mgr: get servicemonitor exporter's interval from MonitoringSpec

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -234,6 +234,11 @@ func MakeCephExporterMetricsService(cephCluster cephv1.CephCluster, servicePortM
 func EnableCephExporterServiceMonitor(context *clusterd.Context, cephCluster cephv1.CephCluster, scheme *runtime.Scheme, opManagerContext context.Context, servicePortMetricName string) error {
 	serviceMonitor := k8sutil.GetServiceMonitor(cephExporterAppName, cephCluster.Namespace, servicePortMetricName)
 
+	if cephCluster.Spec.Monitoring.Interval != nil {
+		duration := cephCluster.Spec.Monitoring.Interval.Duration.String()
+		serviceMonitor.Spec.Endpoints[0].Interval = monitoringv1.Duration(duration)
+	}
+
 	cephv1.GetCephExporterLabels(cephCluster.Spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 
 	err := controllerutil.SetControllerReference(&cephCluster, serviceMonitor, scheme)


### PR DESCRIPTION
This change updates the serviceMonitor interval of the the rook-ceph-exporter with the value from the MonitoringSpec.

**Testing:**

Set the interval to `50s` on cluster spec as following:

```
....
  monitoring:
    enabled: true
    interval: 50s
....
```


```
k get servicemonitors rook-ceph-exporter -o yaml | grep -i "interval:" -A 3 -B 3                       
  uid: 927f13b2-5134-4fc4-9c15-a0b37bd9f206
spec:
  endpoints:
  - interval: 50s
    path: /metrics
    port: ceph-exporter-http-metrics
  namespaceSelector:
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
