### PR TITLE
subvolumegroup: add name spec in subvolumegroup CRD

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1498,6 +1498,18 @@ CephFilesystemSubVolumeGroupSpec
 <table>
 <tr>
 <td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>filesystemName</code><br/>
 <em>
 string
@@ -3554,6 +3566,18 @@ int64
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>filesystemName</code><br/>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -7962,6 +7962,9 @@ spec:
                 filesystemName:
                   description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name. Typically it's the name of the CephFilesystem CR. If not coming from the CephFilesystem CR, it can be retrieved from the list of Ceph Filesystem volumes with `ceph fs volume ls`. To learn more about Ceph Filesystem abstractions see https://docs.ceph.com/en/latest/cephfs/fs-volumes/#fs-volumes-and-subvolumes
                   type: string
+                name:
+                  description: The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+                  type: string
               required:
                 - filesystemName
               type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -7956,6 +7956,9 @@ spec:
                 filesystemName:
                   description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name. Typically it's the name of the CephFilesystem CR. If not coming from the CephFilesystem CR, it can be retrieved from the list of Ceph Filesystem volumes with `ceph fs volume ls`. To learn more about Ceph Filesystem abstractions see https://docs.ceph.com/en/latest/cephfs/fs-volumes/#fs-volumes-and-subvolumes
                   type: string
+                name:
+                  description: The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+                  type: string
               required:
                 - filesystemName
               type: object

--- a/deploy/examples/subvolumegroup.yaml
+++ b/deploy/examples/subvolumegroup.yaml
@@ -5,5 +5,7 @@ metadata:
   name: group-a
   namespace: rook-ceph # namespace:cluster
 spec:
+  # The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+  # name: group-a
   # filesystemName is the metadata name of the CephFilesystem CR where the subvolume group will be created
   filesystemName: myfs

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2913,6 +2913,9 @@ type CephFilesystemSubVolumeGroupList struct {
 
 // CephFilesystemSubVolumeGroupSpec represents the specification of a Ceph Filesystem SubVolumeGroup
 type CephFilesystemSubVolumeGroupSpec struct {
+	// The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
+	// +optional
+	Name string `json:"name,omitempty"`
 	// FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name. Typically it's the name of
 	// the CephFilesystem CR. If not coming from the CephFilesystem CR, it can be retrieved from the
 	// list of Ceph Filesystem volumes with `ceph fs volume ls`. To learn more about Ceph Filesystem

--- a/pkg/daemon/ceph/client/subvolumegroup.go
+++ b/pkg/daemon/ceph/client/subvolumegroup.go
@@ -24,7 +24,7 @@ import (
 // CreateCephFSSubVolumeGroup create a CephFS subvolume group.
 // volName is the name of the Ceph FS volume, the same as the CephFilesystem CR name.
 func CreateCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterInfo, volName, groupName string) error {
-	logger.Infof("creating cephfs subvolume group %q", volName)
+	logger.Infof("creating cephfs %q subvolume group %q", volName, groupName)
 	//  [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>]
 	args := []string{"fs", "subvolumegroup", "create", volName, groupName}
 	cmd := NewCephCommand(context, clusterInfo, args)
@@ -34,13 +34,13 @@ func CreateCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterI
 		return errors.Wrapf(err, "failed to create subvolume group %q. %s", volName, output)
 	}
 
-	logger.Infof("successfully created cephfs subvolume group %q", volName)
+	logger.Infof("successfully created cephfs %q subvolume group %q", volName, groupName)
 	return nil
 }
 
 // DeleteCephFSSubVolumeGroup delete a CephFS subvolume group.
 func DeleteCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterInfo, volName, groupName string) error {
-	logger.Infof("deleting cephfs subvolume group %q", volName)
+	logger.Infof("deleting cephfs %q subvolume group %q", volName, groupName)
 	//  --force?
 	args := []string{"fs", "subvolumegroup", "rm", volName, groupName}
 	cmd := NewCephCommand(context, clusterInfo, args)
@@ -52,6 +52,6 @@ func DeleteCephFSSubVolumeGroup(context *clusterd.Context, clusterInfo *ClusterI
 		return err
 	}
 
-	logger.Infof("successfully deleted cephfs subvolume group %q", volName)
+	logger.Infof("successfully deleted cephfs %q subvolume group %q", volName, groupName)
 	return nil
 }


### PR DESCRIPTION
Originally we create it using this cmd
ceph fs subvolume create <vol_name> <subvol_name>
So we can have 2 variables filesystem and subvolume name, Currently the CR doesn't allow us to make subvolume-name as constant as needed to "csi" because of k8s limitations

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
