### PR TITLE
namespace: add name spec in cephBlockPoolRadosNamespace CRD

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -206,6 +206,18 @@ CephBlockPoolRadosNamespaceSpec
 <table>
 <tr>
 <td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>blockPoolName</code><br/>
 <em>
 string
@@ -2970,6 +2982,18 @@ string
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>blockPoolName</code><br/>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -36,6 +36,9 @@ spec:
                 blockPoolName:
                   description: BlockPoolName is the name of Ceph BlockPool. Typically it's the name of the CephBlockPool CR.
                   type: string
+                name:
+                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
+                  type: string
               required:
                 - blockPoolName
               type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -39,6 +39,9 @@ spec:
                 blockPoolName:
                   description: BlockPoolName is the name of Ceph BlockPool. Typically it's the name of the CephBlockPool CR.
                   type: string
+                name:
+                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
+                  type: string
               required:
                 - blockPoolName
               type: object

--- a/deploy/examples/radosnamespace.yaml
+++ b/deploy/examples/radosnamespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: namespace-a
   namespace: rook-ceph # namespace:cluster
 spec:
+  # The name of the RADOS namespace. If not set, the default is the name of the CR.
+  # name: namespace-a
   # blockPoolName is the name of the CephBlockPool CR where the namespace will be created.
   blockPoolName: replicapool

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2960,6 +2960,9 @@ type CephBlockPoolRadosNamespaceList struct {
 
 // CephBlockPoolRadosNamespaceSpec represents the specification of a CephBlockPool Rados Namespace
 type CephBlockPoolRadosNamespaceSpec struct {
+	// The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
+	// +optional
+	Name string `json:"name,omitempty"`
 	// BlockPoolName is the name of Ceph BlockPool. Typically it's the name of
 	// the CephBlockPool CR.
 	BlockPoolName string `json:"blockPoolName"`


### PR DESCRIPTION
instead of use metadata name as the backend resource name we need to add a new name in the spec which can be the actual backend name

Closes: https://github.com/rook/rook/issues/13220

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #  https://github.com/rook/rook/issues/13220

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
