### PR TITLE
helm: Add namespace to all resource templates

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -5,6 +5,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: {{ $blockpool.name }}
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
 spec:
 {{ toYaml $blockpool.spec | indent 2 }}
 ---

--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -3,6 +3,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: {{ default .Release.Namespace .Values.clusterName }}
+  namespace: {{ .Release.Namespace }} # namespace:cluster
 spec:
 {{- if .Values.monitoring }}
   monitoring:

--- a/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
@@ -5,6 +5,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: {{ $ecblockpool.name }}
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
 spec:
 {{ toYaml $ecblockpool.spec | indent 2 }}
 {{ end }}
@@ -43,4 +44,3 @@ parameters:
 allowVolumeExpansion: {{ $cephEcStorage.allowVolumeExpansion }}
 reclaimPolicy: {{ $cephEcStorage.reclaimPolicy }}
 {{ end }}
-

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -5,6 +5,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
   name: {{ $filesystem.name }}
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
 spec:
 {{ toYaml $filesystem.spec | indent 2 }}
 ---

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ include "capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ .name }}
+  namespace: {{ .Release.Namespace }} # namespace:cluster
   {{- with .ingress.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -5,6 +5,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: {{ $objectstore.name }}
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
 spec:
 {{ toYaml $objectstore.spec | indent 2 }}
 ---

--- a/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rook-config-override
+  namespace: {{ .Release.Namespace }} # namespace:cluster
 data:
   config: |
 {{ .Values.configOverride | nindent 4 }}

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-tools
+  namespace: {{ .Release.Namespace }} # namespace:cluster
   labels:
     app: rook-ceph-tools
 spec:

--- a/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "clusterName" . }}-dashboard
+  namespace: {{ .Release.Namespace }} # namespace:cluster
   {{- if .Values.ingress.dashboard.annotations }}
   annotations: {{- toYaml .Values.ingress.dashboard.annotations | nindent 4 }}
   {{- end }}

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rook-ceph-operator-config
+  namespace: {{ .Release.Namespace }} # namespace:operator
 data:
   ROOK_LOG_LEVEL: {{ .Values.logLevel | quote }}
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: {{ .Values.cephCommandsTimeoutSeconds | quote }}

--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
+  namespace: {{ .Release.Namespace }} # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph


### PR DESCRIPTION
The helm templates assumed that the resources would be installed to the given namespace for the helm install or upgrade. This works perfectly until there is a desire to extract the manifests from the helm chart and instead install with those. Thus, the namespace is added to all the resources in the chart where they were missing.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #13268

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
