### PR TITLE
csi: update default cephcsi version to 3.10.0

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.cephFSKernelMountOptions` | Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options. Set to "ms_mode=secure" when connections.encrypted is enabled in CephCluster CR | `nil` |
 | `csi.cephFSPluginUpdateStrategy` | CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
 | `csi.cephFSPluginUpdateStrategyMaxUnavailable` | A maxUnavailable parameter of CSI cephFS plugin daemonset update strategy. | `1` |
-| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.9.0` |
+| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.10.0` |
 | `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port | `9081` |
 | `csi.cephfsPodLabels` | Labels to add to the CSI CephFS Deployments and DaemonSets Pods | `nil` |
 | `csi.clusterName` | Cluster name identifier to set as metadata on the CephFS subvolume and RBD images. This will be useful in cases like for example, when two container orchestrator clusters (Kubernetes/OCP) are using a single ceph cluster | `nil` |

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
@@ -240,9 +240,10 @@ parameters:
 
 * PVCs created using the new storageclass will be encrypted.
 
-## Enable Read affinity for RBD volumes
+## Enable Read affinity for RBD and CephFS volumes
 
-Ceph CSI supports mapping RBD volumes with KRBD options to allow
+Ceph CSI supports mapping RBD volumes with KRBD options and mounting
+CephFS volumes with ceph mount options to allow
 serving reads from an OSD closest to the client, according to
 OSD locations defined in the CRUSH map and topology labels on nodes.
 

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -18,7 +18,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-ceph-operator-config
 The default upstream images are included below, which you can change to your desired images.
 
 ```yaml
-ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
+ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.10.0"
 ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1"
 ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.6.2"
 ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.4.2"
@@ -32,7 +32,7 @@ ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.7.0"
 If image version is not passed along with the image name in any of the variables above,
 Rook will add the corresponding default version to that image.
 Example: if `ROOK_CSI_CEPH_IMAGE: "quay.io/private-repo/cephcsi"` is passed,
-Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.9.0"`.
+Rook will add internal default version and consume it as `"quay.io/private-repo/cephcsi:v3.10.0"`.
 
 ### **Use default images**
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,3 +9,4 @@
 ## Features
 
 - Added `cephConfig:` to CephCluster to allow setting Ceph config options in the Ceph MON config store via the CRD
+- CephCSI v3.10.0 is now the default CSI driver version. Refer to [Ceph-CSI v3.10.0 Release Notes](https://github.com/ceph/ceph-csi/releases/tag/v3.10.0) for more details.

--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -389,8 +389,6 @@ rules:
   - get
   - list
 ---
-# TODO: remove this, once https://github.com/rook/rook/issues/10141
-# is resolved.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/charts/rook-ceph/templates/role.yaml
+++ b/deploy/charts/rook-ceph/templates/role.yaml
@@ -71,6 +71,11 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- if and .Values.csi.csiAddons .Values.csi.csiAddons.enabled }}
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["create"]
+{{- end }}
 ---
 {{- if and .Values.csi.csiAddons .Values.csi.csiAddons.enabled }}
 kind: Role

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -479,7 +479,7 @@ csi:
 
   cephcsi:
     # -- Ceph CSI image
-    # @default -- `quay.io/cephcsi/cephcsi:v3.9.0`
+    # @default -- `quay.io/cephcsi/cephcsi:v3.10.0`
     image:
 
   registrar:

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -11,8 +11,6 @@ kind: Namespace
 metadata:
   name: rook-ceph # namespace:cluster
 ---
-# TODO: remove this, once https://github.com/rook/rook/issues/10141
-# is resolved.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -728,6 +726,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["create"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,7 +1,7 @@
  gcr.io/k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar:v20230130-v0.1.0-24-gc0cf995
  quay.io/ceph/ceph:v17.2.6
  quay.io/ceph/cosi:v0.1.1
- quay.io/cephcsi/cephcsi:v3.9.0
+ quay.io/cephcsi/cephcsi:v3.10.0
  quay.io/csiaddons/k8s-sidecar:v0.7.0
  registry.k8s.io/sig-storage/csi-attacher:v4.4.2
  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -190,7 +190,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.10.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.9.2"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.6.2"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -106,7 +106,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.9.0"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.10.0"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.9.2"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v3.6.2"

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -131,7 +131,7 @@ var (
 // manually challenging.
 var (
 	// image names
-	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.9.0"
+	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v3.10.0"
 	DefaultRegistrarImage   = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1"
 	DefaultProvisionerImage = "registry.k8s.io/sig-storage/csi-provisioner:v3.6.2"
 	DefaultAttacherImage    = "registry.k8s.io/sig-storage/csi-attacher:v4.4.2"

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -267,7 +267,7 @@ func Test_getImage(t *testing.T) {
 			args: args{
 				data:         map[string]string{},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.10.0",
 			},
 			want: DefaultCSIPluginImage,
 		},
@@ -278,7 +278,7 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi:v8",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.10.0",
 			},
 			want: "registry.io/private/cephcsi:v8",
 		},
@@ -289,9 +289,9 @@ func Test_getImage(t *testing.T) {
 					"ROOK_CSI_CEPH_IMAGE": "registry.io/private/cephcsi",
 				},
 				settingName:  "ROOK_CSI_CEPH_IMAGE",
-				defaultImage: "quay.io/cephcsi/cephcsi:v3.9.0",
+				defaultImage: "quay.io/cephcsi/cephcsi:v3.10.0",
 			},
-			want: "registry.io/private/cephcsi:v3.9.0",
+			want: "registry.io/private/cephcsi:v3.10.0",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -25,14 +25,14 @@ import (
 )
 
 var (
-	//minimum supported version is 3.8.0
-	minimum = CephCSIVersion{3, 8, 0}
+	//minimum supported version is 3.9.0
+	minimum = CephCSIVersion{3, 9, 0}
 	//supportedCSIVersions are versions that rook supports
-	releasev390 = CephCSIVersion{3, 9, 0}
+	releasev310 = CephCSIVersion{3, 10, 0}
 
 	supportedCSIVersions = []CephCSIVersion{
 		minimum,
-		releasev390,
+		releasev310,
 	}
 
 	// for parsing the output of `cephcsi`

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 var (
-	testMinVersion  = CephCSIVersion{3, 8, 0}
-	testReleaseV370 = CephCSIVersion{3, 7, 0}
-	testReleaseV371 = CephCSIVersion{3, 7, 1}
-	testReleaseV380 = CephCSIVersion{3, 8, 0}
-	testReleaseV381 = CephCSIVersion{3, 8, 1}
-	testReleaseV390 = CephCSIVersion{3, 9, 0}
-	testReleaseV391 = CephCSIVersion{3, 9, 1}
+	testMinVersion   = CephCSIVersion{3, 9, 0}
+	testReleaseV380  = CephCSIVersion{3, 8, 0}
+	testReleaseV381  = CephCSIVersion{3, 8, 1}
+	testReleaseV390  = CephCSIVersion{3, 9, 0}
+	testReleaseV391  = CephCSIVersion{3, 9, 1}
+	testreleasev310  = CephCSIVersion{3, 10, 0}
+	testReleaseV3101 = CephCSIVersion{3, 10, 1}
 
 	testVersionUnsupported = CephCSIVersion{4, 0, 0}
 )
@@ -44,20 +44,20 @@ func TestIsAtLeast(t *testing.T) {
 	ret = testMinVersion.isAtLeast(&testMinVersion)
 	assert.Equal(t, true, ret)
 
-	// Test for 3.7.0
-	ret = testReleaseV370.isAtLeast(&testMinVersion)
+	// Test for 3.8.0
+	ret = testReleaseV380.isAtLeast(&testMinVersion)
 	assert.Equal(t, false, ret)
 
-	// Test for 3.7.1
-	ret = testReleaseV371.isAtLeast(&testMinVersion)
+	// Test for 3.8.1
+	ret = testReleaseV381.isAtLeast(&testMinVersion)
 	assert.Equal(t, false, ret)
 
-	// Test for 3.9.0
-	ret = testReleaseV390.isAtLeast(&testReleaseV380)
+	// Test for 3.10.0
+	ret = testreleasev310.isAtLeast(&testReleaseV390)
 	assert.Equal(t, true, ret)
 
-	// Test for 3.9.1
-	ret = testReleaseV391.isAtLeast(&testReleaseV381)
+	// Test for 3.10.1
+	ret = testReleaseV3101.isAtLeast(&testReleaseV3101)
 	assert.Equal(t, true, ret)
 
 }
@@ -70,23 +70,23 @@ func TestSupported(t *testing.T) {
 	ret = testVersionUnsupported.Supported()
 	assert.Equal(t, false, ret)
 
-	// 3.7.x is not supported after 3.9.0 release
-	ret = testReleaseV370.Supported()
-	assert.Equal(t, false, ret)
-
-	ret = testReleaseV371.Supported()
-	assert.Equal(t, false, ret)
-
+	// 3.8.x is not supported after 3.10.0 release
 	ret = testReleaseV380.Supported()
-	assert.Equal(t, true, ret)
+	assert.Equal(t, false, ret)
 
 	ret = testReleaseV381.Supported()
-	assert.Equal(t, true, ret)
+	assert.Equal(t, false, ret)
 
 	ret = testReleaseV390.Supported()
 	assert.Equal(t, true, ret)
 
 	ret = testReleaseV391.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testreleasev310.Supported()
+	assert.Equal(t, true, ret)
+
+	ret = testReleaseV3101.Supported()
 	assert.Equal(t, true, ret)
 }
 

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	dataPoolSuffix     = "data"
-	metaDataPoolSuffix = "metadata"
+	defaultCSISubvolumeGroup = "csi"
+	dataPoolSuffix           = "data"
+	metaDataPoolSuffix       = "metadata"
 )
 
 // Filesystem represents an instance of a Ceph filesystem (CephFS)
@@ -70,6 +71,11 @@ func createFilesystem(
 		if err := cephclient.SetNumMDSRanks(context, clusterInfo, fs.Name, fs.Spec.MetadataServer.ActiveCount); err != nil {
 			logger.Warningf("failed setting active mds count to %d. %v", fs.Spec.MetadataServer.ActiveCount, err)
 		}
+	}
+
+	err := cephclient.CreateCephFSSubVolumeGroup(context, clusterInfo, fs.Name, defaultCSISubvolumeGroup)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create subvolume group %q", defaultCSISubvolumeGroup)
 	}
 
 	return nil

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -152,6 +152,8 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 					return `[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":4,"data_pool_ids":[5],"data_pools":["myfs-data0"]},{"name":"myfs2","metadata_pool":"myfs2-metadata","metadata_pool_id":6,"data_pool_ids":[7],"data_pools":["myfs2-data0"]},{"name":"leseb","metadata_pool":"cephfs.leseb.meta","metadata_pool_id":8,"data_pool_ids":[9],"data_pools":["cephfs.leseb.data"]}]`, nil
 				} else if contains(args, "fs") && contains(args, "dump") {
 					return `{"standbys":[], "filesystems":[]}`, nil
+				} else if reflect.DeepEqual(args[0:5], []string{"fs", "subvolumegroup", "create", fsName, defaultCSISubvolumeGroup}) {
+					return "", nil
 				} else if contains(args, "osd") && contains(args, "lspools") {
 					return "[]", nil
 				} else if contains(args, "mds") && contains(args, "fail") {
@@ -229,6 +231,8 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 				return "[]", nil
 			} else if contains(args, "fs") && contains(args, "dump") {
 				return `{"standbys":[], "filesystems":[]}`, nil
+			} else if reflect.DeepEqual(args[0:5], []string{"fs", "subvolumegroup", "create", fsName, defaultCSISubvolumeGroup}) {
+				return "", nil
 			} else if contains(args, "osd") && contains(args, "lspools") {
 				return "[]", nil
 			} else if contains(args, "mds") && contains(args, "fail") {


### PR DESCRIPTION
This commit updates default cephcsi driver version to v3.10.0 and filesystem reconciler now creates
csi subvolumegroup by default.

**Which issue is resolved by this Pull Request:**
Resolves #13309 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
