### PR TITLE
core: ability to create, update and delete services in other namespaces

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -76,7 +76,6 @@ rules:
   # Node access is needed for determining nodes where mons should run
   - nodes
   - nodes/proxy
-  - services
   # Rook watches secrets which it uses to configure access to external resources.
   # e.g., external Ceph cluster or object store
   - secrets
@@ -96,6 +95,7 @@ rules:
   - persistentvolumeclaims
   # Rook creates endpoints for mgr and object store access
   - endpoints
+  - services
   verbs:
   - get
   - list

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -231,7 +231,6 @@ rules:
       # Node access is needed for determining nodes where mons should run
       - nodes
       - nodes/proxy
-      - services
       # Rook watches secrets which it uses to configure access to external resources.
       # e.g., external Ceph cluster or object store
       - secrets
@@ -251,6 +250,7 @@ rules:
       - persistentvolumeclaims
       # Rook creates endpoints for mgr and object store access
       - endpoints
+      - services
     verbs:
       - get
       - list


### PR DESCRIPTION
This PR adds permissions to create update and delete k8s service by the in the namespaces other than rook operator namespace

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
