### PR TITLE
csi: add rbacs for cephfs csi addon sidecar

### DIFF
--- a/deploy/charts/rook-ceph/templates/role.yaml
+++ b/deploy/charts/rook-ceph/templates/role.yaml
@@ -76,6 +76,16 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: cephfs-csi-nodeplugin
+  namespace: {{ .Release.Namespace }} # namespace:operator
+rules:
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: rbd-csi-nodeplugin
   namespace: {{ .Release.Namespace }} # namespace:operator
 rules:

--- a/deploy/charts/rook-ceph/templates/rolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/rolebinding.yaml
@@ -36,6 +36,20 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: cephfs-csi-nodeplugin-role-cfg
+  namespace: {{ .Release.Namespace }} # namespace:operator
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-plugin-sa
+    namespace: {{ .Release.Namespace }} # namespace:operator
+roleRef:
+  kind: Role
+  name: cephfs-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: rbd-csi-nodeplugin-role-cfg
   namespace: {{ .Release.Namespace }} # namespace:operator
 subjects:

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -722,6 +722,16 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: cephfs-csi-nodeplugin
+  namespace: rook-ceph # namespace:operator
+rules:
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: cephfs-external-provisioner-cfg
   namespace: rook-ceph # namespace:operator
 rules:
@@ -961,6 +971,20 @@ rules:
     verbs:
       - get
       - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin-role-cfg
+  namespace: rook-ceph # namespace:operator
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-plugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: Role
+  name: cephfs-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This adds the missing RBACs in cephfs for csi-addon sidecar

Note: This requires ceph-csi v3.10.0 version.