### PR TITLE
mon: fix mon failover on path change

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -367,30 +367,17 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 		}
 	}
 
-	// failover mons running on host path to use persistent volumes if VolumeClaimTemplate is set and vice versa
+	// failover any mons present in the mon fail over list
 	for _, mon := range c.ClusterInfo.Monitors {
-		if c.HasMonPathChanged(mon.Name) {
-			logger.Infof("fail over mon %q due to change in mon path", mon.Name)
+		if c.monsToFailover.Has(mon.Name) {
+			logger.Infof("fail over mon %q from the mon fail over list", mon.Name)
 			c.failMon(len(c.ClusterInfo.Monitors), desiredMonCount, mon.Name)
+			c.monsToFailover.Delete(mon.Name)
 			return nil
 		}
 	}
 
 	return nil
-}
-
-// HasMonPathChanged checks if the mon storage path has changed from host path to persistent volume or vice versa
-func (c *Cluster) HasMonPathChanged(mon string) bool {
-	var monPathChanged bool
-	if c.mapping.Schedule[mon] != nil && c.spec.Mon.VolumeClaimTemplate != nil {
-		logger.Infof("mon %q path has changed from host path to persistent volumes", mon)
-		monPathChanged = true
-	} else if c.mapping.Schedule[mon] == nil && c.spec.Mon.VolumeClaimTemplate == nil {
-		logger.Infof("mon %q path has changed from persistent volumes to host path", mon)
-		monPathChanged = true
-	}
-
-	return monPathChanged
 }
 
 func (c *Cluster) trackMonInOrOutOfQuorum(monName string, inQuorum bool) (bool, error) {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -645,37 +645,3 @@ func TestUpdateMonInterval(t *testing.T) {
 		assert.Equal(t, time.Minute, h.interval)
 	})
 }
-
-func TestHasMonPathChanged(t *testing.T) {
-	t.Run("mon path changed from pv to hostpath", func(t *testing.T) {
-		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
-		c.mapping.Schedule["a"] = nil
-		result := c.HasMonPathChanged("a")
-		assert.True(t, result)
-	})
-
-	t.Run("mon path has not changed from pv to hostpath", func(t *testing.T) {
-		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
-		c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{}}
-		c.mapping.Schedule["b"] = nil
-		result := c.HasMonPathChanged("b")
-		c.spec.Mon.VolumeClaimTemplate = nil
-		assert.False(t, result)
-	})
-
-	t.Run("mon path changed from hostpath to pv", func(t *testing.T) {
-		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
-		c.mapping.Schedule["c"] = &opcontroller.MonScheduleInfo{}
-		c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{}}
-		result := c.HasMonPathChanged("c")
-		assert.True(t, result)
-	})
-
-	t.Run("mon path has not changed from host path to pv", func(t *testing.T) {
-		c := New(context.TODO(), &clusterd.Context{}, "ns", cephv1.ClusterSpec{}, nil)
-		c.mapping.Schedule["d"] = &opcontroller.MonScheduleInfo{}
-		result := c.HasMonPathChanged("d")
-		c.spec.Mon.VolumeClaimTemplate = nil
-		assert.False(t, result)
-	})
-}


### PR DESCRIPTION
This PR fails over mon when the mon path is changed from hostPath to PVC or vice versa
Operator uses following steps to check if the mon path has changed or not. 

- HostPath to PVC :  The `pvc_name`  label is missing from the existing mon pod deployment and `Mon.VolumeClaimTemplate` is not nil in the cephCluster spec
- PVC to HostPath: The `pvc_name` is present in the existing mon deployment and `Mon.VolumeClaimTemplate` is set to nil in the cephCluster spec.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #13343

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
