### PR TITLE
external: fix the run as a user flag

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -997,8 +997,8 @@ class RadosJSON:
 
         return caps, entity
 
-    def get_healthchecker_caps_and_entity(self):
-        entity = "client.healthchecker"
+    def get_defaultUser_caps_and_entity(self):
+        entity = self.run_as_user
         caps = {
             "mon": "allow r, allow command quorum_status, allow command version",
             "mgr": "allow command config",
@@ -1027,7 +1027,7 @@ class RadosJSON:
         if "client.healthchecker" in user_name:
             if "client.healthchecker" != user_name:
                 self._arg_parser.restricted_auth_permission = True
-            return self.get_healthchecker_caps_and_entity()
+            return self.get_defaultUser_caps_and_entity()
 
         raise ExecutionFailureException(
             f"no user found with user_name: {user_name}, "


### PR DESCRIPTION
there is a hardcoded value of "client.healthchecker" which needs to be replaced by self.run_as_user

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
