### PR TITLE
docs: specify that `rook-ceph` helm chart should be upgraded first

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -111,6 +111,8 @@ The upgrade steps in this guide will clarify what Helm handles automatically.
 
 The `rook-ceph` helm chart upgrade performs the Rook upgrade.
 The `rook-ceph-cluster` helm chart upgrade performs a [Ceph upgrade](#ceph-version-upgrades) if the Ceph image is updated.
+The `rook-ceph` chart should be upgraded before `rook-ceph-cluster`, so the latest operator has the opportunity to update
+custom resources as necessary.
 
 !!! note
     Be sure to update to a [supported Helm version](https://helm.sh/docs/topics/version_skew/#supported-version-skew)


### PR DESCRIPTION
Today, it's unclear that there is an expected order of operation when it comes up upgrades. In reality, the `rook-ceph` helm chart includes the operator, which should have the opportunity to update any custom resources before the `rook-ceph-cluster` is upgraded.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
