### PR TITLE
helm: allow defining multiple cephEcStorageClass

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
@@ -7,26 +7,36 @@ metadata:
   name: {{ $ecblockpool.name }}
   namespace: {{ $root.Release.Namespace }} # namespace:cluster
 spec:
-{{ toYaml $ecblockpool.spec | indent 2 }}
-{{ end }}
-{{- if .Values.cephECStorageClass }}
-{{ $cephEcStorage :=  .Values.cephECStorageClass}}
+{{ toYaml $ecblockpool.spec.dataPool | indent 2 }}
 ---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: {{ $ecblockpool.name }}-metadata
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
+spec:
+{{ toYaml $ecblockpool.spec.metadataPool | indent 2 }}
+---
+{{- if default false $ecblockpool.storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $cephEcStorage.name }}
+  name: {{ $ecblockpool.storageClass.name }}
+  {{- if $ecblockpool.storageClass.isDefault }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{end}}
 {{- if $root.Values.csiDriverNamePrefix }}
 provisioner: {{ $root.Values.csiDriverNamePrefix }}.rbd.csi.ceph.com
 {{- else }}
 provisioner: {{ $root.Values.operatorNamespace }}.rbd.csi.ceph.com
 {{- end }}
 parameters:
-  clusterID: {{ $cephEcStorage.parameters.clusterID }}
-  dataPool: {{ $cephEcStorage.parameters.dataPool }}
-  pool: {{ $cephEcStorage.parameters.pool }}
-  imageFormat: "{{ $cephEcStorage.parameters.imageFormat }}"
-  imageFeatures: {{ $cephEcStorage.parameters.imageFeatures }}
+  clusterID: {{ $ecblockpool.parameters.clusterID }}
+  dataPool: {{ $ecblockpool.name }}-metadata
+  pool: {{ $ecblockpool.name }}
+  imageFormat: "{{ $ecblockpool.parameters.imageFormat }}"
+  imageFeatures: {{ $ecblockpool.parameters.imageFeatures }}
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
@@ -45,6 +55,7 @@ parameters:
 # the PVC to application pod if nodeplugin pod restart.
 # Its still in Alpha support. Therefore, this option is not recommended for production use.
 #mounter: rbd-nbd
-allowVolumeExpansion: {{ $cephEcStorage.allowVolumeExpansion }}
-reclaimPolicy: {{ $cephEcStorage.reclaimPolicy }}
+allowVolumeExpansion: {{ $ecblockpool.storageClass.allowVolumeExpansion }}
+reclaimPolicy: {{ $ecblockpool.storageClass.reclaimPolicy }}
+{{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -626,65 +626,57 @@ cephObjectStores:
       #     - objectstore.example.com
       #   secretName: ceph-objectstore-tls
       # ingressClassName: nginx
-# cephECBlockPools are disabled by default, please remove the comments and set desired values to enable it
+## cephECBlockPools are disabled by default, please remove the comments and set desired values to enable it
+## For erasure coded a replicated metadata pool is required.
+## https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded
 #cephECBlockPools:
-#  # For erasure coded a replicated metadata pool is required.
-#  # https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded
-#  - name: ec-metadata-pool
-#    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
+#  - name: ec-pool
 #    spec:
-#      replicated:
-#        size: 2
-#  - name: ec-data-pool
-#    spec:
-#      failureDomain: osd
-#      erasureCoded:
-#        dataChunks: 2
-#        codingChunks: 1
-#      deviceClass: hdd
-
-# cephECStorageClass also is disabled by default, please remove the comments and set desired values to enable it
-# if cephECBlockPools are uncommented you must remove the comments of cephEcStorageClass as well
-#cephECStorageClass:
-#  name: rook-ceph-block
-#  parameters:
-#    # clusterID is the namespace where the rook cluster is running
-#    # If you change this namespace, also change the namespace below where the secret namespaces are defined
-#    clusterID: rook-ceph # namespace:cluster
+#      metadataPool:
+#        replicated:
+#          size: 2
+#      dataPool:
+#        failureDomain: osd
+#        erasureCoded:
+#          dataChunks: 2
+#          codingChunks: 1
+#        deviceClass: hdd
 #
-#    # If you want to use erasure coded pool with RBD, you need to create
-#    # two pools. one erasure coded and one replicated.
-#    # You need to specify the replicated pool here in the `pool` parameter, it is
-#    # used for the metadata of the images.
-#    # The erasure coded pool must be set as the `dataPool` parameter below.
-#    dataPool: ec-data-pool
-#    pool: ec-metadata-pool
+#    parameters:
+#      # clusterID is the namespace where the rook cluster is running
+#      # If you change this namespace, also change the namespace below where the secret namespaces are defined
+#      clusterID: rook-ceph # namespace:cluster
+#      # (optional) mapOptions is a comma-separated list of map options.
+#      # For krbd options refer
+#      # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+#      # For nbd options refer
+#      # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+#      # mapOptions: lock_on_read,queue_depth=1024
 #
-#    # (optional) mapOptions is a comma-separated list of map options.
-#    # For krbd options refer
-#    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
-#    # For nbd options refer
-#    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-#    # mapOptions: lock_on_read,queue_depth=1024
+#      # (optional) unmapOptions is a comma-separated list of unmap options.
+#      # For krbd options refer
+#      # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+#      # For nbd options refer
+#      # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+#      # unmapOptions: force
 #
-#    # (optional) unmapOptions is a comma-separated list of unmap options.
-#    # For krbd options refer
-#    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
-#    # For nbd options refer
-#    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-#    # unmapOptions: force
+#      # RBD image format. Defaults to "2".
+#      imageFormat: "2"
 #
-#    # RBD image format. Defaults to "2".
-#    imageFormat: "2"
+#      # RBD image features, equivalent to OR'd bitfield value: 63
+#      # Available for imageFormat: "2". Older releases of CSI RBD
+#      # support only the `layering` feature. The Linux kernel (KRBD) supports the
+#      # full feature complement as of 5.4
+#      # imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
+#      imageFeatures: layering
 #
-#    # RBD image features, equivalent to OR'd bitfield value: 63
-#    # Available for imageFormat: "2". Older releases of CSI RBD
-#    # support only the `layering` feature. The Linux kernel (KRBD) supports the
-#    # full feature complement as of 5.4
-#    # imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
-#    imageFeatures: layering
-#  allowVolumeExpansion: true
-#  reclaimPolicy: Delete
+#    storageClass:
+#      provisioner: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
+#      enabled: true
+#      name:  rook-ceph-block
+#      isDefault: false
+#      allowVolumeExpansion: true
+#      reclaimPolicy: Delete
 
 # -- CSI driver name prefix for cephfs, rbd and nfs.
 # @default -- `namespace name where rook-ceph operator is deployed`


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

This Pull Request enables the definition of a list of ecBlockPools, each with its own storageClass. Prior to this change, it was necessary to define separate storage classes. Now, we can specify all the requirements for ecBlockPools directly under each ecBlockPool definition


## Testing
Since this scenario is not covered by CI, you can test by yourself using minikube  with at least 5 nodes

`minikube start --disk-size=20g --extra-disks=1  --driver kvm2 --nodes 5`

And use this configuration in values.yaml

```diff
diff --git a/deploy/charts/rook-ceph-cluster/values.yaml b/deploy/charts/rook-ceph-cluster/values.yaml
index 3b3015113..a6a27367f 100644
--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -279,25 +279,25 @@ cephClusterSpec:
   resources:
     mgr:
       limits:
-        cpu: "1000m"
-        memory: "1Gi"
-      requests:
         cpu: "500m"
         memory: "512Mi"
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
     mon:
       limits:
-        cpu: "2000m"
-        memory: "2Gi"
-      requests:
-        cpu: "1000m"
+        cpu: "500m"
         memory: "1Gi"
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
     osd:
       limits:
-        cpu: "2000m"
-        memory: "4Gi"
-      requests:
         cpu: "1000m"
-        memory: "4Gi"
+        memory: "2Gi"
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
     prepareosd:
       # limits: It is not recommended to set limits on the OSD prepare job
       #         since it's a one-time burst for memory that must be allowed to
@@ -520,11 +520,11 @@ cephFileSystems:
         activeStandby: true
         resources:
           limits:
-            cpu: "2000m"
-            memory: "4Gi"
-          requests:
             cpu: "1000m"
-            memory: "4Gi"
+            memory: "1Gi"
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
         priorityClassName: system-cluster-critical
     storageClass:
       enabled: true
@@ -594,11 +594,11 @@ cephObjectStores:
         port: 80
         resources:
           limits:
-            cpu: "2000m"
-            memory: "2Gi"
-          requests:
             cpu: "1000m"
             memory: "1Gi"
+          requests:
+            cpu: "500m"
+            memory: "500Mi"
         # securePort: 443
         # sslCertificateRef:
         instances: 1
@@ -625,63 +625,63 @@ cephObjectStores:
       #   secretName: ceph-objectstore-tls
       # ingressClassName: nginx
 # cephECBlockPools are disabled by default, please remove the comments and set desired values to enable it
-#cephECBlockPools:
-#  # For erasure coded a replicated metadata pool is required.
-#  # https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded
-#  - name: ec-metadata-pool
-#    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
-#    spec:
-#      replicated:
-#        size: 2
-#  - name: ec-data-pool
-#    spec:
-#      failureDomain: osd
-#      erasureCoded:
-#        dataChunks: 2
-#        codingChunks: 1
-#      deviceClass: hdd
+cephECBlockPools:
+  # For erasure coded a replicated metadata pool is required.
+  # https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded
+  - name: ec-metadata-pool
+    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
+    spec:
+      replicated:
+        size: 2
+  - name: ec-data-pool
+    spec:
+      failureDomain: osd
+      erasureCoded:
+        dataChunks: 2
+        codingChunks: 1
+      deviceClass: hdd
 
 # cephECStorageClass also is disabled by default, please remove the comments and set desired values to enable it
 # if cephECBlockPools are uncommented you must remove the comments of cephEcStorageClass as well
-#cephECStorageClasses:
-#  - name: rook-ceph-block
-#    # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
-#    provisioner: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
-#    parameters:
-#      # clusterID is the namespace where the rook cluster is running
-#      # If you change this namespace, also change the namespace below where the secret namespaces are defined
-#      clusterID: rook-ceph # namespace:cluster
-#
-#      # If you want to use erasure coded pool with RBD, you need to create
-#      # two pools. one erasure coded and one replicated.
-#      # You need to specify the replicated pool here in the `pool` parameter, it is
-#      # used for the metadata of the images.
-#      # The erasure coded pool must be set as the `dataPool` parameter below.
-#      dataPool: ec-data-pool
-#      pool: ec-metadata-pool
-#
-#      # (optional) mapOptions is a comma-separated list of map options.
-#      # For krbd options refer
-#      # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
-#      # For nbd options refer
-#      # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-#      # mapOptions: lock_on_read,queue_depth=1024
-#
-#      # (optional) unmapOptions is a comma-separated list of unmap options.
-#      # For krbd options refer
-#      # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
-#      # For nbd options refer
-#      # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-#      # unmapOptions: force
-#
-#      # RBD image format. Defaults to "2".
-#      imageFormat: "2"
-#
-#      # RBD image features, equivalent to OR'd bitfield value: 63
-#      # Available for imageFormat: "2". Older releases of CSI RBD
-#      # support only the `layering` feature. The Linux kernel (KRBD) supports the
-#      # full feature complement as of 5.4
-#      # imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
-#      imageFeatures: layering
-#    allowVolumeExpansion: true
-#    reclaimPolicy: Delete
\ No newline at end of file
+cephECStorageClasses:
+  - name: rook-ceph-block
+    # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+    provisioner: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
+    parameters:
+    # clusterID is the namespace where the rook cluster is running
+    # If you change this namespace, also change the namespace below where the secret namespaces are defined
+    clusterID: rook-ceph # namespace:cluster
+
+    # If you want to use erasure coded pool with RBD, you need to create
+    # two pools. one erasure coded and one replicated.
+    # You need to specify the replicated pool here in the `pool` parameter, it is
+    # used for the metadata of the images.
+    # The erasure coded pool must be set as the `dataPool` parameter below.
+    dataPool: ec-data-pool
+    pool: ec-metadata-pool
+
+    # (optional) mapOptions is a comma-separated list of map options.
+    # For krbd options refer
+    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+    # For nbd options refer
+    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+    # mapOptions: lock_on_read,queue_depth=1024
+
+    # (optional) unmapOptions is a comma-separated list of unmap options.
+    # For krbd options refer
+    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+    # For nbd options refer
+    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+    # unmapOptions: force
+
+    # RBD image format. Defaults to "2".
+    imageFormat: "2"
+
+    # RBD image features, equivalent to OR'd bitfield value: 63
+    # Available for imageFormat: "2". Older releases of CSI RBD
+    # support only the `layering` feature. The Linux kernel (KRBD) supports the
+    # full feature complement as of 5.4
+    # imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
+    imageFeatures: layering
+    allowVolumeExpansion: true
+    reclaimPolicy: Delete
```

**Which issue is resolved by this Pull Request:**
Resolves #12772

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
