### PR TITLE
docs: Remove specialties for maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -19,17 +19,11 @@ Steering committee members will be added according to the [process for adding a 
 Maintainers will be added according to the [process for adding a maintainer](GOVERNANCE.md#becoming-a-maintainer) in the [governance](GOVERNANCE.md).
 
 * Travis Nielsen <tnielsen@redhat.com> ([travisn](https://github.com/travisn))
-  * Ceph, Operators/Orchestration
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-  * Framework, APIs
 * Alexander Trost <galexrt@googlemail.com> ([galexrt](https://github.com/galexrt))
-  * Ceph, Operators/Orchestration, User support
 * Sebastien Han <shan@redhat.com> ([leseb](https://github.com/leseb))
-  * Ceph
 * Blaine Gardner <blaine.gardner@redhat.com> ([BlaineEXE](https://github.com/BlaineEXE))
-  * Ceph
 * Satoru Takeuchi <satoru.takeuchi@gmail.com> ([satoru-takeuchi](https://github.com/satoru-takeuchi))
-  * Ceph
 
 ## Emeritus maintainers
 


### PR DESCRIPTION
Since all maintainers are essentially focusin on the ceph storage provider, there is no need to list the specialties on the owners page. We all work together to complete the necessary work anyway.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
