### PR TITLE
csi: remove gRPC metrics service

### DIFF
--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
@@ -12,9 +12,5 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: {{ .CephFSLivenessMetricsPort }}
-    - name: csi-grpc-metrics
-      port: 8081
-      protocol: TCP
-      targetPort: {{ .CephFSGRPCMetricsPort }}
   selector:
     contains: csi-cephfsplugin-metrics

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
@@ -12,9 +12,5 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: {{ .RBDLivenessMetricsPort }}
-    - name: csi-grpc-metrics
-      port: 8081
-      protocol: TCP
-      targetPort: {{ .RBDGRPCMetricsPort }}
   selector:
     contains: csi-rbdplugin-metrics


### PR DESCRIPTION
This commit removes the gRPC metrics svc which was missed in PR #13166.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #13419

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
