### PR TITLE
ci: improve collect-log script

### DIFF
--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -58,7 +58,6 @@ jobs:
         run: |
           export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
           export CLUSTER_NAMESPACE="helm-ns"
-          export OPERATOR_NAMESPACE="helm-ns-system"
           tests/scripts/collect-logs.sh
 
       - name: Artifact

--- a/tests/scripts/collect-logs.sh
+++ b/tests/scripts/collect-logs.sh
@@ -18,13 +18,17 @@ $CEPH_CMD osd dump >"${LOG_DIR}"/ceph-osd-dump.txt
 $CEPH_CMD report >"${LOG_DIR}"/ceph-report.txt
 
 NAMESPACES=("$CLUSTER_NAMESPACE")
-NAMESPACES+=("$KUBE_SYSTEM_NAMESPACE")
 if [[ "$OPERATOR_NAMESPACE" != "$CLUSTER_NAMESPACE" ]]; then
   NAMESPACES+=("$OPERATOR_NAMESPACE")
 fi
 
 if [ "$1" == "multi-cluster-mirroring" ]; then
   NAMESPACES+=("rook-ceph-secondary")
+fi
+
+# Add kube-system namespace for multus test only as we need to debug network in multus test
+if [ "$1" == "canary-multus" ]; then
+  NAMESPACES+=("$KUBE_SYSTEM_NAMESPACE")
 fi
 
 for NAMESPACE in "${NAMESPACES[@]}"; do


### PR DESCRIPTION
I was debugging helm tests, I noticed, the operator namespace content is empty and operator is created in same namespace as other pods. Also, let's collect the 'kube-system' namespace logs in multus test only as that is the only test where we need to debug cluster networking and require kube-system logs.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
