### PR TITLE
ci: wait for all OSD pods to become Running in wait_for_prepare_pod

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -54,7 +54,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_cluster
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
@@ -293,7 +293,7 @@ jobs:
           tests/scripts/github-action-helper.sh create_operator_toolbox
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
@@ -350,7 +350,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_cluster two_osds_in_device
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
@@ -400,7 +400,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_cluster osd_with_metadata_device
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
@@ -444,7 +444,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_cluster encryption
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
@@ -493,7 +493,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_cluster lvm
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
@@ -551,7 +551,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 3
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 3
@@ -612,7 +612,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
@@ -659,7 +659,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: |
@@ -708,7 +708,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: |
@@ -767,7 +767,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: |
@@ -817,7 +817,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: |
@@ -883,7 +883,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: |
@@ -958,7 +958,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: |
@@ -1014,7 +1014,7 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 1
 
       - name: wait for ceph to be ready
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
@@ -1390,7 +1390,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_multus_cluster
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: IS_POD_NETWORK=true IS_MULTUS=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
@@ -1446,7 +1446,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh deploy_csi_hostnetwork_disabled_cluster
 
       - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
         run: IS_POD_NETWORK=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2

--- a/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
+++ b/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
@@ -57,7 +57,7 @@ runs:
 
     - name: wait for prepare pod
       shell: bash --noprofile --norc -eo pipefail -x {0}
-      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
     - name: wait for ceph to be ready
       shell: bash --noprofile --norc -eo pipefail -x {0}


### PR DESCRIPTION
Currently, `wait_for_prepare_pod` only waits until 1 prepare pod and 1 OSD pod are in Running state.

So if `wait_for_ceph_to_be_ready` failed after `wait_for_prepare_pod` succeeded, there are 4 possible cases:

1. some prepare pods didn't start correctly;
2. some prepare pods didn't finish correctly;
3. some OSD pods didn't start correctly; or
4. all prepare pods and OSD pods worked correctly, but some other process failed.

As far as I understand, the number of prepare pods on the GitHub CI is always 1, so cases 1 and 2 are not problematic. However, it is hard to distinguish the other two cases from the CI log.

To solve the above problems, this patch makes wait_for_prepare_pod wait for all OSD pods to become running state. If wait_for_prepare_pod timeouts before the OSD pods become running state, this will be a strong indication that the OSD pods didn't start properly (i.e., case 3).

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
