### PR TITLE
build: check if DOCKERCMD is successfully assigned in common.mk

### DIFF
--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -31,6 +31,10 @@ DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 endif
 
+ifeq ($(DOCKERCMD),)
+    $(error "No running container engine found.")
+endif
+
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)
 GOOS := $(shell go env GOOS)


### PR DESCRIPTION
If there is no running docker and podman, DOCKERCMD will be empty and lead to confusing errors. So add check for DOCKERCMD. 