### PR TITLE
core: fix error handling on setting watcher

### DIFF
--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -218,10 +218,10 @@ func (c *Cluster) updateAndCreateOSDsLoop(
 		ResourceVersion: configMapList.ResourceVersion,
 	}
 	watcher, err := cmClient.Watch(c.clusterInfo.Context, watchOptions)
-	defer watcher.Stop()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to start watching OSD provisioning status ConfigMaps")
 	}
+	defer watcher.Stop()
 
 	// tick after a short time of waiting for new OSD provision status configmaps to change state
 	// in order to allow opportunistic deployment updates while we wait


### PR DESCRIPTION
If `cmClient.Watch()` failed, `watcher.Stop()` causes null pointer dereference.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
