### PR TITLE
mon: Allow overriding the mon endpoint with annotation

### DIFF
--- a/Documentation/CRDs/Cluster/network-providers.md
+++ b/Documentation/CRDs/Cluster/network-providers.md
@@ -73,6 +73,14 @@ Ceph daemons will use any network available on the host for communication. To re
 only a specific specific host interfaces or networks, use `addressRanges` to select the network
 CIDRs Ceph will bind to on the host.
 
+If the Ceph mons are expected to bind to a public network that is different from the IP address
+assign to the K8s node where the mon is running, the IP address for the mon can be set by
+adding an annotation to the node:
+
+```yaml
+network.rook.io/mon-ip: <IPAddress>
+```
+
 If the host networking setting is changed in a cluster where mons are already running, the existing mons will
 remain running with the same network settings with which they were created. To complete the conversion
 to or from host networking after you update this setting, you will need to

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -246,4 +246,11 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 	info, err = getNodeInfoFromNode(*node)
 	assert.NoError(t, err)
 	assert.Equal(t, "1.2.3.4", info.Address)
+
+	node.Annotations = map[string]string{
+		monIPAnnotation: "9.8.7.6",
+	}
+	info, err = getNodeInfoFromNode(*node)
+	assert.NoError(t, err)
+	assert.Equal(t, "9.8.7.6", info.Address)
 }


### PR DESCRIPTION
For an advanced network configuration, the mon endpoints expected for the ceph public network may be different from the public IP address that is set on the K8s node. When host networking is enabled in rook, the IP address of the node was only allowed previously. Now, the IP address used for a mon when scheduled on a node can be determined by setting an annotation on each node where mons can run:
  network.rook.io/mon-ip: <ip-address>
This annotation must be set before the mons are created. Mon endpoints cannot be changed after they are already running.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**
Resolves #12363

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
