### PR TITLE
backport: Shorten CRD descriptions to 100 chars

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -23,7 +23,7 @@ set -o pipefail
 SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 CONTROLLER_GEN_BIN_PATH=$1
 YQ_BIN_PATH=$2
-: "${MAX_DESC_LEN:=-1}"
+: "${MAX_DESC_LEN:=100}"
 # allowDangerousTypes is used to accept float64
 CRD_OPTIONS="crd:maxDescLen=$MAX_DESC_LEN,generateEmbeddedObjectMeta=true,allowDangerousTypes=true"
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -23,10 +23,10 @@ spec:
           description: CephBlockPoolRadosNamespace represents a Ceph BlockPool Rados Namespace
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -40,7 +40,7 @@ spec:
                     - message: blockPoolName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
+                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
@@ -97,18 +97,18 @@ spec:
           description: CephBlockPool represents a Ceph Storage Pool
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name. This is more specific than the NamedPoolSpec so we get schema validation on the allowed pool names that can be specified.
+              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
                 compressionMode:
-                  description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                  description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
                     - none
                     - passive
@@ -135,11 +135,11 @@ spec:
                       description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                       minimum: 0
                       type: integer
                   required:
@@ -147,7 +147,7 @@ spec:
                     - dataChunks
                   type: object
                 failureDomain:
-                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                   type: string
                 mirroring:
                   description: The mirroring settings
@@ -243,14 +243,14 @@ spec:
                       description: RequireSafeReplicaSize if false allows you to set replica 1
                       type: boolean
                     size:
-                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                       minimum: 0
                       type: integer
                     subFailureDomain:
                       description: SubFailureDomain the name of the sub-failure domain
                       type: string
                     targetSizeRatio:
-                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                       type: number
                   required:
                     - size
@@ -477,10 +477,10 @@ spec:
           description: CephBucketNotification represents a Bucket Notifications
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -636,10 +636,10 @@ spec:
           description: CephBucketTopic represents a Ceph Object Topic for Bucket Notifications
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -682,7 +682,7 @@ spec:
                           description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         sendCloudEvents:
-                          description: 'Send the notifications with the CloudEvents header: https://github.com/cloudevents/spec/blob/main/cloudevents/adapters/aws-s3.md'
+                          description: 'Send the notifications with the CloudEvents header: https://github.'
                           type: boolean
                         uri:
                           description: The URI of the HTTP endpoint to push notification to
@@ -785,10 +785,10 @@ spec:
           description: CephClient represents a Ceph Client
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -884,10 +884,10 @@ spec:
           description: CephCluster is a Ceph storage cluster
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -920,10 +920,10 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as quay.io/ceph/ceph:<tag> The full list of images can be found at https://quay.io/repository/ceph/ceph?tab=tags
+                      description: Image is the container image used to launch the ceph daemons, such as quay.
                       type: string
                     imagePullPolicy:
-                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNotPresent.
+                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNot
                       enum:
                         - IfNotPresent
                         - Always
@@ -932,11 +932,11 @@ spec:
                       type: string
                   type: object
                 cleanupPolicy:
-                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster deletion is not imminent.
+                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster
                   nullable: true
                   properties:
                     allowUninstallWithVolumes:
-                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images still present
+                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images s
                       type: boolean
                     confirmation:
                       description: Confirmation represents the cleanup confirmation
@@ -966,7 +966,7 @@ spec:
                       type: object
                   type: object
                 continueUpgradeAfterChecksEvenIfNotHealthy:
-                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not clean
+                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not
                   type: boolean
                 crashCollector:
                   description: A spec for the crash controller
@@ -996,7 +996,7 @@ spec:
                       description: ReadAffinity defines the read affinity settings for CSI driver.
                       properties:
                         crushLocationLabels:
-                          description: CrushLocationLabels defines which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map.
+                          description: CrushLocationLabels defines which node labels to use as CRUSH location.
                           items:
                             type: string
                           type: array
@@ -1051,19 +1051,19 @@ spec:
                       description: This enables management of poddisruptionbudgets
                       type: boolean
                     osdMaintenanceTimeout:
-                      description: OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure domains it only works if managePodBudgets is true. the default is 30 minutes
+                      description: 'OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure '
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain if the timeout exceeds. It only works if managePodBudgets is true. No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups t
                       format: int64
                       type: integer
                     pgHealthyRegex:
-                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be considered healthy. The default is `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`
+                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be conside
                       type: string
                   type: object
                 external:
-                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and discover daemons will not be created for external clusters.
+                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and disc
                   nullable: true
                   properties:
                     enable:
@@ -1124,19 +1124,19 @@ spec:
                             description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
@@ -1147,7 +1147,7 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
-                                    description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
@@ -1156,7 +1156,7 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -1164,7 +1164,7 @@ spec:
                                       description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          description: The header field name.
                                           type: string
                                         value:
                                           description: The header field value
@@ -1181,7 +1181,7 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -1190,7 +1190,7 @@ spec:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
@@ -1198,7 +1198,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -1211,17 +1211,17 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
@@ -1236,19 +1236,19 @@ spec:
                             description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
@@ -1259,7 +1259,7 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
-                                    description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
@@ -1268,7 +1268,7 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -1276,7 +1276,7 @@ spec:
                                       description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          description: The header field name.
                                           type: string
                                         value:
                                           description: The header field value
@@ -1293,7 +1293,7 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -1302,7 +1302,7 @@ spec:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
@@ -1310,7 +1310,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -1323,17 +1323,17 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
@@ -1435,13 +1435,13 @@ spec:
                                 description: VolumeClaimTemplate is the PVC template
                                 properties:
                                   apiVersion:
-                                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                    description: APIVersion defines the versioned schema of this representation of an object.
                                     type: string
                                   kind:
-                                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: Kind is a string value representing the REST resource this object represents.
                                     type: string
                                   metadata:
-                                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                    description: 'Standard object''s metadata. More info: https://git.k8s.'
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -1461,18 +1461,18 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: spec defines the desired characteristics of a volume requested by a pod author.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource being referenced
@@ -1486,10 +1486,10 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                        description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource being referenced
@@ -1498,22 +1498,22 @@ spec:
                                             description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        description: resources represents the minimum resources the volume should have.
                                         properties:
                                           claims:
-                                            description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                            description: Claims lists the names of resources, defined in spec.
                                             items:
                                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                               properties:
                                                 name:
-                                                  description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                  description: Name must match the name of one entry in pod.spec.
                                                   type: string
                                               required:
                                                 - name
@@ -1529,7 +1529,7 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -1538,7 +1538,7 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: Requests describes the minimum amount of compute resources required.
                                             type: object
                                         type: object
                                       selector:
@@ -1547,16 +1547,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1568,33 +1568,33 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        description: storageClassName is the name of the StorageClass required by the claim.
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                        description: volumeMode defines what type of volume is required by the claim.
                                         type: string
                                       volumeName:
                                         description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                   status:
-                                    description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: status represents the current information/status of a persistent volume claim. Read-only.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: accessModes contains the actual access modes the volume backing the PVC has.
                                         items:
                                           type: string
                                         type: array
                                       allocatedResourceStatuses:
                                         additionalProperties:
-                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                           type: string
-                                        description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                        description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                         type: object
                                         x-kubernetes-map-type: granular
                                       allocatedResources:
@@ -1604,7 +1604,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                        description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                         type: object
                                       capacity:
                                         additionalProperties:
@@ -1616,7 +1616,7 @@ spec:
                                         description: capacity represents the actual resources of the underlying volume.
                                         type: object
                                       conditions:
-                                        description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                        description: conditions is the current Condition of persistent volume claim.
                                         items:
                                           description: PersistentVolumeClaimCondition contains details about state of pvc
                                           properties:
@@ -1632,7 +1632,7 @@ spec:
                                               description: message is the human-readable message indicating details about last transition.
                                               type: string
                                             reason:
-                                              description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                              description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                               type: string
                                             status:
                                               type: string
@@ -1658,13 +1658,13 @@ spec:
                       description: VolumeClaimTemplate is the PVC definition
                       properties:
                         apiVersion:
-                          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          description: APIVersion defines the versioned schema of this representation of an object.
                           type: string
                         kind:
-                          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          description: Kind is a string value representing the REST resource this object represents.
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: 'Standard object''s metadata. More info: https://git.k8s.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -1684,18 +1684,18 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          description: spec defines the desired characteristics of a volume requested by a pod author.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
                                   description: Kind is the type of resource being referenced
@@ -1709,10 +1709,10 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             dataSourceRef:
-                              description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                              description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
                                   description: Kind is the type of resource being referenced
@@ -1721,22 +1721,22 @@ spec:
                                   description: Name is the name of resource being referenced
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              description: resources represents the minimum resources the volume should have.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                  description: Claims lists the names of resources, defined in spec.
                                   items:
                                     description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -1752,7 +1752,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -1761,7 +1761,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             selector:
@@ -1770,16 +1770,16 @@ spec:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
                                         description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -1791,33 +1791,33 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             storageClassName:
-                              description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              description: storageClassName is the name of the StorageClass required by the claim.
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                              description: volumeMode defines what type of volume is required by the claim.
                               type: string
                             volumeName:
                               description: volumeName is the binding reference to the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          description: status represents the current information/status of a persistent volume claim. Read-only.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              description: accessModes contains the actual access modes the volume backing the PVC has.
                               items:
                                 type: string
                               type: array
                             allocatedResourceStatuses:
                               additionalProperties:
-                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -1827,7 +1827,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                               type: object
                             capacity:
                               additionalProperties:
@@ -1839,7 +1839,7 @@ spec:
                               description: capacity represents the actual resources of the underlying volume.
                               type: object
                             conditions:
-                              description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                              description: conditions is the current Condition of persistent volume claim.
                               items:
                                 description: PersistentVolumeClaimCondition contains details about state of pvc
                                 properties:
@@ -1855,7 +1855,7 @@ spec:
                                     description: message is the human-readable message indicating details about last transition.
                                     type: string
                                   reason:
-                                    description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                    description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                     type: string
                                   status:
                                     type: string
@@ -1888,13 +1888,13 @@ spec:
                             description: VolumeClaimTemplate is the PVC template
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                description: APIVersion defines the versioned schema of this representation of an object.
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: Kind is a string value representing the REST resource this object represents.
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                description: 'Standard object''s metadata. More info: https://git.k8s.'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -1914,18 +1914,18 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: spec defines the desired characteristics of a volume requested by a pod author.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being referenced
@@ -1939,10 +1939,10 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                    description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being referenced
@@ -1951,22 +1951,22 @@ spec:
                                         description: Name is the name of resource being referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    description: resources represents the minimum resources the volume should have.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                        description: Claims lists the names of resources, defined in spec.
                                         items:
                                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                              description: Name must match the name of one entry in pod.spec.
                                               type: string
                                           required:
                                             - name
@@ -1982,7 +1982,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1991,7 +1991,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: Requests describes the minimum amount of compute resources required.
                                         type: object
                                     type: object
                                   selector:
@@ -2000,16 +2000,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -2021,33 +2021,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    description: storageClassName is the name of the StorageClass required by the claim.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                    description: volumeMode defines what type of volume is required by the claim.
                                     type: string
                                   volumeName:
                                     description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: status represents the current information/status of a persistent volume claim. Read-only.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: accessModes contains the actual access modes the volume backing the PVC has.
                                     items:
                                       type: string
                                     type: array
                                   allocatedResourceStatuses:
                                     additionalProperties:
-                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                       type: string
-                                    description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                    description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                     type: object
                                     x-kubernetes-map-type: granular
                                   allocatedResources:
@@ -2057,7 +2057,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                    description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                     type: object
                                   capacity:
                                     additionalProperties:
@@ -2069,7 +2069,7 @@ spec:
                                     description: capacity represents the actual resources of the underlying volume.
                                     type: object
                                   conditions:
-                                    description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                    description: conditions is the current Condition of persistent volume claim.
                                     items:
                                       description: PersistentVolumeClaimCondition contains details about state of pvc
                                       properties:
@@ -2085,7 +2085,7 @@ spec:
                                           description: message is the human-readable message indicating details about last transition.
                                           type: string
                                         reason:
-                                          description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                          description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                           type: string
                                         status:
                                           type: string
@@ -2116,7 +2116,7 @@ spec:
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail. Default is false.
+                      description: Enabled determines whether to create the prometheus rules for the ceph cluster.
                       type: boolean
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
@@ -2127,7 +2127,7 @@ spec:
                             description: The Hostname of this endpoint
                             type: string
                           ip:
-                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.0/16 or fe80::/10), or link-local multicast (224.0.0.0/24 or ff02::/16).
+                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.
                             type: string
                           nodeName:
                             description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
@@ -2139,22 +2139,22 @@ spec:
                                 description: API version of the referent.
                                 type: string
                               fieldPath:
-                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                description: If referring to a piece of an object instead of an entire object, this string should contain a valid
                                 type: string
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.'
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'Name of the referent. More info: https://kubernetes.'
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                description: 'Namespace of the referent. More info: https://kubernetes.'
                                 type: string
                               resourceVersion:
-                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.'
                                 type: string
                               uid:
-                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                description: 'UID of the referent. More info: https://kubernetes.'
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -2173,7 +2173,7 @@ spec:
                       description: Interval determines prometheus scrape interval
                       type: string
                     metricsDisabled:
-                      description: Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled. If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+                      description: Whether to disable the metrics reported by Ceph.
                       type: boolean
                     port:
                       description: Port is the prometheus server port
@@ -2186,20 +2186,20 @@ spec:
                   nullable: true
                   properties:
                     addressRanges:
-                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluster_network' configurations. This config section may be used for the "host" or "multus" network providers.
+                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluste
                       nullable: true
                       properties:
                         cluster:
                           description: Cluster defines a list of CIDRs to use for Ceph cluster network communication.
                           items:
-                            description: "An IPv4 or IPv6 network CIDR. \n This naive kubebuilder regex provides immediate feedback for some typos and for a common problem case where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code."
+                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                         public:
                           description: Public defines a list of CIDRs to use for Ceph public network communication.
                           items:
-                            description: "An IPv4 or IPv6 network CIDR. \n This naive kubebuilder regex provides immediate feedback for some typos and for a common problem case where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code."
+                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
@@ -2221,18 +2221,18 @@ spec:
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network. The default is not set. Even if encryption is not enabled, clients still establish a strong initial authentication for the connection and data integrity is still validated with a crc check. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
+                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the netw
                               type: boolean
                           type: object
                         requireMsgr2:
-                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled. If true, the msgr1 port (6789) will be disabled. Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer).
+                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled.
                           type: boolean
                       type: object
                     dualStack:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network. If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to apply the new network settings.
+                      description: HostNetwork to enable host network.
                       type: boolean
                     ipFamily:
                       description: IPFamily is the single stack IPv6 or IPv4 protocol
@@ -2245,14 +2245,14 @@ spec:
                       description: Enable multiClusterService to export the Services between peer clusters
                       properties:
                         clusterID:
-                          description: 'ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services. For example: <clusterid>.<svc>.<ns>.svc.clusterset.local'
+                          description: ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services.
                           type: string
                         enabled:
-                          description: Enable multiClusterService to export the mon and OSD services to peer cluster. Ensure that peer clusters are connected using an MCS API compatible application, like Globalnet Submariner.
+                          description: Enable multiClusterService to export the mon and OSD services to peer cluster.
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus". If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.
+                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
                       enum:
                         - ""
                         - host
@@ -2265,7 +2265,7 @@ spec:
                     selectors:
                       additionalProperties:
                         type: string
-                      description: "Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks when the \"multus\" network provider is used. This config section is not used for other network providers. \n Valid keys are \"public\" and \"cluster\". Refer to Ceph networking documentation for more: https://docs.ceph.com/en/reef/rados/configuration/network-config-ref/ \n Refer to Multus network annotation documentation for help selecting values: https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#run-pod-with-network-annotation \n Rook will make a best-effort attempt to automatically detect CIDR address ranges for given network attachment definitions. Rook's methods are robust but may be imprecise for sufficiently complicated networks. Rook's auto-detection process obtains a new IP address lease for each CephCluster reconcile. If Rook fails to detect, incorrectly detects, only partially detects, or if underlying networks do not support reusing old IP addresses, it is best to use the 'addressRanges' config section to specify CIDR ranges for the Ceph cluster. \n As a contrived example, one can use a theoretical Kubernetes-wide network for Ceph client traffic and a theoretical Rook-only network for Ceph replication traffic as shown: selectors: public: \"default/cluster-fast-net\" cluster: \"rook-ceph/ceph-backend-net\""
+                      description: Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks whe
                       nullable: true
                       type: object
                   type: object
@@ -2281,9 +2281,9 @@ spec:
                         description: NodeAffinity is a group of node affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                               properties:
                                 preference:
                                   description: A node selector term, associated with the corresponding weight.
@@ -2291,16 +2291,16 @@ spec:
                                     matchExpressions:
                                       description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2312,16 +2312,16 @@ spec:
                                     matchFields:
                                       description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2342,26 +2342,26 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             properties:
                               nodeSelectorTerms:
                                 description: Required. A list of node selector terms. The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                   properties:
                                     matchExpressions:
                                       description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2373,16 +2373,16 @@ spec:
                                     matchFields:
                                       description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2403,9 +2403,9 @@ spec:
                         description: PodAffinity is a group of inter pod affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
                                   description: Required. A pod affinity term, associated with the corresponding weight.
@@ -2416,16 +2416,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2437,26 +2437,26 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2468,17 +2468,17 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
@@ -2493,9 +2493,9 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources, in this case pods.
@@ -2503,16 +2503,16 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2524,26 +2524,26 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2555,17 +2555,17 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2576,9 +2576,9 @@ spec:
                         description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
                                   description: Required. A pod affinity term, associated with the corresponding weight.
@@ -2589,16 +2589,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2610,26 +2610,26 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2641,17 +2641,17 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
@@ -2666,9 +2666,9 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources, in this case pods.
@@ -2676,16 +2676,16 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2697,26 +2697,26 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2728,17 +2728,17 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2746,25 +2746,25 @@ spec:
                             type: array
                         type: object
                       tolerations:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         items:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to.
                               type: string
                           type: object
                         type: array
@@ -2774,21 +2774,21 @@ spec:
                           description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              description: LabelSelector is used to find matching pods.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
                                         description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -2800,35 +2800,35 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                              description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: MaxSkew describes the degree to which pods may be unevenly distributed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                              description: MinDomains indicates a minimum number of eligible domains.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                               type: string
                             nodeTaintsPolicy:
-                              description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                              description: TopologyKey is the key of node labels.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                               type: string
                           required:
                             - maxSkew
@@ -2856,12 +2856,12 @@ spec:
                     description: ResourceRequirements describes the compute resource requirements.
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                        description: Claims lists the names of resources, defined in spec.
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                              description: Name must match the name of one entry in pod.spec.
                               type: string
                           required:
                             - name
@@ -2877,7 +2877,7 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                         type: object
                       requests:
                         additionalProperties:
@@ -2886,7 +2886,7 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute resources required.
                         type: object
                     type: object
                   description: Resources set resource requests and limits
@@ -2964,7 +2964,7 @@ spec:
                       type: array
                       x-kubernetes-preserve-unknown-fields: true
                     flappingRestartIntervalHours:
-                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit code, will sleep before restarting. This is needed for OSD flapping where OSD daemons are marked down more than 5 times in 600 seconds by Ceph. Preventing the OSD pods to restart immediately in such scenarios will prevent Rook from marking OSD as `up` and thus peering of the PGs mapped to the OSD. User needs to manually restart the OSD pod if they manage to fix the underlying OSD flapping issue before the restart interval. The sleep will be disabled if this interval is set to 0.
+                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit cod
                       type: integer
                     nodes:
                       items:
@@ -3008,12 +3008,12 @@ spec:
                             nullable: true
                             properties:
                               claims:
-                                description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                description: Claims lists the names of resources, defined in spec.
                                 items:
                                   description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -3029,7 +3029,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3038,7 +3038,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -3051,13 +3051,13 @@ spec:
                               description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -3077,18 +3077,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -3102,10 +3102,10 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -3114,22 +3114,22 @@ spec:
                                           description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                          description: Claims lists the names of resources, defined in spec.
                                           items:
                                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                description: Name must match the name of one entry in pod.spec.
                                                 type: string
                                             required:
                                               - name
@@ -3145,7 +3145,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3154,7 +3154,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
@@ -3163,16 +3163,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3184,33 +3184,33 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
                                       description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -3220,7 +3220,7 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -3232,7 +3232,7 @@ spec:
                                       description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
                                         description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
@@ -3248,7 +3248,7 @@ spec:
                                             description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
@@ -3300,9 +3300,9 @@ spec:
                                 description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated with the corresponding weight.
@@ -3310,16 +3310,16 @@ spec:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3331,16 +3331,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3361,26 +3361,26 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3392,16 +3392,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3422,9 +3422,9 @@ spec:
                                 description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -3435,16 +3435,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3456,26 +3456,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3487,17 +3487,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -3512,9 +3512,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -3522,16 +3522,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3543,26 +3543,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3574,17 +3574,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3595,9 +3595,9 @@ spec:
                                 description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -3608,16 +3608,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3629,26 +3629,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3660,17 +3660,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -3685,9 +3685,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -3695,16 +3695,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3716,26 +3716,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3747,17 +3747,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3765,25 +3765,25 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
@@ -3793,21 +3793,21 @@ spec:
                                   description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3819,35 +3819,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -3868,9 +3868,9 @@ spec:
                                 description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated with the corresponding weight.
@@ -3878,16 +3878,16 @@ spec:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3899,16 +3899,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3929,26 +3929,26 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3960,16 +3960,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3990,9 +3990,9 @@ spec:
                                 description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -4003,16 +4003,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4024,26 +4024,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4055,17 +4055,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -4080,9 +4080,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -4090,16 +4090,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4111,26 +4111,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4142,17 +4142,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4163,9 +4163,9 @@ spec:
                                 description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -4176,16 +4176,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4197,26 +4197,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4228,17 +4228,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -4253,9 +4253,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -4263,16 +4263,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4284,26 +4284,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4315,17 +4315,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4333,25 +4333,25 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
@@ -4361,21 +4361,21 @@ spec:
                                   description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4387,35 +4387,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -4430,12 +4430,12 @@ spec:
                             nullable: true
                             properties:
                               claims:
-                                description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                description: Claims lists the names of resources, defined in spec.
                                 items:
                                   description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -4451,7 +4451,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4460,7 +4460,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -4479,13 +4479,13 @@ spec:
                               description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -4506,18 +4506,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -4531,10 +4531,10 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -4543,22 +4543,22 @@ spec:
                                           description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                          description: Claims lists the names of resources, defined in spec.
                                           items:
                                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                description: Name must match the name of one entry in pod.spec.
                                                 type: string
                                             required:
                                               - name
@@ -4574,7 +4574,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4583,7 +4583,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
@@ -4592,16 +4592,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4613,33 +4613,33 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
                                       description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -4649,7 +4649,7 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -4661,7 +4661,7 @@ spec:
                                       description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
                                         description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
@@ -4677,7 +4677,7 @@ spec:
                                             description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
@@ -4712,7 +4712,7 @@ spec:
                             - bluestore-rdr
                           type: string
                         updateStore:
-                          description: UpdateStore updates the backend store for existing OSDs. It destroys each OSD one at a time, cleans up the backing disk and prepares same OSD on that disk
+                          description: UpdateStore updates the backend store for existing OSDs.
                           pattern: ^$|^yes-really-update-store$
                           type: string
                       type: object
@@ -4727,13 +4727,13 @@ spec:
                         description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                         properties:
                           apiVersion:
-                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            description: APIVersion defines the versioned schema of this representation of an object.
                             type: string
                           kind:
-                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: Kind is a string value representing the REST resource this object represents.
                             type: string
                           metadata:
-                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            description: 'Standard object''s metadata. More info: https://git.k8s.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -4753,18 +4753,18 @@ spec:
                                 type: string
                             type: object
                           spec:
-                            description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: spec defines the desired characteristics of a volume requested by a pod author.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
                                     description: Kind is the type of resource being referenced
@@ -4778,10 +4778,10 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               dataSourceRef:
-                                description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
                                     description: Kind is the type of resource being referenced
@@ -4790,22 +4790,22 @@ spec:
                                     description: Name is the name of resource being referenced
                                     type: string
                                   namespace:
-                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               resources:
-                                description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                description: resources represents the minimum resources the volume should have.
                                 properties:
                                   claims:
-                                    description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                    description: Claims lists the names of resources, defined in spec.
                                     items:
                                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                          description: Name must match the name of one entry in pod.spec.
                                           type: string
                                       required:
                                         - name
@@ -4821,7 +4821,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -4830,7 +4830,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: Requests describes the minimum amount of compute resources required.
                                     type: object
                                 type: object
                               selector:
@@ -4839,16 +4839,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -4860,33 +4860,33 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               storageClassName:
-                                description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                description: storageClassName is the name of the StorageClass required by the claim.
                                 type: string
                               volumeMode:
-                                description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                description: volumeMode defines what type of volume is required by the claim.
                                 type: string
                               volumeName:
                                 description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
-                            description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: status represents the current information/status of a persistent volume claim. Read-only.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                description: accessModes contains the actual access modes the volume backing the PVC has.
                                 items:
                                   type: string
                                 type: array
                               allocatedResourceStatuses:
                                 additionalProperties:
-                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                   type: string
-                                description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                 type: object
                                 x-kubernetes-map-type: granular
                               allocatedResources:
@@ -4896,7 +4896,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -4908,7 +4908,7 @@ spec:
                                 description: capacity represents the actual resources of the underlying volume.
                                 type: object
                               conditions:
-                                description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                description: conditions is the current Condition of persistent volume claim.
                                 items:
                                   description: PersistentVolumeClaimCondition contains details about state of pvc
                                   properties:
@@ -4924,7 +4924,7 @@ spec:
                                       description: message is the human-readable message indicating details about last transition.
                                       type: string
                                     reason:
-                                      description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                      description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                       type: string
                                     status:
                                       type: string
@@ -4944,7 +4944,7 @@ spec:
                       type: array
                   type: object
                 waitTimeoutForHealthyOSDInMinutes:
-                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart. If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`. The default wait timeout is 10 minutes.
+                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stop
                   format: int64
                   type: integer
               type: object
@@ -5137,10 +5137,10 @@ spec:
           description: CephCOSIDriver represents the CRD for the Ceph COSI Driver Deployment
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -5167,9 +5167,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -5177,16 +5177,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5198,16 +5198,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5228,26 +5228,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5259,16 +5259,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5289,9 +5289,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5302,16 +5302,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5323,26 +5323,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5354,17 +5354,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -5379,9 +5379,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -5389,16 +5389,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5410,26 +5410,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5441,17 +5441,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5462,9 +5462,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5475,16 +5475,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5496,26 +5496,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5527,17 +5527,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -5552,9 +5552,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -5562,16 +5562,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5583,26 +5583,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5614,17 +5614,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5632,25 +5632,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -5660,21 +5660,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -5686,35 +5686,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -5727,12 +5727,12 @@ spec:
                   description: Resources is the resource requirements for the COSI driver
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -5748,7 +5748,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -5757,7 +5757,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -5795,10 +5795,10 @@ spec:
           description: CephFilesystemMirror is the Ceph Filesystem Mirror object definition
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -5825,9 +5825,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -5835,16 +5835,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5856,16 +5856,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5886,26 +5886,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5917,16 +5917,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5947,9 +5947,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5960,16 +5960,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5981,26 +5981,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6012,17 +6012,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -6037,9 +6037,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -6047,16 +6047,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6068,26 +6068,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6099,17 +6099,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6120,9 +6120,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -6133,16 +6133,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6154,26 +6154,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6185,17 +6185,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -6210,9 +6210,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -6220,16 +6220,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6241,26 +6241,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6272,17 +6272,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6290,25 +6290,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -6318,21 +6318,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -6344,35 +6344,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -6389,12 +6389,12 @@ spec:
                   nullable: true
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -6410,7 +6410,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -6419,7 +6419,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -6498,10 +6498,10 @@ spec:
           description: CephFilesystem represents a Ceph Filesystem
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -6514,7 +6514,7 @@ spec:
                     description: NamedPoolSpec represents the named ceph pool spec
                     properties:
                       compressionMode:
-                        description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                        description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
                           - none
                           - passive
@@ -6541,11 +6541,11 @@ spec:
                             description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                             minimum: 0
                             type: integer
                         required:
@@ -6553,7 +6553,7 @@ spec:
                           - dataChunks
                         type: object
                       failureDomain:
-                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                         type: string
                       mirroring:
                         description: The mirroring settings
@@ -6645,14 +6645,14 @@ spec:
                             description: RequireSafeReplicaSize if false allows you to set replica 1
                             type: boolean
                           size:
-                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                             minimum: 0
                             type: integer
                           subFailureDomain:
                             description: SubFailureDomain the name of the sub-failure domain
                             type: string
                           targetSizeRatio:
-                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                             type: number
                         required:
                           - size
@@ -6682,7 +6682,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -6709,11 +6709,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -6721,7 +6721,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -6810,14 +6810,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -6844,13 +6844,13 @@ spec:
                   description: The mds pod info
                   properties:
                     activeCount:
-                      description: The number of metadata servers that are active. The remaining servers in the cluster will be in standby mode.
+                      description: The number of metadata servers that are active.
                       format: int32
                       maximum: 10
                       minimum: 1
                       type: integer
                     activeStandby:
-                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster failover. If false, standbys will still be available, but will not have a warm metadata cache.
+                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster f
                       type: boolean
                     annotations:
                       additionalProperties:
@@ -6873,19 +6873,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -6896,7 +6896,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -6905,7 +6905,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -6913,7 +6913,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -6930,7 +6930,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -6939,7 +6939,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -6947,7 +6947,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -6960,17 +6960,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -6983,9 +6983,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -6993,16 +6993,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7014,16 +7014,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7044,26 +7044,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7075,16 +7075,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7105,9 +7105,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -7118,16 +7118,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7139,26 +7139,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7170,17 +7170,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -7195,9 +7195,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -7205,16 +7205,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7226,26 +7226,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7257,17 +7257,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7278,9 +7278,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -7291,16 +7291,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7312,26 +7312,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7343,17 +7343,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -7368,9 +7368,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -7378,16 +7378,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7399,26 +7399,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7430,17 +7430,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7448,25 +7448,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -7476,21 +7476,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -7502,35 +7502,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -7548,12 +7548,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -7569,7 +7569,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -7578,7 +7578,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -7589,19 +7589,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -7612,7 +7612,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -7621,7 +7621,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -7629,7 +7629,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -7646,7 +7646,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -7655,7 +7655,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -7663,7 +7663,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -7676,17 +7676,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -7712,7 +7712,7 @@ spec:
                           type: array
                       type: object
                     snapshotRetention:
-                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy. A policy can however contain multiple count-time period pairs in order to specify complex retention policies
+                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy.
                       items:
                         description: SnapshotScheduleRetentionSpec is a retention policy
                         properties:
@@ -7742,7 +7742,7 @@ spec:
                       type: array
                   type: object
                 preserveFilesystemOnDelete:
-                  description: Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.
+                  description: Preserve the fs in the cluster on CephFilesystem CR deletion.
                   type: boolean
                 preservePoolsOnDelete:
                   description: Preserve pools on filesystem deletion
@@ -7906,7 +7906,7 @@ spec:
                           rel_path:
                             type: string
                           retention:
-                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot schedule
+                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot s
                             properties:
                               active:
                                 description: Active is whether the scheduled is active or not
@@ -7980,10 +7980,10 @@ spec:
           description: CephFilesystemSubVolumeGroup represents a Ceph Filesystem SubVolumeGroup
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -7991,7 +7991,7 @@ spec:
               description: Spec represents the specification of a Ceph Filesystem SubVolumeGroup
               properties:
                 filesystemName:
-                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name. Typically it's the name of the CephFilesystem CR. If not coming from the CephFilesystem CR, it can be retrieved from the list of Ceph Filesystem volumes with `ceph fs volume ls`. To learn more about Ceph Filesystem abstractions see https://docs.ceph.com/en/latest/cephfs/fs-volumes/#fs-volumes-and-subvolumes
+                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name.
                   type: string
                   x-kubernetes-validations:
                     - message: filesystemName is immutable
@@ -8003,7 +8003,7 @@ spec:
                     - message: name is immutable
                       rule: self == oldSelf
                 pinning:
-                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.com/en/latest/cephfs/fs-volumes/#pinning-subvolumes-and-subvolume-groups only one out of (export, distributed, random) can be set at a time
+                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.
                   properties:
                     distributed:
                       maximum: 1
@@ -8078,10 +8078,10 @@ spec:
           description: CephNFS represents a Ceph NFS
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -8093,10 +8093,10 @@ spec:
                   nullable: true
                   properties:
                     namespace:
-                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored. This setting is deprecated as it is internally set to the name of the CephNFS.
+                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored.
                       type: string
                     pool:
-                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons. This setting is deprecated, as it is internally required to be ".nfs".
+                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons.
                       type: string
                   type: object
                 security:
@@ -8108,20 +8108,20 @@ spec:
                       nullable: true
                       properties:
                         configFiles:
-                          description: "ConfigFiles defines where the Kerberos configuration should be sourced from. Config files will be placed into the `/etc/krb5.conf.rook/` directory. \n If this is left empty, Rook will not add any files. This allows you to manage the files yourself however you wish. For example, you may build them into your custom Ceph container image or use the Vault agent injector to securely add the files via annotations on the CephNFS spec (passed to the NFS server pods). \n Rook configures Kerberos to log to stderr. We suggest removing logging sections from config files to avoid consuming unnecessary disk space from logging to files."
+                          description: ConfigFiles defines where the Kerberos configuration should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos configuration files like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. The volume may contain multiple files, all of which will be loaded.
+                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos confi
                               properties:
                                 configMap:
                                   description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8129,11 +8129,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8141,7 +8141,7 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8149,36 +8149,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
                                       description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8190,7 +8190,7 @@ spec:
                                   description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
@@ -8202,7 +8202,7 @@ spec:
                                             description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8210,11 +8210,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8222,7 +8222,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -8251,14 +8251,14 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
                                                           description: 'Container name: required for volumes, optional for env vars'
@@ -8286,7 +8286,7 @@ spec:
                                             description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8294,11 +8294,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8306,7 +8306,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional field specify whether the Secret or its key must be defined
@@ -8317,10 +8317,10 @@ spec:
                                             description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
@@ -8333,14 +8333,14 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8348,11 +8348,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8363,7 +8363,7 @@ spec:
                                       description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
@@ -8372,20 +8372,20 @@ spec:
                           description: DomainName should be set to the Kerberos Realm.
                           type: string
                         keytabFile:
-                          description: KeytabFile defines where the Kerberos keytab should be sourced from. The keytab file will be placed into `/etc/krb5.keytab`. If this is left empty, Rook will not add the file. This allows you to manage the `krb5.keytab` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                          description: KeytabFile defines where the Kerberos keytab should be sourced from.
                           properties:
                             volumeSource:
-                              description: 'VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos keytab file like what is normally used to configure Volumes for a Pod. For example, a Secret or HostPath. There are two requirements for the source''s content: 1. The config file must be mountable via `subPath: krb5.keytab`. For example, in a Secret, the data item must be named `krb5.keytab`, or `items` must be defined to select the key and give it path `krb5.keytab`. A HostPath directory must have the `krb5.keytab` file. 2. The volume or config file must have mode 0600.'
+                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos k
                               properties:
                                 configMap:
                                   description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8393,11 +8393,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8405,7 +8405,7 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8413,36 +8413,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
                                       description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8454,7 +8454,7 @@ spec:
                                   description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
@@ -8466,7 +8466,7 @@ spec:
                                             description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8474,11 +8474,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8486,7 +8486,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -8515,14 +8515,14 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
                                                           description: 'Container name: required for volumes, optional for env vars'
@@ -8550,7 +8550,7 @@ spec:
                                             description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8558,11 +8558,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8570,7 +8570,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional field specify whether the Secret or its key must be defined
@@ -8581,10 +8581,10 @@ spec:
                                             description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
@@ -8597,14 +8597,14 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8612,11 +8612,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8627,45 +8627,45 @@ spec:
                                       description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         principalName:
                           default: nfs
-                          description: 'PrincipalName corresponds directly to NFS-Ganesha''s NFS_KRB5:PrincipalName config. In practice, this is the service prefix of the principal name. The default is "nfs". This value is combined with (a) the namespace and name of the CephNFS (with a hyphen between) and (b) the Realm configured in the user-provided krb5.conf to determine the full principal name: <principalName>/<namespace>-<name>@<realm>. e.g., nfs/rook-ceph-my-nfs@example.net. See https://github.com/nfs-ganesha/nfs-ganesha/wiki/RPCSEC_GSS for more detail.'
+                          description: PrincipalName corresponds directly to NFS-Ganesha's NFS_KRB5:PrincipalName config.
                           type: string
                       type: object
                     sssd:
-                      description: SSSD enables integration with System Security Services Daemon (SSSD). SSSD can be used to provide user ID mapping from a number of sources. See https://sssd.io for more information about the SSSD project.
+                      description: SSSD enables integration with System Security Services Daemon (SSSD).
                       nullable: true
                       properties:
                         sidecar:
                           description: Sidecar tells Rook to run SSSD in a sidecar alongside the NFS-Ganesha server in each NFS pod.
                           properties:
                             additionalFiles:
-                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar. These files may be referenced by the sssd.conf config file.
+                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar.
                               items:
-                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configuration should come from and are made available.
+                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configu
                                 properties:
                                   subPath:
-                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be placed. Each subPath definition must be unique and must not contain ':'.
+                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be pl
                                     minLength: 1
                                     pattern: ^[^:]+$
                                     type: string
                                   volumeSource:
-                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional file(s) like what is normally used to configure Volumes for a Pod. Fore example, a ConfigMap, Secret, or HostPath. Each VolumeSource adds one or more additional files to the SSSD sidecar container in the `/etc/sssd/rook-additional/<subPath>` directory. Be aware that some files may need to have a specific file mode like 0600 due to requirements by SSSD for some files. For example, CA or TLS certificates.
+                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional
                                     properties:
                                       configMap:
                                         description: configMap represents a configMap that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
@@ -8673,11 +8673,11 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -8685,7 +8685,7 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            description: 'Name of the referent. More info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -8693,36 +8693,36 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       emptyDir:
-                                        description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                         properties:
                                           medium:
-                                            description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            description: medium represents what type of storage medium should back this directory.
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                               - type: integer
                                               - type: string
-                                            description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       hostPath:
-                                        description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                        description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                         properties:
                                           path:
-                                            description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            description: path of the directory on the host.
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                             type: string
                                         required:
                                           - path
                                         type: object
                                       persistentVolumeClaim:
-                                        description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                         properties:
                                           claimName:
-                                            description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                            description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                             type: string
                                           readOnly:
                                             description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8734,7 +8734,7 @@ spec:
                                         description: projected items for all in one resources secrets, configmaps, and downward API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                            description: defaultMode are the mode bits used to set permissions on created files by default.
                                             format: int32
                                             type: integer
                                           sources:
@@ -8746,7 +8746,7 @@ spec:
                                                   description: configMap information about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                       items:
                                                         description: Maps a string key to a path within a volume.
                                                         properties:
@@ -8754,11 +8754,11 @@ spec:
                                                             description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -8766,7 +8766,7 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
                                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8795,14 +8795,14 @@ spec:
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                            description: 'Required: Path is  the relative path name of the file to be created.'
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                             properties:
                                                               containerName:
                                                                 description: 'Container name: required for volumes, optional for env vars'
@@ -8830,7 +8830,7 @@ spec:
                                                   description: secret information about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                       items:
                                                         description: Maps a string key to a path within a volume.
                                                         properties:
@@ -8838,11 +8838,11 @@ spec:
                                                             description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -8850,7 +8850,7 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
                                                       description: optional field specify whether the Secret or its key must be defined
@@ -8861,10 +8861,10 @@ spec:
                                                   description: serviceAccountToken is information about the serviceAccountToken data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                      description: audience is the intended audience of the token.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                      description: expirationSeconds is the requested duration of validity of the service account token.
                                                       format: int64
                                                       type: integer
                                                     path:
@@ -8877,14 +8877,14 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
@@ -8892,11 +8892,11 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -8907,7 +8907,7 @@ spec:
                                             description: optional field specify whether the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                             type: string
                                         type: object
                                     type: object
@@ -8917,7 +8917,7 @@ spec:
                                 type: object
                               type: array
                             debugLevel:
-                              description: 'DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing. Otherwise, this may be a value between 1 and 10. See SSSD docs for more info: https://sssd.io/troubleshooting/basics.html#sssd-debug-logs'
+                              description: DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing.
                               maximum: 10
                               minimum: 0
                               type: integer
@@ -8929,12 +8929,12 @@ spec:
                               description: Resources allow specifying resource requests/limits on the SSSD sidecar container.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                  description: Claims lists the names of resources, defined in spec.
                                   items:
                                     description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -8950,7 +8950,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -8959,24 +8959,24 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             sssdConfigFile:
-                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from. The config file will be placed into `/etc/sssd/sssd.conf`. If this is left empty, Rook will not add the file. This allows you to manage the `sssd.conf` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from.
                               properties:
                                 volumeSource:
-                                  description: 'VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD configuration file like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. There are two requirements for the source''s content: 1. The config file must be mountable via `subPath: sssd.conf`. For example, in a ConfigMap, the data item must be named `sssd.conf`, or `items` must be defined to select the key and give it path `sssd.conf`. A HostPath directory must have the `sssd.conf` file. 2. The volume or config file must have mode 0600.'
+                                  description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD confi
                                   properties:
                                     configMap:
                                       description: configMap represents a configMap that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                           items:
                                             description: Maps a string key to a path within a volume.
                                             properties:
@@ -8984,11 +8984,11 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -8996,7 +8996,7 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          description: 'Name of the referent. More info: https://kubernetes.'
                                           type: string
                                         optional:
                                           description: optional specify whether the ConfigMap or its keys must be defined
@@ -9004,36 +9004,36 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                       properties:
                                         medium:
-                                          description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: medium represents what type of storage medium should back this directory.
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                      description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                       properties:
                                         path:
-                                          description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: path of the directory on the host.
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                           type: string
                                         readOnly:
                                           description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -9045,7 +9045,7 @@ spec:
                                       description: projected items for all in one resources secrets, configmaps, and downward API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                          description: defaultMode are the mode bits used to set permissions on created files by default.
                                           format: int32
                                           type: integer
                                         sources:
@@ -9057,7 +9057,7 @@ spec:
                                                 description: configMap information about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                     items:
                                                       description: Maps a string key to a path within a volume.
                                                       properties:
@@ -9065,11 +9065,11 @@ spec:
                                                           description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9077,7 +9077,7 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
                                                     description: optional specify whether the ConfigMap or its keys must be defined
@@ -9106,14 +9106,14 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                          description: 'Required: Path is  the relative path name of the file to be created.'
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                           properties:
                                                             containerName:
                                                               description: 'Container name: required for volumes, optional for env vars'
@@ -9141,7 +9141,7 @@ spec:
                                                 description: secret information about the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                     items:
                                                       description: Maps a string key to a path within a volume.
                                                       properties:
@@ -9149,11 +9149,11 @@ spec:
                                                           description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9161,7 +9161,7 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
                                                     description: optional field specify whether the Secret or its key must be defined
@@ -9172,10 +9172,10 @@ spec:
                                                 description: serviceAccountToken is information about the serviceAccountToken data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                    description: audience is the intended audience of the token.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                    description: expirationSeconds is the requested duration of validity of the service account token.
                                                     format: int64
                                                     type: integer
                                                   path:
@@ -9188,14 +9188,14 @@ spec:
                                           type: array
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                           items:
                                             description: Maps a string key to a path within a volume.
                                             properties:
@@ -9203,11 +9203,11 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9218,7 +9218,7 @@ spec:
                                           description: optional field specify whether the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                           type: string
                                       type: object
                                   type: object
@@ -9242,7 +9242,7 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     hostNetwork:
-                      description: Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
+                      description: Whether host networking is enabled for the Ganesha server.
                       nullable: true
                       type: boolean
                     labels:
@@ -9253,25 +9253,25 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.Disabled is false and LivenessProbe.Probe is nil uses default probe.
+                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.
                       properties:
                         disabled:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -9282,7 +9282,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -9291,7 +9291,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -9299,7 +9299,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -9316,7 +9316,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -9325,7 +9325,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -9333,7 +9333,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -9346,17 +9346,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -9372,9 +9372,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -9382,16 +9382,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9403,16 +9403,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9433,26 +9433,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9464,16 +9464,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9494,9 +9494,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -9507,16 +9507,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9528,26 +9528,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9559,17 +9559,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -9584,9 +9584,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -9594,16 +9594,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9615,26 +9615,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9646,17 +9646,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -9667,9 +9667,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -9680,16 +9680,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9701,26 +9701,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9732,17 +9732,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -9757,9 +9757,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -9767,16 +9767,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9788,26 +9788,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9819,17 +9819,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -9837,25 +9837,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -9865,21 +9865,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -9891,35 +9891,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -9937,12 +9937,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -9958,7 +9958,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -9967,7 +9967,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10042,10 +10042,10 @@ spec:
           description: CephObjectRealm represents a Ceph Object Store Gateway Realm
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -10129,10 +10129,10 @@ spec:
           description: CephObjectStore represents a Ceph Object Store Gateway
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -10140,7 +10140,7 @@ spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
                 allowUsersInNamespaces:
-                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store users may be created. Specify "*" to allow all namespaces, otherwise list individual namespaces that are to be allowed. This is useful for applications that need object store credentials to be created in their own namespace, where neither OBCs nor COSI is being used to create buckets. The default is empty.
+                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store use
                   items:
                     type: string
                   type: array
@@ -10149,7 +10149,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -10176,11 +10176,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -10188,7 +10188,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -10277,14 +10277,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -10328,25 +10328,25 @@ spec:
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     disableMultisiteSyncTraffic:
-                      description: 'DisableMultisiteSyncTraffic, when true, prevents this object store''s gateways from transmitting multisite replication data. Note that this value does not affect whether gateways receive multisite replication traffic: see ObjectZone.spec.customEndpoints for that. If false or unset, this object store''s gateways will be able to transmit multisite replication data.'
+                      description: DisableMultisiteSyncTraffic, when true, prevents this object store's gateways from transmitting mult
                       type: boolean
                     externalRgwEndpoints:
-                      description: ExternalRgwEndpoints points to external RGW endpoint(s). Multiple endpoints can be given, but for stability of ObjectBucketClaims, we highly recommend that users give only a single external RGW endpoint that is a load balancer that sends requests to the multiple RGWs.
+                      description: ExternalRgwEndpoints points to external RGW endpoint(s).
                       items:
-                        description: EndpointAddress is a tuple that describes a single IP address or host name. This is a subset of Kubernetes's v1.EndpointAddress.
+                        description: EndpointAddress is a tuple that describes a single IP address or host name.
                         properties:
                           hostname:
-                            description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
+                            description: The DNS-addressable Hostname of this endpoint.
                             type: string
                           ip:
-                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
+                            description: The IP of this endpoint.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       nullable: true
                       type: array
                     hostNetwork:
-                      description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                      description: Whether host networking is enabled for the rgw daemon.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
@@ -10370,9 +10370,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -10380,16 +10380,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10401,16 +10401,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10431,26 +10431,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10462,16 +10462,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10492,9 +10492,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -10505,16 +10505,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10526,26 +10526,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10557,17 +10557,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -10582,9 +10582,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -10592,16 +10592,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10613,26 +10613,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10644,17 +10644,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10665,9 +10665,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -10678,16 +10678,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10699,26 +10699,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10730,17 +10730,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -10755,9 +10755,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -10765,16 +10765,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10786,26 +10786,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10817,17 +10817,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10835,25 +10835,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -10863,21 +10863,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -10889,35 +10889,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -10939,12 +10939,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -10960,7 +10960,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -10969,7 +10969,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -11006,19 +11006,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -11029,7 +11029,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -11038,7 +11038,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -11046,7 +11046,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -11063,7 +11063,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -11072,7 +11072,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -11080,7 +11080,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -11093,17 +11093,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -11116,19 +11116,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -11139,7 +11139,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -11148,7 +11148,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -11156,7 +11156,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -11173,7 +11173,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -11182,7 +11182,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -11190,7 +11190,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -11203,17 +11203,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -11224,7 +11224,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11251,11 +11251,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11263,7 +11263,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -11352,14 +11352,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -11536,10 +11536,10 @@ spec:
           description: CephObjectStoreUser represents a Ceph Object Store Gateway User
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11551,7 +11551,7 @@ spec:
                   nullable: true
                   properties:
                     amz-cache:
-                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/quincy/radosgw/rgw-cache/#cache-api
+                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11559,7 +11559,7 @@ spec:
                         - read, write
                       type: string
                     bilog:
-                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11567,7 +11567,7 @@ spec:
                         - read, write
                       type: string
                     bucket:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11575,7 +11575,7 @@ spec:
                         - read, write
                       type: string
                     buckets:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11583,7 +11583,7 @@ spec:
                         - read, write
                       type: string
                     datalog:
-                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11591,7 +11591,7 @@ spec:
                         - read, write
                       type: string
                     info:
-                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11599,7 +11599,7 @@ spec:
                         - read, write
                       type: string
                     mdlog:
-                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11607,7 +11607,7 @@ spec:
                         - read, write
                       type: string
                     metadata:
-                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11615,7 +11615,7 @@ spec:
                         - read, write
                       type: string
                     oidc-provider:
-                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11623,7 +11623,7 @@ spec:
                         - read, write
                       type: string
                     ratelimit:
-                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11631,7 +11631,7 @@ spec:
                         - read, write
                       type: string
                     roles:
-                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11639,7 +11639,7 @@ spec:
                         - read, write
                       type: string
                     usage:
-                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11647,7 +11647,7 @@ spec:
                         - read, write
                       type: string
                     user:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11655,7 +11655,7 @@ spec:
                         - read, write
                       type: string
                     user-policy:
-                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11663,7 +11663,7 @@ spec:
                         - read, write
                       type: string
                     users:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11671,7 +11671,7 @@ spec:
                         - read, write
                       type: string
                     zone:
-                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11686,7 +11686,7 @@ spec:
                   description: The display name for the ceph users
                   type: string
                 quotas:
-                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
+                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage.
                   nullable: true
                   properties:
                     maxBuckets:
@@ -11702,7 +11702,7 @@ spec:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info.
+                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
@@ -11763,10 +11763,10 @@ spec:
           description: CephObjectZoneGroup represents a Ceph Object Store Gateway Zone Group
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11848,10 +11848,10 @@ spec:
           description: CephObjectZone represents a Ceph Object Store Gateway Zone
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11859,7 +11859,7 @@ spec:
               description: ObjectZoneSpec represent the spec of an ObjectZone
               properties:
                 customEndpoints:
-                  description: "If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint(s). You may include the port in the definition. For example: \"https://my-object-store.my-domain.net:443\". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters. The list can have one or more endpoints pointing to different RGW servers in the zone. \n If a CephObjectStore endpoint is omitted from this list, that object store's gateways will not receive multisite replication data (see CephObjectStore.spec.gateway.disableMultisiteSyncTraffic)."
+                  description: If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint cre
                   items:
                     type: string
                   nullable: true
@@ -11869,7 +11869,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11896,11 +11896,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11908,7 +11908,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -11997,14 +11997,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -12032,7 +12032,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12059,11 +12059,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12071,7 +12071,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -12160,14 +12160,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -12271,10 +12271,10 @@ spec:
           description: CephRBDMirror represents a Ceph RBD Mirror
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -12317,9 +12317,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -12327,16 +12327,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12348,16 +12348,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12378,26 +12378,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12409,16 +12409,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12439,9 +12439,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -12452,16 +12452,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12473,26 +12473,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12504,17 +12504,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -12529,9 +12529,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -12539,16 +12539,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12560,26 +12560,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12591,17 +12591,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -12612,9 +12612,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -12625,16 +12625,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12646,26 +12646,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12677,17 +12677,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -12702,9 +12702,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -12712,16 +12712,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12733,26 +12733,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12764,17 +12764,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -12782,25 +12782,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -12810,21 +12810,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -12836,35 +12836,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -12882,12 +12882,12 @@ spec:
                   nullable: true
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -12903,7 +12903,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -12912,7 +12912,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -26,10 +26,10 @@ spec:
           description: CephBlockPoolRadosNamespace represents a Ceph BlockPool Rados Namespace
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -43,7 +43,7 @@ spec:
                     - message: blockPoolName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
+                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
@@ -99,18 +99,18 @@ spec:
           description: CephBlockPool represents a Ceph Storage Pool
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name. This is more specific than the NamedPoolSpec so we get schema validation on the allowed pool names that can be specified.
+              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
                 compressionMode:
-                  description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                  description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
                     - none
                     - passive
@@ -137,11 +137,11 @@ spec:
                       description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                       minimum: 0
                       type: integer
                   required:
@@ -149,7 +149,7 @@ spec:
                     - dataChunks
                   type: object
                 failureDomain:
-                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                   type: string
                 mirroring:
                   description: The mirroring settings
@@ -245,14 +245,14 @@ spec:
                       description: RequireSafeReplicaSize if false allows you to set replica 1
                       type: boolean
                     size:
-                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                       minimum: 0
                       type: integer
                     subFailureDomain:
                       description: SubFailureDomain the name of the sub-failure domain
                       type: string
                     targetSizeRatio:
-                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                       type: number
                   required:
                     - size
@@ -478,10 +478,10 @@ spec:
           description: CephBucketNotification represents a Bucket Notifications
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -636,10 +636,10 @@ spec:
           description: CephBucketTopic represents a Ceph Object Topic for Bucket Notifications
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -682,7 +682,7 @@ spec:
                           description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         sendCloudEvents:
-                          description: 'Send the notifications with the CloudEvents header: https://github.com/cloudevents/spec/blob/main/cloudevents/adapters/aws-s3.md'
+                          description: 'Send the notifications with the CloudEvents header: https://github.'
                           type: boolean
                         uri:
                           description: The URI of the HTTP endpoint to push notification to
@@ -784,10 +784,10 @@ spec:
           description: CephClient represents a Ceph Client
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -882,10 +882,10 @@ spec:
           description: CephCluster is a Ceph storage cluster
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -918,10 +918,10 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as quay.io/ceph/ceph:<tag> The full list of images can be found at https://quay.io/repository/ceph/ceph?tab=tags
+                      description: Image is the container image used to launch the ceph daemons, such as quay.
                       type: string
                     imagePullPolicy:
-                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNotPresent.
+                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNot
                       enum:
                         - IfNotPresent
                         - Always
@@ -930,11 +930,11 @@ spec:
                       type: string
                   type: object
                 cleanupPolicy:
-                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster deletion is not imminent.
+                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster
                   nullable: true
                   properties:
                     allowUninstallWithVolumes:
-                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images still present
+                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images s
                       type: boolean
                     confirmation:
                       description: Confirmation represents the cleanup confirmation
@@ -964,7 +964,7 @@ spec:
                       type: object
                   type: object
                 continueUpgradeAfterChecksEvenIfNotHealthy:
-                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not clean
+                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not
                   type: boolean
                 crashCollector:
                   description: A spec for the crash controller
@@ -994,7 +994,7 @@ spec:
                       description: ReadAffinity defines the read affinity settings for CSI driver.
                       properties:
                         crushLocationLabels:
-                          description: CrushLocationLabels defines which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map.
+                          description: CrushLocationLabels defines which node labels to use as CRUSH location.
                           items:
                             type: string
                           type: array
@@ -1049,19 +1049,19 @@ spec:
                       description: This enables management of poddisruptionbudgets
                       type: boolean
                     osdMaintenanceTimeout:
-                      description: OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure domains it only works if managePodBudgets is true. the default is 30 minutes
+                      description: 'OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure '
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain if the timeout exceeds. It only works if managePodBudgets is true. No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups t
                       format: int64
                       type: integer
                     pgHealthyRegex:
-                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be considered healthy. The default is `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`
+                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be conside
                       type: string
                   type: object
                 external:
-                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and discover daemons will not be created for external clusters.
+                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and disc
                   nullable: true
                   properties:
                     enable:
@@ -1122,19 +1122,19 @@ spec:
                             description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
@@ -1145,7 +1145,7 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
-                                    description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
@@ -1154,7 +1154,7 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -1162,7 +1162,7 @@ spec:
                                       description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          description: The header field name.
                                           type: string
                                         value:
                                           description: The header field value
@@ -1179,7 +1179,7 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -1188,7 +1188,7 @@ spec:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
@@ -1196,7 +1196,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -1209,17 +1209,17 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
@@ -1234,19 +1234,19 @@ spec:
                             description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
@@ -1257,7 +1257,7 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
-                                    description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
@@ -1266,7 +1266,7 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -1274,7 +1274,7 @@ spec:
                                       description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          description: The header field name.
                                           type: string
                                         value:
                                           description: The header field value
@@ -1291,7 +1291,7 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -1300,7 +1300,7 @@ spec:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
@@ -1308,7 +1308,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -1321,17 +1321,17 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
@@ -1433,13 +1433,13 @@ spec:
                                 description: VolumeClaimTemplate is the PVC template
                                 properties:
                                   apiVersion:
-                                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                    description: APIVersion defines the versioned schema of this representation of an object.
                                     type: string
                                   kind:
-                                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: Kind is a string value representing the REST resource this object represents.
                                     type: string
                                   metadata:
-                                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                    description: 'Standard object''s metadata. More info: https://git.k8s.'
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -1459,18 +1459,18 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: spec defines the desired characteristics of a volume requested by a pod author.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource being referenced
@@ -1484,10 +1484,10 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                        description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
                                             description: Kind is the type of resource being referenced
@@ -1496,22 +1496,22 @@ spec:
                                             description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        description: resources represents the minimum resources the volume should have.
                                         properties:
                                           claims:
-                                            description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                            description: Claims lists the names of resources, defined in spec.
                                             items:
                                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                               properties:
                                                 name:
-                                                  description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                  description: Name must match the name of one entry in pod.spec.
                                                   type: string
                                               required:
                                                 - name
@@ -1527,7 +1527,7 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -1536,7 +1536,7 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            description: Requests describes the minimum amount of compute resources required.
                                             type: object
                                         type: object
                                       selector:
@@ -1545,16 +1545,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1566,33 +1566,33 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        description: storageClassName is the name of the StorageClass required by the claim.
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                        description: volumeMode defines what type of volume is required by the claim.
                                         type: string
                                       volumeName:
                                         description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                   status:
-                                    description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: status represents the current information/status of a persistent volume claim. Read-only.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        description: accessModes contains the actual access modes the volume backing the PVC has.
                                         items:
                                           type: string
                                         type: array
                                       allocatedResourceStatuses:
                                         additionalProperties:
-                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                           type: string
-                                        description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                        description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                         type: object
                                         x-kubernetes-map-type: granular
                                       allocatedResources:
@@ -1602,7 +1602,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                        description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                         type: object
                                       capacity:
                                         additionalProperties:
@@ -1614,7 +1614,7 @@ spec:
                                         description: capacity represents the actual resources of the underlying volume.
                                         type: object
                                       conditions:
-                                        description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                        description: conditions is the current Condition of persistent volume claim.
                                         items:
                                           description: PersistentVolumeClaimCondition contains details about state of pvc
                                           properties:
@@ -1630,7 +1630,7 @@ spec:
                                               description: message is the human-readable message indicating details about last transition.
                                               type: string
                                             reason:
-                                              description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                              description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                               type: string
                                             status:
                                               type: string
@@ -1656,13 +1656,13 @@ spec:
                       description: VolumeClaimTemplate is the PVC definition
                       properties:
                         apiVersion:
-                          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          description: APIVersion defines the versioned schema of this representation of an object.
                           type: string
                         kind:
-                          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          description: Kind is a string value representing the REST resource this object represents.
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: 'Standard object''s metadata. More info: https://git.k8s.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -1682,18 +1682,18 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          description: spec defines the desired characteristics of a volume requested by a pod author.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
                                   description: Kind is the type of resource being referenced
@@ -1707,10 +1707,10 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             dataSourceRef:
-                              description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                              description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
                                   description: Kind is the type of resource being referenced
@@ -1719,22 +1719,22 @@ spec:
                                   description: Name is the name of resource being referenced
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              description: resources represents the minimum resources the volume should have.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                  description: Claims lists the names of resources, defined in spec.
                                   items:
                                     description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -1750,7 +1750,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -1759,7 +1759,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             selector:
@@ -1768,16 +1768,16 @@ spec:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
                                         description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -1789,33 +1789,33 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             storageClassName:
-                              description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              description: storageClassName is the name of the StorageClass required by the claim.
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                              description: volumeMode defines what type of volume is required by the claim.
                               type: string
                             volumeName:
                               description: volumeName is the binding reference to the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          description: status represents the current information/status of a persistent volume claim. Read-only.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              description: accessModes contains the actual access modes the volume backing the PVC has.
                               items:
                                 type: string
                               type: array
                             allocatedResourceStatuses:
                               additionalProperties:
-                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -1825,7 +1825,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                               type: object
                             capacity:
                               additionalProperties:
@@ -1837,7 +1837,7 @@ spec:
                               description: capacity represents the actual resources of the underlying volume.
                               type: object
                             conditions:
-                              description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                              description: conditions is the current Condition of persistent volume claim.
                               items:
                                 description: PersistentVolumeClaimCondition contains details about state of pvc
                                 properties:
@@ -1853,7 +1853,7 @@ spec:
                                     description: message is the human-readable message indicating details about last transition.
                                     type: string
                                   reason:
-                                    description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                    description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                     type: string
                                   status:
                                     type: string
@@ -1886,13 +1886,13 @@ spec:
                             description: VolumeClaimTemplate is the PVC template
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                description: APIVersion defines the versioned schema of this representation of an object.
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: Kind is a string value representing the REST resource this object represents.
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                description: 'Standard object''s metadata. More info: https://git.k8s.'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -1912,18 +1912,18 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: spec defines the desired characteristics of a volume requested by a pod author.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being referenced
@@ -1937,10 +1937,10 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                    description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being referenced
@@ -1949,22 +1949,22 @@ spec:
                                         description: Name is the name of resource being referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    description: resources represents the minimum resources the volume should have.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                        description: Claims lists the names of resources, defined in spec.
                                         items:
                                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                              description: Name must match the name of one entry in pod.spec.
                                               type: string
                                           required:
                                             - name
@@ -1980,7 +1980,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1989,7 +1989,7 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: Requests describes the minimum amount of compute resources required.
                                         type: object
                                     type: object
                                   selector:
@@ -1998,16 +1998,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -2019,33 +2019,33 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    description: storageClassName is the name of the StorageClass required by the claim.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                    description: volumeMode defines what type of volume is required by the claim.
                                     type: string
                                   volumeName:
                                     description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: status represents the current information/status of a persistent volume claim. Read-only.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: accessModes contains the actual access modes the volume backing the PVC has.
                                     items:
                                       type: string
                                     type: array
                                   allocatedResourceStatuses:
                                     additionalProperties:
-                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                       type: string
-                                    description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                    description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                     type: object
                                     x-kubernetes-map-type: granular
                                   allocatedResources:
@@ -2055,7 +2055,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                    description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                     type: object
                                   capacity:
                                     additionalProperties:
@@ -2067,7 +2067,7 @@ spec:
                                     description: capacity represents the actual resources of the underlying volume.
                                     type: object
                                   conditions:
-                                    description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                    description: conditions is the current Condition of persistent volume claim.
                                     items:
                                       description: PersistentVolumeClaimCondition contains details about state of pvc
                                       properties:
@@ -2083,7 +2083,7 @@ spec:
                                           description: message is the human-readable message indicating details about last transition.
                                           type: string
                                         reason:
-                                          description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                          description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                           type: string
                                         status:
                                           type: string
@@ -2114,7 +2114,7 @@ spec:
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus types must exist or the creation will fail. Default is false.
+                      description: Enabled determines whether to create the prometheus rules for the ceph cluster.
                       type: boolean
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
@@ -2125,7 +2125,7 @@ spec:
                             description: The Hostname of this endpoint
                             type: string
                           ip:
-                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.0/16 or fe80::/10), or link-local multicast (224.0.0.0/24 or ff02::/16).
+                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.
                             type: string
                           nodeName:
                             description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
@@ -2137,22 +2137,22 @@ spec:
                                 description: API version of the referent.
                                 type: string
                               fieldPath:
-                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                description: If referring to a piece of an object instead of an entire object, this string should contain a valid
                                 type: string
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.'
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'Name of the referent. More info: https://kubernetes.'
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                description: 'Namespace of the referent. More info: https://kubernetes.'
                                 type: string
                               resourceVersion:
-                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.'
                                 type: string
                               uid:
-                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                description: 'UID of the referent. More info: https://kubernetes.'
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -2171,7 +2171,7 @@ spec:
                       description: Interval determines prometheus scrape interval
                       type: string
                     metricsDisabled:
-                      description: Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled. If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
+                      description: Whether to disable the metrics reported by Ceph.
                       type: boolean
                     port:
                       description: Port is the prometheus server port
@@ -2184,20 +2184,20 @@ spec:
                   nullable: true
                   properties:
                     addressRanges:
-                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluster_network' configurations. This config section may be used for the "host" or "multus" network providers.
+                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluste
                       nullable: true
                       properties:
                         cluster:
                           description: Cluster defines a list of CIDRs to use for Ceph cluster network communication.
                           items:
-                            description: "An IPv4 or IPv6 network CIDR. \n This naive kubebuilder regex provides immediate feedback for some typos and for a common problem case where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code."
+                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                         public:
                           description: Public defines a list of CIDRs to use for Ceph public network communication.
                           items:
-                            description: "An IPv4 or IPv6 network CIDR. \n This naive kubebuilder regex provides immediate feedback for some typos and for a common problem case where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code."
+                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
@@ -2219,18 +2219,18 @@ spec:
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network. The default is not set. Even if encryption is not enabled, clients still establish a strong initial authentication for the connection and data integrity is still validated with a crc check. When encryption is enabled, all communication between clients and Ceph daemons, or between Ceph daemons will be encrypted.
+                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the netw
                               type: boolean
                           type: object
                         requireMsgr2:
-                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled. If true, the msgr1 port (6789) will be disabled. Requires a kernel that supports msgr2 (kernel 5.11 or CentOS 8.4 or newer).
+                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled.
                           type: boolean
                       type: object
                     dualStack:
                       description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network. If host networking is enabled or disabled on a running cluster, then the operator will automatically fail over all the mons to apply the new network settings.
+                      description: HostNetwork to enable host network.
                       type: boolean
                     ipFamily:
                       description: IPFamily is the single stack IPv6 or IPv4 protocol
@@ -2243,14 +2243,14 @@ spec:
                       description: Enable multiClusterService to export the Services between peer clusters
                       properties:
                         clusterID:
-                          description: 'ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services. For example: <clusterid>.<svc>.<ns>.svc.clusterset.local'
+                          description: ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services.
                           type: string
                         enabled:
-                          description: Enable multiClusterService to export the mon and OSD services to peer cluster. Ensure that peer clusters are connected using an MCS API compatible application, like Globalnet Submariner.
+                          description: Enable multiClusterService to export the mon and OSD services to peer cluster.
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus". If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.
+                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
                       enum:
                         - ""
                         - host
@@ -2263,7 +2263,7 @@ spec:
                     selectors:
                       additionalProperties:
                         type: string
-                      description: "Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks when the \"multus\" network provider is used. This config section is not used for other network providers. \n Valid keys are \"public\" and \"cluster\". Refer to Ceph networking documentation for more: https://docs.ceph.com/en/reef/rados/configuration/network-config-ref/ \n Refer to Multus network annotation documentation for help selecting values: https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#run-pod-with-network-annotation \n Rook will make a best-effort attempt to automatically detect CIDR address ranges for given network attachment definitions. Rook's methods are robust but may be imprecise for sufficiently complicated networks. Rook's auto-detection process obtains a new IP address lease for each CephCluster reconcile. If Rook fails to detect, incorrectly detects, only partially detects, or if underlying networks do not support reusing old IP addresses, it is best to use the 'addressRanges' config section to specify CIDR ranges for the Ceph cluster. \n As a contrived example, one can use a theoretical Kubernetes-wide network for Ceph client traffic and a theoretical Rook-only network for Ceph replication traffic as shown: selectors: public: \"default/cluster-fast-net\" cluster: \"rook-ceph/ceph-backend-net\""
+                      description: Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks whe
                       nullable: true
                       type: object
                   type: object
@@ -2279,9 +2279,9 @@ spec:
                         description: NodeAffinity is a group of node affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                               properties:
                                 preference:
                                   description: A node selector term, associated with the corresponding weight.
@@ -2289,16 +2289,16 @@ spec:
                                     matchExpressions:
                                       description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2310,16 +2310,16 @@ spec:
                                     matchFields:
                                       description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2340,26 +2340,26 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             properties:
                               nodeSelectorTerms:
                                 description: Required. A list of node selector terms. The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                   properties:
                                     matchExpressions:
                                       description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2371,16 +2371,16 @@ spec:
                                     matchFields:
                                       description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
                                             description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2401,9 +2401,9 @@ spec:
                         description: PodAffinity is a group of inter pod affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
                                   description: Required. A pod affinity term, associated with the corresponding weight.
@@ -2414,16 +2414,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2435,26 +2435,26 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2466,17 +2466,17 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
@@ -2491,9 +2491,9 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources, in this case pods.
@@ -2501,16 +2501,16 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2522,26 +2522,26 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2553,17 +2553,17 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2574,9 +2574,9 @@ spec:
                         description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
                                   description: Required. A pod affinity term, associated with the corresponding weight.
@@ -2587,16 +2587,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2608,26 +2608,26 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2639,17 +2639,17 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
@@ -2664,9 +2664,9 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources, in this case pods.
@@ -2674,16 +2674,16 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2695,26 +2695,26 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2726,17 +2726,17 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2744,25 +2744,25 @@ spec:
                             type: array
                         type: object
                       tolerations:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         items:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to.
                               type: string
                           type: object
                         type: array
@@ -2772,21 +2772,21 @@ spec:
                           description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              description: LabelSelector is used to find matching pods.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
                                         description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -2798,35 +2798,35 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                              description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: MaxSkew describes the degree to which pods may be unevenly distributed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                              description: MinDomains indicates a minimum number of eligible domains.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                               type: string
                             nodeTaintsPolicy:
-                              description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                              description: TopologyKey is the key of node labels.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                               type: string
                           required:
                             - maxSkew
@@ -2854,12 +2854,12 @@ spec:
                     description: ResourceRequirements describes the compute resource requirements.
                     properties:
                       claims:
-                        description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                        description: Claims lists the names of resources, defined in spec.
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                              description: Name must match the name of one entry in pod.spec.
                               type: string
                           required:
                             - name
@@ -2875,7 +2875,7 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                         type: object
                       requests:
                         additionalProperties:
@@ -2884,7 +2884,7 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute resources required.
                         type: object
                     type: object
                   description: Resources set resource requests and limits
@@ -2962,7 +2962,7 @@ spec:
                       type: array
                       x-kubernetes-preserve-unknown-fields: true
                     flappingRestartIntervalHours:
-                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit code, will sleep before restarting. This is needed for OSD flapping where OSD daemons are marked down more than 5 times in 600 seconds by Ceph. Preventing the OSD pods to restart immediately in such scenarios will prevent Rook from marking OSD as `up` and thus peering of the PGs mapped to the OSD. User needs to manually restart the OSD pod if they manage to fix the underlying OSD flapping issue before the restart interval. The sleep will be disabled if this interval is set to 0.
+                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit cod
                       type: integer
                     nodes:
                       items:
@@ -3006,12 +3006,12 @@ spec:
                             nullable: true
                             properties:
                               claims:
-                                description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                description: Claims lists the names of resources, defined in spec.
                                 items:
                                   description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -3027,7 +3027,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3036,7 +3036,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -3049,13 +3049,13 @@ spec:
                               description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -3075,18 +3075,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -3100,10 +3100,10 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -3112,22 +3112,22 @@ spec:
                                           description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                          description: Claims lists the names of resources, defined in spec.
                                           items:
                                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                description: Name must match the name of one entry in pod.spec.
                                                 type: string
                                             required:
                                               - name
@@ -3143,7 +3143,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3152,7 +3152,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
@@ -3161,16 +3161,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3182,33 +3182,33 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
                                       description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -3218,7 +3218,7 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -3230,7 +3230,7 @@ spec:
                                       description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
                                         description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
@@ -3246,7 +3246,7 @@ spec:
                                             description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
@@ -3298,9 +3298,9 @@ spec:
                                 description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated with the corresponding weight.
@@ -3308,16 +3308,16 @@ spec:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3329,16 +3329,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3359,26 +3359,26 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3390,16 +3390,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3420,9 +3420,9 @@ spec:
                                 description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -3433,16 +3433,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3454,26 +3454,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3485,17 +3485,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -3510,9 +3510,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -3520,16 +3520,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3541,26 +3541,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3572,17 +3572,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3593,9 +3593,9 @@ spec:
                                 description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -3606,16 +3606,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3627,26 +3627,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3658,17 +3658,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -3683,9 +3683,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -3693,16 +3693,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3714,26 +3714,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3745,17 +3745,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3763,25 +3763,25 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
@@ -3791,21 +3791,21 @@ spec:
                                   description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3817,35 +3817,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -3866,9 +3866,9 @@ spec:
                                 description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated with the corresponding weight.
@@ -3876,16 +3876,16 @@ spec:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3897,16 +3897,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3927,26 +3927,26 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3958,16 +3958,16 @@ spec:
                                             matchFields:
                                               description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
                                                     description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3988,9 +3988,9 @@ spec:
                                 description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -4001,16 +4001,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4022,26 +4022,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4053,17 +4053,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -4078,9 +4078,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -4088,16 +4088,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4109,26 +4109,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4140,17 +4140,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4161,9 +4161,9 @@ spec:
                                 description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
                                           description: Required. A pod affinity term, associated with the corresponding weight.
@@ -4174,16 +4174,16 @@ spec:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4195,26 +4195,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
                                                         description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4226,17 +4226,17 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
@@ -4251,9 +4251,9 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of resources, in this case pods.
@@ -4261,16 +4261,16 @@ spec:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4282,26 +4282,26 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
                                                     description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4313,17 +4313,17 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4331,25 +4331,25 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
@@ -4359,21 +4359,21 @@ spec:
                                   description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4385,35 +4385,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -4428,12 +4428,12 @@ spec:
                             nullable: true
                             properties:
                               claims:
-                                description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                description: Claims lists the names of resources, defined in spec.
                                 items:
                                   description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -4449,7 +4449,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4458,7 +4458,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -4477,13 +4477,13 @@ spec:
                               description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -4504,18 +4504,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -4529,10 +4529,10 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
                                           description: Kind is the type of resource being referenced
@@ -4541,22 +4541,22 @@ spec:
                                           description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                          description: Claims lists the names of resources, defined in spec.
                                           items:
                                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                description: Name must match the name of one entry in pod.spec.
                                                 type: string
                                             required:
                                               - name
@@ -4572,7 +4572,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4581,7 +4581,7 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
@@ -4590,16 +4590,16 @@ spec:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
                                                 description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4611,33 +4611,33 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
                                       description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -4647,7 +4647,7 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -4659,7 +4659,7 @@ spec:
                                       description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
                                         description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
@@ -4675,7 +4675,7 @@ spec:
                                             description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
@@ -4710,7 +4710,7 @@ spec:
                             - bluestore-rdr
                           type: string
                         updateStore:
-                          description: UpdateStore updates the backend store for existing OSDs. It destroys each OSD one at a time, cleans up the backing disk and prepares same OSD on that disk
+                          description: UpdateStore updates the backend store for existing OSDs.
                           pattern: ^$|^yes-really-update-store$
                           type: string
                       type: object
@@ -4725,13 +4725,13 @@ spec:
                         description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                         properties:
                           apiVersion:
-                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            description: APIVersion defines the versioned schema of this representation of an object.
                             type: string
                           kind:
-                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: Kind is a string value representing the REST resource this object represents.
                             type: string
                           metadata:
-                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            description: 'Standard object''s metadata. More info: https://git.k8s.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -4751,18 +4751,18 @@ spec:
                                 type: string
                             type: object
                           spec:
-                            description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: spec defines the desired characteristics of a volume requested by a pod author.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
                                     description: Kind is the type of resource being referenced
@@ -4776,10 +4776,10 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               dataSourceRef:
-                                description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn''t specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn''t set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                                description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
                                     description: Kind is the type of resource being referenced
@@ -4788,22 +4788,22 @@ spec:
                                     description: Name is the name of resource being referenced
                                     type: string
                                   namespace:
-                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               resources:
-                                description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                description: resources represents the minimum resources the volume should have.
                                 properties:
                                   claims:
-                                    description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                    description: Claims lists the names of resources, defined in spec.
                                     items:
                                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                          description: Name must match the name of one entry in pod.spec.
                                           type: string
                                       required:
                                         - name
@@ -4819,7 +4819,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -4828,7 +4828,7 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: Requests describes the minimum amount of compute resources required.
                                     type: object
                                 type: object
                               selector:
@@ -4837,16 +4837,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -4858,33 +4858,33 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               storageClassName:
-                                description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                description: storageClassName is the name of the StorageClass required by the claim.
                                 type: string
                               volumeMode:
-                                description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                description: volumeMode defines what type of volume is required by the claim.
                                 type: string
                               volumeName:
                                 description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
-                            description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: status represents the current information/status of a persistent volume claim. Read-only.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                description: accessModes contains the actual access modes the volume backing the PVC has.
                                 items:
                                   type: string
                                 type: array
                               allocatedResourceStatuses:
                                 additionalProperties:
-                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource that it does not recognizes, then it should ignore that update and let other controllers handle it.
+                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                   type: string
-                                description: "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n ClaimResourceStatus can be in any of following states: - ControllerResizeInProgress: State set when resize controller starts resizing the volume in control-plane. - ControllerResizeFailed: State set when resize has failed in resize controller with a terminal error. - NodeResizePending: State set when resize controller has finished resizing the volume but further resizing of volume is needed on the node. - NodeResizeInProgress: State set when kubelet starts resizing the volume. - NodeResizeFailed: State set when resizing has failed in kubelet with a terminal error. Transient errors don't set NodeResizeFailed. For example: if expanding a PVC for more capacity - this field can be one of the following states: - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\" When this field is not set, it means that no resize operation is in progress for the given PVC. \n A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                 type: object
                                 x-kubernetes-map-type: granular
                               allocatedResources:
@@ -4894,7 +4894,7 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either: * Un-prefixed keys: - storage - the capacity of the volume. * Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\" Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used. \n Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. \n A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC. \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                                description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -4906,7 +4906,7 @@ spec:
                                 description: capacity represents the actual resources of the underlying volume.
                                 type: object
                               conditions:
-                                description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                description: conditions is the current Condition of persistent volume claim.
                                 items:
                                   description: PersistentVolumeClaimCondition contains details about state of pvc
                                   properties:
@@ -4922,7 +4922,7 @@ spec:
                                       description: message is the human-readable message indicating details about last transition.
                                       type: string
                                     reason:
-                                      description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                      description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                       type: string
                                     status:
                                       type: string
@@ -4942,7 +4942,7 @@ spec:
                       type: array
                   type: object
                 waitTimeoutForHealthyOSDInMinutes:
-                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart. If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`. The default wait timeout is 10 minutes.
+                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stop
                   format: int64
                   type: integer
               type: object
@@ -5134,10 +5134,10 @@ spec:
           description: CephCOSIDriver represents the CRD for the Ceph COSI Driver Deployment
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -5164,9 +5164,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -5174,16 +5174,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5195,16 +5195,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5225,26 +5225,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5256,16 +5256,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5286,9 +5286,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5299,16 +5299,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5320,26 +5320,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5351,17 +5351,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -5376,9 +5376,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -5386,16 +5386,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5407,26 +5407,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5438,17 +5438,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5459,9 +5459,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5472,16 +5472,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5493,26 +5493,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5524,17 +5524,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -5549,9 +5549,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -5559,16 +5559,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5580,26 +5580,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5611,17 +5611,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5629,25 +5629,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -5657,21 +5657,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -5683,35 +5683,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -5724,12 +5724,12 @@ spec:
                   description: Resources is the resource requirements for the COSI driver
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -5745,7 +5745,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -5754,7 +5754,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -5791,10 +5791,10 @@ spec:
           description: CephFilesystemMirror is the Ceph Filesystem Mirror object definition
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -5821,9 +5821,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -5831,16 +5831,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5852,16 +5852,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5882,26 +5882,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5913,16 +5913,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5943,9 +5943,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -5956,16 +5956,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5977,26 +5977,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6008,17 +6008,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -6033,9 +6033,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -6043,16 +6043,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6064,26 +6064,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6095,17 +6095,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6116,9 +6116,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -6129,16 +6129,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6150,26 +6150,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6181,17 +6181,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -6206,9 +6206,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -6216,16 +6216,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6237,26 +6237,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6268,17 +6268,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6286,25 +6286,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -6314,21 +6314,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -6340,35 +6340,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -6385,12 +6385,12 @@ spec:
                   nullable: true
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -6406,7 +6406,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -6415,7 +6415,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -6493,10 +6493,10 @@ spec:
           description: CephFilesystem represents a Ceph Filesystem
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -6509,7 +6509,7 @@ spec:
                     description: NamedPoolSpec represents the named ceph pool spec
                     properties:
                       compressionMode:
-                        description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                        description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
                           - none
                           - passive
@@ -6536,11 +6536,11 @@ spec:
                             description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                             minimum: 0
                             type: integer
                         required:
@@ -6548,7 +6548,7 @@ spec:
                           - dataChunks
                         type: object
                       failureDomain:
-                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                         type: string
                       mirroring:
                         description: The mirroring settings
@@ -6640,14 +6640,14 @@ spec:
                             description: RequireSafeReplicaSize if false allows you to set replica 1
                             type: boolean
                           size:
-                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                             minimum: 0
                             type: integer
                           subFailureDomain:
                             description: SubFailureDomain the name of the sub-failure domain
                             type: string
                           targetSizeRatio:
-                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                             type: number
                         required:
                           - size
@@ -6677,7 +6677,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -6704,11 +6704,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -6716,7 +6716,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -6805,14 +6805,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -6839,13 +6839,13 @@ spec:
                   description: The mds pod info
                   properties:
                     activeCount:
-                      description: The number of metadata servers that are active. The remaining servers in the cluster will be in standby mode.
+                      description: The number of metadata servers that are active.
                       format: int32
                       maximum: 10
                       minimum: 1
                       type: integer
                     activeStandby:
-                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster failover. If false, standbys will still be available, but will not have a warm metadata cache.
+                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster f
                       type: boolean
                     annotations:
                       additionalProperties:
@@ -6868,19 +6868,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -6891,7 +6891,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -6900,7 +6900,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -6908,7 +6908,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -6925,7 +6925,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -6934,7 +6934,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -6942,7 +6942,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -6955,17 +6955,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -6978,9 +6978,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -6988,16 +6988,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7009,16 +7009,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7039,26 +7039,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7070,16 +7070,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7100,9 +7100,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -7113,16 +7113,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7134,26 +7134,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7165,17 +7165,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -7190,9 +7190,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -7200,16 +7200,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7221,26 +7221,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7252,17 +7252,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7273,9 +7273,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -7286,16 +7286,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7307,26 +7307,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7338,17 +7338,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -7363,9 +7363,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -7373,16 +7373,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7394,26 +7394,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7425,17 +7425,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7443,25 +7443,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -7471,21 +7471,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -7497,35 +7497,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -7543,12 +7543,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -7564,7 +7564,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -7573,7 +7573,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -7584,19 +7584,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -7607,7 +7607,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -7616,7 +7616,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -7624,7 +7624,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -7641,7 +7641,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -7650,7 +7650,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -7658,7 +7658,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -7671,17 +7671,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -7707,7 +7707,7 @@ spec:
                           type: array
                       type: object
                     snapshotRetention:
-                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy. A policy can however contain multiple count-time period pairs in order to specify complex retention policies
+                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy.
                       items:
                         description: SnapshotScheduleRetentionSpec is a retention policy
                         properties:
@@ -7737,7 +7737,7 @@ spec:
                       type: array
                   type: object
                 preserveFilesystemOnDelete:
-                  description: Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.
+                  description: Preserve the fs in the cluster on CephFilesystem CR deletion.
                   type: boolean
                 preservePoolsOnDelete:
                   description: Preserve pools on filesystem deletion
@@ -7901,7 +7901,7 @@ spec:
                           rel_path:
                             type: string
                           retention:
-                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot schedule
+                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot s
                             properties:
                               active:
                                 description: Active is whether the scheduled is active or not
@@ -7974,10 +7974,10 @@ spec:
           description: CephFilesystemSubVolumeGroup represents a Ceph Filesystem SubVolumeGroup
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -7985,7 +7985,7 @@ spec:
               description: Spec represents the specification of a Ceph Filesystem SubVolumeGroup
               properties:
                 filesystemName:
-                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name. Typically it's the name of the CephFilesystem CR. If not coming from the CephFilesystem CR, it can be retrieved from the list of Ceph Filesystem volumes with `ceph fs volume ls`. To learn more about Ceph Filesystem abstractions see https://docs.ceph.com/en/latest/cephfs/fs-volumes/#fs-volumes-and-subvolumes
+                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name.
                   type: string
                   x-kubernetes-validations:
                     - message: filesystemName is immutable
@@ -7997,7 +7997,7 @@ spec:
                     - message: name is immutable
                       rule: self == oldSelf
                 pinning:
-                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.com/en/latest/cephfs/fs-volumes/#pinning-subvolumes-and-subvolume-groups only one out of (export, distributed, random) can be set at a time
+                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.
                   properties:
                     distributed:
                       maximum: 1
@@ -8071,10 +8071,10 @@ spec:
           description: CephNFS represents a Ceph NFS
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -8086,10 +8086,10 @@ spec:
                   nullable: true
                   properties:
                     namespace:
-                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored. This setting is deprecated as it is internally set to the name of the CephNFS.
+                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored.
                       type: string
                     pool:
-                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons. This setting is deprecated, as it is internally required to be ".nfs".
+                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons.
                       type: string
                   type: object
                 security:
@@ -8101,20 +8101,20 @@ spec:
                       nullable: true
                       properties:
                         configFiles:
-                          description: "ConfigFiles defines where the Kerberos configuration should be sourced from. Config files will be placed into the `/etc/krb5.conf.rook/` directory. \n If this is left empty, Rook will not add any files. This allows you to manage the files yourself however you wish. For example, you may build them into your custom Ceph container image or use the Vault agent injector to securely add the files via annotations on the CephNFS spec (passed to the NFS server pods). \n Rook configures Kerberos to log to stderr. We suggest removing logging sections from config files to avoid consuming unnecessary disk space from logging to files."
+                          description: ConfigFiles defines where the Kerberos configuration should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos configuration files like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. The volume may contain multiple files, all of which will be loaded.
+                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos confi
                               properties:
                                 configMap:
                                   description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8122,11 +8122,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8134,7 +8134,7 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8142,36 +8142,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
                                       description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8183,7 +8183,7 @@ spec:
                                   description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
@@ -8195,7 +8195,7 @@ spec:
                                             description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8203,11 +8203,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8215,7 +8215,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -8244,14 +8244,14 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
                                                           description: 'Container name: required for volumes, optional for env vars'
@@ -8279,7 +8279,7 @@ spec:
                                             description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8287,11 +8287,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8299,7 +8299,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional field specify whether the Secret or its key must be defined
@@ -8310,10 +8310,10 @@ spec:
                                             description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
@@ -8326,14 +8326,14 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8341,11 +8341,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8356,7 +8356,7 @@ spec:
                                       description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
@@ -8365,20 +8365,20 @@ spec:
                           description: DomainName should be set to the Kerberos Realm.
                           type: string
                         keytabFile:
-                          description: KeytabFile defines where the Kerberos keytab should be sourced from. The keytab file will be placed into `/etc/krb5.keytab`. If this is left empty, Rook will not add the file. This allows you to manage the `krb5.keytab` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                          description: KeytabFile defines where the Kerberos keytab should be sourced from.
                           properties:
                             volumeSource:
-                              description: 'VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos keytab file like what is normally used to configure Volumes for a Pod. For example, a Secret or HostPath. There are two requirements for the source''s content: 1. The config file must be mountable via `subPath: krb5.keytab`. For example, in a Secret, the data item must be named `krb5.keytab`, or `items` must be defined to select the key and give it path `krb5.keytab`. A HostPath directory must have the `krb5.keytab` file. 2. The volume or config file must have mode 0600.'
+                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos k
                               properties:
                                 configMap:
                                   description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8386,11 +8386,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8398,7 +8398,7 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8406,36 +8406,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
                                       description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8447,7 +8447,7 @@ spec:
                                   description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
@@ -8459,7 +8459,7 @@ spec:
                                             description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8467,11 +8467,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8479,7 +8479,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional specify whether the ConfigMap or its keys must be defined
@@ -8508,14 +8508,14 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
                                                           description: 'Container name: required for volumes, optional for env vars'
@@ -8543,7 +8543,7 @@ spec:
                                             description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
                                                   description: Maps a string key to a path within a volume.
                                                   properties:
@@ -8551,11 +8551,11 @@ spec:
                                                       description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8563,7 +8563,7 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
                                                 description: optional field specify whether the Secret or its key must be defined
@@ -8574,10 +8574,10 @@ spec:
                                             description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
@@ -8590,14 +8590,14 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
                                         description: Maps a string key to a path within a volume.
                                         properties:
@@ -8605,11 +8605,11 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8620,45 +8620,45 @@ spec:
                                       description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         principalName:
                           default: nfs
-                          description: 'PrincipalName corresponds directly to NFS-Ganesha''s NFS_KRB5:PrincipalName config. In practice, this is the service prefix of the principal name. The default is "nfs". This value is combined with (a) the namespace and name of the CephNFS (with a hyphen between) and (b) the Realm configured in the user-provided krb5.conf to determine the full principal name: <principalName>/<namespace>-<name>@<realm>. e.g., nfs/rook-ceph-my-nfs@example.net. See https://github.com/nfs-ganesha/nfs-ganesha/wiki/RPCSEC_GSS for more detail.'
+                          description: PrincipalName corresponds directly to NFS-Ganesha's NFS_KRB5:PrincipalName config.
                           type: string
                       type: object
                     sssd:
-                      description: SSSD enables integration with System Security Services Daemon (SSSD). SSSD can be used to provide user ID mapping from a number of sources. See https://sssd.io for more information about the SSSD project.
+                      description: SSSD enables integration with System Security Services Daemon (SSSD).
                       nullable: true
                       properties:
                         sidecar:
                           description: Sidecar tells Rook to run SSSD in a sidecar alongside the NFS-Ganesha server in each NFS pod.
                           properties:
                             additionalFiles:
-                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar. These files may be referenced by the sssd.conf config file.
+                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar.
                               items:
-                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configuration should come from and are made available.
+                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configu
                                 properties:
                                   subPath:
-                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be placed. Each subPath definition must be unique and must not contain ':'.
+                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be pl
                                     minLength: 1
                                     pattern: ^[^:]+$
                                     type: string
                                   volumeSource:
-                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional file(s) like what is normally used to configure Volumes for a Pod. Fore example, a ConfigMap, Secret, or HostPath. Each VolumeSource adds one or more additional files to the SSSD sidecar container in the `/etc/sssd/rook-additional/<subPath>` directory. Be aware that some files may need to have a specific file mode like 0600 due to requirements by SSSD for some files. For example, CA or TLS certificates.
+                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional
                                     properties:
                                       configMap:
                                         description: configMap represents a configMap that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
@@ -8666,11 +8666,11 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -8678,7 +8678,7 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            description: 'Name of the referent. More info: https://kubernetes.'
                                             type: string
                                           optional:
                                             description: optional specify whether the ConfigMap or its keys must be defined
@@ -8686,36 +8686,36 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       emptyDir:
-                                        description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                         properties:
                                           medium:
-                                            description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            description: medium represents what type of storage medium should back this directory.
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                               - type: integer
                                               - type: string
-                                            description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       hostPath:
-                                        description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                        description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                         properties:
                                           path:
-                                            description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            description: path of the directory on the host.
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                             type: string
                                         required:
                                           - path
                                         type: object
                                       persistentVolumeClaim:
-                                        description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                         properties:
                                           claimName:
-                                            description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                            description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                             type: string
                                           readOnly:
                                             description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -8727,7 +8727,7 @@ spec:
                                         description: projected items for all in one resources secrets, configmaps, and downward API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                            description: defaultMode are the mode bits used to set permissions on created files by default.
                                             format: int32
                                             type: integer
                                           sources:
@@ -8739,7 +8739,7 @@ spec:
                                                   description: configMap information about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                       items:
                                                         description: Maps a string key to a path within a volume.
                                                         properties:
@@ -8747,11 +8747,11 @@ spec:
                                                             description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -8759,7 +8759,7 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
                                                       description: optional specify whether the ConfigMap or its keys must be defined
@@ -8788,14 +8788,14 @@ spec:
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                            description: 'Required: Path is  the relative path name of the file to be created.'
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                             properties:
                                                               containerName:
                                                                 description: 'Container name: required for volumes, optional for env vars'
@@ -8823,7 +8823,7 @@ spec:
                                                   description: secret information about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                       items:
                                                         description: Maps a string key to a path within a volume.
                                                         properties:
@@ -8831,11 +8831,11 @@ spec:
                                                             description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -8843,7 +8843,7 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
                                                       description: optional field specify whether the Secret or its key must be defined
@@ -8854,10 +8854,10 @@ spec:
                                                   description: serviceAccountToken is information about the serviceAccountToken data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                      description: audience is the intended audience of the token.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                      description: expirationSeconds is the requested duration of validity of the service account token.
                                                       format: int64
                                                       type: integer
                                                     path:
@@ -8870,14 +8870,14 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
@@ -8885,11 +8885,11 @@ spec:
                                                   description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -8900,7 +8900,7 @@ spec:
                                             description: optional field specify whether the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                             type: string
                                         type: object
                                     type: object
@@ -8910,7 +8910,7 @@ spec:
                                 type: object
                               type: array
                             debugLevel:
-                              description: 'DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing. Otherwise, this may be a value between 1 and 10. See SSSD docs for more info: https://sssd.io/troubleshooting/basics.html#sssd-debug-logs'
+                              description: DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing.
                               maximum: 10
                               minimum: 0
                               type: integer
@@ -8922,12 +8922,12 @@ spec:
                               description: Resources allow specifying resource requests/limits on the SSSD sidecar container.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                                  description: Claims lists the names of resources, defined in spec.
                                   items:
                                     description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -8943,7 +8943,7 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -8952,24 +8952,24 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             sssdConfigFile:
-                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from. The config file will be placed into `/etc/sssd/sssd.conf`. If this is left empty, Rook will not add the file. This allows you to manage the `sssd.conf` file yourself however you wish. For example, you may build it into your custom Ceph container image or use the Vault agent injector to securely add the file via annotations on the CephNFS spec (passed to the NFS server pods).
+                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from.
                               properties:
                                 volumeSource:
-                                  description: 'VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD configuration file like what is normally used to configure Volumes for a Pod. For example, a ConfigMap, Secret, or HostPath. There are two requirements for the source''s content: 1. The config file must be mountable via `subPath: sssd.conf`. For example, in a ConfigMap, the data item must be named `sssd.conf`, or `items` must be defined to select the key and give it path `sssd.conf`. A HostPath directory must have the `sssd.conf` file. 2. The volume or config file must have mode 0600.'
+                                  description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD confi
                                   properties:
                                     configMap:
                                       description: configMap represents a configMap that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                           items:
                                             description: Maps a string key to a path within a volume.
                                             properties:
@@ -8977,11 +8977,11 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -8989,7 +8989,7 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          description: 'Name of the referent. More info: https://kubernetes.'
                                           type: string
                                         optional:
                                           description: optional specify whether the ConfigMap or its keys must be defined
@@ -8997,36 +8997,36 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                       properties:
                                         medium:
-                                          description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: medium represents what type of storage medium should back this directory.
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath ---'
+                                      description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                       properties:
                                         path:
-                                          description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: path of the directory on the host.
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                           type: string
                                         readOnly:
                                           description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
@@ -9038,7 +9038,7 @@ spec:
                                       description: projected items for all in one resources secrets, configmaps, and downward API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                          description: defaultMode are the mode bits used to set permissions on created files by default.
                                           format: int32
                                           type: integer
                                         sources:
@@ -9050,7 +9050,7 @@ spec:
                                                 description: configMap information about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                     items:
                                                       description: Maps a string key to a path within a volume.
                                                       properties:
@@ -9058,11 +9058,11 @@ spec:
                                                           description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9070,7 +9070,7 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
                                                     description: optional specify whether the ConfigMap or its keys must be defined
@@ -9099,14 +9099,14 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                          description: 'Required: Path is  the relative path name of the file to be created.'
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                           properties:
                                                             containerName:
                                                               description: 'Container name: required for volumes, optional for env vars'
@@ -9134,7 +9134,7 @@ spec:
                                                 description: secret information about the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                     items:
                                                       description: Maps a string key to a path within a volume.
                                                       properties:
@@ -9142,11 +9142,11 @@ spec:
                                                           description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9154,7 +9154,7 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
                                                     description: optional field specify whether the Secret or its key must be defined
@@ -9165,10 +9165,10 @@ spec:
                                                 description: serviceAccountToken is information about the serviceAccountToken data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                    description: audience is the intended audience of the token.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                    description: expirationSeconds is the requested duration of validity of the service account token.
                                                     format: int64
                                                     type: integer
                                                   path:
@@ -9181,14 +9181,14 @@ spec:
                                           type: array
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                           items:
                                             description: Maps a string key to a path within a volume.
                                             properties:
@@ -9196,11 +9196,11 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9211,7 +9211,7 @@ spec:
                                           description: optional field specify whether the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                           type: string
                                       type: object
                                   type: object
@@ -9235,7 +9235,7 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     hostNetwork:
-                      description: Whether host networking is enabled for the Ganesha server. If not set, the network settings from the cluster CR will be applied.
+                      description: Whether host networking is enabled for the Ganesha server.
                       nullable: true
                       type: boolean
                     labels:
@@ -9246,25 +9246,25 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.Disabled is false and LivenessProbe.Probe is nil uses default probe.
+                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.
                       properties:
                         disabled:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -9275,7 +9275,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -9284,7 +9284,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -9292,7 +9292,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -9309,7 +9309,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -9318,7 +9318,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -9326,7 +9326,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -9339,17 +9339,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -9365,9 +9365,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -9375,16 +9375,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9396,16 +9396,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9426,26 +9426,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9457,16 +9457,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9487,9 +9487,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -9500,16 +9500,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9521,26 +9521,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9552,17 +9552,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -9577,9 +9577,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -9587,16 +9587,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9608,26 +9608,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9639,17 +9639,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -9660,9 +9660,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -9673,16 +9673,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9694,26 +9694,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -9725,17 +9725,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -9750,9 +9750,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -9760,16 +9760,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9781,26 +9781,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -9812,17 +9812,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -9830,25 +9830,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -9858,21 +9858,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -9884,35 +9884,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -9930,12 +9930,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -9951,7 +9951,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -9960,7 +9960,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10034,10 +10034,10 @@ spec:
           description: CephObjectRealm represents a Ceph Object Store Gateway Realm
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -10120,10 +10120,10 @@ spec:
           description: CephObjectStore represents a Ceph Object Store Gateway
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -10131,7 +10131,7 @@ spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
                 allowUsersInNamespaces:
-                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store users may be created. Specify "*" to allow all namespaces, otherwise list individual namespaces that are to be allowed. This is useful for applications that need object store credentials to be created in their own namespace, where neither OBCs nor COSI is being used to create buckets. The default is empty.
+                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store use
                   items:
                     type: string
                   type: array
@@ -10140,7 +10140,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -10167,11 +10167,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -10179,7 +10179,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -10268,14 +10268,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -10319,25 +10319,25 @@ spec:
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     disableMultisiteSyncTraffic:
-                      description: 'DisableMultisiteSyncTraffic, when true, prevents this object store''s gateways from transmitting multisite replication data. Note that this value does not affect whether gateways receive multisite replication traffic: see ObjectZone.spec.customEndpoints for that. If false or unset, this object store''s gateways will be able to transmit multisite replication data.'
+                      description: DisableMultisiteSyncTraffic, when true, prevents this object store's gateways from transmitting mult
                       type: boolean
                     externalRgwEndpoints:
-                      description: ExternalRgwEndpoints points to external RGW endpoint(s). Multiple endpoints can be given, but for stability of ObjectBucketClaims, we highly recommend that users give only a single external RGW endpoint that is a load balancer that sends requests to the multiple RGWs.
+                      description: ExternalRgwEndpoints points to external RGW endpoint(s).
                       items:
-                        description: EndpointAddress is a tuple that describes a single IP address or host name. This is a subset of Kubernetes's v1.EndpointAddress.
+                        description: EndpointAddress is a tuple that describes a single IP address or host name.
                         properties:
                           hostname:
-                            description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
+                            description: The DNS-addressable Hostname of this endpoint.
                             type: string
                           ip:
-                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
+                            description: The IP of this endpoint.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       nullable: true
                       type: array
                     hostNetwork:
-                      description: Whether host networking is enabled for the rgw daemon. If not set, the network settings from the cluster CR will be applied.
+                      description: Whether host networking is enabled for the rgw daemon.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
@@ -10361,9 +10361,9 @@ spec:
                           description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated with the corresponding weight.
@@ -10371,16 +10371,16 @@ spec:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10392,16 +10392,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10422,26 +10422,26 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10453,16 +10453,16 @@ spec:
                                       matchFields:
                                         description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
                                               description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10483,9 +10483,9 @@ spec:
                           description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -10496,16 +10496,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10517,26 +10517,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10548,17 +10548,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -10573,9 +10573,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -10583,16 +10583,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10604,26 +10604,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10635,17 +10635,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10656,9 +10656,9 @@ spec:
                           description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
                                     description: Required. A pod affinity term, associated with the corresponding weight.
@@ -10669,16 +10669,16 @@ spec:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10690,26 +10690,26 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
                                                   description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10721,17 +10721,17 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
@@ -10746,9 +10746,9 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources, in this case pods.
@@ -10756,16 +10756,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10777,26 +10777,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10808,17 +10808,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10826,25 +10826,25 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
@@ -10854,21 +10854,21 @@ spec:
                             description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -10880,35 +10880,35 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -10930,12 +10930,12 @@ spec:
                       nullable: true
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                          description: Claims lists the names of resources, defined in spec.
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -10951,7 +10951,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -10960,7 +10960,7 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10997,19 +10997,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -11020,7 +11020,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -11029,7 +11029,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -11037,7 +11037,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -11054,7 +11054,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -11063,7 +11063,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -11071,7 +11071,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -11084,17 +11084,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -11107,19 +11107,19 @@ spec:
                           description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
                               description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
@@ -11130,7 +11130,7 @@ spec:
                                   format: int32
                                   type: integer
                                 service:
-                                  description: "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC."
+                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
@@ -11139,7 +11139,7 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
                                   description: Custom headers to set in the request. HTTP allows repeated headers.
@@ -11147,7 +11147,7 @@ spec:
                                     description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        description: The header field name.
                                         type: string
                                       value:
                                         description: The header field value
@@ -11164,7 +11164,7 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
                                   description: Scheme to use for connecting to the host. Defaults to HTTP.
@@ -11173,7 +11173,7 @@ spec:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
@@ -11181,7 +11181,7 @@ spec:
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
@@ -11194,17 +11194,17 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -11215,7 +11215,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11242,11 +11242,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11254,7 +11254,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -11343,14 +11343,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -11526,10 +11526,10 @@ spec:
           description: CephObjectStoreUser represents a Ceph Object Store Gateway User
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11541,7 +11541,7 @@ spec:
                   nullable: true
                   properties:
                     amz-cache:
-                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/quincy/radosgw/rgw-cache/#cache-api
+                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11549,7 +11549,7 @@ spec:
                         - read, write
                       type: string
                     bilog:
-                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11557,7 +11557,7 @@ spec:
                         - read, write
                       type: string
                     bucket:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11565,7 +11565,7 @@ spec:
                         - read, write
                       type: string
                     buckets:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11573,7 +11573,7 @@ spec:
                         - read, write
                       type: string
                     datalog:
-                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11581,7 +11581,7 @@ spec:
                         - read, write
                       type: string
                     info:
-                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11589,7 +11589,7 @@ spec:
                         - read, write
                       type: string
                     mdlog:
-                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11597,7 +11597,7 @@ spec:
                         - read, write
                       type: string
                     metadata:
-                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11605,7 +11605,7 @@ spec:
                         - read, write
                       type: string
                     oidc-provider:
-                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11613,7 +11613,7 @@ spec:
                         - read, write
                       type: string
                     ratelimit:
-                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11621,7 +11621,7 @@ spec:
                         - read, write
                       type: string
                     roles:
-                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11629,7 +11629,7 @@ spec:
                         - read, write
                       type: string
                     usage:
-                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11637,7 +11637,7 @@ spec:
                         - read, write
                       type: string
                     user:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11645,7 +11645,7 @@ spec:
                         - read, write
                       type: string
                     user-policy:
-                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11653,7 +11653,7 @@ spec:
                         - read, write
                       type: string
                     users:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11661,7 +11661,7 @@ spec:
                         - read, write
                       type: string
                     zone:
-                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -11676,7 +11676,7 @@ spec:
                   description: The display name for the ceph users
                   type: string
                 quotas:
-                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
+                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage.
                   nullable: true
                   properties:
                     maxBuckets:
@@ -11692,7 +11692,7 @@ spec:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info.
+                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
@@ -11752,10 +11752,10 @@ spec:
           description: CephObjectZoneGroup represents a Ceph Object Store Gateway Zone Group
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11836,10 +11836,10 @@ spec:
           description: CephObjectZone represents a Ceph Object Store Gateway Zone
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -11847,7 +11847,7 @@ spec:
               description: ObjectZoneSpec represent the spec of an ObjectZone
               properties:
                 customEndpoints:
-                  description: "If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint(s). You may include the port in the definition. For example: \"https://my-object-store.my-domain.net:443\". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters. The list can have one or more endpoints pointing to different RGW servers in the zone. \n If a CephObjectStore endpoint is omitted from this list, that object store's gateways will not receive multisite replication data (see CephObjectStore.spec.gateway.disableMultisiteSyncTraffic)."
+                  description: If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint cre
                   items:
                     type: string
                   nullable: true
@@ -11857,7 +11857,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11884,11 +11884,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11896,7 +11896,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -11985,14 +11985,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -12020,7 +12020,7 @@ spec:
                   nullable: true
                   properties:
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g., Parameters["compression_mode"] = "force" The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force) Do NOT set a default value for kubebuilder as this will override the Parameters'
+                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12047,11 +12047,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12059,7 +12059,7 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
+                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
                       description: The mirroring settings
@@ -12148,14 +12148,14 @@ spec:
                           description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
@@ -12258,10 +12258,10 @@ spec:
           description: CephRBDMirror represents a Ceph RBD Mirror
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
@@ -12304,9 +12304,9 @@ spec:
                       description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the corresponding weight.
@@ -12314,16 +12314,16 @@ spec:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12335,16 +12335,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12365,26 +12365,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12396,16 +12396,16 @@ spec:
                                   matchFields:
                                     description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
                                           description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12426,9 +12426,9 @@ spec:
                       description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -12439,16 +12439,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12460,26 +12460,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12491,17 +12491,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -12516,9 +12516,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -12526,16 +12526,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12547,26 +12547,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12578,17 +12578,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -12599,9 +12599,9 @@ spec:
                       description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
                                 description: Required. A pod affinity term, associated with the corresponding weight.
@@ -12612,16 +12612,16 @@ spec:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12633,26 +12633,26 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
                                               description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -12664,17 +12664,17 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -12689,9 +12689,9 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
                                 description: A label query over a set of resources, in this case pods.
@@ -12699,16 +12699,16 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12720,26 +12720,26 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -12751,17 +12751,17 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -12769,25 +12769,25 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
@@ -12797,21 +12797,21 @@ spec:
                         description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -12823,35 +12823,35 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -12869,12 +12869,12 @@ spec:
                   nullable: true
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers."
+                      description: Claims lists the names of resources, defined in spec.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -12890,7 +12890,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -12899,7 +12899,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Long CRD descriptions were pushing the size of the CRDs manifest over 1MB, which causes issues when creating the CRDs. To shorten the manifest, the descriptions are now limited to 100 chars. This still gives some ability for dev tools to show a brief description if needed. The generated CRD docs still contain the full descriptions for reference.

Backports part of #13422 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
