### PR TITLE
osd: create config before migration osd

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	osddaemon "github.com/rook/rook/pkg/daemon/ceph/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -254,6 +255,10 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	clusterInfo.OwnerInfo = ownerInfo
 	clusterInfo.Context = cmd.Context()
 	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerInfo)
+
+	if err := client.WriteCephConfig(context, &clusterInfo); err != nil {
+		return errors.Wrap(err, "failed to generate ceph config")
+	}
 
 	// destroy the OSD using the OSD ID
 	var replaceOSD *oposd.OSDReplaceInfo

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -181,10 +181,6 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating}
 	oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)
 
-	if err := client.WriteCephConfig(context, agent.clusterInfo); err != nil {
-		return errors.Wrap(err, "failed to generate ceph config")
-	}
-
 	logger.Infof("discovering hardware")
 
 	var rawDevices []*sys.LocalDisk


### PR DESCRIPTION
create the ceph config and keyring file in the osd prepare pod before starting the OSD migration. These files are needed to run any ceph command.

This used to work in 1.12 where the `rook-data` mount path had the config and keyring files. See `osd-prepare-pod-before.txt` file. 
[osd-prepare-pod-before.txt](https://github.com/rook/rook/files/13858693/osd-prepare-pod-before.txt)


In 1.13 this has started failing. `ceph-osd-prepare` pod fails with `exist status 1` error. Got the following error after after running the command manually inside the prepare pod:
``` 
sh-5.1# ceph osd destroy osd.0 --yes-i-really-mean-it --connect-timeout=15 --cluster=openshift-storage --conf=/var/lib/rook/openshift-storage/openshift-storage.config --name=client.admin --keyring=/var/lib/rook/openshift-storage/client.admin.keyring --format json
Error initializing cluster client: ObjectNotFound('RADOS object not found (error calling conf_read_file)')
sh-5.1# cd /var/lib/rook/openshift-storage/
sh-5.1# ls
crash  log  ocs-deviceset-thin-csi-odf-2-data-0d6lbq
sh-5.1#     
sh-5.1#  
```

Latest osd-prepare-pod-logs

[osd-prepar-logs-now.txt](https://github.com/rook/rook/files/13858730/osd-prepar-logs-now.txt)


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Which issue is resolved by this Pull Request:**

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
