### PR TITLE
DNM: debug ceph-volume PR ceph/ceph#54423

### DIFF
--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v18
+    image: docker.io/guits/ceph:rook-debug
     allowUnsupported: true
   mon:
     count: 1


### PR DESCRIPTION
*Do Not Merge*

This PR is only for debugging a ceph-volume regression which seems to only appear in rook CI.