### PR TITLE
ci: allow canary test to run on custom ceph image

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -13,6 +13,11 @@ on:
     paths-ignore:
       - "Documentation/**"
       - "design/**"
+  workflow_dispatch:
+    inputs:
+      ceph-image:
+        description: 'Ceph image for creating Ceph cluster'
+        default: 'quay.io/ceph/ceph:v18'
 
 defaults:
   run:
@@ -41,6 +46,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
@@ -286,6 +294,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
 
@@ -350,6 +361,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
 
@@ -393,6 +407,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
@@ -444,6 +461,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
 
@@ -487,6 +507,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
@@ -536,6 +559,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk and create partitions for osds
         run: |
@@ -607,6 +633,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: use local disk
         run: tests/scripts/github-action-helper.sh use_local_disk
 
@@ -652,6 +681,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk
         run: tests/scripts/github-action-helper.sh use_local_disk
@@ -701,6 +733,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk and create partitions for osds
         run: |
@@ -763,6 +798,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: use local disk
         run: tests/scripts/github-action-helper.sh use_local_disk
 
@@ -810,6 +848,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk
         run: tests/scripts/github-action-helper.sh use_local_disk
@@ -868,6 +909,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk and create partitions for osds
         run: |
@@ -948,6 +992,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: use local disk and create partitions for osds
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
@@ -1007,6 +1054,9 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: create cluster prerequisites
         run: tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
@@ -1057,6 +1107,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk into two partitions
         run: |
@@ -1308,11 +1361,11 @@ jobs:
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
 
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
+
       - name: run RGW multisite test
         uses: ./.github/workflows/rgw-multisite-test
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # ceph-image: # use default
 
       - name: upload test result
         uses: actions/upload-artifact@v4
@@ -1375,6 +1428,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: install deps
         shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -1449,6 +1505,9 @@ jobs:
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
       - name: use local disk and create partitions for osds
         run: |

--- a/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
+++ b/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
@@ -7,9 +7,6 @@ inputs:
   ibm-service-api-key:
     description: IBM_KP_SERVICE_API_KEY from the calling workflow
     required: true
-  github-token:
-    description: GITHUB_TOKEN from the calling workflow
-    required: true
 
 runs:
   using: "composite"
@@ -24,8 +21,10 @@ runs:
 
     - name: setup cluster resources
       uses: ./.github/workflows/canary-test-config
-      with:
-        github-token: ${{ inputs.github-token }}
+
+    - name: set Ceph version in CephCluster manifest
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
 
     - name: use local disk and create partitions for osds
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/rgw-multisite-test/action.yml
+++ b/.github/workflows/rgw-multisite-test/action.yml
@@ -1,20 +1,11 @@
 name: RGW Multisite Test
 description: Reusable workflow to test RGW multisite integration
-inputs:
-  github-token:
-    description: GITHUB_TOKEN from the calling workflow
-    required: true
-  ceph-image:
-    description: Ceph image to use for the workflow (e.g., quay.io/ceph/ceph:v17)
-    required: false
 
 runs:
   using: "composite"
   steps:
     - name: setup cluster resources
       uses: ./.github/workflows/canary-test-config
-      with:
-        github-token: ${{ inputs.github-token }}
 
     - name: install additional deps for object testing
       shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -28,12 +19,6 @@ runs:
         tests/scripts/github-action-helper.sh use_local_disk
         tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
         sudo lsblk
-
-    - name: set Ceph version in CephCluster manifest
-      shell: bash --noprofile --norc -eo pipefail -x {0}
-      run: |
-        tests/scripts/github-action-helper.sh replace_ceph_image \
-          "deploy/examples/cluster-test.yaml" "${{ inputs.ceph-image }}"
 
     - name: deploy first cluster rook
       shell: bash --noprofile --norc -eo pipefail -x {0}


### PR DESCRIPTION
Sometimes we need to run canary test on custom ceph images to test any issue. For this we always need to create separate PR with custom image. Now, with github action `workflow_dispatch` we can use GitHub UI to pass ceph image as input for CI tests and that image will be used to run the canary test otherwise, it will be default value provided.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13545 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
