### PR TITLE
csi: fix cephFS struct overwrite

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -271,14 +271,11 @@ func updateCSIDriverOptions(curr, clusterKey string,
 	for i := range cc {
 		// If the clusterID belongs to the same cluster, update the entry.
 		if clusterKey == cc[i].Namespace {
-			cc[i].ReadAffinity = cephcsi.ReadAffinity{
-				Enabled:             csiDriverOptions.ReadAffinity.Enabled,
-				CrushLocationLabels: csiDriverOptions.ReadAffinity.CrushLocationLabels,
-			}
-			cc[i].CephFS = cephcsi.CephFS{
-				KernelMountOptions: csiDriverOptions.CephFS.KernelMountOptions,
-				FuseMountOptions:   csiDriverOptions.CephFS.FuseMountOptions,
-			}
+			cc[i].ReadAffinity.Enabled = csiDriverOptions.ReadAffinity.Enabled
+			cc[i].ReadAffinity.CrushLocationLabels = csiDriverOptions.ReadAffinity.CrushLocationLabels
+
+			cc[i].CephFS.KernelMountOptions = csiDriverOptions.CephFS.KernelMountOptions
+			cc[i].CephFS.FuseMountOptions = csiDriverOptions.CephFS.FuseMountOptions
 		}
 	}
 

--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -474,6 +474,9 @@ func TestUpdateCSIDriverOptions(t *testing.T) {
 						ClusterInfo: cephcsi.ClusterInfo{
 							ClusterID: "rook-ceph",
 							Monitors:  []string{"1.1.1.1"},
+							CephFS: cephcsi.CephFS{
+								NetNamespaceFilePath: "netnamespacefilepath",
+							},
 						},
 					},
 				},
@@ -500,8 +503,9 @@ func TestUpdateCSIDriverOptions(t *testing.T) {
 							CrushLocationLabels: []string{"topology.rook.io/rack"},
 						},
 						CephFS: cephcsi.CephFS{
-							KernelMountOptions: "rw,noatime",
-							FuseMountOptions:   "debug",
+							KernelMountOptions:   "rw,noatime",
+							FuseMountOptions:     "debug",
+							NetNamespaceFilePath: "netnamespacefilepath",
 						},
 					},
 				},


### PR DESCRIPTION
The updateCSIDriverOptions() func was overwriting the ClusterInfo.CephFS struct. Due to which multus and csi hostnetwork canary tests were hanging.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Fixes: #13578 