### PR TITLE
mgr: fixing dashboard configuration handling

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -51,7 +51,8 @@ const (
 )
 
 var (
-	dashboardInitWaitTime = 5 * time.Second
+	dashboardInitWaitTime        = 5 * time.Second
+	removeMgrDaemonConfiguration = true
 )
 
 func (c *Cluster) configureDashboardService() error {
@@ -93,15 +94,9 @@ func (c *Cluster) configureDashboardModules() error {
 		return errors.Wrap(err, "failed to initialize dashboard")
 	}
 
-	var hasChanged bool
-	for _, daemonID := range c.getDaemonIDs() {
-		changed, err := c.configureDashboardModuleSettings(daemonID)
-		if err != nil {
-			return err
-		}
-		if changed {
-			hasChanged = true
-		}
+	hasChanged, err := c.configureDashboardModuleSettings()
+	if err != nil {
+		return err
 	}
 	if hasChanged {
 		logger.Info("dashboard config has changed. restarting the dashboard module")
@@ -110,20 +105,19 @@ func (c *Cluster) configureDashboardModules() error {
 	return nil
 }
 
-func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error) {
+func (c *Cluster) configureDashboardModuleSettings() (bool, error) {
+
 	monStore := config.GetMonStore(c.context, c.clusterInfo)
 
-	daemonID = fmt.Sprintf("mgr.%s", daemonID)
-
 	// url prefix
-	hasChanged, err := monStore.SetIfChanged(daemonID, "mgr/dashboard/url_prefix", c.spec.Dashboard.URLPrefix)
+	hasChanged, err := monStore.SetIfChanged(config.MgrType, "mgr/dashboard/url_prefix", c.spec.Dashboard.URLPrefix)
 	if err != nil {
 		return false, err
 	}
 
 	// ssl support
 	ssl := strconv.FormatBool(c.spec.Dashboard.SSL)
-	changed, err := monStore.SetIfChanged(daemonID, "mgr/dashboard/ssl", ssl)
+	changed, err := monStore.SetIfChanged(config.MgrType, "mgr/dashboard/ssl", ssl)
 	if err != nil {
 		return false, err
 	}
@@ -131,7 +125,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// Prometheus host end point
 	prometheusEndpoint := c.spec.Dashboard.PrometheusEndpoint
-	changed, err = monStore.SetIfChanged(daemonID, "mgr/dashboard/PROMETHEUS_API_HOST", prometheusEndpoint)
+	changed, err = monStore.SetIfChanged(config.MgrType, "mgr/dashboard/PROMETHEUS_API_HOST", prometheusEndpoint)
 	if err != nil {
 		return false, err
 	}
@@ -139,7 +133,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// Prometheus host end point ssl verify
 	prometheusEndpointSSLVerify := strconv.FormatBool(c.spec.Dashboard.PrometheusEndpointSSLVerify)
-	changed, err = monStore.SetIfChanged(daemonID, "mgr/dashboard/PROMETHEUS_API_SSL_VERIFY", prometheusEndpointSSLVerify)
+	changed, err = monStore.SetIfChanged(config.MgrType, "mgr/dashboard/PROMETHEUS_API_SSL_VERIFY", prometheusEndpointSSLVerify)
 	if err != nil {
 		return false, err
 	}
@@ -147,7 +141,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// server port
 	port := strconv.Itoa(c.dashboardInternalPort())
-	changed, err = monStore.SetIfChanged(daemonID, "mgr/dashboard/server_port", port)
+	changed, err = monStore.SetIfChanged(config.MgrType, "mgr/dashboard/server_port", port)
 	if err != nil {
 		return false, err
 	}
@@ -155,11 +149,26 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// SSL enabled. Needed to set specifically the ssl port setting
 	if c.spec.Dashboard.SSL {
-		changed, err = monStore.SetIfChanged(daemonID, "mgr/dashboard/ssl_server_port", port)
+		changed, err = monStore.SetIfChanged(config.MgrType, "mgr/dashboard/ssl_server_port", port)
 		if err != nil {
 			return false, err
 		}
 		hasChanged = hasChanged || changed
+	}
+
+	// Remove any existing per mgr-daemon configuration
+	if removeMgrDaemonConfiguration {
+		logger.Info("Removing any previous per mgr-daemon configuration")
+		for _, daemonID := range c.getDaemonIDs() {
+			mgrDaemonID := fmt.Sprintf("%s.%s", config.MgrType, daemonID)
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/url_prefix")
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/ssl")
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/PROMETHEUS_API_HOST")
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/PROMETHEUS_API_SSL_VERIFY")
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/server_port")
+			monStore.Delete(mgrDaemonID, "mgr/dashboard/ssl_server_port")
+		}
+		removeMgrDaemonConfiguration = false
 	}
 
 	return hasChanged, nil

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -108,7 +108,7 @@ func (m *MonStore) Set(who, option, value string) error {
 
 // Delete a config in the centralized mon configuration database.
 func (m *MonStore) Delete(who, option string) error {
-	logger.Infof("deleting %q option from the mon configuration database", option)
+	logger.Infof("deleting %q %q option from the mon configuration database", who, option)
 	args := []string{"config", "rm", who, normalizeKey(option)}
 	cephCmd := client.NewCephCommand(m.context, m.clusterInfo, args)
 	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)


### PR DESCRIPTION
previously, the dashboard parameters supported by Rook were stored in the daemon configuration section (mgr.X, for example). This differs from Cephadm-based deployments, where all configurations are stored in the global mgr configuration section. This variance could result in configuration mismatches between the active and standby dashboards. Furthermore, all Ceph dashboard documentation exclusively points to the global mgr configuration section and makes no use of individual daemons sections.

Fixes: https://github.com/rook/rook/issues/13577

**Upgrade test**

Starting from previous vesion (`image: rook/ceph:master`) and using the following configuration:

```
  mgr:
    count: 2
    allowMultiplePerNode: true
  dashboard:
    enabled: true
    port: 7777
    ssl: false
    prometheusEndpoint: "http://192.168.39.54:30900"
    prometheusEndpointSSLVerify: false
```

Let's get the status of the config once the cluster is up&running:

```
bash-4.4$ ceph config get mgr.a
WHO     MASK  LEVEL     OPTION                                   VALUE                       RO
mgr.a         advanced  mgr/dashboard/PROMETHEUS_API_HOST        http://192.168.39.54:30900  * 
mgr.a         advanced  mgr/dashboard/PROMETHEUS_API_SSL_VERIFY  false                       * 
mgr.a         advanced  mgr/dashboard/server_port                7777                        * 
mgr.a         advanced  mgr/dashboard/ssl                        false                       * 
mgr           advanced  mgr/orchestrator/orchestrator            rook                          
mgr           advanced  mgr/prometheus/rbd_stats_pools                                       * 

bash-4.4$ ceph config get mgr.b
WHO     MASK  LEVEL     OPTION                                   VALUE                       RO
mgr.b         advanced  mgr/dashboard/PROMETHEUS_API_HOST        http://192.168.39.54:30900  * 
mgr.b         advanced  mgr/dashboard/PROMETHEUS_API_SSL_VERIFY  false                       * 
mgr.b         advanced  mgr/dashboard/server_port                7777                        * 
mgr.b         advanced  mgr/dashboard/ssl                        false                       * 
mgr           advanced  mgr/orchestrator/orchestrator            rook                          
mgr           advanced  mgr/prometheus/rbd_stats_pools                                       * 

bash-4.4$ ceph config get mgr  
WHO     MASK  LEVEL     OPTION                             VALUE                        RO
mgr           advanced  mgr/dashboard/PROMETHEUS_API_HOST  http://192.168.39.215:30900  * 
mgr           advanced  mgr/orchestrator/orchestrator      rook                           
mgr           advanced  mgr/prometheus/rbd_stats_pools                                  * 
bash-4.4$ 

```

Mgr daemons configuration after the upgrade (no specific per-daemon configuration anymore). The configuration related to ssl now is part of the main mgr section.

```
bash-4.4$ ceph config get mgr.a
WHO     MASK  LEVEL     OPTION                                   VALUE                       RO
mgr           advanced  mgr/dashboard/PROMETHEUS_API_HOST        http://192.168.39.54:30900  * 
mgr           advanced  mgr/dashboard/PROMETHEUS_API_SSL_VERIFY  false                       * 
mgr           advanced  mgr/dashboard/server_port                7777                        * 
mgr           advanced  mgr/dashboard/ssl                        false                       * 
mgr           advanced  mgr/orchestrator/orchestrator            rook                          
mgr           advanced  mgr/prometheus/rbd_stats_pools                                       * 

bash-4.4$ 
bash-4.4$ ceph config get mgr.b
WHO     MASK  LEVEL     OPTION                                   VALUE                       RO
mgr           advanced  mgr/dashboard/PROMETHEUS_API_HOST        http://192.168.39.54:30900  * 
mgr           advanced  mgr/dashboard/PROMETHEUS_API_SSL_VERIFY  false                       * 
mgr           advanced  mgr/dashboard/server_port                7777                        * 
mgr           advanced  mgr/dashboard/ssl                        false                       * 
mgr           advanced  mgr/orchestrator/orchestrator            rook                          
mgr           advanced  mgr/prometheus/rbd_stats_pools                                       * 
bash-4.4$ 

bash-4.4$ ceph config get mgr  
WHO     MASK  LEVEL     OPTION                                   VALUE                       RO
mgr           advanced  mgr/dashboard/PROMETHEUS_API_HOST        http://192.168.39.54:30900  * 
mgr           advanced  mgr/dashboard/PROMETHEUS_API_SSL_VERIFY  false                       * 
mgr           advanced  mgr/dashboard/server_port                7777                        * 
mgr           advanced  mgr/dashboard/ssl                        false                       * 
mgr           advanced  mgr/orchestrator/orchestrator            rook                          
mgr           advanced  mgr/prometheus/rbd_stats_pools                                       * 
```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
