### PR TITLE
csi: update netNamespaceFilePath for all clusterIDs

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -149,6 +149,9 @@ func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *C
 			if newCsiClusterConfigEntry.RBD.RadosNamespace != "" || newCsiClusterConfigEntry.RBD.NetNamespaceFilePath != "" {
 				centry.RBD = newCsiClusterConfigEntry.RBD
 			}
+			if len(newCsiClusterConfigEntry.ReadAffinity.CrushLocationLabels) != 0 {
+				centry.ReadAffinity = newCsiClusterConfigEntry.ReadAffinity
+			}
 			found = true
 			cc[i] = centry
 			break
@@ -170,6 +173,9 @@ func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *C
 			}
 			if newCsiClusterConfigEntry.NFS.NetNamespaceFilePath != "" {
 				centry.NFS = newCsiClusterConfigEntry.NFS
+			}
+			if len(newCsiClusterConfigEntry.ReadAffinity.CrushLocationLabels) != 0 {
+				centry.ReadAffinity = newCsiClusterConfigEntry.ReadAffinity
 			}
 			cc = append(cc, centry)
 		}

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -103,6 +103,49 @@ func MonEndpoints(mons map[string]*cephclient.MonInfo, requireMsgr2 bool) []stri
 	return endpoints
 }
 
+// updateNetNamespaceFilePath modify the netNamespaceFilePath for all cluster IDs.
+// If holderEnabled is set to true. Otherwise, removes the netNamespaceFilePath value
+// for all the clusterIDs.
+func updateNetNamespaceFilePath(clusterNamespace string, cc csiClusterConfig) {
+	var (
+		cephFSNetNamespaceFilePath string
+		rbdNetNamespaceFilePath    string
+		nfsNetNamespaceFilePath    string
+	)
+
+	if IsHolderEnabled() {
+		for _, centry := range cc {
+			if centry.Namespace == clusterNamespace && centry.ClusterID == clusterNamespace {
+				if centry.CephFS.NetNamespaceFilePath != "" {
+					cephFSNetNamespaceFilePath = centry.CephFS.NetNamespaceFilePath
+				}
+				if centry.RBD.NetNamespaceFilePath != "" {
+					rbdNetNamespaceFilePath = centry.RBD.NetNamespaceFilePath
+				}
+				if centry.NFS.NetNamespaceFilePath != "" {
+					nfsNetNamespaceFilePath = centry.NFS.NetNamespaceFilePath
+				}
+			}
+		}
+
+		for i, centry := range cc {
+			if centry.Namespace == clusterNamespace {
+				cc[i].CephFS.NetNamespaceFilePath = cephFSNetNamespaceFilePath
+				cc[i].RBD.NetNamespaceFilePath = rbdNetNamespaceFilePath
+				cc[i].NFS.NetNamespaceFilePath = nfsNetNamespaceFilePath
+			}
+		}
+	} else {
+		for i := range cc {
+			if cc[i].Namespace == clusterNamespace {
+				cc[i].CephFS.NetNamespaceFilePath = ""
+				cc[i].RBD.NetNamespaceFilePath = ""
+				cc[i].NFS.NetNamespaceFilePath = ""
+			}
+		}
+	}
+}
+
 // updateCsiClusterConfig returns a json-formatted string containing
 // the cluster-to-mon mapping required to configure ceph csi.
 func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *CSIClusterConfigEntry) (string, error) {
@@ -164,7 +207,7 @@ func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *C
 			centry.ClusterID = clusterKey
 			centry.Namespace = newCsiClusterConfigEntry.Namespace
 			centry.Monitors = newCsiClusterConfigEntry.Monitors
-			if newCsiClusterConfigEntry.RBD.RadosNamespace != "" || newCsiClusterConfigEntry.CephFS.NetNamespaceFilePath != "" {
+			if newCsiClusterConfigEntry.RBD.RadosNamespace != "" || newCsiClusterConfigEntry.RBD.NetNamespaceFilePath != "" {
 				centry.RBD = newCsiClusterConfigEntry.RBD
 			}
 			// Add a condition not to fill with empty values
@@ -181,6 +224,7 @@ func updateCsiClusterConfig(curr, clusterKey string, newCsiClusterConfigEntry *C
 		}
 	}
 
+	updateNetNamespaceFilePath(clusterKey, cc)
 	return formatCsiClusterConfig(cc)
 }
 

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -120,7 +120,7 @@ var (
 	AllowUnsupported          = false
 	CustomCSICephConfigExists = false
 
-	//driver names
+	// driver names
 	CephFSDriverName string
 	NFSDriverName    string
 	RBDDriverName    string
@@ -174,6 +174,8 @@ var (
 	NFSProvisionerDepTemplatePath string
 	//go:embed template/nfs/csi-nfsplugin-holder.yaml
 	NFSPluginHolderTemplatePath string
+
+	holderEnabled bool
 )
 
 const (
@@ -272,6 +274,10 @@ const (
 
 func CSIEnabled() bool {
 	return EnableRBD || EnableCephFS || EnableNFS
+}
+
+func IsHolderEnabled() bool {
+	return holderEnabled
 }
 
 func validateCSIParam() error {
@@ -391,7 +397,7 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 		})
 	}
 
-	holderEnabled := !CSIParam.EnableCSIHostNetwork
+	holderEnabled = !CSIParam.EnableCSIHostNetwork
 
 	for i := range r.clustersWithHolder {
 		if r.clustersWithHolder[i].cluster.Spec.Network.IsMultus() {
@@ -749,7 +755,6 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 		CSIParam.CSIPluginImage,
 		corev1.PullPolicy(CSIParam.ImagePullPolicy),
 	)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up ceph CSI version job")
 	}
@@ -890,6 +895,7 @@ func (r *ReconcileCSI) configureHolder(driver driverDetails, c ClusterDetail, tp
 			},
 		},
 	}
+
 	netNamespaceFilePath := generateNetNamespaceFilePath(CSIParam.KubeletDirPath, driver.fullName, c.cluster.Namespace)
 	if driver.name == RBDDriverShortName {
 		clusterConfigEntry.RBD.NetNamespaceFilePath = netNamespaceFilePath
@@ -900,6 +906,7 @@ func (r *ReconcileCSI) configureHolder(driver driverDetails, c ClusterDetail, tp
 	if driver.name == NFSDriverShortName {
 		clusterConfigEntry.NFS.NetNamespaceFilePath = netNamespaceFilePath
 	}
+
 	// Save the path of the network namespace file for ceph-csi to use
 	err = SaveClusterConfig(r.context.Clientset, c.cluster.Namespace, c.clusterInfo, clusterConfigEntry)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

This PR has the following changes - 
- adds the default crush location labels to all clusterID's in the csi configMap.
This change resolves the issue where the default crush location labels were not being
updated for all clusterIDs in a given namespace.
- adds netNamespaceFilePath for all clusterIDs in csi configMap.
This change resolves the issue where the netNamespaceFilePath
was not being updated for all clusterIDs in a given namespace.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.

Closes: #13580 
