### PR TITLE
build: add ability to stash docker build context

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -31,7 +31,9 @@ YQv3_VERSION = 3.4.1
 GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go
 MANIFESTS_DIR=../../deploy/examples
 
-TEMP := $(shell mktemp -d)
+ifeq ($(BUILD_CONTEXT_DIR),)
+BUILD_CONTEXT_DIR := $(shell mktemp -d)
+endif
 
 # Note: as of version 1.3 of operator-sdk, the url format changed to:
 # ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
@@ -68,33 +70,36 @@ export OPERATOR_SDK YQv3
 
 do.build:
 	@echo === container build $(CEPH_IMAGE)
-	@cp Dockerfile $(TEMP)
-	@cp toolbox.sh $(TEMP)
-	@cp set-ceph-debug-level $(TEMP)
-	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
-	@cp -r $(MANIFESTS_DIR)/monitoring $(TEMP)/ceph-monitoring
-	@mkdir -p $(TEMP)/rook-external/test-data
-	@cp $(MANIFESTS_DIR)/create-external-cluster-resources.* $(TEMP)/rook-external/
-	@cp ../../tests/ceph-status-out $(TEMP)/rook-external/test-data/
+	@mkdir -p $(BUILD_CONTEXT_DIR)
+	@cp Dockerfile $(BUILD_CONTEXT_DIR)
+	@cp toolbox.sh $(BUILD_CONTEXT_DIR)
+	@cp set-ceph-debug-level $(BUILD_CONTEXT_DIR)
+	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(BUILD_CONTEXT_DIR)
+	@cp -r $(MANIFESTS_DIR)/monitoring $(BUILD_CONTEXT_DIR)/ceph-monitoring
+	@mkdir -p $(BUILD_CONTEXT_DIR)/rook-external/test-data
+	@cp $(MANIFESTS_DIR)/create-external-cluster-resources.* $(BUILD_CONTEXT_DIR)/rook-external/
+	@cp ../../tests/ceph-status-out $(BUILD_CONTEXT_DIR)/rook-external/test-data/
 
 ifeq ($(INCLUDE_CSV_TEMPLATES),true)
 	@$(MAKE) csv
-	@cp -r ../../build/csv $(TEMP)/ceph-csv-templates
-	@rm $(TEMP)/ceph-csv-templates/csv-gen.sh
+	@cp -r ../../build/csv $(BUILD_CONTEXT_DIR)/ceph-csv-templates
+	@rm $(BUILD_CONTEXT_DIR)/ceph-csv-templates/csv-gen.sh
 	@$(MAKE) csv-clean
 
 else
-	mkdir $(TEMP)/ceph-csv-templates
+	mkdir $(BUILD_CONTEXT_DIR)/ceph-csv-templates
 endif
-	@cd $(TEMP) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+	@cd $(BUILD_CONTEXT_DIR) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@if [ -z "$(BUILD_CONTAINER_IMAGE)" ]; then\
 		$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
 		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
 		-t $(CEPH_IMAGE) \
-		$(TEMP);\
+		$(BUILD_CONTEXT_DIR);\
 	fi
-	@rm -fr $(TEMP)
+	@if [ -z "$(SAVE_BUILD_CONTEXT_DIR)" ]; then\
+		rm -fr $(BUILD_CONTEXT_DIR);\
+	fi
 
 # call this before building multiple arches in parallel to prevent parallel build processes from
 # conflicting


### PR DESCRIPTION
This commit gives builders the necessary tooling to save off a docker build context for use with other tools that dont follow the same command format as $DOCKERCMD.


Example usage:

```
> make BUILD_CONTAINER_IMAGE=false SAVE_BUILD_CONTEXT_DIR=true BUILD_CONTEXT_DIR=/tmp/mybuild build
> /kaniko/executor --context /tmp/mybuild --dockerfile /tmp/mybuild/Dockerfile --no-push
```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
