### PR TITLE
Introduce a "host-strict" network provider as a superset of "host"

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -8389,6 +8389,8 @@ PoolSpec
 <td></td>
 </tr><tr><td><p>&#34;host&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;host-strict&#34;</p></td>
+<td></td>
 </tr><tr><td><p>&#34;multus&#34;</p></td>
 <td></td>
 </tr></tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -20,27 +20,21 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephBlockPoolRadosNamespace represents a Ceph BlockPool Rados Namespace
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph BlockPool Rados Namespace
               properties:
                 blockPoolName:
-                  description: BlockPoolName is the name of Ceph BlockPool. Typically it's the name of the CephBlockPool CR.
                   type: string
                   x-kubernetes-validations:
                     - message: blockPoolName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
@@ -49,7 +43,6 @@ spec:
                 - blockPoolName
               type: object
             status:
-              description: Status represents the status of a CephBlockPool Rados Namespace
               properties:
                 info:
                   additionalProperties:
@@ -57,7 +50,6 @@ spec:
                   nullable: true
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -94,24 +86,19 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephBlockPool represents a Ceph Storage Pool
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
                 application:
                   description: The application name to set on the pool. Only expected to be set for rgw pools.
                   type: string
                 compressionMode:
-                  description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
                     - none
                     - passive
@@ -121,28 +108,21 @@ spec:
                   nullable: true
                   type: string
                 crushRoot:
-                  description: The root of the crush hierarchy utilized by the pool
                   nullable: true
                   type: string
                 deviceClass:
-                  description: The device class the OSD should set to for use in the pool
                   nullable: true
                   type: string
                 enableRBDStats:
-                  description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                   type: boolean
                 erasureCoded:
-                  description: The erasure code settings
                   properties:
                     algorithm:
-                      description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                       minimum: 0
                       type: integer
                   required:
@@ -150,46 +130,34 @@ spec:
                     - dataChunks
                   type: object
                 failureDomain:
-                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                   type: string
                 mirroring:
-                  description: The mirroring settings
                   properties:
                     enabled:
-                      description: Enabled whether this pool is mirrored or not
                       type: boolean
                     mode:
-                      description: 'Mode is the mirroring mode: either pool or image'
                       type: string
                     peers:
-                      description: Peers represents the peers spec
                       nullable: true
                       properties:
                         secretNames:
-                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                           items:
                             type: string
                           type: array
                       type: object
                     snapshotSchedules:
-                      description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                       items:
-                        description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
                             type: string
                           path:
-                            description: Path is the path to snapshot, only valid for CephFS
                             type: string
                           startTime:
-                            description: StartTime indicates when to start the snapshot
                             type: string
                         type: object
                       type: array
                   type: object
                 name:
-                  description: The desired name of the pool if different from the CephBlockPool CR name.
                   enum:
                     - .rgw.root
                     - .nfs
@@ -198,40 +166,31 @@ spec:
                 parameters:
                   additionalProperties:
                     type: string
-                  description: Parameters is a list of properties to enable on a given pool
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 quotas:
-                  description: The quota settings
                   nullable: true
                   properties:
                     maxBytes:
-                      description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                       format: int64
                       type: integer
                     maxObjects:
-                      description: MaxObjects represents the quota in objects
                       format: int64
                       type: integer
                     maxSize:
-                      description: MaxSize represents the quota in bytes as a string
                       pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                       type: string
                   type: object
                 replicated:
-                  description: The replication settings
                   properties:
                     hybridStorage:
-                      description: HybridStorage represents hybrid storage tier settings
                       nullable: true
                       properties:
                         primaryDeviceClass:
-                          description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                           minLength: 1
                           type: string
                         secondaryDeviceClass:
-                          description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                           minLength: 1
                           type: string
                       required:
@@ -239,36 +198,28 @@ spec:
                         - secondaryDeviceClass
                       type: object
                     replicasPerFailureDomain:
-                      description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                       minimum: 1
                       type: integer
                     requireSafeReplicaSize:
-                      description: RequireSafeReplicaSize if false allows you to set replica 1
                       type: boolean
                     size:
-                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                       minimum: 0
                       type: integer
                     subFailureDomain:
-                      description: SubFailureDomain the name of the sub-failure domain
                       type: string
                     targetSizeRatio:
-                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                       type: number
                   required:
                     - size
                   type: object
                 statusCheck:
-                  description: The mirroring statusCheck
                   properties:
                     mirror:
-                      description: HealthCheckSpec represents the health check of an object store bucket
                       nullable: true
                       properties:
                         disabled:
                           type: boolean
                         interval:
-                          description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                           type: string
                         timeout:
                           type: string
@@ -277,11 +228,9 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
               type: object
             status:
-              description: CephBlockPoolStatus represents the mirroring status of Ceph Storage Pool
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -292,12 +241,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
@@ -307,7 +254,6 @@ spec:
                   nullable: true
                   type: object
                 mirroringInfo:
-                  description: MirroringInfoSpec is the status of the pool mirroring
                   properties:
                     details:
                       type: string
@@ -316,131 +262,91 @@ spec:
                     lastChecked:
                       type: string
                     mode:
-                      description: Mode is the mirroring mode
                       type: string
                     peers:
-                      description: Peers are the list of peer sites connected to that cluster
                       items:
-                        description: PeersSpec contains peer details
                         properties:
                           client_name:
-                            description: ClientName is the CephX user used to connect to the peer
                             type: string
                           direction:
-                            description: Direction is the peer mirroring direction
                             type: string
                           mirror_uuid:
-                            description: MirrorUUID is the mirror UUID
                             type: string
                           site_name:
-                            description: SiteName is the current site name
                             type: string
                           uuid:
-                            description: UUID is the peer UUID
                             type: string
                         type: object
                       type: array
                     site_name:
-                      description: SiteName is the current site name
                       type: string
                   type: object
                 mirroringStatus:
-                  description: MirroringStatusSpec is the status of the pool mirroring
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     summary:
-                      description: Summary is the mirroring status summary
                       properties:
                         daemon_health:
-                          description: DaemonHealth is the health of the mirroring daemon
                           type: string
                         health:
-                          description: Health is the mirroring health
                           type: string
                         image_health:
-                          description: ImageHealth is the health of the mirrored image
                           type: string
                         states:
-                          description: States is the various state for all mirrored images
                           nullable: true
                           properties:
                             error:
-                              description: Error is when the mirroring state is errored
                               type: integer
                             replaying:
-                              description: Replaying is when the replay of the mirroring journal is on-going
                               type: integer
                             starting_replay:
-                              description: StartingReplay is when the replay of the mirroring journal starts
                               type: integer
                             stopped:
-                              description: Stopped is when the mirroring state is stopped
                               type: integer
                             stopping_replay:
-                              description: StopReplaying is when the replay of the mirroring journal stops
                               type: integer
                             syncing:
-                              description: Syncing is when the image is syncing
                               type: integer
                             unknown:
-                              description: Unknown is when the mirroring state is unknown
                               type: integer
                           type: object
                       type: object
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 snapshotScheduleStatus:
-                  description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     snapshotSchedules:
-                      description: SnapshotSchedules is the list of snapshots scheduled
                       items:
-                        description: SnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool
                         properties:
                           image:
-                            description: Image is the mirrored image
                             type: string
                           items:
-                            description: Items is the list schedules times for a given snapshot
                             items:
-                              description: SnapshotSchedule is a schedule
                               properties:
                                 interval:
-                                  description: Interval is the interval in which snapshots will be taken
                                   type: string
                                 start_time:
-                                  description: StartTime is the snapshot starting time
                                   type: string
                               type: object
                             type: array
                           namespace:
-                            description: Namespace is the RADOS namespace the image is part of
                             type: string
                           pool:
-                            description: Pool is the pool name
                             type: string
                         type: object
                       nullable: true
@@ -477,23 +383,17 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephBucketNotification represents a Bucket Notifications
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
               properties:
                 events:
-                  description: List of events that should trigger the notification
                   items:
-                    description: BucketNotificationSpec represent the event type of the bucket notification
                     enum:
                       - s3:ObjectCreated:*
                       - s3:ObjectCreated:Put
@@ -506,22 +406,17 @@ spec:
                     type: string
                   type: array
                 filter:
-                  description: Spec of notification filter
                   properties:
                     keyFilters:
-                      description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the filter - prefix/suffix/regex
                             enum:
                               - prefix
                               - suffix
                               - regex
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -529,16 +424,12 @@ spec:
                         type: object
                       type: array
                     metadataFilters:
-                      description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the metadata or tag
                             minLength: 1
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -546,16 +437,12 @@ spec:
                         type: object
                       type: array
                     tagFilters:
-                      description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the metadata or tag
                             minLength: 1
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -564,18 +451,15 @@ spec:
                       type: array
                   type: object
                 topic:
-                  description: The name of the topic associated with this notification
                   minLength: 1
                   type: string
               required:
                 - topic
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -586,17 +470,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -636,42 +517,32 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephBucketTopic represents a Ceph Object Topic for Bucket Notifications
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
               properties:
                 endpoint:
-                  description: Contains the endpoint spec of the topic
                   properties:
                     amqp:
-                      description: Spec of AMQP endpoint
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker/routeable)
                           enum:
                             - none
                             - broker
                             - routeable
                           type: string
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         exchange:
-                          description: Name of the exchange that is used to route messages based on topics
                           minLength: 1
                           type: string
                         uri:
-                          description: The URI of the AMQP endpoint to push notification to
                           minLength: 1
                           type: string
                       required:
@@ -679,58 +550,45 @@ spec:
                         - uri
                       type: object
                     http:
-                      description: Spec of HTTP endpoint
                       properties:
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         sendCloudEvents:
-                          description: 'Send the notifications with the CloudEvents header: https://github.'
                           type: boolean
                         uri:
-                          description: The URI of the HTTP endpoint to push notification to
                           minLength: 1
                           type: string
                       required:
                         - uri
                       type: object
                     kafka:
-                      description: Spec of Kafka endpoint
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker)
                           enum:
                             - none
                             - broker
                           type: string
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         uri:
-                          description: The URI of the Kafka endpoint to push notification to
                           minLength: 1
                           type: string
                         useSSL:
-                          description: Indicate whether to use SSL when communicating with the broker
                           type: boolean
                       required:
                         - uri
                       type: object
                   type: object
                 objectStoreName:
-                  description: The name of the object store on which to define the topic
                   minLength: 1
                   type: string
                 objectStoreNamespace:
-                  description: The namespace of the object store on which to define the topic
                   minLength: 1
                   type: string
                 opaqueData:
-                  description: Data which is sent in each event
                   type: string
                 persistent:
-                  description: Indication whether notifications to this endpoint are persistent or not
                   type: boolean
               required:
                 - endpoint
@@ -738,14 +596,11 @@ spec:
                 - objectStoreNamespace
               type: object
             status:
-              description: BucketTopicStatus represents the Status of a CephBucketTopic
               properties:
                 ARN:
-                  description: The ARN of the topic generated by the RGW
                   nullable: true
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -785,18 +640,14 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephClient represents a Ceph Client
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph Client
               properties:
                 caps:
                   additionalProperties:
@@ -809,7 +660,6 @@ spec:
                 - caps
               type: object
             status:
-              description: Status represents the status of a Ceph Client
               properties:
                 info:
                   additionalProperties:
@@ -817,11 +667,9 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -884,26 +732,20 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephCluster is a Ceph storage cluster
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ClusterSpec represents the specification of Ceph Cluster
               properties:
                 annotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations
                     type: object
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -912,21 +754,16 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Ceph Config options
                   nullable: true
                   type: object
                 cephVersion:
-                  description: The version information that instructs Rook to orchestrate a particular version of Ceph.
                   nullable: true
                   properties:
                     allowUnsupported:
-                      description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as quay.
                       type: string
                     imagePullPolicy:
-                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNot
                       enum:
                         - IfNotPresent
                         - Always
@@ -935,33 +772,26 @@ spec:
                       type: string
                   type: object
                 cleanupPolicy:
-                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster
                   nullable: true
                   properties:
                     allowUninstallWithVolumes:
-                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images s
                       type: boolean
                     confirmation:
-                      description: Confirmation represents the cleanup confirmation
                       nullable: true
                       pattern: ^$|^yes-really-destroy-data$
                       type: string
                     sanitizeDisks:
-                      description: SanitizeDisks represents way we sanitize disks
                       nullable: true
                       properties:
                         dataSource:
-                          description: DataSource is the data source to use to sanitize the disk with
                           enum:
                             - zero
                             - random
                           type: string
                         iteration:
-                          description: Iteration is the number of pass to apply the sanitizing
                           format: int32
                           type: integer
                         method:
-                          description: Method is the method we use to sanitize disks
                           enum:
                             - complete
                             - quick
@@ -969,151 +799,115 @@ spec:
                       type: object
                   type: object
                 continueUpgradeAfterChecksEvenIfNotHealthy:
-                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not
                   type: boolean
                 crashCollector:
-                  description: A spec for the crash controller
                   nullable: true
                   properties:
                     daysToRetain:
-                      description: DaysToRetain represents the number of days to retain crash until they get pruned
                       type: integer
                     disable:
-                      description: Disable determines whether we should enable the crash collector
                       type: boolean
                   type: object
                 csi:
-                  description: CSI Driver Options applied per cluster.
                   properties:
                     cephfs:
-                      description: CephFS defines CSI Driver settings for CephFS driver.
                       properties:
                         fuseMountOptions:
-                          description: FuseMountOptions defines the mount options for ceph fuse mounter.
                           type: string
                         kernelMountOptions:
-                          description: KernelMountOptions defines the mount options for kernel mounter.
                           type: string
                       type: object
                     readAffinity:
-                      description: ReadAffinity defines the read affinity settings for CSI driver.
                       properties:
                         crushLocationLabels:
-                          description: CrushLocationLabels defines which node labels to use as CRUSH location.
                           items:
                             type: string
                           type: array
                         enabled:
-                          description: Enables read affinity for CSI driver.
                           type: boolean
                       type: object
                   type: object
                 dashboard:
-                  description: Dashboard settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to enable the dashboard
                       type: boolean
                     port:
-                      description: Port is the dashboard webserver port
                       maximum: 65535
                       minimum: 0
                       type: integer
                     prometheusEndpoint:
-                      description: Endpoint for the Prometheus host
                       type: string
                     prometheusEndpointSSLVerify:
-                      description: Whether to verify the ssl endpoint for prometheus. Set to false for a self-signed cert.
                       type: boolean
                     ssl:
-                      description: SSL determines whether SSL should be used
                       type: boolean
                     urlPrefix:
-                      description: URLPrefix is a prefix for all URLs to use the dashboard with a reverse proxy
                       type: string
                   type: object
                 dataDirHostPath:
-                  description: The path on the host where config and data can be persisted
                   pattern: ^/(\S+)
                   type: string
                   x-kubernetes-validations:
                     - message: DataDirHostPath is immutable
                       rule: self == oldSelf
                 disruptionManagement:
-                  description: A spec for configuring disruption management.
                   nullable: true
                   properties:
                     machineDisruptionBudgetNamespace:
-                      description: Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController
                       type: string
                     manageMachineDisruptionBudgets:
-                      description: Deprecated. This enables management of machinedisruptionbudgets.
                       type: boolean
                     managePodBudgets:
-                      description: This enables management of poddisruptionbudgets
                       type: boolean
                     osdMaintenanceTimeout:
-                      description: 'OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure '
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups t
                       format: int64
                       type: integer
                     pgHealthyRegex:
-                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be conside
                       type: string
                   type: object
                 external:
-                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and disc
                   nullable: true
                   properties:
                     enable:
-                      description: Enable determines whether external mode is enabled or not
                       type: boolean
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 healthCheck:
-                  description: Internal daemon healthchecks and liveness probe
                   nullable: true
                   properties:
                     daemonHealth:
-                      description: DaemonHealth is the health check for a given daemon
                       nullable: true
                       properties:
                         mon:
-                          description: Monitor represents the health check settings for the Ceph monitor
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
                           type: object
                         osd:
-                          description: ObjectStorageDaemon represents the health check settings for the Ceph OSDs
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
                           type: object
                         status:
-                          description: Status represents the health check settings for the Ceph health
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -1121,56 +915,41 @@ spec:
                       type: object
                     livenessProbe:
                       additionalProperties:
-                        description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                         properties:
                           disabled:
-                            description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
-                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1178,111 +957,84 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
                         type: object
-                      description: LivenessProbe allows changing the livenessProbe configuration for a given daemon
                       type: object
                     startupProbe:
                       additionalProperties:
-                        description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                         properties:
                           disabled:
-                            description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
-                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1290,161 +1042,122 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
                         type: object
-                      description: StartupProbe allows changing the startupProbe configuration for a given daemon
                       type: object
                   type: object
                 labels:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Labels are label for a given daemons
                     type: object
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled represents whether the log collector is enabled
                       type: boolean
                     maxLogSize:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: MaxLogSize is the maximum size of the log per ceph daemons. Must be at least 1M.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     periodicity:
-                      description: Periodicity is the periodicity of the log rotation.
                       pattern: ^$|^(hourly|daily|weekly|monthly|1h|24h|1d)$
                       type: string
                   type: object
                 mgr:
-                  description: A spec for mgr related options
                   nullable: true
                   properties:
                     allowMultiplePerNode:
-                      description: AllowMultiplePerNode allows to run multiple managers on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of manager daemons to run
                       maximum: 5
                       minimum: 0
                       type: integer
                     modules:
-                      description: Modules is the list of ceph manager modules to enable/disable
                       items:
-                        description: Module represents mgr modules that the user wants to enable or disable
                         properties:
                           enabled:
-                            description: Enabled determines whether a module should be enabled or not
                             type: boolean
                           name:
-                            description: Name is the name of the ceph manager module
                             type: string
                         type: object
                       nullable: true
                       type: array
                   type: object
                 mon:
-                  description: A spec for mon related options
                   nullable: true
                   properties:
                     allowMultiplePerNode:
-                      description: AllowMultiplePerNode determines if we can run multiple monitors on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of Ceph monitors
                       maximum: 9
                       minimum: 0
                       type: integer
                     failureDomainLabel:
                       type: string
                     stretchCluster:
-                      description: StretchCluster is the stretch cluster specification
                       properties:
                         failureDomainLabel:
-                          description: 'FailureDomainLabel the failure domain name (e,g: zone)'
                           type: string
                         subFailureDomain:
-                          description: SubFailureDomain is the failure domain within a zone
                           type: string
                         zones:
-                          description: Zones is the list of zones
                           items:
-                            description: MonZoneSpec represents the specification of a zone in a Ceph Cluster
                             properties:
                               arbiter:
-                                description: Arbiter determines if the zone contains the arbiter used for stretch cluster mode
                                 type: boolean
                               name:
-                                description: Name is the name of the zone
                                 type: string
                               volumeClaimTemplate:
-                                description: VolumeClaimTemplate is the PVC template
                                 properties:
                                   apiVersion:
-                                    description: APIVersion defines the versioned schema of this representation of an object.
                                     type: string
                                   kind:
-                                    description: Kind is a string value representing the REST resource this object represents.
                                     type: string
                                   metadata:
-                                    description: 'Standard object''s metadata. More info: https://git.k8s.'
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -1464,24 +1177,18 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: spec defines the desired characteristics of a volume requested by a pod author.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                         required:
                                           - kind
@@ -1489,26 +1196,20 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: resources represents the minimum resources the volume should have.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -1517,7 +1218,6 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -1526,25 +1226,18 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: Requests describes the minimum amount of compute resources required.
                                             type: object
                                         type: object
                                       selector:
-                                        description: selector is a label query over volumes to consider for binding.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1556,36 +1249,27 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: storageClassName is the name of the StorageClass required by the claim.
                                         type: string
                                       volumeAttributesClassName:
-                                        description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type of volume is required by the claim.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                   status:
-                                    description: status represents the current information/status of a persistent volume claim. Read-only.
                                     properties:
                                       accessModes:
-                                        description: accessModes contains the actual access modes the volume backing the PVC has.
                                         items:
                                           type: string
                                         type: array
                                       allocatedResourceStatuses:
                                         additionalProperties:
-                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                           type: string
-                                        description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                         type: object
                                         x-kubernetes-map-type: granular
                                       allocatedResources:
@@ -1595,7 +1279,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                         type: object
                                       capacity:
                                         additionalProperties:
@@ -1604,31 +1287,23 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: capacity represents the actual resources of the underlying volume.
                                         type: object
                                       conditions:
-                                        description: conditions is the current Condition of persistent volume claim.
                                         items:
-                                          description: PersistentVolumeClaimCondition contains details about state of pvc
                                           properties:
                                             lastProbeTime:
-                                              description: lastProbeTime is the time we probed the condition.
                                               format: date-time
                                               type: string
                                             lastTransitionTime:
-                                              description: lastTransitionTime is the time the condition transitioned from one status to another.
                                               format: date-time
                                               type: string
                                             message:
-                                              description: message is the human-readable message indicating details about last transition.
                                               type: string
                                             reason:
-                                              description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                               type: string
                                             status:
                                               type: string
                                             type:
-                                              description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                               type: string
                                           required:
                                             - status
@@ -1636,22 +1311,17 @@ spec:
                                           type: object
                                         type: array
                                       currentVolumeAttributesClassName:
-                                        description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                         type: string
                                       modifyVolumeStatus:
-                                        description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                         properties:
                                           status:
-                                            description: status is the status of the ControllerModifyVolume operation.
                                             type: string
                                           targetVolumeAttributesClassName:
-                                            description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                             type: string
                                         required:
                                           - status
                                         type: object
                                       phase:
-                                        description: phase represents the current phase of PersistentVolumeClaim.
                                         type: string
                                     type: object
                                 type: object
@@ -1661,16 +1331,12 @@ spec:
                           type: array
                       type: object
                     volumeClaimTemplate:
-                      description: VolumeClaimTemplate is the PVC definition
                       properties:
                         apiVersion:
-                          description: APIVersion defines the versioned schema of this representation of an object.
                           type: string
                         kind:
-                          description: Kind is a string value representing the REST resource this object represents.
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -1690,24 +1356,18 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: spec defines the desired characteristics of a volume requested by a pod author.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
@@ -1715,26 +1375,20 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             dataSourceRef:
-                              description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: resources represents the minimum resources the volume should have.
                               properties:
                                 limits:
                                   additionalProperties:
@@ -1743,7 +1397,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -1752,25 +1405,18 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             selector:
-                              description: selector is a label query over volumes to consider for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -1782,36 +1428,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             storageClassName:
-                              description: storageClassName is the name of the StorageClass required by the claim.
                               type: string
                             volumeAttributesClassName:
-                              description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is required by the claim.
                               type: string
                             volumeName:
-                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: status represents the current information/status of a persistent volume claim. Read-only.
                           properties:
                             accessModes:
-                              description: accessModes contains the actual access modes the volume backing the PVC has.
                               items:
                                 type: string
                               type: array
                             allocatedResourceStatuses:
                               additionalProperties:
-                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                 type: string
-                              description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -1821,7 +1458,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                               type: object
                             capacity:
                               additionalProperties:
@@ -1830,31 +1466,23 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: capacity represents the actual resources of the underlying volume.
                               type: object
                             conditions:
-                              description: conditions is the current Condition of persistent volume claim.
                               items:
-                                description: PersistentVolumeClaimCondition contains details about state of pvc
                                 properties:
                                   lastProbeTime:
-                                    description: lastProbeTime is the time we probed the condition.
                                     format: date-time
                                     type: string
                                   lastTransitionTime:
-                                    description: lastTransitionTime is the time the condition transitioned from one status to another.
                                     format: date-time
                                     type: string
                                   message:
-                                    description: message is the human-readable message indicating details about last transition.
                                     type: string
                                   reason:
-                                    description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                     type: string
                                 required:
                                   - status
@@ -1862,48 +1490,35 @@ spec:
                                 type: object
                               type: array
                             currentVolumeAttributesClassName:
-                              description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                               type: string
                             modifyVolumeStatus:
-                              description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                               properties:
                                 status:
-                                  description: status is the status of the ControllerModifyVolume operation.
                                   type: string
                                 targetVolumeAttributesClassName:
-                                  description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                   type: string
                               required:
                                 - status
                               type: object
                             phase:
-                              description: phase represents the current phase of PersistentVolumeClaim.
                               type: string
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     zones:
-                      description: Zones are specified when we want to provide zonal awareness to mons
                       items:
-                        description: MonZoneSpec represents the specification of a zone in a Ceph Cluster
                         properties:
                           arbiter:
-                            description: Arbiter determines if the zone contains the arbiter used for stretch cluster mode
                             type: boolean
                           name:
-                            description: Name is the name of the zone
                             type: string
                           volumeClaimTemplate:
-                            description: VolumeClaimTemplate is the PVC template
                             properties:
                               apiVersion:
-                                description: APIVersion defines the versioned schema of this representation of an object.
                                 type: string
                               kind:
-                                description: Kind is a string value representing the REST resource this object represents.
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info: https://git.k8s.'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -1923,24 +1538,18 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: spec defines the desired characteristics of a volume requested by a pod author.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being referenced
                                         type: string
                                     required:
                                       - kind
@@ -1948,26 +1557,20 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: resources represents the minimum resources the volume should have.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1976,7 +1579,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1985,25 +1587,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Requests describes the minimum amount of compute resources required.
                                         type: object
                                     type: object
                                   selector:
-                                    description: selector is a label query over volumes to consider for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -2015,36 +1610,27 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: storageClassName is the name of the StorageClass required by the claim.
                                     type: string
                                   volumeAttributesClassName:
-                                    description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume is required by the claim.
                                     type: string
                                   volumeName:
-                                    description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: status represents the current information/status of a persistent volume claim. Read-only.
                                 properties:
                                   accessModes:
-                                    description: accessModes contains the actual access modes the volume backing the PVC has.
                                     items:
                                       type: string
                                     type: array
                                   allocatedResourceStatuses:
                                     additionalProperties:
-                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                       type: string
-                                    description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                     type: object
                                     x-kubernetes-map-type: granular
                                   allocatedResources:
@@ -2054,7 +1640,6 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                     type: object
                                   capacity:
                                     additionalProperties:
@@ -2063,31 +1648,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: capacity represents the actual resources of the underlying volume.
                                     type: object
                                   conditions:
-                                    description: conditions is the current Condition of persistent volume claim.
                                     items:
-                                      description: PersistentVolumeClaimCondition contains details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: lastProbeTime is the time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: lastTransitionTime is the time the condition transitioned from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: message is the human-readable message indicating details about last transition.
                                           type: string
                                         reason:
-                                          description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -2095,22 +1672,17 @@ spec:
                                       type: object
                                     type: array
                                   currentVolumeAttributesClassName:
-                                    description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                     type: string
                                   modifyVolumeStatus:
-                                    description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                     properties:
                                       status:
-                                        description: status is the status of the ControllerModifyVolume operation.
                                         type: string
                                       targetVolumeAttributesClassName:
-                                        description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                         type: string
                                     required:
                                       - status
                                     type: object
                                   phase:
-                                    description: phase represents the current phase of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
@@ -2124,49 +1696,34 @@ spec:
                     - message: stretchCluster zones must be equal to 3
                       rule: '!has(self.stretchCluster) || (has(self.stretchCluster) && (size(self.stretchCluster.zones) > 0) && (size(self.stretchCluster.zones) == 3))'
                 monitoring:
-                  description: Prometheus based Monitoring settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster.
                       type: boolean
                     externalMgrEndpoints:
-                      description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
                       items:
-                        description: EndpointAddress is a tuple that describes single IP address.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
                             type: string
                           ip:
-                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.
                             type: string
                           nodeName:
-                            description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                             type: string
                           targetRef:
-                            description: Reference to object providing the endpoint.
                             properties:
                               apiVersion:
-                                description: API version of the referent.
                                 type: string
                               fieldPath:
-                                description: If referring to a piece of an object instead of an entire object, this string should contain a valid
                                 type: string
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.'
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.'
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.'
                                 type: string
                               resourceVersion:
-                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.'
                                 type: string
                               uid:
-                                description: 'UID of the referent. More info: https://kubernetes.'
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -2177,97 +1734,75 @@ spec:
                       nullable: true
                       type: array
                     externalMgrPrometheusPort:
-                      description: ExternalMgrPrometheusPort Prometheus exporter port
                       maximum: 65535
                       minimum: 0
                       type: integer
                     interval:
-                      description: Interval determines prometheus scrape interval
                       type: string
                     metricsDisabled:
-                      description: Whether to disable the metrics reported by Ceph.
                       type: boolean
                     port:
-                      description: Port is the prometheus server port
                       maximum: 65535
                       minimum: 0
                       type: integer
                   type: object
                 network:
-                  description: Network related configuration
                   nullable: true
                   properties:
                     addressRanges:
-                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluste
                       nullable: true
                       properties:
                         cluster:
-                          description: Cluster defines a list of CIDRs to use for Ceph cluster network communication.
                           items:
-                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                         public:
-                          description: Public defines a list of CIDRs to use for Ceph public network communication.
                           items:
-                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                       type: object
                     connections:
-                      description: Settings for network connections such as compression and encryption across the wire.
                       nullable: true
                       properties:
                         compression:
-                          description: Compression settings for the network connections.
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to compress the data in transit across the wire. The default is not set.
                               type: boolean
                           type: object
                         encryption:
-                          description: Encryption settings for the network connections.
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the netw
                               type: boolean
                           type: object
                         requireMsgr2:
-                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled.
                           type: boolean
                       type: object
                     dualStack:
-                      description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network.
                       type: boolean
                     ipFamily:
-                      description: IPFamily is the single stack IPv6 or IPv4 protocol
                       enum:
                         - IPv4
                         - IPv6
                       nullable: true
                       type: string
                     multiClusterService:
-                      description: Enable multiClusterService to export the Services between peer clusters
                       properties:
                         clusterID:
-                          description: ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services.
                           type: string
                         enabled:
-                          description: Enable multiClusterService to export the mon and OSD services to peer cluster.
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
                       enum:
                         - ""
                         - host
+                        - host-strict
                         - multus
                       nullable: true
                       type: string
@@ -2277,7 +1812,6 @@ spec:
                     selectors:
                       additionalProperties:
                         type: string
-                      description: Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks whe
                       nullable: true
                       type: object
                   type: object
@@ -2289,32 +1823,22 @@ spec:
                       rule: '!has(self.hostNetwork) || self.hostNetwork == false || !has(self.provider) || self.provider == ""'
                 placement:
                   additionalProperties:
-                    description: Placement is the placement for an object
                     properties:
                       nodeAffinity:
-                        description: NodeAffinity is a group of node affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2324,18 +1848,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2347,7 +1866,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2356,26 +1874,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms. The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2385,18 +1895,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2414,32 +1919,22 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: PodAffinity is a group of inter pod affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2451,38 +1946,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2494,23 +1980,19 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2519,26 +2001,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2550,38 +2024,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2593,17 +2058,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2611,32 +2073,22 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2648,38 +2100,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2691,23 +2134,19 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2716,26 +2155,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2747,38 +2178,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2790,17 +2212,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2808,49 +2227,34 @@ spec:
                             type: array
                         type: object
                       tolerations:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         items:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match. Empty means match all taint effects.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration matches to.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                         items:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -2862,35 +2266,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: MaxSkew describes the degree to which pods may be unevenly distributed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: MinDomains indicates a minimum number of eligible domains.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                               type: string
                             nodeTaintsPolicy:
-                              description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels.
                               type: string
                             whenUnsatisfiable:
-                              description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                               type: string
                           required:
                             - maxSkew
@@ -2899,31 +2295,24 @@ spec:
                           type: object
                         type: array
                     type: object
-                  description: The placement-related configuration to pass to kubernetes (affinity, node selector, tolerations).
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 priorityClassNames:
                   additionalProperties:
                     type: string
-                  description: PriorityClassNames sets priority classes on components
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 removeOSDsIfOutAndSafeToRemove:
-                  description: Remove the OSD that is out and safe to remove only if this option is true
                   type: boolean
                 resources:
                   additionalProperties:
-                    description: ResourceRequirements describes the compute resource requirements.
                     properties:
                       claims:
-                        description: Claims lists the names of resources, defined in spec.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in pod.spec.
                               type: string
                           required:
                             - name
@@ -2939,7 +2328,6 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                         type: object
                       requests:
                         additionalProperties:
@@ -2948,50 +2336,39 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required.
                         type: object
                     type: object
-                  description: Resources set resource requests and limits
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 security:
-                  description: Security represents security settings
                   nullable: true
                   properties:
                     keyRotation:
-                      description: KeyRotation defines options for Key Rotation.
                       nullable: true
                       properties:
                         enabled:
                           default: false
-                          description: Enabled represents whether the key rotation is enabled.
                           type: boolean
                         schedule:
-                          description: Schedule represents the cron schedule for key rotation.
                           type: string
                       type: object
                     kms:
-                      description: KeyManagementService is the main Key Management option
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                   type: object
                 skipUpgradeChecks:
-                  description: SkipUpgradeChecks defines if an upgrade should be forced even if one of the check fails
                   type: boolean
                 storage:
-                  description: A spec for available storage in the cluster and how it should be used
                   nullable: true
                   properties:
                     config:
@@ -3001,15 +2378,11 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     deviceFilter:
-                      description: A regular expression to allow more fine-grained selection of devices on nodes across the cluster
                       type: string
                     devicePathFilter:
-                      description: A regular expression to allow more fine-grained selection of devices with path names
                       type: string
                     devices:
-                      description: List of devices to use as storage devices
                       items:
-                        description: Device represents a disk to use in the cluster
                         properties:
                           config:
                             additionalProperties:
@@ -3026,11 +2399,9 @@ spec:
                       type: array
                       x-kubernetes-preserve-unknown-fields: true
                     flappingRestartIntervalHours:
-                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit cod
                       type: integer
                     nodes:
                       items:
-                        description: Node is a storage nodes
                         properties:
                           config:
                             additionalProperties:
@@ -3039,15 +2410,11 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           deviceFilter:
-                            description: A regular expression to allow more fine-grained selection of devices on nodes across the cluster
                             type: string
                           devicePathFilter:
-                            description: A regular expression to allow more fine-grained selection of devices with path names
                             type: string
                           devices:
-                            description: List of devices to use as storage devices
                             items:
-                              description: Device represents a disk to use in the cluster
                               properties:
                                 config:
                                   additionalProperties:
@@ -3066,16 +2433,12 @@ spec:
                           name:
                             type: string
                           resources:
-                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               claims:
-                                description: Claims lists the names of resources, defined in spec.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -3091,7 +2454,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3100,26 +2462,19 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           useAllDevices:
-                            description: Whether to consume all the storage devices found on a machine
                             type: boolean
                           volumeClaimTemplates:
-                            description: PersistentVolumeClaims to use as storage
                             items:
-                              description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -3139,24 +2494,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                         - kind
@@ -3164,26 +2513,20 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -3192,7 +2535,6 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3201,25 +2543,18 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3231,36 +2566,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeAttributesClassName:
-                                      description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -3270,7 +2596,6 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -3279,31 +2604,23 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
-                                        description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
                                           lastProbeTime:
-                                            description: lastProbeTime is the time we probed the condition.
                                             format: date-time
                                             type: string
                                           lastTransitionTime:
-                                            description: lastTransitionTime is the time the condition transitioned from one status to another.
                                             format: date-time
                                             type: string
                                           message:
-                                            description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
                                           type:
-                                            description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                             type: string
                                         required:
                                           - status
@@ -3311,22 +2628,17 @@ spec:
                                         type: object
                                       type: array
                                     currentVolumeAttributesClassName:
-                                      description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                       type: string
                                     modifyVolumeStatus:
-                                      description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                       properties:
                                         status:
-                                          description: status is the status of the ControllerModifyVolume operation.
                                           type: string
                                         targetVolumeAttributesClassName:
-                                          description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                           type: string
                                       required:
                                         - status
                                       type: object
                                     phase:
-                                      description: phase represents the current phase of PersistentVolumeClaim.
                                       type: string
                                   type: object
                               type: object
@@ -3338,53 +2650,38 @@ spec:
                       type: boolean
                     storageClassDeviceSets:
                       items:
-                        description: StorageClassDeviceSet is a storage class device set
                         properties:
                           config:
                             additionalProperties:
                               type: string
-                            description: Provider-specific device configuration
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           count:
-                            description: Count is the number of devices in this set
                             minimum: 1
                             type: integer
                           encrypted:
-                            description: Whether to encrypt the deviceSet
                             type: boolean
                           name:
-                            description: Name is a unique identifier for the set
                             type: string
                           placement:
-                            description: Placement is the placement for an object
                             nullable: true
                             properties:
                               nodeAffinity:
-                                description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3394,18 +2691,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3417,7 +2709,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3426,26 +2717,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3455,18 +2738,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3484,32 +2762,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3521,38 +2789,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3564,23 +2823,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3589,26 +2844,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3620,38 +2867,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3663,17 +2901,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3681,32 +2916,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3718,38 +2943,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3761,23 +2977,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3786,26 +2998,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3817,38 +3021,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3860,17 +3055,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3878,49 +3070,34 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                                 items:
-                                  description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3932,35 +3109,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -3971,36 +3140,25 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           portable:
-                            description: Portable represents OSD portability across the hosts
                             type: boolean
                           preparePlacement:
-                            description: Placement is the placement for an object
                             nullable: true
                             properties:
                               nodeAffinity:
-                                description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4010,18 +3168,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4033,7 +3186,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4042,26 +3194,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4071,18 +3215,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4100,32 +3239,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4137,38 +3266,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4180,23 +3300,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4205,26 +3321,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4236,38 +3344,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4279,17 +3378,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4297,32 +3393,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4334,38 +3420,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4377,23 +3454,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4402,26 +3475,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4433,38 +3498,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4476,17 +3532,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4494,49 +3547,34 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                                 items:
-                                  description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4548,35 +3586,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -4587,16 +3617,12 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           resources:
-                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               claims:
-                                description: Claims lists the names of resources, defined in spec.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -4612,7 +3638,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4621,32 +3646,23 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           schedulerName:
-                            description: Scheduler name for OSD pod placement
                             type: string
                           tuneDeviceClass:
-                            description: TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
                             type: boolean
                           tuneFastDeviceClass:
-                            description: TuneFastDeviceClass Tune the OSD when running on a fast Device Class
                             type: boolean
                           volumeClaimTemplates:
-                            description: VolumeClaimTemplates is a list of PVC templates for the underlying storage devices
                             items:
-                              description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -4667,24 +3683,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                         - kind
@@ -4692,26 +3702,20 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -4720,7 +3724,6 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4729,25 +3732,18 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4759,36 +3755,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeAttributesClassName:
-                                      description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -4798,7 +3785,6 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -4807,31 +3793,23 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
-                                        description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
                                           lastProbeTime:
-                                            description: lastProbeTime is the time we probed the condition.
                                             format: date-time
                                             type: string
                                           lastTransitionTime:
-                                            description: lastTransitionTime is the time the condition transitioned from one status to another.
                                             format: date-time
                                             type: string
                                           message:
-                                            description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
                                           type:
-                                            description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                             type: string
                                         required:
                                           - status
@@ -4839,22 +3817,17 @@ spec:
                                         type: object
                                       type: array
                                     currentVolumeAttributesClassName:
-                                      description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                       type: string
                                     modifyVolumeStatus:
-                                      description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                       properties:
                                         status:
-                                          description: status is the status of the ControllerModifyVolume operation.
                                           type: string
                                         targetVolumeAttributesClassName:
-                                          description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                           type: string
                                       required:
                                         - status
                                       type: object
                                     phase:
-                                      description: phase represents the current phase of PersistentVolumeClaim.
                                       type: string
                                   type: object
                               type: object
@@ -4867,37 +3840,28 @@ spec:
                       nullable: true
                       type: array
                     store:
-                      description: OSDStore is the backend storage type used for creating the OSDs
                       properties:
                         type:
-                          description: Type of backend storage to be used while creating OSDs. If empty, then bluestore will be used
                           enum:
                             - bluestore
                             - bluestore-rdr
                           type: string
                         updateStore:
-                          description: UpdateStore updates the backend store for existing OSDs.
                           pattern: ^$|^yes-really-update-store$
                           type: string
                       type: object
                     useAllDevices:
-                      description: Whether to consume all the storage devices found on a machine
                       type: boolean
                     useAllNodes:
                       type: boolean
                     volumeClaimTemplates:
-                      description: PersistentVolumeClaims to use as storage
                       items:
-                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                         properties:
                           apiVersion:
-                            description: APIVersion defines the versioned schema of this representation of an object.
                             type: string
                           kind:
-                            description: Kind is a string value representing the REST resource this object represents.
                             type: string
                           metadata:
-                            description: 'Standard object''s metadata. More info: https://git.k8s.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -4917,24 +3881,18 @@ spec:
                                 type: string
                             type: object
                           spec:
-                            description: spec defines the desired characteristics of a volume requested by a pod author.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
                                     type: string
                                 required:
                                   - kind
@@ -4942,26 +3900,20 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               dataSourceRef:
-                                description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
                                     type: string
                                   namespace:
-                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               resources:
-                                description: resources represents the minimum resources the volume should have.
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -4970,7 +3922,6 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -4979,25 +3930,18 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Requests describes the minimum amount of compute resources required.
                                     type: object
                                 type: object
                               selector:
-                                description: selector is a label query over volumes to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5009,36 +3953,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               storageClassName:
-                                description: storageClassName is the name of the StorageClass required by the claim.
                                 type: string
                               volumeAttributesClassName:
-                                description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                 type: string
                               volumeMode:
-                                description: volumeMode defines what type of volume is required by the claim.
                                 type: string
                               volumeName:
-                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
-                            description: status represents the current information/status of a persistent volume claim. Read-only.
                             properties:
                               accessModes:
-                                description: accessModes contains the actual access modes the volume backing the PVC has.
                                 items:
                                   type: string
                                 type: array
                               allocatedResourceStatuses:
                                 additionalProperties:
-                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                   type: string
-                                description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                 type: object
                                 x-kubernetes-map-type: granular
                               allocatedResources:
@@ -5048,7 +3983,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -5057,31 +3991,23 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: capacity represents the actual resources of the underlying volume.
                                 type: object
                               conditions:
-                                description: conditions is the current Condition of persistent volume claim.
                                 items:
-                                  description: PersistentVolumeClaimCondition contains details about state of pvc
                                   properties:
                                     lastProbeTime:
-                                      description: lastProbeTime is the time we probed the condition.
                                       format: date-time
                                       type: string
                                     lastTransitionTime:
-                                      description: lastTransitionTime is the time the condition transitioned from one status to another.
                                       format: date-time
                                       type: string
                                     message:
-                                      description: message is the human-readable message indicating details about last transition.
                                       type: string
                                     reason:
-                                      description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                       type: string
                                     status:
                                       type: string
                                     type:
-                                      description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                       type: string
                                   required:
                                     - status
@@ -5089,41 +4015,32 @@ spec:
                                   type: object
                                 type: array
                               currentVolumeAttributesClassName:
-                                description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                 type: string
                               modifyVolumeStatus:
-                                description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                 properties:
                                   status:
-                                    description: status is the status of the ControllerModifyVolume operation.
                                     type: string
                                   targetVolumeAttributesClassName:
-                                    description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                     type: string
                                 required:
                                   - status
                                 type: object
                               phase:
-                                description: phase represents the current phase of PersistentVolumeClaim.
                                 type: string
                             type: object
                         type: object
                       type: array
                   type: object
                 waitTimeoutForHealthyOSDInMinutes:
-                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stop
                   format: int64
                   type: integer
               type: object
             status:
-              description: ClusterStatus represents the status of a Ceph cluster
               nullable: true
               properties:
                 ceph:
-                  description: CephStatus is the details health of a Ceph Cluster
                   properties:
                     capacity:
-                      description: Capacity is the capacity information of a Ceph Cluster
                       properties:
                         bytesAvailable:
                           format: int64
@@ -5139,7 +4056,6 @@ spec:
                       type: object
                     details:
                       additionalProperties:
-                        description: CephHealthMessage represents the health message of a Ceph Cluster
                         properties:
                           message:
                             type: string
@@ -5161,53 +4077,43 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
                             type: integer
-                          description: CephFSMirror shows CephFSMirror Ceph version
                           type: object
                         mds:
                           additionalProperties:
                             type: integer
-                          description: Mds shows Mds Ceph version
                           type: object
                         mgr:
                           additionalProperties:
                             type: integer
-                          description: Mgr shows Mgr Ceph version
                           type: object
                         mon:
                           additionalProperties:
                             type: integer
-                          description: Mon shows Mon Ceph version
                           type: object
                         osd:
                           additionalProperties:
                             type: integer
-                          description: Osd shows Osd Ceph version
                           type: object
                         overall:
                           additionalProperties:
                             type: integer
-                          description: Overall shows overall Ceph version
                           type: object
                         rbd-mirror:
                           additionalProperties:
                             type: integer
-                          description: RbdMirror shows RbdMirror Ceph version
                           type: object
                         rgw:
                           additionalProperties:
                             type: integer
-                          description: Rgw shows Rgw Ceph version
                           type: object
                       type: object
                   type: object
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -5218,50 +4124,40 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 message:
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 state:
-                  description: ClusterState represents the state of a Ceph Cluster
                   type: string
                 storage:
-                  description: CephStorage represents flavors of Ceph Cluster Storage
                   properties:
                     deviceClasses:
                       items:
-                        description: DeviceClasses represents device classes of a Ceph Cluster
                         properties:
                           name:
                             type: string
                         type: object
                       type: array
                     osd:
-                      description: OSDStatus represents OSD status of the ceph Cluster
                       properties:
                         storeType:
                           additionalProperties:
                             type: integer
-                          description: StoreType is a mapping between the OSD backend stores and number of OSDs using these stores
                           type: object
                       type: object
                   type: object
                 version:
-                  description: ClusterVersion represents the version of a Ceph Cluster
                   properties:
                     image:
                       type: string
@@ -5301,59 +4197,42 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephCOSIDriver represents the CRD for the Ceph COSI Driver Deployment
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph COSI Driver
               properties:
                 deploymentStrategy:
-                  description: DeploymentStrategy is the strategy to use to deploy the COSI driver.
                   enum:
                     - Never
                     - Auto
                     - Always
                   type: string
                 image:
-                  description: Image is the container image to run the Ceph COSI driver
                   type: string
                 objectProvisionerImage:
-                  description: ObjectProvisionerImage is the container image to run the COSI driver sidecar
                   type: string
                 placement:
-                  description: Placement is the placement strategy to use for the COSI driver
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5363,18 +4242,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5386,7 +4260,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5395,26 +4268,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5424,18 +4289,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5453,32 +4313,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5490,38 +4340,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5533,23 +4374,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5558,26 +4395,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5589,38 +4418,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5632,17 +4452,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5650,32 +4467,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5687,38 +4494,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5730,23 +4528,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5755,26 +4549,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5786,38 +4572,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5829,17 +4606,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5847,49 +4621,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -5901,35 +4660,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -5939,15 +4690,11 @@ spec:
                       type: array
                   type: object
                 resources:
-                  description: Resources is the resource requirements for the COSI driver
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -5963,7 +4710,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -5972,7 +4718,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -6007,59 +4752,43 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystemMirror is the Ceph Filesystem Mirror object definition
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: FilesystemMirroringSpec is the filesystem mirroring specification
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                 labels:
                   additionalProperties:
                     type: string
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                 placement:
-                  description: The affinity to place the rgw pods (default is to place on any available node)
                   nullable: true
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6069,18 +4798,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6092,7 +4816,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6101,26 +4824,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6130,18 +4845,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6159,32 +4869,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6196,38 +4896,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6239,23 +4930,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6264,26 +4951,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6295,38 +4974,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6338,17 +5008,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6356,32 +5023,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6393,38 +5050,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6436,23 +5084,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6461,26 +5105,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6492,38 +5128,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6535,17 +5162,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6553,49 +5177,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -6607,35 +5216,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -6645,19 +5246,14 @@ spec:
                       type: array
                   type: object
                 priorityClassName:
-                  description: PriorityClassName sets priority class on the cephfs-mirror pods
                   type: string
                 resources:
-                  description: The resource requirements for the cephfs-mirror pods
                   nullable: true
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -6673,7 +5269,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -6682,16 +5277,13 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -6702,17 +5294,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -6758,29 +5347,22 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystem represents a Ceph Filesystem
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: FilesystemSpec represents the spec of a file system
               properties:
                 dataPools:
-                  description: The data pool settings, with optional predefined pool name.
                   items:
-                    description: NamedPoolSpec represents the named ceph pool spec
                     properties:
                       application:
                         description: The application name to set on the pool. Only expected to be set for rgw pools.
                         type: string
                       compressionMode:
-                        description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
                           - none
                           - passive
@@ -6790,28 +5372,21 @@ spec:
                         nullable: true
                         type: string
                       crushRoot:
-                        description: The root of the crush hierarchy utilized by the pool
                         nullable: true
                         type: string
                       deviceClass:
-                        description: The device class the OSD should set to for use in the pool
                         nullable: true
                         type: string
                       enableRBDStats:
-                        description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                         type: boolean
                       erasureCoded:
-                        description: The erasure code settings
                         properties:
                           algorithm:
-                            description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                             minimum: 0
                             type: integer
                         required:
@@ -6819,84 +5394,63 @@ spec:
                           - dataChunks
                         type: object
                       failureDomain:
-                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                         type: string
                       mirroring:
-                        description: The mirroring settings
                         properties:
                           enabled:
-                            description: Enabled whether this pool is mirrored or not
                             type: boolean
                           mode:
-                            description: 'Mode is the mirroring mode: either pool or image'
                             type: string
                           peers:
-                            description: Peers represents the peers spec
                             nullable: true
                             properties:
                               secretNames:
-                                description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                                 items:
                                   type: string
                                 type: array
                             type: object
                           snapshotSchedules:
-                            description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                             items:
-                              description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
                                   type: string
                                 path:
-                                  description: Path is the path to snapshot, only valid for CephFS
                                   type: string
                                 startTime:
-                                  description: StartTime indicates when to start the snapshot
                                   type: string
                               type: object
                             type: array
                         type: object
                       name:
-                        description: Name of the pool
                         type: string
                       parameters:
                         additionalProperties:
                           type: string
-                        description: Parameters is a list of properties to enable on a given pool
                         nullable: true
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       quotas:
-                        description: The quota settings
                         nullable: true
                         properties:
                           maxBytes:
-                            description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                             format: int64
                             type: integer
                           maxObjects:
-                            description: MaxObjects represents the quota in objects
                             format: int64
                             type: integer
                           maxSize:
-                            description: MaxSize represents the quota in bytes as a string
                             pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                             type: string
                         type: object
                       replicated:
-                        description: The replication settings
                         properties:
                           hybridStorage:
-                            description: HybridStorage represents hybrid storage tier settings
                             nullable: true
                             properties:
                               primaryDeviceClass:
-                                description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                                 minLength: 1
                                 type: string
                               secondaryDeviceClass:
-                                description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                                 minLength: 1
                                 type: string
                             required:
@@ -6904,36 +5458,28 @@ spec:
                               - secondaryDeviceClass
                             type: object
                           replicasPerFailureDomain:
-                            description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                             minimum: 1
                             type: integer
                           requireSafeReplicaSize:
-                            description: RequireSafeReplicaSize if false allows you to set replica 1
                             type: boolean
                           size:
-                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                             minimum: 0
                             type: integer
                           subFailureDomain:
-                            description: SubFailureDomain the name of the sub-failure domain
                             type: string
                           targetSizeRatio:
-                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                             type: number
                         required:
                           - size
                         type: object
                       statusCheck:
-                        description: The mirroring statusCheck
                         properties:
                           mirror:
-                            description: HealthCheckSpec represents the health check of an object store bucket
                             nullable: true
                             properties:
                               disabled:
                                 type: boolean
                               interval:
-                                description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                                 type: string
                               timeout:
                                 type: string
@@ -6944,14 +5490,12 @@ spec:
                   nullable: true
                   type: array
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -6961,28 +5505,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -6990,40 +5527,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -7031,40 +5557,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -7072,36 +5589,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -7110,82 +5619,62 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 metadataServer:
-                  description: The mds pod info
                   properties:
                     activeCount:
-                      description: The number of metadata servers that are active.
                       format: int32
                       maximum: 50
                       minimum: 1
                       type: integer
                     activeStandby:
-                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster f
                       type: boolean
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -7193,85 +5682,64 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                     placement:
-                      description: The affinity to place the mds pods (default is to place on all available node) with a daemonset
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7281,18 +5749,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7304,7 +5767,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7313,26 +5775,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7342,18 +5796,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7371,32 +5820,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7408,38 +5847,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7451,23 +5881,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7476,26 +5902,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7507,38 +5925,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7550,17 +5959,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7568,32 +5974,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7605,38 +6001,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7648,23 +6035,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7673,26 +6056,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7704,38 +6079,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7747,17 +6113,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7765,49 +6128,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -7819,35 +6167,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -7858,19 +6198,14 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     priorityClassName:
-                      description: PriorityClassName sets priority classes on components
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -7886,7 +6221,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -7895,61 +6229,45 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     startupProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -7957,53 +6275,42 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -8012,69 +6319,51 @@ spec:
                     - activeCount
                   type: object
                 mirroring:
-                  description: The mirroring settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled whether this filesystem is mirrored or not
                       type: boolean
                     peers:
-                      description: Peers represents the peers spec
                       nullable: true
                       properties:
                         secretNames:
-                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                           items:
                             type: string
                           type: array
                       type: object
                     snapshotRetention:
-                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy.
                       items:
-                        description: SnapshotScheduleRetentionSpec is a retention policy
                         properties:
                           duration:
-                            description: Duration represents the retention duration for a snapshot
                             type: string
                           path:
-                            description: Path is the path to snapshot
                             type: string
                         type: object
                       type: array
                     snapshotSchedules:
-                      description: SnapshotSchedules is the scheduling of snapshot for mirrored filesystems
                       items:
-                        description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
                             type: string
                           path:
-                            description: Path is the path to snapshot, only valid for CephFS
                             type: string
                           startTime:
-                            description: StartTime indicates when to start the snapshot
                             type: string
                         type: object
                       type: array
                   type: object
                 preserveFilesystemOnDelete:
-                  description: Preserve the fs in the cluster on CephFilesystem CR deletion.
                   type: boolean
                 preservePoolsOnDelete:
-                  description: Preserve pools on filesystem deletion
                   type: boolean
                 statusCheck:
-                  description: The mirroring statusCheck
                   properties:
                     mirror:
-                      description: HealthCheckSpec represents the health check of an object store bucket
                       nullable: true
                       properties:
                         disabled:
                           type: boolean
                         interval:
-                          description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                           type: string
                         timeout:
                           type: string
@@ -8087,11 +6376,9 @@ spec:
                 - metadataServer
               type: object
             status:
-              description: CephFilesystemStatus represents the status of a Ceph Filesystem
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -8102,76 +6389,54 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 info:
                   additionalProperties:
                     type: string
-                  description: Use only info and put mirroringStatus in it?
                   nullable: true
                   type: object
                 mirroringStatus:
-                  description: MirroringStatus is the filesystem mirroring status
                   properties:
                     daemonsStatus:
-                      description: PoolMirroringStatus is the mirroring status of a filesystem
                       items:
-                        description: FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem
                         properties:
                           daemon_id:
-                            description: DaemonID is the cephfs-mirror name
                             type: integer
                           filesystems:
-                            description: Filesystems is the list of filesystems managed by a given cephfs-mirror daemon
                             items:
-                              description: FilesystemsSpec is spec for the mirrored filesystem
                               properties:
                                 directory_count:
-                                  description: DirectoryCount is the number of directories in the filesystem
                                   type: integer
                                 filesystem_id:
-                                  description: FilesystemID is the filesystem identifier
                                   type: integer
                                 name:
-                                  description: Name is name of the filesystem
                                   type: string
                                 peers:
-                                  description: Peers represents the mirroring peers
                                   items:
-                                    description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
                                         properties:
                                           client_name:
-                                            description: ClientName is cephx name
                                             type: string
                                           cluster_name:
-                                            description: ClusterName is the name of the cluster
                                             type: string
                                           fs_name:
-                                            description: FsName is the filesystem name
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
                                         properties:
                                           failure_count:
-                                            description: FailureCount is the number of mirroring failure
                                             type: integer
                                           recovery_count:
-                                            description: RecoveryCount is the number of recovery attempted after failures
                                             type: integer
                                         type: object
                                       uuid:
-                                        description: UUID is the peer unique identifier
                                         type: string
                                     type: object
                                   type: array
@@ -8181,79 +6446,56 @@ spec:
                       nullable: true
                       type: array
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 snapshotScheduleStatus:
-                  description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     snapshotSchedules:
-                      description: SnapshotSchedules is the list of snapshots scheduled
                       items:
-                        description: FilesystemSnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool
                         properties:
                           fs:
-                            description: Fs is the name of the Ceph Filesystem
                             type: string
                           path:
-                            description: Path is the path on the filesystem
                             type: string
                           rel_path:
                             type: string
                           retention:
-                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot s
                             properties:
                               active:
-                                description: Active is whether the scheduled is active or not
                                 type: boolean
                               created:
-                                description: Created is when the snapshot schedule was created
                                 type: string
                               created_count:
-                                description: CreatedCount is total amount of snapshots
                                 type: integer
                               first:
-                                description: First is when the first snapshot schedule was taken
                                 type: string
                               last:
-                                description: Last is when the last snapshot schedule was taken
                                 type: string
                               last_pruned:
-                                description: LastPruned is when the last snapshot schedule was pruned
                                 type: string
                               pruned_count:
-                                description: PrunedCount is total amount of pruned snapshots
                                 type: integer
                               start:
-                                description: Start is when the snapshot schedule starts
                                 type: string
                             type: object
                           schedule:
                             type: string
                           subvol:
-                            description: Subvol is the name of the sub volume
                             type: string
                         type: object
                       nullable: true
@@ -8294,33 +6536,26 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystemSubVolumeGroup represents a Ceph Filesystem SubVolumeGroup
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph Filesystem SubVolumeGroup
               properties:
                 filesystemName:
-                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name.
                   type: string
                   x-kubernetes-validations:
                     - message: filesystemName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
                       rule: self == oldSelf
                 pinning:
-                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.
                   properties:
                     distributed:
                       maximum: 1
@@ -8345,7 +6580,6 @@ spec:
                 - filesystemName
               type: object
             status:
-              description: Status represents the status of a CephFilesystem SubvolumeGroup
               properties:
                 info:
                   additionalProperties:
@@ -8353,11 +6587,9 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -8392,65 +6624,47 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephNFS represents a Ceph NFS
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NFSGaneshaSpec represents the spec of an nfs ganesha server
               properties:
                 rados:
-                  description: RADOS is the Ganesha RADOS specification
                   nullable: true
                   properties:
                     namespace:
-                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored.
                       type: string
                     pool:
-                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons.
                       type: string
                   type: object
                 security:
-                  description: Security allows specifying security configurations for the NFS cluster
                   nullable: true
                   properties:
                     kerberos:
-                      description: Kerberos configures NFS-Ganesha to secure NFS client connections with Kerberos.
                       nullable: true
                       properties:
                         configFiles:
-                          description: ConfigFiles defines where the Kerberos configuration should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos confi
                               properties:
                                 configMap:
-                                  description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8458,82 +6672,60 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                     - claimName
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: ClusterTrustBundle allows a pod to access the `.spec.
                                             properties:
                                               labelSelector:
-                                                description: Select all ClusterTrustBundles that match this label selector.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -8545,42 +6737,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: Select a single ClusterTrustBundle by object name.
                                                 type: string
                                               optional:
-                                                description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                 type: string
                                             required:
                                               - path
                                             type: object
                                           configMap:
-                                            description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8588,56 +6769,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional specify whether the ConfigMap or its keys must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume file
                                                 items:
-                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the field to select in the specified API version.
                                                           type: string
                                                       required:
                                                         - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container name: required for volumes, optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                             - type: integer
                                                             - type: string
-                                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required: resource to select'
                                                           type: string
                                                       required:
                                                         - resource
@@ -8649,22 +6816,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8672,25 +6833,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional field specify whether the Secret or its key must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative to the mount point of the file to project the token into.
                                                 type: string
                                             required:
                                               - path
@@ -8699,26 +6854,19 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8726,44 +6874,32 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         domainName:
-                          description: DomainName should be set to the Kerberos Realm.
                           type: string
                         keytabFile:
-                          description: KeytabFile defines where the Kerberos keytab should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos k
                               properties:
                                 configMap:
-                                  description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8771,82 +6907,60 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                     - claimName
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: ClusterTrustBundle allows a pod to access the `.spec.
                                             properties:
                                               labelSelector:
-                                                description: Select all ClusterTrustBundles that match this label selector.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -8858,42 +6972,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: Select a single ClusterTrustBundle by object name.
                                                 type: string
                                               optional:
-                                                description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                 type: string
                                             required:
                                               - path
                                             type: object
                                           configMap:
-                                            description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8901,56 +7004,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional specify whether the ConfigMap or its keys must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume file
                                                 items:
-                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the field to select in the specified API version.
                                                           type: string
                                                       required:
                                                         - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container name: required for volumes, optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                             - type: integer
                                                             - type: string
-                                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required: resource to select'
                                                           type: string
                                                       required:
                                                         - resource
@@ -8962,22 +7051,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8985,25 +7068,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional field specify whether the Secret or its key must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative to the mount point of the file to project the token into.
                                                 type: string
                                             required:
                                               - path
@@ -9012,26 +7089,19 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -9039,60 +7109,44 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         principalName:
                           default: nfs
-                          description: PrincipalName corresponds directly to NFS-Ganesha's NFS_KRB5:PrincipalName config.
                           type: string
                       type: object
                     sssd:
-                      description: SSSD enables integration with System Security Services Daemon (SSSD).
                       nullable: true
                       properties:
                         sidecar:
-                          description: Sidecar tells Rook to run SSSD in a sidecar alongside the NFS-Ganesha server in each NFS pod.
                           properties:
                             additionalFiles:
-                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar.
                               items:
-                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configu
                                 properties:
                                   subPath:
-                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be pl
                                     minLength: 1
                                     pattern: ^[^:]+$
                                     type: string
                                   volumeSource:
-                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional
                                     properties:
                                       configMap:
-                                        description: configMap represents a configMap that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -9100,82 +7154,60 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       emptyDir:
-                                        description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                         properties:
                                           medium:
-                                            description: medium represents what type of storage medium should back this directory.
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                               - type: integer
                                               - type: string
-                                            description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       hostPath:
-                                        description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                         properties:
                                           path:
-                                            description: path of the directory on the host.
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                             type: string
                                         required:
                                           - path
                                         type: object
                                       persistentVolumeClaim:
-                                        description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                         properties:
                                           claimName:
-                                            description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                             type: string
                                           readOnly:
-                                            description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                             type: boolean
                                         required:
                                           - claimName
                                         type: object
                                       projected:
-                                        description: projected items for all in one resources secrets, configmaps, and downward API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode bits used to set permissions on created files by default.
                                             format: int32
                                             type: integer
                                           sources:
-                                            description: sources is the list of volume projections
                                             items:
-                                              description: Projection that may be projected along with other supported volume types
                                               properties:
                                                 clusterTrustBundle:
-                                                  description: ClusterTrustBundle allows a pod to access the `.spec.
                                                   properties:
                                                     labelSelector:
-                                                      description: Select all ClusterTrustBundles that match this label selector.
                                                       properties:
                                                         matchExpressions:
-                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                           items:
-                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                             properties:
                                                               key:
-                                                                description: key is the label key that the selector applies to.
                                                                 type: string
                                                               operator:
-                                                                description: operator represents a key's relationship to a set of values.
                                                                 type: string
                                                               values:
-                                                                description: values is an array of string values.
                                                                 items:
                                                                   type: string
                                                                 type: array
@@ -9187,42 +7219,31 @@ spec:
                                                         matchLabels:
                                                           additionalProperties:
                                                             type: string
-                                                          description: matchLabels is a map of {key,value} pairs.
                                                           type: object
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     name:
-                                                      description: Select a single ClusterTrustBundle by object name.
                                                       type: string
                                                     optional:
-                                                      description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                       type: boolean
                                                     path:
-                                                      description: Relative path from the volume root to write the bundle.
                                                       type: string
                                                     signerName:
-                                                      description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                       type: string
                                                   required:
                                                     - path
                                                   type: object
                                                 configMap:
-                                                  description: configMap information about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                       items:
-                                                        description: Maps a string key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -9230,56 +7251,42 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
-                                                      description: optional specify whether the ConfigMap or its keys must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 downwardAPI:
-                                                  description: downwardAPI information about the downwardAPI data to project
                                                   properties:
                                                     items:
-                                                      description: Items is a list of DownwardAPIVolume file
                                                       items:
-                                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                         properties:
                                                           fieldRef:
-                                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                             properties:
                                                               apiVersion:
-                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                                 type: string
                                                               fieldPath:
-                                                                description: Path of the field to select in the specified API version.
                                                                 type: string
                                                             required:
                                                               - fieldPath
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required: Path is  the relative path name of the file to be created.'
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                             properties:
                                                               containerName:
-                                                                description: 'Container name: required for volumes, optional for env vars'
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
                                                                   - type: integer
                                                                   - type: string
-                                                                description: Specifies the output format of the exposed resources, defaults to "1"
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
-                                                                description: 'Required: resource to select'
                                                                 type: string
                                                             required:
                                                               - resource
@@ -9291,22 +7298,16 @@ spec:
                                                       type: array
                                                   type: object
                                                 secret:
-                                                  description: secret information about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                       items:
-                                                        description: Maps a string key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -9314,25 +7315,19 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
-                                                      description: optional field specify whether the Secret or its key must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 serviceAccountToken:
-                                                  description: serviceAccountToken is information about the serviceAccountToken data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the intended audience of the token.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds is the requested duration of validity of the service account token.
                                                       format: int64
                                                       type: integer
                                                     path:
-                                                      description: path is the path relative to the mount point of the file to project the token into.
                                                       type: string
                                                   required:
                                                     - path
@@ -9341,26 +7336,19 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -9368,10 +7356,8 @@ spec:
                                               type: object
                                             type: array
                                           optional:
-                                            description: optional field specify whether the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                             type: string
                                         type: object
                                     type: object
@@ -9381,24 +7367,18 @@ spec:
                                 type: object
                               type: array
                             debugLevel:
-                              description: DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing.
                               maximum: 10
                               minimum: 0
                               type: integer
                             image:
-                              description: Image defines the container image that should be used for the SSSD sidecar.
                               minLength: 1
                               type: string
                             resources:
-                              description: Resources allow specifying resource requests/limits on the SSSD sidecar container.
                               properties:
                                 claims:
-                                  description: Claims lists the names of resources, defined in spec.
                                   items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -9414,7 +7394,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -9423,36 +7402,26 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             sssdConfigFile:
-                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from.
                               properties:
                                 volumeSource:
-                                  description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD confi
                                   properties:
                                     configMap:
-                                      description: configMap represents a configMap that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9460,82 +7429,60 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
                                           type: string
                                         optional:
-                                          description: optional specify whether the ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     emptyDir:
-                                      description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                       properties:
                                         medium:
-                                          description: medium represents what type of storage medium should back this directory.
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     hostPath:
-                                      description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                       properties:
                                         path:
-                                          description: path of the directory on the host.
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     persistentVolumeClaim:
-                                      description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                       properties:
                                         claimName:
-                                          description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                         - claimName
                                       type: object
                                     projected:
-                                      description: projected items for all in one resources secrets, configmaps, and downward API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits used to set permissions on created files by default.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume projections
                                           items:
-                                            description: Projection that may be projected along with other supported volume types
                                             properties:
                                               clusterTrustBundle:
-                                                description: ClusterTrustBundle allows a pod to access the `.spec.
                                                 properties:
                                                   labelSelector:
-                                                    description: Select all ClusterTrustBundles that match this label selector.
                                                     properties:
                                                       matchExpressions:
-                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                         items:
-                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                           properties:
                                                             key:
-                                                              description: key is the label key that the selector applies to.
                                                               type: string
                                                             operator:
-                                                              description: operator represents a key's relationship to a set of values.
                                                               type: string
                                                             values:
-                                                              description: values is an array of string values.
                                                               items:
                                                                 type: string
                                                               type: array
@@ -9547,42 +7494,31 @@ spec:
                                                       matchLabels:
                                                         additionalProperties:
                                                           type: string
-                                                        description: matchLabels is a map of {key,value} pairs.
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   name:
-                                                    description: Select a single ClusterTrustBundle by object name.
                                                     type: string
                                                   optional:
-                                                    description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                     type: boolean
                                                   path:
-                                                    description: Relative path from the volume root to write the bundle.
                                                     type: string
                                                   signerName:
-                                                    description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                     type: string
                                                 required:
                                                   - path
                                                 type: object
                                               configMap:
-                                                description: configMap information about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                     items:
-                                                      description: Maps a string key to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9590,56 +7526,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
-                                                    description: optional specify whether the ConfigMap or its keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of the field to select in the specified API version.
                                                               type: string
                                                           required:
                                                             - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required: Path is  the relative path name of the file to be created.'
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container name: required for volumes, optional for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                                 - type: integer
                                                                 - type: string
-                                                              description: Specifies the output format of the exposed resources, defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required: resource to select'
                                                               type: string
                                                           required:
                                                             - resource
@@ -9651,22 +7573,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                     items:
-                                                      description: Maps a string key to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9674,25 +7590,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify whether the Secret or its key must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is information about the serviceAccountToken data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended audience of the token.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds is the requested duration of validity of the service account token.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path relative to the mount point of the file to project the token into.
                                                     type: string
                                                 required:
                                                   - path
@@ -9701,26 +7611,19 @@ spec:
                                           type: array
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9728,10 +7631,8 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                           type: string
                                       type: object
                                   type: object
@@ -9742,80 +7643,60 @@ spec:
                       type: object
                   type: object
                 server:
-                  description: Server is the Ganesha Server specification
                   properties:
                     active:
-                      description: The number of active Ganesha servers
                       type: integer
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     hostNetwork:
-                      description: Whether host networking is enabled for the Ganesha server.
                       nullable: true
                       type: boolean
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -9823,88 +7704,66 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
                       type: string
                     placement:
-                      description: The affinity to place the ganesha pods
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9914,18 +7773,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9937,7 +7791,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -9946,26 +7799,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9975,18 +7820,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10004,32 +7844,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10041,38 +7871,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10084,23 +7905,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10109,26 +7926,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10140,38 +7949,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10183,17 +7983,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10201,32 +7998,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10238,38 +8025,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10281,23 +8059,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10306,26 +8080,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10337,38 +8103,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10380,17 +8137,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10398,49 +8152,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -10452,35 +8191,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -10491,19 +8222,14 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     priorityClassName:
-                      description: PriorityClassName sets the priority class on the pods
                       type: string
                     resources:
-                      description: Resources set resource requests and limits
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -10519,7 +8245,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -10528,7 +8253,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10539,11 +8263,9 @@ spec:
                 - server
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -10554,17 +8276,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -10600,22 +8319,17 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectRealm represents a Ceph Object Store Gateway Realm
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
               nullable: true
               properties:
                 pull:
-                  description: PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm
                   properties:
                     endpoint:
                       pattern: ^https*://
@@ -10623,11 +8337,9 @@ spec:
                   type: object
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -10638,17 +8350,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -10687,33 +8396,26 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStore represents a Ceph Object Store Gateway
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
               properties:
                 allowUsersInNamespaces:
-                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store use
                   items:
                     type: string
                   type: array
                 dataPool:
-                  description: The data pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -10723,28 +8425,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -10752,40 +8447,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -10793,40 +8477,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -10834,36 +8509,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -10872,88 +8539,66 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 gateway:
-                  description: The rgw pod info
                   nullable: true
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     caBundleRef:
-                      description: The name of the secret that stores custom ca-bundle with root and intermediate certificates.
                       nullable: true
                       type: string
                     dashboardEnabled:
-                      description: Whether rgw dashboard is enabled for the rgw daemon. If not set, the rgw dashboard will be enabled.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     disableMultisiteSyncTraffic:
-                      description: DisableMultisiteSyncTraffic, when true, prevents this object store's gateways from transmitting mult
                       type: boolean
                     externalRgwEndpoints:
-                      description: ExternalRgwEndpoints points to external RGW endpoint(s).
                       items:
-                        description: EndpointAddress is a tuple that describes a single IP address or host name.
                         properties:
                           hostname:
-                            description: The DNS-addressable Hostname of this endpoint.
                             type: string
                           ip:
-                            description: The IP of this endpoint.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       nullable: true
                       type: array
                     hostNetwork:
-                      description: Whether host networking is enabled for the rgw daemon.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     instances:
-                      description: The number of pods in the rgw replicaset.
                       format: int32
                       nullable: true
                       type: integer
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     placement:
-                      description: The affinity to place the rgw pods (default is to place on any available node)
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10963,18 +8608,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10986,7 +8626,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10995,26 +8634,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -11024,18 +8655,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -11053,32 +8679,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11090,38 +8706,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11133,23 +8740,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -11158,26 +8761,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11189,38 +8784,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11232,17 +8818,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -11250,32 +8833,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11287,38 +8860,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11330,23 +8894,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -11355,26 +8915,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11386,38 +8938,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11429,17 +8972,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -11447,49 +8987,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -11501,35 +9026,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -11540,23 +9057,17 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     port:
-                      description: The port the rgw service will be listening on (http)
                       format: int32
                       type: integer
                     priorityClassName:
-                      description: PriorityClassName sets priority classes on the rgw pods
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -11572,7 +9083,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -11581,87 +9091,66 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     securePort:
-                      description: The port the rgw service will be listening on (https)
                       format: int32
                       maximum: 65535
                       minimum: 0
                       nullable: true
                       type: integer
                     service:
-                      description: The configuration related to add/set on each rgw service.
                       nullable: true
                       properties:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: The annotations-related configuration to add/set on each rgw service. nullable optional
                           type: object
                       type: object
                     sslCertificateRef:
-                      description: The name of the secret that stores the ssl certificate for secure rgw connections
                       nullable: true
                       type: string
                   type: object
                 healthCheck:
-                  description: The RGW health probes
                   nullable: true
                   properties:
                     readinessProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -11669,109 +9158,83 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     startupProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -11779,67 +9242,54 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                   type: object
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11849,28 +9299,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11878,40 +9321,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -11919,40 +9351,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -11960,36 +9383,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -11998,72 +9413,57 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 preservePoolsOnDelete:
-                  description: Preserve pools on object store deletion
                   type: boolean
                 security:
-                  description: Security represents security settings
                   nullable: true
                   properties:
                     keyRotation:
-                      description: KeyRotation defines options for Key Rotation.
                       nullable: true
                       properties:
                         enabled:
                           default: false
-                          description: Enabled represents whether the key rotation is enabled.
                           type: boolean
                         schedule:
-                          description: Schedule represents the cron schedule for key rotation.
                           type: string
                       type: object
                     kms:
-                      description: KeyManagementService is the main Key Management option
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                     s3:
-                      description: The settings for supporting AWS-SSE:S3 with RGW
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                   type: object
                 zone:
-                  description: The multisite info
                   nullable: true
                   properties:
                     name:
-                      description: RGW Zone the Object Store is in
                       type: string
                   required:
                     - name
                   type: object
               type: object
             status:
-              description: ObjectStoreStatus represents the status of a Ceph Object Store resource
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12074,12 +9474,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
@@ -12104,11 +9502,9 @@ spec:
                 message:
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -12148,25 +9544,19 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStoreUser represents a Ceph Object Store Gateway User
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
               properties:
                 capabilities:
-                  description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
                     amz-cache:
-                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12174,7 +9564,6 @@ spec:
                         - read, write
                       type: string
                     bilog:
-                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12182,7 +9571,6 @@ spec:
                         - read, write
                       type: string
                     bucket:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12190,7 +9578,6 @@ spec:
                         - read, write
                       type: string
                     buckets:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12198,7 +9585,6 @@ spec:
                         - read, write
                       type: string
                     datalog:
-                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12206,7 +9592,6 @@ spec:
                         - read, write
                       type: string
                     info:
-                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12214,7 +9599,6 @@ spec:
                         - read, write
                       type: string
                     mdlog:
-                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12222,7 +9606,6 @@ spec:
                         - read, write
                       type: string
                     metadata:
-                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12230,7 +9613,6 @@ spec:
                         - read, write
                       type: string
                     oidc-provider:
-                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12238,7 +9620,6 @@ spec:
                         - read, write
                       type: string
                     ratelimit:
-                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12246,7 +9627,6 @@ spec:
                         - read, write
                       type: string
                     roles:
-                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12254,7 +9634,6 @@ spec:
                         - read, write
                       type: string
                     usage:
-                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12262,7 +9641,6 @@ spec:
                         - read, write
                       type: string
                     user:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12270,7 +9648,6 @@ spec:
                         - read, write
                       type: string
                     user-policy:
-                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12278,7 +9655,6 @@ spec:
                         - read, write
                       type: string
                     users:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12286,7 +9662,6 @@ spec:
                         - read, write
                       type: string
                     zone:
-                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12295,21 +9670,16 @@ spec:
                       type: string
                   type: object
                 clusterNamespace:
-                  description: The namespace where the parent CephCluster and CephObjectStore are found
                   type: string
                 displayName:
-                  description: The display name for the ceph users
                   type: string
                 quotas:
-                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage.
                   nullable: true
                   properties:
                     maxBuckets:
-                      description: Maximum bucket limit for the ceph user
                       nullable: true
                       type: integer
                     maxObjects:
-                      description: Maximum number of objects across all the user's buckets
                       format: int64
                       nullable: true
                       type: integer
@@ -12317,17 +9687,14 @@ spec:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                   type: object
                 store:
-                  description: The store the user will be created in
                   type: string
               type: object
             status:
-              description: ObjectStoreUserStatus represents the status Ceph Object Store Gateway User
               properties:
                 info:
                   additionalProperties:
@@ -12335,7 +9702,6 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12375,31 +9741,24 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectZoneGroup represents a Ceph Object Store Gateway Zone Group
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
               properties:
                 realm:
-                  description: The display name for the ceph users
                   type: string
               required:
                 - realm
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12410,17 +9769,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12460,34 +9816,27 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectZone represents a Ceph Object Store Gateway Zone
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
               properties:
                 customEndpoints:
-                  description: If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint cre
                   items:
                     type: string
                   nullable: true
                   type: array
                 dataPool:
-                  description: The data pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12497,28 +9846,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12526,40 +9868,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -12567,40 +9898,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -12608,36 +9930,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -12646,14 +9960,12 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12663,28 +9975,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12692,40 +9997,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -12733,40 +10027,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -12774,36 +10059,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -12813,10 +10090,8 @@ spec:
                   type: object
                 preservePoolsOnDelete:
                   default: true
-                  description: Preserve pools on object zone deletion
                   type: boolean
                 zoneGroup:
-                  description: The display name for the ceph users
                   type: string
               required:
                 - dataPool
@@ -12824,11 +10099,9 @@ spec:
                 - zoneGroup
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12839,17 +10112,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12889,75 +10159,56 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephRBDMirror represents a Ceph RBD Mirror
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: RBDMirroringSpec represents the specification of an RBD mirror daemon
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 count:
-                  description: Count represents the number of rbd mirror instance to run
                   minimum: 1
                   type: integer
                 labels:
                   additionalProperties:
                     type: string
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 peers:
-                  description: Peers represents the peers spec
                   nullable: true
                   properties:
                     secretNames:
-                      description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                       items:
                         type: string
                       type: array
                   type: object
                 placement:
-                  description: The affinity to place the rgw pods (default is to place on any available node)
                   nullable: true
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12967,18 +10218,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12990,7 +10236,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -12999,26 +10244,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -13028,18 +10265,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -13057,32 +10289,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13094,38 +10316,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13137,23 +10350,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -13162,26 +10371,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13193,38 +10394,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13236,17 +10428,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -13254,32 +10443,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13291,38 +10470,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13334,23 +10504,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -13359,26 +10525,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13390,38 +10548,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13433,17 +10582,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -13451,49 +10597,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -13505,35 +10636,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -13544,19 +10667,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 priorityClassName:
-                  description: PriorityClassName sets priority class on the rbd mirror pods
                   type: string
                 resources:
-                  description: The resource requirements for the rbd mirror pods
                   nullable: true
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -13572,7 +10690,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -13581,7 +10698,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -13589,11 +10705,9 @@ spec:
                 - count
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -13604,17 +10718,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -13627,123 +10738,6 @@ spec:
           type: object
       served: true
       storage: true
-      subresources:
-        status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: objectbucketclaims.objectbucket.io
-  annotations:
-    helm.sh/resource-policy: keep
-spec:
-  group: objectbucket.io
-  names:
-    kind: ObjectBucketClaim
-    listKind: ObjectBucketClaimList
-    plural: objectbucketclaims
-    singular: objectbucketclaim
-    shortNames:
-      - obc
-      - obcs
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                storageClassName:
-                  type: string
-                bucketName:
-                  type: string
-                generateBucketName:
-                  type: string
-                additionalConfig:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                objectBucketName:
-                  type: string
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-      subresources:
-        status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: objectbuckets.objectbucket.io
-  annotations:
-    helm.sh/resource-policy: keep
-spec:
-  group: objectbucket.io
-  names:
-    kind: ObjectBucket
-    listKind: ObjectBucketList
-    plural: objectbuckets
-    singular: objectbucket
-    shortNames:
-      - ob
-      - obs
-  scope: Cluster
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                storageClassName:
-                  type: string
-                endpoint:
-                  type: object
-                  nullable: true
-                  properties:
-                    bucketHost:
-                      type: string
-                    bucketPort:
-                      type: integer
-                      format: int32
-                    bucketName:
-                      type: string
-                    region:
-                      type: string
-                    subRegion:
-                      type: string
-                    additionalConfig:
-                      type: object
-                      nullable: true
-                      x-kubernetes-preserve-unknown-fields: true
-                authentication:
-                  type: object
-                  nullable: true
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                additionalState:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                reclaimPolicy:
-                  type: string
-                claimRef:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
 

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -23,27 +23,21 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephBlockPoolRadosNamespace represents a Ceph BlockPool Rados Namespace
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph BlockPool Rados Namespace
               properties:
                 blockPoolName:
-                  description: BlockPoolName is the name of Ceph BlockPool. Typically it's the name of the CephBlockPool CR.
                   type: string
                   x-kubernetes-validations:
                     - message: blockPoolName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the CephBlockPoolRadosNamespaceSpec namespace.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
@@ -52,7 +46,6 @@ spec:
                 - blockPoolName
               type: object
             status:
-              description: Status represents the status of a CephBlockPool Rados Namespace
               properties:
                 info:
                   additionalProperties:
@@ -60,7 +53,6 @@ spec:
                   nullable: true
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -96,24 +88,19 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephBlockPool represents a Ceph Storage Pool
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
                 application:
                   description: The application name to set on the pool. Only expected to be set for rgw pools.
                   type: string
                 compressionMode:
-                  description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
                     - none
                     - passive
@@ -123,28 +110,21 @@ spec:
                   nullable: true
                   type: string
                 crushRoot:
-                  description: The root of the crush hierarchy utilized by the pool
                   nullable: true
                   type: string
                 deviceClass:
-                  description: The device class the OSD should set to for use in the pool
                   nullable: true
                   type: string
                 enableRBDStats:
-                  description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                   type: boolean
                 erasureCoded:
-                  description: The erasure code settings
                   properties:
                     algorithm:
-                      description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                       minimum: 0
                       type: integer
                   required:
@@ -152,46 +132,34 @@ spec:
                     - dataChunks
                   type: object
                 failureDomain:
-                  description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                   type: string
                 mirroring:
-                  description: The mirroring settings
                   properties:
                     enabled:
-                      description: Enabled whether this pool is mirrored or not
                       type: boolean
                     mode:
-                      description: 'Mode is the mirroring mode: either pool or image'
                       type: string
                     peers:
-                      description: Peers represents the peers spec
                       nullable: true
                       properties:
                         secretNames:
-                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                           items:
                             type: string
                           type: array
                       type: object
                     snapshotSchedules:
-                      description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                       items:
-                        description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
                             type: string
                           path:
-                            description: Path is the path to snapshot, only valid for CephFS
                             type: string
                           startTime:
-                            description: StartTime indicates when to start the snapshot
                             type: string
                         type: object
                       type: array
                   type: object
                 name:
-                  description: The desired name of the pool if different from the CephBlockPool CR name.
                   enum:
                     - .rgw.root
                     - .nfs
@@ -200,40 +168,31 @@ spec:
                 parameters:
                   additionalProperties:
                     type: string
-                  description: Parameters is a list of properties to enable on a given pool
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 quotas:
-                  description: The quota settings
                   nullable: true
                   properties:
                     maxBytes:
-                      description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                       format: int64
                       type: integer
                     maxObjects:
-                      description: MaxObjects represents the quota in objects
                       format: int64
                       type: integer
                     maxSize:
-                      description: MaxSize represents the quota in bytes as a string
                       pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                       type: string
                   type: object
                 replicated:
-                  description: The replication settings
                   properties:
                     hybridStorage:
-                      description: HybridStorage represents hybrid storage tier settings
                       nullable: true
                       properties:
                         primaryDeviceClass:
-                          description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                           minLength: 1
                           type: string
                         secondaryDeviceClass:
-                          description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                           minLength: 1
                           type: string
                       required:
@@ -241,36 +200,28 @@ spec:
                         - secondaryDeviceClass
                       type: object
                     replicasPerFailureDomain:
-                      description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                       minimum: 1
                       type: integer
                     requireSafeReplicaSize:
-                      description: RequireSafeReplicaSize if false allows you to set replica 1
                       type: boolean
                     size:
-                      description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                       minimum: 0
                       type: integer
                     subFailureDomain:
-                      description: SubFailureDomain the name of the sub-failure domain
                       type: string
                     targetSizeRatio:
-                      description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                       type: number
                   required:
                     - size
                   type: object
                 statusCheck:
-                  description: The mirroring statusCheck
                   properties:
                     mirror:
-                      description: HealthCheckSpec represents the health check of an object store bucket
                       nullable: true
                       properties:
                         disabled:
                           type: boolean
                         interval:
-                          description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                           type: string
                         timeout:
                           type: string
@@ -279,11 +230,9 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
               type: object
             status:
-              description: CephBlockPoolStatus represents the mirroring status of Ceph Storage Pool
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -294,12 +243,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
@@ -309,7 +256,6 @@ spec:
                   nullable: true
                   type: object
                 mirroringInfo:
-                  description: MirroringInfoSpec is the status of the pool mirroring
                   properties:
                     details:
                       type: string
@@ -318,131 +264,91 @@ spec:
                     lastChecked:
                       type: string
                     mode:
-                      description: Mode is the mirroring mode
                       type: string
                     peers:
-                      description: Peers are the list of peer sites connected to that cluster
                       items:
-                        description: PeersSpec contains peer details
                         properties:
                           client_name:
-                            description: ClientName is the CephX user used to connect to the peer
                             type: string
                           direction:
-                            description: Direction is the peer mirroring direction
                             type: string
                           mirror_uuid:
-                            description: MirrorUUID is the mirror UUID
                             type: string
                           site_name:
-                            description: SiteName is the current site name
                             type: string
                           uuid:
-                            description: UUID is the peer UUID
                             type: string
                         type: object
                       type: array
                     site_name:
-                      description: SiteName is the current site name
                       type: string
                   type: object
                 mirroringStatus:
-                  description: MirroringStatusSpec is the status of the pool mirroring
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     summary:
-                      description: Summary is the mirroring status summary
                       properties:
                         daemon_health:
-                          description: DaemonHealth is the health of the mirroring daemon
                           type: string
                         health:
-                          description: Health is the mirroring health
                           type: string
                         image_health:
-                          description: ImageHealth is the health of the mirrored image
                           type: string
                         states:
-                          description: States is the various state for all mirrored images
                           nullable: true
                           properties:
                             error:
-                              description: Error is when the mirroring state is errored
                               type: integer
                             replaying:
-                              description: Replaying is when the replay of the mirroring journal is on-going
                               type: integer
                             starting_replay:
-                              description: StartingReplay is when the replay of the mirroring journal starts
                               type: integer
                             stopped:
-                              description: Stopped is when the mirroring state is stopped
                               type: integer
                             stopping_replay:
-                              description: StopReplaying is when the replay of the mirroring journal stops
                               type: integer
                             syncing:
-                              description: Syncing is when the image is syncing
                               type: integer
                             unknown:
-                              description: Unknown is when the mirroring state is unknown
                               type: integer
                           type: object
                       type: object
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 snapshotScheduleStatus:
-                  description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     snapshotSchedules:
-                      description: SnapshotSchedules is the list of snapshots scheduled
                       items:
-                        description: SnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool
                         properties:
                           image:
-                            description: Image is the mirrored image
                             type: string
                           items:
-                            description: Items is the list schedules times for a given snapshot
                             items:
-                              description: SnapshotSchedule is a schedule
                               properties:
                                 interval:
-                                  description: Interval is the interval in which snapshots will be taken
                                   type: string
                                 start_time:
-                                  description: StartTime is the snapshot starting time
                                   type: string
                               type: object
                             type: array
                           namespace:
-                            description: Namespace is the RADOS namespace the image is part of
                             type: string
                           pool:
-                            description: Pool is the pool name
                             type: string
                         type: object
                       nullable: true
@@ -478,23 +384,17 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephBucketNotification represents a Bucket Notifications
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
               properties:
                 events:
-                  description: List of events that should trigger the notification
                   items:
-                    description: BucketNotificationSpec represent the event type of the bucket notification
                     enum:
                       - s3:ObjectCreated:*
                       - s3:ObjectCreated:Put
@@ -507,22 +407,17 @@ spec:
                     type: string
                   type: array
                 filter:
-                  description: Spec of notification filter
                   properties:
                     keyFilters:
-                      description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the filter - prefix/suffix/regex
                             enum:
                               - prefix
                               - suffix
                               - regex
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -530,16 +425,12 @@ spec:
                         type: object
                       type: array
                     metadataFilters:
-                      description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the metadata or tag
                             minLength: 1
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -547,16 +438,12 @@ spec:
                         type: object
                       type: array
                     tagFilters:
-                      description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
                         properties:
                           name:
-                            description: Name of the metadata or tag
                             minLength: 1
                             type: string
                           value:
-                            description: Value to filter on
                             type: string
                         required:
                           - name
@@ -565,18 +452,15 @@ spec:
                       type: array
                   type: object
                 topic:
-                  description: The name of the topic associated with this notification
                   minLength: 1
                   type: string
               required:
                 - topic
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -587,17 +471,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -636,42 +517,32 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephBucketTopic represents a Ceph Object Topic for Bucket Notifications
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
               properties:
                 endpoint:
-                  description: Contains the endpoint spec of the topic
                   properties:
                     amqp:
-                      description: Spec of AMQP endpoint
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker/routeable)
                           enum:
                             - none
                             - broker
                             - routeable
                           type: string
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         exchange:
-                          description: Name of the exchange that is used to route messages based on topics
                           minLength: 1
                           type: string
                         uri:
-                          description: The URI of the AMQP endpoint to push notification to
                           minLength: 1
                           type: string
                       required:
@@ -679,58 +550,45 @@ spec:
                         - uri
                       type: object
                     http:
-                      description: Spec of HTTP endpoint
                       properties:
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         sendCloudEvents:
-                          description: 'Send the notifications with the CloudEvents header: https://github.'
                           type: boolean
                         uri:
-                          description: The URI of the HTTP endpoint to push notification to
                           minLength: 1
                           type: string
                       required:
                         - uri
                       type: object
                     kafka:
-                      description: Spec of Kafka endpoint
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker)
                           enum:
                             - none
                             - broker
                           type: string
                         disableVerifySSL:
-                          description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
                         uri:
-                          description: The URI of the Kafka endpoint to push notification to
                           minLength: 1
                           type: string
                         useSSL:
-                          description: Indicate whether to use SSL when communicating with the broker
                           type: boolean
                       required:
                         - uri
                       type: object
                   type: object
                 objectStoreName:
-                  description: The name of the object store on which to define the topic
                   minLength: 1
                   type: string
                 objectStoreNamespace:
-                  description: The namespace of the object store on which to define the topic
                   minLength: 1
                   type: string
                 opaqueData:
-                  description: Data which is sent in each event
                   type: string
                 persistent:
-                  description: Indication whether notifications to this endpoint are persistent or not
                   type: boolean
               required:
                 - endpoint
@@ -738,14 +596,11 @@ spec:
                 - objectStoreNamespace
               type: object
             status:
-              description: BucketTopicStatus represents the Status of a CephBucketTopic
               properties:
                 ARN:
-                  description: The ARN of the topic generated by the RGW
                   nullable: true
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -784,18 +639,14 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephClient represents a Ceph Client
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph Client
               properties:
                 caps:
                   additionalProperties:
@@ -808,7 +659,6 @@ spec:
                 - caps
               type: object
             status:
-              description: Status represents the status of a Ceph Client
               properties:
                 info:
                   additionalProperties:
@@ -816,11 +666,9 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -882,26 +730,20 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephCluster is a Ceph storage cluster
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ClusterSpec represents the specification of Ceph Cluster
               properties:
                 annotations:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations
                     type: object
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -910,21 +752,16 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  description: Ceph Config options
                   nullable: true
                   type: object
                 cephVersion:
-                  description: The version information that instructs Rook to orchestrate a particular version of Ceph.
                   nullable: true
                   properties:
                     allowUnsupported:
-                      description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as quay.
                       type: string
                     imagePullPolicy:
-                      description: ImagePullPolicy describes a policy for if/when to pull a container image One of Always, Never, IfNot
                       enum:
                         - IfNotPresent
                         - Always
@@ -933,33 +770,26 @@ spec:
                       type: string
                   type: object
                 cleanupPolicy:
-                  description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster
                   nullable: true
                   properties:
                     allowUninstallWithVolumes:
-                      description: AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images s
                       type: boolean
                     confirmation:
-                      description: Confirmation represents the cleanup confirmation
                       nullable: true
                       pattern: ^$|^yes-really-destroy-data$
                       type: string
                     sanitizeDisks:
-                      description: SanitizeDisks represents way we sanitize disks
                       nullable: true
                       properties:
                         dataSource:
-                          description: DataSource is the data source to use to sanitize the disk with
                           enum:
                             - zero
                             - random
                           type: string
                         iteration:
-                          description: Iteration is the number of pass to apply the sanitizing
                           format: int32
                           type: integer
                         method:
-                          description: Method is the method we use to sanitize disks
                           enum:
                             - complete
                             - quick
@@ -967,151 +797,115 @@ spec:
                       type: object
                   type: object
                 continueUpgradeAfterChecksEvenIfNotHealthy:
-                  description: ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not
                   type: boolean
                 crashCollector:
-                  description: A spec for the crash controller
                   nullable: true
                   properties:
                     daysToRetain:
-                      description: DaysToRetain represents the number of days to retain crash until they get pruned
                       type: integer
                     disable:
-                      description: Disable determines whether we should enable the crash collector
                       type: boolean
                   type: object
                 csi:
-                  description: CSI Driver Options applied per cluster.
                   properties:
                     cephfs:
-                      description: CephFS defines CSI Driver settings for CephFS driver.
                       properties:
                         fuseMountOptions:
-                          description: FuseMountOptions defines the mount options for ceph fuse mounter.
                           type: string
                         kernelMountOptions:
-                          description: KernelMountOptions defines the mount options for kernel mounter.
                           type: string
                       type: object
                     readAffinity:
-                      description: ReadAffinity defines the read affinity settings for CSI driver.
                       properties:
                         crushLocationLabels:
-                          description: CrushLocationLabels defines which node labels to use as CRUSH location.
                           items:
                             type: string
                           type: array
                         enabled:
-                          description: Enables read affinity for CSI driver.
                           type: boolean
                       type: object
                   type: object
                 dashboard:
-                  description: Dashboard settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to enable the dashboard
                       type: boolean
                     port:
-                      description: Port is the dashboard webserver port
                       maximum: 65535
                       minimum: 0
                       type: integer
                     prometheusEndpoint:
-                      description: Endpoint for the Prometheus host
                       type: string
                     prometheusEndpointSSLVerify:
-                      description: Whether to verify the ssl endpoint for prometheus. Set to false for a self-signed cert.
                       type: boolean
                     ssl:
-                      description: SSL determines whether SSL should be used
                       type: boolean
                     urlPrefix:
-                      description: URLPrefix is a prefix for all URLs to use the dashboard with a reverse proxy
                       type: string
                   type: object
                 dataDirHostPath:
-                  description: The path on the host where config and data can be persisted
                   pattern: ^/(\S+)
                   type: string
                   x-kubernetes-validations:
                     - message: DataDirHostPath is immutable
                       rule: self == oldSelf
                 disruptionManagement:
-                  description: A spec for configuring disruption management.
                   nullable: true
                   properties:
                     machineDisruptionBudgetNamespace:
-                      description: Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController
                       type: string
                     manageMachineDisruptionBudgets:
-                      description: Deprecated. This enables management of machinedisruptionbudgets.
                       type: boolean
                     managePodBudgets:
-                      description: This enables management of poddisruptionbudgets
                       type: boolean
                     osdMaintenanceTimeout:
-                      description: 'OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure '
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups t
                       format: int64
                       type: integer
                     pgHealthyRegex:
-                      description: PgHealthyRegex is the regular expression that is used to determine which PG states should be conside
                       type: string
                   type: object
                 external:
-                  description: Whether the Ceph Cluster is running external to this Kubernetes cluster mon, mgr, osd, mds, and disc
                   nullable: true
                   properties:
                     enable:
-                      description: Enable determines whether external mode is enabled or not
                       type: boolean
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 healthCheck:
-                  description: Internal daemon healthchecks and liveness probe
                   nullable: true
                   properties:
                     daemonHealth:
-                      description: DaemonHealth is the health check for a given daemon
                       nullable: true
                       properties:
                         mon:
-                          description: Monitor represents the health check settings for the Ceph monitor
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
                           type: object
                         osd:
-                          description: ObjectStorageDaemon represents the health check settings for the Ceph OSDs
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
                           type: object
                         status:
-                          description: Status represents the health check settings for the Ceph health
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -1119,56 +913,41 @@ spec:
                       type: object
                     livenessProbe:
                       additionalProperties:
-                        description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                         properties:
                           disabled:
-                            description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
-                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1176,111 +955,84 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
                         type: object
-                      description: LivenessProbe allows changing the livenessProbe configuration for a given daemon
                       type: object
                     startupProbe:
                       additionalProperties:
-                        description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                         properties:
                           disabled:
-                            description: Disabled determines whether probe is disable or not
                             type: boolean
                           probe:
-                            description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
-                                    description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1288,161 +1040,122 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: Number of seconds after the container has started before liveness probes are initiated.
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                                 format: int32
                                 type: integer
                             type: object
                         type: object
-                      description: StartupProbe allows changing the startupProbe configuration for a given daemon
                       type: object
                   type: object
                 labels:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Labels are label for a given daemons
                     type: object
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled represents whether the log collector is enabled
                       type: boolean
                     maxLogSize:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: MaxLogSize is the maximum size of the log per ceph daemons. Must be at least 1M.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     periodicity:
-                      description: Periodicity is the periodicity of the log rotation.
                       pattern: ^$|^(hourly|daily|weekly|monthly|1h|24h|1d)$
                       type: string
                   type: object
                 mgr:
-                  description: A spec for mgr related options
                   nullable: true
                   properties:
                     allowMultiplePerNode:
-                      description: AllowMultiplePerNode allows to run multiple managers on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of manager daemons to run
                       maximum: 5
                       minimum: 0
                       type: integer
                     modules:
-                      description: Modules is the list of ceph manager modules to enable/disable
                       items:
-                        description: Module represents mgr modules that the user wants to enable or disable
                         properties:
                           enabled:
-                            description: Enabled determines whether a module should be enabled or not
                             type: boolean
                           name:
-                            description: Name is the name of the ceph manager module
                             type: string
                         type: object
                       nullable: true
                       type: array
                   type: object
                 mon:
-                  description: A spec for mon related options
                   nullable: true
                   properties:
                     allowMultiplePerNode:
-                      description: AllowMultiplePerNode determines if we can run multiple monitors on the same node (not recommended)
                       type: boolean
                     count:
-                      description: Count is the number of Ceph monitors
                       maximum: 9
                       minimum: 0
                       type: integer
                     failureDomainLabel:
                       type: string
                     stretchCluster:
-                      description: StretchCluster is the stretch cluster specification
                       properties:
                         failureDomainLabel:
-                          description: 'FailureDomainLabel the failure domain name (e,g: zone)'
                           type: string
                         subFailureDomain:
-                          description: SubFailureDomain is the failure domain within a zone
                           type: string
                         zones:
-                          description: Zones is the list of zones
                           items:
-                            description: MonZoneSpec represents the specification of a zone in a Ceph Cluster
                             properties:
                               arbiter:
-                                description: Arbiter determines if the zone contains the arbiter used for stretch cluster mode
                                 type: boolean
                               name:
-                                description: Name is the name of the zone
                                 type: string
                               volumeClaimTemplate:
-                                description: VolumeClaimTemplate is the PVC template
                                 properties:
                                   apiVersion:
-                                    description: APIVersion defines the versioned schema of this representation of an object.
                                     type: string
                                   kind:
-                                    description: Kind is a string value representing the REST resource this object represents.
                                     type: string
                                   metadata:
-                                    description: 'Standard object''s metadata. More info: https://git.k8s.'
                                     properties:
                                       annotations:
                                         additionalProperties:
@@ -1462,24 +1175,18 @@ spec:
                                         type: string
                                     type: object
                                   spec:
-                                    description: spec defines the desired characteristics of a volume requested by a pod author.
                                     properties:
                                       accessModes:
-                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                         items:
                                           type: string
                                         type: array
                                       dataSource:
-                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                         required:
                                           - kind
@@ -1487,26 +1194,20 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                         properties:
                                           apiGroup:
-                                            description: APIGroup is the group for the resource being referenced.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: resources represents the minimum resources the volume should have.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -1515,7 +1216,6 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -1524,25 +1224,18 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: Requests describes the minimum amount of compute resources required.
                                             type: object
                                         type: object
                                       selector:
-                                        description: selector is a label query over volumes to consider for binding.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1554,36 +1247,27 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: storageClassName is the name of the StorageClass required by the claim.
                                         type: string
                                       volumeAttributesClassName:
-                                        description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         type: string
                                       volumeMode:
-                                        description: volumeMode defines what type of volume is required by the claim.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                   status:
-                                    description: status represents the current information/status of a persistent volume claim. Read-only.
                                     properties:
                                       accessModes:
-                                        description: accessModes contains the actual access modes the volume backing the PVC has.
                                         items:
                                           type: string
                                         type: array
                                       allocatedResourceStatuses:
                                         additionalProperties:
-                                          description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                           type: string
-                                        description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                         type: object
                                         x-kubernetes-map-type: granular
                                       allocatedResources:
@@ -1593,7 +1277,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                         type: object
                                       capacity:
                                         additionalProperties:
@@ -1602,31 +1285,23 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: capacity represents the actual resources of the underlying volume.
                                         type: object
                                       conditions:
-                                        description: conditions is the current Condition of persistent volume claim.
                                         items:
-                                          description: PersistentVolumeClaimCondition contains details about state of pvc
                                           properties:
                                             lastProbeTime:
-                                              description: lastProbeTime is the time we probed the condition.
                                               format: date-time
                                               type: string
                                             lastTransitionTime:
-                                              description: lastTransitionTime is the time the condition transitioned from one status to another.
                                               format: date-time
                                               type: string
                                             message:
-                                              description: message is the human-readable message indicating details about last transition.
                                               type: string
                                             reason:
-                                              description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                               type: string
                                             status:
                                               type: string
                                             type:
-                                              description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                               type: string
                                           required:
                                             - status
@@ -1634,22 +1309,17 @@ spec:
                                           type: object
                                         type: array
                                       currentVolumeAttributesClassName:
-                                        description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                         type: string
                                       modifyVolumeStatus:
-                                        description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                         properties:
                                           status:
-                                            description: status is the status of the ControllerModifyVolume operation.
                                             type: string
                                           targetVolumeAttributesClassName:
-                                            description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                             type: string
                                         required:
                                           - status
                                         type: object
                                       phase:
-                                        description: phase represents the current phase of PersistentVolumeClaim.
                                         type: string
                                     type: object
                                 type: object
@@ -1659,16 +1329,12 @@ spec:
                           type: array
                       type: object
                     volumeClaimTemplate:
-                      description: VolumeClaimTemplate is the PVC definition
                       properties:
                         apiVersion:
-                          description: APIVersion defines the versioned schema of this representation of an object.
                           type: string
                         kind:
-                          description: Kind is a string value representing the REST resource this object represents.
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -1688,24 +1354,18 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: spec defines the desired characteristics of a volume requested by a pod author.
                           properties:
                             accessModes:
-                              description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
@@ -1713,26 +1373,20 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             dataSourceRef:
-                              description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource being referenced.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                                 namespace:
-                                  description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: resources represents the minimum resources the volume should have.
                               properties:
                                 limits:
                                   additionalProperties:
@@ -1741,7 +1395,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -1750,25 +1403,18 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             selector:
-                              description: selector is a label query over volumes to consider for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -1780,36 +1426,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             storageClassName:
-                              description: storageClassName is the name of the StorageClass required by the claim.
                               type: string
                             volumeAttributesClassName:
-                              description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is required by the claim.
                               type: string
                             volumeName:
-                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: status represents the current information/status of a persistent volume claim. Read-only.
                           properties:
                             accessModes:
-                              description: accessModes contains the actual access modes the volume backing the PVC has.
                               items:
                                 type: string
                               type: array
                             allocatedResourceStatuses:
                               additionalProperties:
-                                description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                 type: string
-                              description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -1819,7 +1456,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                               type: object
                             capacity:
                               additionalProperties:
@@ -1828,31 +1464,23 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: capacity represents the actual resources of the underlying volume.
                               type: object
                             conditions:
-                              description: conditions is the current Condition of persistent volume claim.
                               items:
-                                description: PersistentVolumeClaimCondition contains details about state of pvc
                                 properties:
                                   lastProbeTime:
-                                    description: lastProbeTime is the time we probed the condition.
                                     format: date-time
                                     type: string
                                   lastTransitionTime:
-                                    description: lastTransitionTime is the time the condition transitioned from one status to another.
                                     format: date-time
                                     type: string
                                   message:
-                                    description: message is the human-readable message indicating details about last transition.
                                     type: string
                                   reason:
-                                    description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                     type: string
                                 required:
                                   - status
@@ -1860,48 +1488,35 @@ spec:
                                 type: object
                               type: array
                             currentVolumeAttributesClassName:
-                              description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                               type: string
                             modifyVolumeStatus:
-                              description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                               properties:
                                 status:
-                                  description: status is the status of the ControllerModifyVolume operation.
                                   type: string
                                 targetVolumeAttributesClassName:
-                                  description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                   type: string
                               required:
                                 - status
                               type: object
                             phase:
-                              description: phase represents the current phase of PersistentVolumeClaim.
                               type: string
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     zones:
-                      description: Zones are specified when we want to provide zonal awareness to mons
                       items:
-                        description: MonZoneSpec represents the specification of a zone in a Ceph Cluster
                         properties:
                           arbiter:
-                            description: Arbiter determines if the zone contains the arbiter used for stretch cluster mode
                             type: boolean
                           name:
-                            description: Name is the name of the zone
                             type: string
                           volumeClaimTemplate:
-                            description: VolumeClaimTemplate is the PVC template
                             properties:
                               apiVersion:
-                                description: APIVersion defines the versioned schema of this representation of an object.
                                 type: string
                               kind:
-                                description: Kind is a string value representing the REST resource this object represents.
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info: https://git.k8s.'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -1921,24 +1536,18 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: spec defines the desired characteristics of a volume requested by a pod author.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being referenced
                                         type: string
                                     required:
                                       - kind
@@ -1946,26 +1555,20 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource being referenced.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: resources represents the minimum resources the volume should have.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1974,7 +1577,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1983,25 +1585,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Requests describes the minimum amount of compute resources required.
                                         type: object
                                     type: object
                                   selector:
-                                    description: selector is a label query over volumes to consider for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -2013,36 +1608,27 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: storageClassName is the name of the StorageClass required by the claim.
                                     type: string
                                   volumeAttributesClassName:
-                                    description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume is required by the claim.
                                     type: string
                                   volumeName:
-                                    description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: status represents the current information/status of a persistent volume claim. Read-only.
                                 properties:
                                   accessModes:
-                                    description: accessModes contains the actual access modes the volume backing the PVC has.
                                     items:
                                       type: string
                                     type: array
                                   allocatedResourceStatuses:
                                     additionalProperties:
-                                      description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                       type: string
-                                    description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                     type: object
                                     x-kubernetes-map-type: granular
                                   allocatedResources:
@@ -2052,7 +1638,6 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                     type: object
                                   capacity:
                                     additionalProperties:
@@ -2061,31 +1646,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: capacity represents the actual resources of the underlying volume.
                                     type: object
                                   conditions:
-                                    description: conditions is the current Condition of persistent volume claim.
                                     items:
-                                      description: PersistentVolumeClaimCondition contains details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: lastProbeTime is the time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: lastTransitionTime is the time the condition transitioned from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: message is the human-readable message indicating details about last transition.
                                           type: string
                                         reason:
-                                          description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -2093,22 +1670,17 @@ spec:
                                       type: object
                                     type: array
                                   currentVolumeAttributesClassName:
-                                    description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                     type: string
                                   modifyVolumeStatus:
-                                    description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                     properties:
                                       status:
-                                        description: status is the status of the ControllerModifyVolume operation.
                                         type: string
                                       targetVolumeAttributesClassName:
-                                        description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                         type: string
                                     required:
                                       - status
                                     type: object
                                   phase:
-                                    description: phase represents the current phase of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
@@ -2122,49 +1694,34 @@ spec:
                     - message: stretchCluster zones must be equal to 3
                       rule: '!has(self.stretchCluster) || (has(self.stretchCluster) && (size(self.stretchCluster.zones) > 0) && (size(self.stretchCluster.zones) == 3))'
                 monitoring:
-                  description: Prometheus based Monitoring settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled determines whether to create the prometheus rules for the ceph cluster.
                       type: boolean
                     externalMgrEndpoints:
-                      description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
                       items:
-                        description: EndpointAddress is a tuple that describes single IP address.
                         properties:
                           hostname:
-                            description: The Hostname of this endpoint
                             type: string
                           ip:
-                            description: The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.
                             type: string
                           nodeName:
-                            description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
                             type: string
                           targetRef:
-                            description: Reference to object providing the endpoint.
                             properties:
                               apiVersion:
-                                description: API version of the referent.
                                 type: string
                               fieldPath:
-                                description: If referring to a piece of an object instead of an entire object, this string should contain a valid
                                 type: string
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.'
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.'
                                 type: string
                               namespace:
-                                description: 'Namespace of the referent. More info: https://kubernetes.'
                                 type: string
                               resourceVersion:
-                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.'
                                 type: string
                               uid:
-                                description: 'UID of the referent. More info: https://kubernetes.'
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -2175,97 +1732,75 @@ spec:
                       nullable: true
                       type: array
                     externalMgrPrometheusPort:
-                      description: ExternalMgrPrometheusPort Prometheus exporter port
                       maximum: 65535
                       minimum: 0
                       type: integer
                     interval:
-                      description: Interval determines prometheus scrape interval
                       type: string
                     metricsDisabled:
-                      description: Whether to disable the metrics reported by Ceph.
                       type: boolean
                     port:
-                      description: Port is the prometheus server port
                       maximum: 65535
                       minimum: 0
                       type: integer
                   type: object
                 network:
-                  description: Network related configuration
                   nullable: true
                   properties:
                     addressRanges:
-                      description: AddressRanges specify a list of CIDRs that Rook will apply to Ceph's 'public_network' and/or 'cluste
                       nullable: true
                       properties:
                         cluster:
-                          description: Cluster defines a list of CIDRs to use for Ceph cluster network communication.
                           items:
-                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                         public:
-                          description: Public defines a list of CIDRs to use for Ceph public network communication.
                           items:
-                            description: An IPv4 or IPv6 network CIDR.
                             pattern: ^[0-9a-fA-F:.]{2,}\/[0-9]{1,3}$
                             type: string
                           type: array
                       type: object
                     connections:
-                      description: Settings for network connections such as compression and encryption across the wire.
                       nullable: true
                       properties:
                         compression:
-                          description: Compression settings for the network connections.
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to compress the data in transit across the wire. The default is not set.
                               type: boolean
                           type: object
                         encryption:
-                          description: Encryption settings for the network connections.
                           nullable: true
                           properties:
                             enabled:
-                              description: Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the netw
                               type: boolean
                           type: object
                         requireMsgr2:
-                          description: Whether to require msgr2 (port 3300) even if compression or encryption are not enabled.
                           type: boolean
                       type: object
                     dualStack:
-                      description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
                       type: boolean
                     hostNetwork:
-                      description: HostNetwork to enable host network.
                       type: boolean
                     ipFamily:
-                      description: IPFamily is the single stack IPv6 or IPv4 protocol
                       enum:
                         - IPv4
                         - IPv6
                       nullable: true
                       type: string
                     multiClusterService:
-                      description: Enable multiClusterService to export the Services between peer clusters
                       properties:
                         clusterID:
-                          description: ClusterID uniquely identifies a cluster. It is used as a prefix to nslookup exported services.
                           type: string
                         enabled:
-                          description: Enable multiClusterService to export the mon and OSD services to peer cluster.
                           type: boolean
                       type: object
                     provider:
-                      description: Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
                       enum:
                         - ""
                         - host
+                        - host-strict
                         - multus
                       nullable: true
                       type: string
@@ -2275,7 +1810,6 @@ spec:
                     selectors:
                       additionalProperties:
                         type: string
-                      description: Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster networks whe
                       nullable: true
                       type: object
                   type: object
@@ -2287,32 +1821,22 @@ spec:
                       rule: '!has(self.hostNetwork) || self.hostNetwork == false || !has(self.provider) || self.provider == ""'
                 placement:
                   additionalProperties:
-                    description: Placement is the placement for an object
                     properties:
                       nodeAffinity:
-                        description: NodeAffinity is a group of node affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2322,18 +1846,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2345,7 +1864,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2354,26 +1872,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms. The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2383,18 +1893,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
                                       items:
-                                        description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2412,32 +1917,22 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: PodAffinity is a group of inter pod affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2449,38 +1944,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2492,23 +1978,19 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2517,26 +1999,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2548,38 +2022,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2591,17 +2056,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2609,32 +2071,22 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2646,38 +2098,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2689,23 +2132,19 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                       type: string
                                   required:
                                     - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2714,26 +2153,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                             items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2745,38 +2176,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
                                             items:
                                               type: string
                                             type: array
@@ -2788,17 +2210,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                   type: string
                               required:
                                 - topologyKey
@@ -2806,49 +2225,34 @@ spec:
                             type: array
                         type: object
                       tolerations:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         items:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match. Empty means match all taint effects.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration matches to.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                         items:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
                                         items:
                                           type: string
                                         type: array
@@ -2860,35 +2264,27 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: MaxSkew describes the degree to which pods may be unevenly distributed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: MinDomains indicates a minimum number of eligible domains.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                               type: string
                             nodeTaintsPolicy:
-                              description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels.
                               type: string
                             whenUnsatisfiable:
-                              description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                               type: string
                           required:
                             - maxSkew
@@ -2897,31 +2293,24 @@ spec:
                           type: object
                         type: array
                     type: object
-                  description: The placement-related configuration to pass to kubernetes (affinity, node selector, tolerations).
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 priorityClassNames:
                   additionalProperties:
                     type: string
-                  description: PriorityClassNames sets priority classes on components
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 removeOSDsIfOutAndSafeToRemove:
-                  description: Remove the OSD that is out and safe to remove only if this option is true
                   type: boolean
                 resources:
                   additionalProperties:
-                    description: ResourceRequirements describes the compute resource requirements.
                     properties:
                       claims:
-                        description: Claims lists the names of resources, defined in spec.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: Name must match the name of one entry in pod.spec.
                               type: string
                           required:
                             - name
@@ -2937,7 +2326,6 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                         type: object
                       requests:
                         additionalProperties:
@@ -2946,50 +2334,39 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: Requests describes the minimum amount of compute resources required.
                         type: object
                     type: object
-                  description: Resources set resource requests and limits
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 security:
-                  description: Security represents security settings
                   nullable: true
                   properties:
                     keyRotation:
-                      description: KeyRotation defines options for Key Rotation.
                       nullable: true
                       properties:
                         enabled:
                           default: false
-                          description: Enabled represents whether the key rotation is enabled.
                           type: boolean
                         schedule:
-                          description: Schedule represents the cron schedule for key rotation.
                           type: string
                       type: object
                     kms:
-                      description: KeyManagementService is the main Key Management option
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                   type: object
                 skipUpgradeChecks:
-                  description: SkipUpgradeChecks defines if an upgrade should be forced even if one of the check fails
                   type: boolean
                 storage:
-                  description: A spec for available storage in the cluster and how it should be used
                   nullable: true
                   properties:
                     config:
@@ -2999,15 +2376,11 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     deviceFilter:
-                      description: A regular expression to allow more fine-grained selection of devices on nodes across the cluster
                       type: string
                     devicePathFilter:
-                      description: A regular expression to allow more fine-grained selection of devices with path names
                       type: string
                     devices:
-                      description: List of devices to use as storage devices
                       items:
-                        description: Device represents a disk to use in the cluster
                         properties:
                           config:
                             additionalProperties:
@@ -3024,11 +2397,9 @@ spec:
                       type: array
                       x-kubernetes-preserve-unknown-fields: true
                     flappingRestartIntervalHours:
-                      description: FlappingRestartIntervalHours defines the time for which the OSD pods, that failed with zero exit cod
                       type: integer
                     nodes:
                       items:
-                        description: Node is a storage nodes
                         properties:
                           config:
                             additionalProperties:
@@ -3037,15 +2408,11 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           deviceFilter:
-                            description: A regular expression to allow more fine-grained selection of devices on nodes across the cluster
                             type: string
                           devicePathFilter:
-                            description: A regular expression to allow more fine-grained selection of devices with path names
                             type: string
                           devices:
-                            description: List of devices to use as storage devices
                             items:
-                              description: Device represents a disk to use in the cluster
                               properties:
                                 config:
                                   additionalProperties:
@@ -3064,16 +2431,12 @@ spec:
                           name:
                             type: string
                           resources:
-                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               claims:
-                                description: Claims lists the names of resources, defined in spec.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -3089,7 +2452,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3098,26 +2460,19 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           useAllDevices:
-                            description: Whether to consume all the storage devices found on a machine
                             type: boolean
                           volumeClaimTemplates:
-                            description: PersistentVolumeClaims to use as storage
                             items:
-                              description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -3137,24 +2492,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                         - kind
@@ -3162,26 +2511,20 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -3190,7 +2533,6 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3199,25 +2541,18 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3229,36 +2564,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeAttributesClassName:
-                                      description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -3268,7 +2594,6 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -3277,31 +2602,23 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
-                                        description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
                                           lastProbeTime:
-                                            description: lastProbeTime is the time we probed the condition.
                                             format: date-time
                                             type: string
                                           lastTransitionTime:
-                                            description: lastTransitionTime is the time the condition transitioned from one status to another.
                                             format: date-time
                                             type: string
                                           message:
-                                            description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
                                           type:
-                                            description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                             type: string
                                         required:
                                           - status
@@ -3309,22 +2626,17 @@ spec:
                                         type: object
                                       type: array
                                     currentVolumeAttributesClassName:
-                                      description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                       type: string
                                     modifyVolumeStatus:
-                                      description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                       properties:
                                         status:
-                                          description: status is the status of the ControllerModifyVolume operation.
                                           type: string
                                         targetVolumeAttributesClassName:
-                                          description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                           type: string
                                       required:
                                         - status
                                       type: object
                                     phase:
-                                      description: phase represents the current phase of PersistentVolumeClaim.
                                       type: string
                                   type: object
                               type: object
@@ -3336,53 +2648,38 @@ spec:
                       type: boolean
                     storageClassDeviceSets:
                       items:
-                        description: StorageClassDeviceSet is a storage class device set
                         properties:
                           config:
                             additionalProperties:
                               type: string
-                            description: Provider-specific device configuration
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           count:
-                            description: Count is the number of devices in this set
                             minimum: 1
                             type: integer
                           encrypted:
-                            description: Whether to encrypt the deviceSet
                             type: boolean
                           name:
-                            description: Name is a unique identifier for the set
                             type: string
                           placement:
-                            description: Placement is the placement for an object
                             nullable: true
                             properties:
                               nodeAffinity:
-                                description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3392,18 +2689,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3415,7 +2707,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3424,26 +2715,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3453,18 +2736,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3482,32 +2760,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3519,38 +2787,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3562,23 +2821,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3587,26 +2842,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3618,38 +2865,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3661,17 +2899,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3679,32 +2914,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3716,38 +2941,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3759,23 +2975,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -3784,26 +2996,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3815,38 +3019,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3858,17 +3053,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -3876,49 +3068,34 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                                 items:
-                                  description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3930,35 +3107,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -3969,36 +3138,25 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           portable:
-                            description: Portable represents OSD portability across the hosts
                             type: boolean
                           preparePlacement:
-                            description: Placement is the placement for an object
                             nullable: true
                             properties:
                               nodeAffinity:
-                                description: NodeAffinity is a group of node affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4008,18 +3166,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4031,7 +3184,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4040,26 +3192,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4069,18 +3213,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4098,32 +3237,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: PodAffinity is a group of inter pod affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4135,38 +3264,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4178,23 +3298,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4203,26 +3319,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4234,38 +3342,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4277,17 +3376,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4295,32 +3391,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4332,38 +3418,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the set of namespaces that the term applies to.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -4375,23 +3452,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a static list of namespace names that the term applies to.
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                               type: string
                                           required:
                                             - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -4400,26 +3473,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4431,38 +3496,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4474,17 +3530,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to.
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                           type: string
                                       required:
                                         - topologyKey
@@ -4492,49 +3545,34 @@ spec:
                                     type: array
                                 type: object
                               tolerations:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                 items:
-                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration matches to.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                                 items:
-                                  description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4546,35 +3584,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: MinDomains indicates a minimum number of eligible domains.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node labels.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                       type: string
                                   required:
                                     - maxSkew
@@ -4585,16 +3615,12 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           resources:
-                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               claims:
-                                description: Claims lists the names of resources, defined in spec.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one entry in pod.spec.
                                       type: string
                                   required:
                                     - name
@@ -4610,7 +3636,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4619,32 +3644,23 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: Requests describes the minimum amount of compute resources required.
                                 type: object
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           schedulerName:
-                            description: Scheduler name for OSD pod placement
                             type: string
                           tuneDeviceClass:
-                            description: TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
                             type: boolean
                           tuneFastDeviceClass:
-                            description: TuneFastDeviceClass Tune the OSD when running on a fast Device Class
                             type: boolean
                           volumeClaimTemplates:
-                            description: VolumeClaimTemplates is a list of PVC templates for the underlying storage devices
                             items:
-                              description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                               properties:
                                 apiVersion:
-                                  description: APIVersion defines the versioned schema of this representation of an object.
                                   type: string
                                 kind:
-                                  description: Kind is a string value representing the REST resource this object represents.
                                   type: string
                                 metadata:
-                                  description: 'Standard object''s metadata. More info: https://git.k8s.'
                                   properties:
                                     annotations:
                                       additionalProperties:
@@ -4665,24 +3681,18 @@ spec:
                                       type: string
                                   type: object
                                 spec:
-                                  description: spec defines the desired characteristics of a volume requested by a pod author.
                                   properties:
                                     accessModes:
-                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                         - kind
@@ -4690,26 +3700,20 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
-                                      description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the resource being referenced.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
                                           type: string
                                         namespace:
-                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                           type: string
                                       required:
                                         - kind
                                         - name
                                       type: object
                                     resources:
-                                      description: resources represents the minimum resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -4718,7 +3722,6 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4727,25 +3730,18 @@ spec:
                                               - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: Requests describes the minimum amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values.
                                                 type: string
                                               values:
-                                                description: values is an array of string values.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4757,36 +3753,27 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
-                                      description: storageClassName is the name of the StorageClass required by the claim.
                                       type: string
                                     volumeAttributesClassName:
-                                      description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of volume is required by the claim.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                                 status:
-                                  description: status represents the current information/status of a persistent volume claim. Read-only.
                                   properties:
                                     accessModes:
-                                      description: accessModes contains the actual access modes the volume backing the PVC has.
                                       items:
                                         type: string
                                       type: array
                                     allocatedResourceStatuses:
                                       additionalProperties:
-                                        description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                         type: string
-                                      description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                       type: object
                                       x-kubernetes-map-type: granular
                                     allocatedResources:
@@ -4796,7 +3783,6 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                       type: object
                                     capacity:
                                       additionalProperties:
@@ -4805,31 +3791,23 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: capacity represents the actual resources of the underlying volume.
                                       type: object
                                     conditions:
-                                      description: conditions is the current Condition of persistent volume claim.
                                       items:
-                                        description: PersistentVolumeClaimCondition contains details about state of pvc
                                         properties:
                                           lastProbeTime:
-                                            description: lastProbeTime is the time we probed the condition.
                                             format: date-time
                                             type: string
                                           lastTransitionTime:
-                                            description: lastTransitionTime is the time the condition transitioned from one status to another.
                                             format: date-time
                                             type: string
                                           message:
-                                            description: message is the human-readable message indicating details about last transition.
                                             type: string
                                           reason:
-                                            description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                             type: string
                                           status:
                                             type: string
                                           type:
-                                            description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                             type: string
                                         required:
                                           - status
@@ -4837,22 +3815,17 @@ spec:
                                         type: object
                                       type: array
                                     currentVolumeAttributesClassName:
-                                      description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                       type: string
                                     modifyVolumeStatus:
-                                      description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                       properties:
                                         status:
-                                          description: status is the status of the ControllerModifyVolume operation.
                                           type: string
                                         targetVolumeAttributesClassName:
-                                          description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                           type: string
                                       required:
                                         - status
                                       type: object
                                     phase:
-                                      description: phase represents the current phase of PersistentVolumeClaim.
                                       type: string
                                   type: object
                               type: object
@@ -4865,37 +3838,28 @@ spec:
                       nullable: true
                       type: array
                     store:
-                      description: OSDStore is the backend storage type used for creating the OSDs
                       properties:
                         type:
-                          description: Type of backend storage to be used while creating OSDs. If empty, then bluestore will be used
                           enum:
                             - bluestore
                             - bluestore-rdr
                           type: string
                         updateStore:
-                          description: UpdateStore updates the backend store for existing OSDs.
                           pattern: ^$|^yes-really-update-store$
                           type: string
                       type: object
                     useAllDevices:
-                      description: Whether to consume all the storage devices found on a machine
                       type: boolean
                     useAllNodes:
                       type: boolean
                     volumeClaimTemplates:
-                      description: PersistentVolumeClaims to use as storage
                       items:
-                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                         properties:
                           apiVersion:
-                            description: APIVersion defines the versioned schema of this representation of an object.
                             type: string
                           kind:
-                            description: Kind is a string value representing the REST resource this object represents.
                             type: string
                           metadata:
-                            description: 'Standard object''s metadata. More info: https://git.k8s.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -4915,24 +3879,18 @@ spec:
                                 type: string
                             type: object
                           spec:
-                            description: spec defines the desired characteristics of a volume requested by a pod author.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
                                     type: string
                                 required:
                                   - kind
@@ -4940,26 +3898,20 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               dataSourceRef:
-                                description: dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volum
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource being referenced.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being referenced
                                     type: string
                                   namespace:
-                                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a g
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               resources:
-                                description: resources represents the minimum resources the volume should have.
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -4968,7 +3920,6 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -4977,25 +3928,18 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Requests describes the minimum amount of compute resources required.
                                     type: object
                                 type: object
                               selector:
-                                description: selector is a label query over volumes to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5007,36 +3951,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               storageClassName:
-                                description: storageClassName is the name of the StorageClass required by the claim.
                                 type: string
                               volumeAttributesClassName:
-                                description: volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                 type: string
                               volumeMode:
-                                description: volumeMode defines what type of volume is required by the claim.
                                 type: string
                               volumeName:
-                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                 type: string
                             type: object
                           status:
-                            description: status represents the current information/status of a persistent volume claim. Read-only.
                             properties:
                               accessModes:
-                                description: accessModes contains the actual access modes the volume backing the PVC has.
                                 items:
                                   type: string
                                 type: array
                               allocatedResourceStatuses:
                                 additionalProperties:
-                                  description: When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource tha
                                   type: string
-                                description: allocatedResourceStatuses stores status of resource being resized for the given PVC.
                                 type: object
                                 x-kubernetes-map-type: granular
                               allocatedResources:
@@ -5046,7 +3981,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: allocatedResources tracks the resources allocated to a PVC including its capacity.
                                 type: object
                               capacity:
                                 additionalProperties:
@@ -5055,31 +3989,23 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: capacity represents the actual resources of the underlying volume.
                                 type: object
                               conditions:
-                                description: conditions is the current Condition of persistent volume claim.
                                 items:
-                                  description: PersistentVolumeClaimCondition contains details about state of pvc
                                   properties:
                                     lastProbeTime:
-                                      description: lastProbeTime is the time we probed the condition.
                                       format: date-time
                                       type: string
                                     lastTransitionTime:
-                                      description: lastTransitionTime is the time the condition transitioned from one status to another.
                                       format: date-time
                                       type: string
                                     message:
-                                      description: message is the human-readable message indicating details about last transition.
                                       type: string
                                     reason:
-                                      description: 'reason is a unique, this should be a short, machine understandable string that gives the reason for '
                                       type: string
                                     status:
                                       type: string
                                     type:
-                                      description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
                                       type: string
                                   required:
                                     - status
@@ -5087,41 +4013,32 @@ spec:
                                   type: object
                                 type: array
                               currentVolumeAttributesClassName:
-                                description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                 type: string
                               modifyVolumeStatus:
-                                description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                 properties:
                                   status:
-                                    description: status is the status of the ControllerModifyVolume operation.
                                     type: string
                                   targetVolumeAttributesClassName:
-                                    description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being rec
                                     type: string
                                 required:
                                   - status
                                 type: object
                               phase:
-                                description: phase represents the current phase of PersistentVolumeClaim.
                                 type: string
                             type: object
                         type: object
                       type: array
                   type: object
                 waitTimeoutForHealthyOSDInMinutes:
-                  description: WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stop
                   format: int64
                   type: integer
               type: object
             status:
-              description: ClusterStatus represents the status of a Ceph cluster
               nullable: true
               properties:
                 ceph:
-                  description: CephStatus is the details health of a Ceph Cluster
                   properties:
                     capacity:
-                      description: Capacity is the capacity information of a Ceph Cluster
                       properties:
                         bytesAvailable:
                           format: int64
@@ -5137,7 +4054,6 @@ spec:
                       type: object
                     details:
                       additionalProperties:
-                        description: CephHealthMessage represents the health message of a Ceph Cluster
                         properties:
                           message:
                             type: string
@@ -5159,53 +4075,43 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
                             type: integer
-                          description: CephFSMirror shows CephFSMirror Ceph version
                           type: object
                         mds:
                           additionalProperties:
                             type: integer
-                          description: Mds shows Mds Ceph version
                           type: object
                         mgr:
                           additionalProperties:
                             type: integer
-                          description: Mgr shows Mgr Ceph version
                           type: object
                         mon:
                           additionalProperties:
                             type: integer
-                          description: Mon shows Mon Ceph version
                           type: object
                         osd:
                           additionalProperties:
                             type: integer
-                          description: Osd shows Osd Ceph version
                           type: object
                         overall:
                           additionalProperties:
                             type: integer
-                          description: Overall shows overall Ceph version
                           type: object
                         rbd-mirror:
                           additionalProperties:
                             type: integer
-                          description: RbdMirror shows RbdMirror Ceph version
                           type: object
                         rgw:
                           additionalProperties:
                             type: integer
-                          description: Rgw shows Rgw Ceph version
                           type: object
                       type: object
                   type: object
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -5216,50 +4122,40 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 message:
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 state:
-                  description: ClusterState represents the state of a Ceph Cluster
                   type: string
                 storage:
-                  description: CephStorage represents flavors of Ceph Cluster Storage
                   properties:
                     deviceClasses:
                       items:
-                        description: DeviceClasses represents device classes of a Ceph Cluster
                         properties:
                           name:
                             type: string
                         type: object
                       type: array
                     osd:
-                      description: OSDStatus represents OSD status of the ceph Cluster
                       properties:
                         storeType:
                           additionalProperties:
                             type: integer
-                          description: StoreType is a mapping between the OSD backend stores and number of OSDs using these stores
                           type: object
                       type: object
                   type: object
                 version:
-                  description: ClusterVersion represents the version of a Ceph Cluster
                   properties:
                     image:
                       type: string
@@ -5298,59 +4194,42 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephCOSIDriver represents the CRD for the Ceph COSI Driver Deployment
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph COSI Driver
               properties:
                 deploymentStrategy:
-                  description: DeploymentStrategy is the strategy to use to deploy the COSI driver.
                   enum:
                     - Never
                     - Auto
                     - Always
                   type: string
                 image:
-                  description: Image is the container image to run the Ceph COSI driver
                   type: string
                 objectProvisionerImage:
-                  description: ObjectProvisionerImage is the container image to run the COSI driver sidecar
                   type: string
                 placement:
-                  description: Placement is the placement strategy to use for the COSI driver
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5360,18 +4239,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5383,7 +4257,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5392,26 +4265,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5421,18 +4286,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -5450,32 +4310,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5487,38 +4337,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5530,23 +4371,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5555,26 +4392,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5586,38 +4415,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5629,17 +4449,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5647,32 +4464,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5684,38 +4491,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -5727,23 +4525,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -5752,26 +4546,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5783,38 +4569,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -5826,17 +4603,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -5844,49 +4618,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -5898,35 +4657,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -5936,15 +4687,11 @@ spec:
                       type: array
                   type: object
                 resources:
-                  description: Resources is the resource requirements for the COSI driver
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -5960,7 +4707,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -5969,7 +4715,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
@@ -6003,59 +4748,43 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystemMirror is the Ceph Filesystem Mirror object definition
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: FilesystemMirroringSpec is the filesystem mirroring specification
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                 labels:
                   additionalProperties:
                     type: string
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                 placement:
-                  description: The affinity to place the rgw pods (default is to place on any available node)
                   nullable: true
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6065,18 +4794,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6088,7 +4812,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6097,26 +4820,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6126,18 +4841,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -6155,32 +4865,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6192,38 +4892,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6235,23 +4926,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6260,26 +4947,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6291,38 +4970,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6334,17 +5004,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6352,32 +5019,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6389,38 +5046,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -6432,23 +5080,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -6457,26 +5101,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6488,38 +5124,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -6531,17 +5158,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -6549,49 +5173,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -6603,35 +5212,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -6641,19 +5242,14 @@ spec:
                       type: array
                   type: object
                 priorityClassName:
-                  description: PriorityClassName sets priority class on the cephfs-mirror pods
                   type: string
                 resources:
-                  description: The resource requirements for the cephfs-mirror pods
                   nullable: true
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -6669,7 +5265,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -6678,16 +5273,13 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -6698,17 +5290,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -6753,29 +5342,22 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystem represents a Ceph Filesystem
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: FilesystemSpec represents the spec of a file system
               properties:
                 dataPools:
-                  description: The data pool settings, with optional predefined pool name.
                   items:
-                    description: NamedPoolSpec represents the named ceph pool spec
                     properties:
                       application:
                         description: The application name to set on the pool. Only expected to be set for rgw pools.
                         type: string
                       compressionMode:
-                        description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
                           - none
                           - passive
@@ -6785,28 +5367,21 @@ spec:
                         nullable: true
                         type: string
                       crushRoot:
-                        description: The root of the crush hierarchy utilized by the pool
                         nullable: true
                         type: string
                       deviceClass:
-                        description: The device class the OSD should set to for use in the pool
                         nullable: true
                         type: string
                       enableRBDStats:
-                        description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                         type: boolean
                       erasureCoded:
-                        description: The erasure code settings
                         properties:
                           algorithm:
-                            description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                             minimum: 0
                             type: integer
                         required:
@@ -6814,84 +5389,63 @@ spec:
                           - dataChunks
                         type: object
                       failureDomain:
-                        description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                         type: string
                       mirroring:
-                        description: The mirroring settings
                         properties:
                           enabled:
-                            description: Enabled whether this pool is mirrored or not
                             type: boolean
                           mode:
-                            description: 'Mode is the mirroring mode: either pool or image'
                             type: string
                           peers:
-                            description: Peers represents the peers spec
                             nullable: true
                             properties:
                               secretNames:
-                                description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                                 items:
                                   type: string
                                 type: array
                             type: object
                           snapshotSchedules:
-                            description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                             items:
-                              description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
                                   type: string
                                 path:
-                                  description: Path is the path to snapshot, only valid for CephFS
                                   type: string
                                 startTime:
-                                  description: StartTime indicates when to start the snapshot
                                   type: string
                               type: object
                             type: array
                         type: object
                       name:
-                        description: Name of the pool
                         type: string
                       parameters:
                         additionalProperties:
                           type: string
-                        description: Parameters is a list of properties to enable on a given pool
                         nullable: true
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       quotas:
-                        description: The quota settings
                         nullable: true
                         properties:
                           maxBytes:
-                            description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                             format: int64
                             type: integer
                           maxObjects:
-                            description: MaxObjects represents the quota in objects
                             format: int64
                             type: integer
                           maxSize:
-                            description: MaxSize represents the quota in bytes as a string
                             pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                             type: string
                         type: object
                       replicated:
-                        description: The replication settings
                         properties:
                           hybridStorage:
-                            description: HybridStorage represents hybrid storage tier settings
                             nullable: true
                             properties:
                               primaryDeviceClass:
-                                description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                                 minLength: 1
                                 type: string
                               secondaryDeviceClass:
-                                description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                                 minLength: 1
                                 type: string
                             required:
@@ -6899,36 +5453,28 @@ spec:
                               - secondaryDeviceClass
                             type: object
                           replicasPerFailureDomain:
-                            description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                             minimum: 1
                             type: integer
                           requireSafeReplicaSize:
-                            description: RequireSafeReplicaSize if false allows you to set replica 1
                             type: boolean
                           size:
-                            description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                             minimum: 0
                             type: integer
                           subFailureDomain:
-                            description: SubFailureDomain the name of the sub-failure domain
                             type: string
                           targetSizeRatio:
-                            description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                             type: number
                         required:
                           - size
                         type: object
                       statusCheck:
-                        description: The mirroring statusCheck
                         properties:
                           mirror:
-                            description: HealthCheckSpec represents the health check of an object store bucket
                             nullable: true
                             properties:
                               disabled:
                                 type: boolean
                               interval:
-                                description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                                 type: string
                               timeout:
                                 type: string
@@ -6939,14 +5485,12 @@ spec:
                   nullable: true
                   type: array
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -6956,28 +5500,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -6985,40 +5522,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -7026,40 +5552,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -7067,36 +5584,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -7105,82 +5614,62 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 metadataServer:
-                  description: The mds pod info
                   properties:
                     activeCount:
-                      description: The number of metadata servers that are active.
                       format: int32
                       maximum: 50
                       minimum: 1
                       type: integer
                     activeStandby:
-                      description: Whether each active MDS instance will have an active standby with a warm metadata cache for faster f
                       type: boolean
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -7188,85 +5677,64 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                     placement:
-                      description: The affinity to place the mds pods (default is to place on all available node) with a daemonset
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7276,18 +5744,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7299,7 +5762,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7308,26 +5770,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7337,18 +5791,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -7366,32 +5815,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7403,38 +5842,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7446,23 +5876,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7471,26 +5897,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7502,38 +5920,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7545,17 +5954,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7563,32 +5969,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7600,38 +5996,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -7643,23 +6030,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -7668,26 +6051,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7699,38 +6074,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -7742,17 +6108,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -7760,49 +6123,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -7814,35 +6162,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -7853,19 +6193,14 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     priorityClassName:
-                      description: PriorityClassName sets priority classes on components
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -7881,7 +6216,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -7890,61 +6224,45 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     startupProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -7952,53 +6270,42 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
@@ -8007,69 +6314,51 @@ spec:
                     - activeCount
                   type: object
                 mirroring:
-                  description: The mirroring settings
                   nullable: true
                   properties:
                     enabled:
-                      description: Enabled whether this filesystem is mirrored or not
                       type: boolean
                     peers:
-                      description: Peers represents the peers spec
                       nullable: true
                       properties:
                         secretNames:
-                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                           items:
                             type: string
                           type: array
                       type: object
                     snapshotRetention:
-                      description: Retention is the retention policy for a snapshot schedule One path has exactly one retention policy.
                       items:
-                        description: SnapshotScheduleRetentionSpec is a retention policy
                         properties:
                           duration:
-                            description: Duration represents the retention duration for a snapshot
                             type: string
                           path:
-                            description: Path is the path to snapshot
                             type: string
                         type: object
                       type: array
                     snapshotSchedules:
-                      description: SnapshotSchedules is the scheduling of snapshot for mirrored filesystems
                       items:
-                        description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
                             type: string
                           path:
-                            description: Path is the path to snapshot, only valid for CephFS
                             type: string
                           startTime:
-                            description: StartTime indicates when to start the snapshot
                             type: string
                         type: object
                       type: array
                   type: object
                 preserveFilesystemOnDelete:
-                  description: Preserve the fs in the cluster on CephFilesystem CR deletion.
                   type: boolean
                 preservePoolsOnDelete:
-                  description: Preserve pools on filesystem deletion
                   type: boolean
                 statusCheck:
-                  description: The mirroring statusCheck
                   properties:
                     mirror:
-                      description: HealthCheckSpec represents the health check of an object store bucket
                       nullable: true
                       properties:
                         disabled:
                           type: boolean
                         interval:
-                          description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                           type: string
                         timeout:
                           type: string
@@ -8082,11 +6371,9 @@ spec:
                 - metadataServer
               type: object
             status:
-              description: CephFilesystemStatus represents the status of a Ceph Filesystem
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -8097,76 +6384,54 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 info:
                   additionalProperties:
                     type: string
-                  description: Use only info and put mirroringStatus in it?
                   nullable: true
                   type: object
                 mirroringStatus:
-                  description: MirroringStatus is the filesystem mirroring status
                   properties:
                     daemonsStatus:
-                      description: PoolMirroringStatus is the mirroring status of a filesystem
                       items:
-                        description: FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem
                         properties:
                           daemon_id:
-                            description: DaemonID is the cephfs-mirror name
                             type: integer
                           filesystems:
-                            description: Filesystems is the list of filesystems managed by a given cephfs-mirror daemon
                             items:
-                              description: FilesystemsSpec is spec for the mirrored filesystem
                               properties:
                                 directory_count:
-                                  description: DirectoryCount is the number of directories in the filesystem
                                   type: integer
                                 filesystem_id:
-                                  description: FilesystemID is the filesystem identifier
                                   type: integer
                                 name:
-                                  description: Name is name of the filesystem
                                   type: string
                                 peers:
-                                  description: Peers represents the mirroring peers
                                   items:
-                                    description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
                                         properties:
                                           client_name:
-                                            description: ClientName is cephx name
                                             type: string
                                           cluster_name:
-                                            description: ClusterName is the name of the cluster
                                             type: string
                                           fs_name:
-                                            description: FsName is the filesystem name
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
                                         properties:
                                           failure_count:
-                                            description: FailureCount is the number of mirroring failure
                                             type: integer
                                           recovery_count:
-                                            description: RecoveryCount is the number of recovery attempted after failures
                                             type: integer
                                         type: object
                                       uuid:
-                                        description: UUID is the peer unique identifier
                                         type: string
                                     type: object
                                   type: array
@@ -8176,79 +6441,56 @@ spec:
                       nullable: true
                       type: array
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
                 snapshotScheduleStatus:
-                  description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
                   properties:
                     details:
-                      description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
                       type: string
                     snapshotSchedules:
-                      description: SnapshotSchedules is the list of snapshots scheduled
                       items:
-                        description: FilesystemSnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool
                         properties:
                           fs:
-                            description: Fs is the name of the Ceph Filesystem
                             type: string
                           path:
-                            description: Path is the path on the filesystem
                             type: string
                           rel_path:
                             type: string
                           retention:
-                            description: FilesystemSnapshotScheduleStatusRetention is the retention specification for a filesystem snapshot s
                             properties:
                               active:
-                                description: Active is whether the scheduled is active or not
                                 type: boolean
                               created:
-                                description: Created is when the snapshot schedule was created
                                 type: string
                               created_count:
-                                description: CreatedCount is total amount of snapshots
                                 type: integer
                               first:
-                                description: First is when the first snapshot schedule was taken
                                 type: string
                               last:
-                                description: Last is when the last snapshot schedule was taken
                                 type: string
                               last_pruned:
-                                description: LastPruned is when the last snapshot schedule was pruned
                                 type: string
                               pruned_count:
-                                description: PrunedCount is total amount of pruned snapshots
                                 type: integer
                               start:
-                                description: Start is when the snapshot schedule starts
                                 type: string
                             type: object
                           schedule:
                             type: string
                           subvol:
-                            description: Subvol is the name of the sub volume
                             type: string
                         type: object
                       nullable: true
@@ -8288,33 +6530,26 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephFilesystemSubVolumeGroup represents a Ceph Filesystem SubVolumeGroup
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: Spec represents the specification of a Ceph Filesystem SubVolumeGroup
               properties:
                 filesystemName:
-                  description: FilesystemName is the name of Ceph Filesystem SubVolumeGroup volume name.
                   type: string
                   x-kubernetes-validations:
                     - message: filesystemName is immutable
                       rule: self == oldSelf
                 name:
-                  description: The name of the subvolume group. If not set, the default is the name of the subvolumeGroup CR.
                   type: string
                   x-kubernetes-validations:
                     - message: name is immutable
                       rule: self == oldSelf
                 pinning:
-                  description: Pinning configuration of CephFilesystemSubVolumeGroup, reference https://docs.ceph.
                   properties:
                     distributed:
                       maximum: 1
@@ -8339,7 +6574,6 @@ spec:
                 - filesystemName
               type: object
             status:
-              description: Status represents the status of a CephFilesystem SubvolumeGroup
               properties:
                 info:
                   additionalProperties:
@@ -8347,11 +6581,9 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -8385,65 +6617,47 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephNFS represents a Ceph NFS
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: NFSGaneshaSpec represents the spec of an nfs ganesha server
               properties:
                 rados:
-                  description: RADOS is the Ganesha RADOS specification
                   nullable: true
                   properties:
                     namespace:
-                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored.
                       type: string
                     pool:
-                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons.
                       type: string
                   type: object
                 security:
-                  description: Security allows specifying security configurations for the NFS cluster
                   nullable: true
                   properties:
                     kerberos:
-                      description: Kerberos configures NFS-Ganesha to secure NFS client connections with Kerberos.
                       nullable: true
                       properties:
                         configFiles:
-                          description: ConfigFiles defines where the Kerberos configuration should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for Kerberos confi
                               properties:
                                 configMap:
-                                  description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8451,82 +6665,60 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                     - claimName
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: ClusterTrustBundle allows a pod to access the `.spec.
                                             properties:
                                               labelSelector:
-                                                description: Select all ClusterTrustBundles that match this label selector.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -8538,42 +6730,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: Select a single ClusterTrustBundle by object name.
                                                 type: string
                                               optional:
-                                                description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                 type: string
                                             required:
                                               - path
                                             type: object
                                           configMap:
-                                            description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8581,56 +6762,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional specify whether the ConfigMap or its keys must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume file
                                                 items:
-                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the field to select in the specified API version.
                                                           type: string
                                                       required:
                                                         - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container name: required for volumes, optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                             - type: integer
                                                             - type: string
-                                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required: resource to select'
                                                           type: string
                                                       required:
                                                         - resource
@@ -8642,22 +6809,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8665,25 +6826,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional field specify whether the Secret or its key must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative to the mount point of the file to project the token into.
                                                 type: string
                                             required:
                                               - path
@@ -8692,26 +6847,19 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8719,44 +6867,32 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         domainName:
-                          description: DomainName should be set to the Kerberos Realm.
                           type: string
                         keytabFile:
-                          description: KeytabFile defines where the Kerberos keytab should be sourced from.
                           properties:
                             volumeSource:
-                              description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the Kerberos k
                               properties:
                                 configMap:
-                                  description: configMap represents a configMap that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -8764,82 +6900,60 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.'
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 emptyDir:
-                                  description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: medium represents what type of storage medium should back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 hostPath:
-                                  description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                   properties:
                                     path:
-                                      description: path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                     - path
                                   type: object
                                 persistentVolumeClaim:
-                                  description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                   properties:
                                     claimName:
-                                      description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                     - claimName
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used to set permissions on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: ClusterTrustBundle allows a pod to access the `.spec.
                                             properties:
                                               labelSelector:
-                                                description: Select all ClusterTrustBundles that match this label selector.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -8851,42 +6965,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: Select a single ClusterTrustBundle by object name.
                                                 type: string
                                               optional:
-                                                description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                 type: string
                                             required:
                                               - path
                                             type: object
                                           configMap:
-                                            description: configMap information about the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8894,56 +6997,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional specify whether the ConfigMap or its keys must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume file
                                                 items:
-                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the field to select in the specified API version.
                                                           type: string
                                                       required:
                                                         - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container name: required for volumes, optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                             - type: integer
                                                             - type: string
-                                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required: resource to select'
                                                           type: string
                                                       required:
                                                         - resource
@@ -8955,22 +7044,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                       type: string
                                                   required:
                                                     - key
@@ -8978,25 +7061,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: optional field specify whether the Secret or its key must be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information about the serviceAccountToken data to project
                                             properties:
                                               audience:
-                                                description: audience is the intended audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is the requested duration of validity of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative to the mount point of the file to project the token into.
                                                 type: string
                                             required:
                                               - path
@@ -9005,26 +7082,19 @@ spec:
                                       type: array
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                       items:
-                                        description: Maps a string key to a path within a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                             type: string
                                         required:
                                           - key
@@ -9032,60 +7102,44 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                               type: object
                           type: object
                         principalName:
                           default: nfs
-                          description: PrincipalName corresponds directly to NFS-Ganesha's NFS_KRB5:PrincipalName config.
                           type: string
                       type: object
                     sssd:
-                      description: SSSD enables integration with System Security Services Daemon (SSSD).
                       nullable: true
                       properties:
                         sidecar:
-                          description: Sidecar tells Rook to run SSSD in a sidecar alongside the NFS-Ganesha server in each NFS pod.
                           properties:
                             additionalFiles:
-                              description: AdditionalFiles defines any number of additional files that should be mounted into the SSSD sidecar.
                               items:
-                                description: SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD configu
                                 properties:
                                   subPath:
-                                    description: SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s) will be pl
                                     minLength: 1
                                     pattern: ^[^:]+$
                                     type: string
                                   volumeSource:
-                                    description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the additional
                                     properties:
                                       configMap:
-                                        description: configMap represents a configMap that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -9093,82 +7147,60 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       emptyDir:
-                                        description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                         properties:
                                           medium:
-                                            description: medium represents what type of storage medium should back this directory.
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                               - type: integer
                                               - type: string
-                                            description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       hostPath:
-                                        description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                         properties:
                                           path:
-                                            description: path of the directory on the host.
                                             type: string
                                           type:
-                                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                             type: string
                                         required:
                                           - path
                                         type: object
                                       persistentVolumeClaim:
-                                        description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                         properties:
                                           claimName:
-                                            description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                             type: string
                                           readOnly:
-                                            description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                             type: boolean
                                         required:
                                           - claimName
                                         type: object
                                       projected:
-                                        description: projected items for all in one resources secrets, configmaps, and downward API
                                         properties:
                                           defaultMode:
-                                            description: defaultMode are the mode bits used to set permissions on created files by default.
                                             format: int32
                                             type: integer
                                           sources:
-                                            description: sources is the list of volume projections
                                             items:
-                                              description: Projection that may be projected along with other supported volume types
                                               properties:
                                                 clusterTrustBundle:
-                                                  description: ClusterTrustBundle allows a pod to access the `.spec.
                                                   properties:
                                                     labelSelector:
-                                                      description: Select all ClusterTrustBundles that match this label selector.
                                                       properties:
                                                         matchExpressions:
-                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                           items:
-                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                             properties:
                                                               key:
-                                                                description: key is the label key that the selector applies to.
                                                                 type: string
                                                               operator:
-                                                                description: operator represents a key's relationship to a set of values.
                                                                 type: string
                                                               values:
-                                                                description: values is an array of string values.
                                                                 items:
                                                                   type: string
                                                                 type: array
@@ -9180,42 +7212,31 @@ spec:
                                                         matchLabels:
                                                           additionalProperties:
                                                             type: string
-                                                          description: matchLabels is a map of {key,value} pairs.
                                                           type: object
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     name:
-                                                      description: Select a single ClusterTrustBundle by object name.
                                                       type: string
                                                     optional:
-                                                      description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                       type: boolean
                                                     path:
-                                                      description: Relative path from the volume root to write the bundle.
                                                       type: string
                                                     signerName:
-                                                      description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                       type: string
                                                   required:
                                                     - path
                                                   type: object
                                                 configMap:
-                                                  description: configMap information about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                       items:
-                                                        description: Maps a string key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -9223,56 +7244,42 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
-                                                      description: optional specify whether the ConfigMap or its keys must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 downwardAPI:
-                                                  description: downwardAPI information about the downwardAPI data to project
                                                   properties:
                                                     items:
-                                                      description: Items is a list of DownwardAPIVolume file
                                                       items:
-                                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                         properties:
                                                           fieldRef:
-                                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                             properties:
                                                               apiVersion:
-                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                                 type: string
                                                               fieldPath:
-                                                                description: Path of the field to select in the specified API version.
                                                                 type: string
                                                             required:
                                                               - fieldPath
                                                             type: object
                                                             x-kubernetes-map-type: atomic
                                                           mode:
-                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: 'Required: Path is  the relative path name of the file to be created.'
                                                             type: string
                                                           resourceFieldRef:
-                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                             properties:
                                                               containerName:
-                                                                description: 'Container name: required for volumes, optional for env vars'
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
                                                                   - type: integer
                                                                   - type: string
-                                                                description: Specifies the output format of the exposed resources, defaults to "1"
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
-                                                                description: 'Required: resource to select'
                                                                 type: string
                                                             required:
                                                               - resource
@@ -9284,22 +7291,16 @@ spec:
                                                       type: array
                                                   type: object
                                                 secret:
-                                                  description: secret information about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                       items:
-                                                        description: Maps a string key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: key is the key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                             type: string
                                                         required:
                                                           - key
@@ -9307,25 +7308,19 @@ spec:
                                                         type: object
                                                       type: array
                                                     name:
-                                                      description: 'Name of the referent. More info: https://kubernetes.'
                                                       type: string
                                                     optional:
-                                                      description: optional field specify whether the Secret or its key must be defined
                                                       type: boolean
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 serviceAccountToken:
-                                                  description: serviceAccountToken is information about the serviceAccountToken data to project
                                                   properties:
                                                     audience:
-                                                      description: audience is the intended audience of the token.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: expirationSeconds is the requested duration of validity of the service account token.
                                                       format: int64
                                                       type: integer
                                                     path:
-                                                      description: path is the path relative to the mount point of the file to project the token into.
                                                       type: string
                                                   required:
                                                     - path
@@ -9334,26 +7329,19 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                         properties:
                                           defaultMode:
-                                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                   type: string
                                               required:
                                                 - key
@@ -9361,10 +7349,8 @@ spec:
                                               type: object
                                             type: array
                                           optional:
-                                            description: optional field specify whether the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                             type: string
                                         type: object
                                     type: object
@@ -9374,24 +7360,18 @@ spec:
                                 type: object
                               type: array
                             debugLevel:
-                              description: DebugLevel sets the debug level for SSSD. If unset or set to 0, Rook does nothing.
                               maximum: 10
                               minimum: 0
                               type: integer
                             image:
-                              description: Image defines the container image that should be used for the SSSD sidecar.
                               minLength: 1
                               type: string
                             resources:
-                              description: Resources allow specifying resource requests/limits on the SSSD sidecar container.
                               properties:
                                 claims:
-                                  description: Claims lists the names of resources, defined in spec.
                                   items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one entry in pod.spec.
                                         type: string
                                     required:
                                       - name
@@ -9407,7 +7387,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -9416,36 +7395,26 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Requests describes the minimum amount of compute resources required.
                                   type: object
                               type: object
                             sssdConfigFile:
-                              description: SSSDConfigFile defines where the SSSD configuration should be sourced from.
                               properties:
                                 volumeSource:
-                                  description: VolumeSource accepts a pared down version of the standard Kubernetes VolumeSource for the SSSD confi
                                   properties:
                                     configMap:
-                                      description: configMap represents a configMap that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9453,82 +7422,60 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
                                           type: string
                                         optional:
-                                          description: optional specify whether the ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     emptyDir:
-                                      description: emptyDir represents a temporary directory that shares a pod's lifetime.
                                       properties:
                                         medium:
-                                          description: medium represents what type of storage medium should back this directory.
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: sizeLimit is the total amount of local storage required for this EmptyDir volume.
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     hostPath:
-                                      description: hostPath represents a pre-existing file or directory on the host machine that is directly exposed to
                                       properties:
                                         path:
-                                          description: path of the directory on the host.
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.'
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     persistentVolumeClaim:
-                                      description: persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
                                       properties:
                                         claimName:
-                                          description: claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                           type: boolean
                                       required:
                                         - claimName
                                       type: object
                                     projected:
-                                      description: projected items for all in one resources secrets, configmaps, and downward API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits used to set permissions on created files by default.
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume projections
                                           items:
-                                            description: Projection that may be projected along with other supported volume types
                                             properties:
                                               clusterTrustBundle:
-                                                description: ClusterTrustBundle allows a pod to access the `.spec.
                                                 properties:
                                                   labelSelector:
-                                                    description: Select all ClusterTrustBundles that match this label selector.
                                                     properties:
                                                       matchExpressions:
-                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                         items:
-                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                                           properties:
                                                             key:
-                                                              description: key is the label key that the selector applies to.
                                                               type: string
                                                             operator:
-                                                              description: operator represents a key's relationship to a set of values.
                                                               type: string
                                                             values:
-                                                              description: values is an array of string values.
                                                               items:
                                                                 type: string
                                                               type: array
@@ -9540,42 +7487,31 @@ spec:
                                                       matchLabels:
                                                         additionalProperties:
                                                           type: string
-                                                        description: matchLabels is a map of {key,value} pairs.
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   name:
-                                                    description: Select a single ClusterTrustBundle by object name.
                                                     type: string
                                                   optional:
-                                                    description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.
                                                     type: boolean
                                                   path:
-                                                    description: Relative path from the volume root to write the bundle.
                                                     type: string
                                                   signerName:
-                                                    description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.
                                                     type: string
                                                 required:
                                                   - path
                                                 type: object
                                               configMap:
-                                                description: configMap information about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be proj
                                                     items:
-                                                      description: Maps a string key to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9583,56 +7519,42 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
-                                                    description: optional specify whether the ConfigMap or its keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               downwardAPI:
-                                                description: downwardAPI information about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of the field to select in the specified API version.
                                                               type: string
                                                           required:
                                                             - fieldPath
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required: Path is  the relative path name of the file to be created.'
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container name: required for volumes, optional for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                                 - type: integer
                                                                 - type: string
-                                                              description: Specifies the output format of the exposed resources, defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required: resource to select'
                                                               type: string
                                                           required:
                                                             - resource
@@ -9644,22 +7566,16 @@ spec:
                                                     type: array
                                                 type: object
                                               secret:
-                                                description: secret information about the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                                     items:
-                                                      description: Maps a string key to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: key is the key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                           type: string
                                                       required:
                                                         - key
@@ -9667,25 +7583,19 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent. More info: https://kubernetes.'
                                                     type: string
                                                   optional:
-                                                    description: optional field specify whether the Secret or its key must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               serviceAccountToken:
-                                                description: serviceAccountToken is information about the serviceAccountToken data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended audience of the token.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds is the requested duration of validity of the service account token.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path relative to the mount point of the file to project the token into.
                                                     type: string
                                                 required:
                                                   - path
@@ -9694,26 +7604,19 @@ spec:
                                           type: array
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.'
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode bits used to set permissions on created files by default.'
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be project
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode bits used to set permissions on this file.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative path of the file to map the key to. May not be an absolute path.
                                                 type: string
                                             required:
                                               - key
@@ -9721,10 +7624,8 @@ spec:
                                             type: object
                                           type: array
                                         optional:
-                                          description: optional field specify whether the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
                                           type: string
                                       type: object
                                   type: object
@@ -9735,80 +7636,60 @@ spec:
                       type: object
                   type: object
                 server:
-                  description: Server is the Ganesha Server specification
                   properties:
                     active:
-                      description: The number of active Ganesha servers
                       type: integer
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     hostNetwork:
-                      description: Whether host networking is enabled for the Ganesha server.
                       nullable: true
                       type: boolean
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     livenessProbe:
-                      description: A liveness-probe to verify that Ganesha server has valid run-time state. If LivenessProbe.
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -9816,88 +7697,66 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
                       type: string
                     placement:
-                      description: The affinity to place the ganesha pods
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9907,18 +7766,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9930,7 +7784,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -9939,26 +7792,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9968,18 +7813,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9997,32 +7837,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10034,38 +7864,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10077,23 +7898,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10102,26 +7919,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10133,38 +7942,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10176,17 +7976,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10194,32 +7991,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10231,38 +8018,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10274,23 +8052,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10299,26 +8073,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10330,38 +8096,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -10373,17 +8130,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -10391,49 +8145,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -10445,35 +8184,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -10484,19 +8215,14 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     priorityClassName:
-                      description: PriorityClassName sets the priority class on the pods
                       type: string
                     resources:
-                      description: Resources set resource requests and limits
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -10512,7 +8238,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -10521,7 +8246,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -10532,11 +8256,9 @@ spec:
                 - server
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -10547,17 +8269,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -10592,22 +8311,17 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectRealm represents a Ceph Object Store Gateway Realm
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
               nullable: true
               properties:
                 pull:
-                  description: PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm
                   properties:
                     endpoint:
                       pattern: ^https*://
@@ -10615,11 +8329,9 @@ spec:
                   type: object
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -10630,17 +8342,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -10678,33 +8387,26 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStore represents a Ceph Object Store Gateway
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
               properties:
                 allowUsersInNamespaces:
-                  description: The list of allowed namespaces in addition to the object store namespace where ceph object store use
                   items:
                     type: string
                   type: array
                 dataPool:
-                  description: The data pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -10714,28 +8416,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -10743,40 +8438,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -10784,40 +8468,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -10825,36 +8500,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -10863,88 +8530,66 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 gateway:
-                  description: The rgw pod info
                   nullable: true
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: The annotations-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     caBundleRef:
-                      description: The name of the secret that stores custom ca-bundle with root and intermediate certificates.
                       nullable: true
                       type: string
                     dashboardEnabled:
-                      description: Whether rgw dashboard is enabled for the rgw daemon. If not set, the rgw dashboard will be enabled.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     disableMultisiteSyncTraffic:
-                      description: DisableMultisiteSyncTraffic, when true, prevents this object store's gateways from transmitting mult
                       type: boolean
                     externalRgwEndpoints:
-                      description: ExternalRgwEndpoints points to external RGW endpoint(s).
                       items:
-                        description: EndpointAddress is a tuple that describes a single IP address or host name.
                         properties:
                           hostname:
-                            description: The DNS-addressable Hostname of this endpoint.
                             type: string
                           ip:
-                            description: The IP of this endpoint.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       nullable: true
                       type: array
                     hostNetwork:
-                      description: Whether host networking is enabled for the rgw daemon.
                       nullable: true
                       type: boolean
                       x-kubernetes-preserve-unknown-fields: true
                     instances:
-                      description: The number of pods in the rgw replicaset.
                       format: int32
                       nullable: true
                       type: integer
                     labels:
                       additionalProperties:
                         type: string
-                      description: The labels-related configuration to add/set on each Pod related object.
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     placement:
-                      description: The affinity to place the rgw pods (default is to place on any available node)
                       nullable: true
                       properties:
                         nodeAffinity:
-                          description: NodeAffinity is a group of node affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10954,18 +8599,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -10977,7 +8617,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -10986,26 +8625,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -11015,18 +8646,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -11044,32 +8670,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: PodAffinity is a group of inter pod affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11081,38 +8697,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11124,23 +8731,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -11149,26 +8752,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11180,38 +8775,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11223,17 +8809,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -11241,32 +8824,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources, in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11278,38 +8851,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of namespaces that the term applies to.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values.
                                                   items:
                                                     type: string
                                                   type: array
@@ -11321,23 +8885,19 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static list of namespace names that the term applies to.
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -11346,26 +8906,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                               items:
-                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11377,38 +8929,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -11420,17 +8963,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
@@ -11438,49 +8978,34 @@ spec:
                               type: array
                           type: object
                         tolerations:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                           items:
-                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match. Empty means match all taint effects.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration matches to.
                                 type: string
                             type: object
                           type: array
                         topologySpreadConstraints:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                           items:
-                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                             properties:
                               labelSelector:
-                                description: LabelSelector is used to find matching pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -11492,35 +9017,27 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               maxSkew:
-                                description: MaxSkew describes the degree to which pods may be unevenly distributed.
                                 format: int32
                                 type: integer
                               minDomains:
-                                description: MinDomains indicates a minimum number of eligible domains.
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
-                                description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                                 type: string
                               nodeTaintsPolicy:
-                                description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                                 type: string
                               topologyKey:
-                                description: TopologyKey is the key of node labels.
                                 type: string
                               whenUnsatisfiable:
-                                description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                                 type: string
                             required:
                               - maxSkew
@@ -11531,23 +9048,17 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     port:
-                      description: The port the rgw service will be listening on (http)
                       format: int32
                       type: integer
                     priorityClassName:
-                      description: PriorityClassName sets priority classes on the rgw pods
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
                       nullable: true
                       properties:
                         claims:
-                          description: Claims lists the names of resources, defined in spec.
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry in pod.spec.
                                 type: string
                             required:
                               - name
@@ -11563,7 +9074,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                           type: object
                         requests:
                           additionalProperties:
@@ -11572,87 +9082,66 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: Requests describes the minimum amount of compute resources required.
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     securePort:
-                      description: The port the rgw service will be listening on (https)
                       format: int32
                       maximum: 65535
                       minimum: 0
                       nullable: true
                       type: integer
                     service:
-                      description: The configuration related to add/set on each rgw service.
                       nullable: true
                       properties:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: The annotations-related configuration to add/set on each rgw service. nullable optional
                           type: object
                       type: object
                     sslCertificateRef:
-                      description: The name of the secret that stores the ssl certificate for secure rgw connections
                       nullable: true
                       type: string
                   type: object
                 healthCheck:
-                  description: The RGW health probes
                   nullable: true
                   properties:
                     readinessProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -11660,109 +9149,83 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     startupProbe:
-                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
                       properties:
                         disabled:
-                          description: Disabled determines whether probe is disable or not
                           type: boolean
                         probe:
-                          description: 'Probe describes a health check to be performed against a container to determine whether it is alive '
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: 'Command is the command line to execute inside the container, the working directory for the command  '
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
                               properties:
                                 port:
-                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                   format: int32
                                   type: integer
                                 service:
-                                  description: Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.
                                   type: string
                               required:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                       - name
@@ -11770,67 +9233,54 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
                                   type: string
                               required:
                                 - port
                               type: object
                             initialDelaySeconds:
-                              description: Number of seconds after the container has started before liveness probes are initiated.
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
                                   x-kubernetes-int-or-string: true
                               required:
                                 - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
                               format: int32
                               type: integer
                           type: object
                       type: object
                   type: object
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -11840,28 +9290,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -11869,40 +9312,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -11910,40 +9342,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -11951,36 +9374,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -11989,72 +9404,57 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 preservePoolsOnDelete:
-                  description: Preserve pools on object store deletion
                   type: boolean
                 security:
-                  description: Security represents security settings
                   nullable: true
                   properties:
                     keyRotation:
-                      description: KeyRotation defines options for Key Rotation.
                       nullable: true
                       properties:
                         enabled:
                           default: false
-                          description: Enabled represents whether the key rotation is enabled.
                           type: boolean
                         schedule:
-                          description: Schedule represents the cron schedule for key rotation.
                           type: string
                       type: object
                     kms:
-                      description: KeyManagementService is the main Key Management option
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                     s3:
-                      description: The settings for supporting AWS-SSE:S3 with RGW
                       nullable: true
                       properties:
                         connectionDetails:
                           additionalProperties:
                             type: string
-                          description: ConnectionDetails contains the KMS connection details (address, port etc)
                           nullable: true
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
-                          description: TokenSecretName is the kubernetes secret containing the KMS token
                           type: string
                       type: object
                   type: object
                 zone:
-                  description: The multisite info
                   nullable: true
                   properties:
                     name:
-                      description: RGW Zone the Object Store is in
                       type: string
                   required:
                     - name
                   type: object
               type: object
             status:
-              description: ObjectStoreStatus represents the status of a Ceph Object Store resource
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12065,12 +9465,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
@@ -12095,11 +9493,9 @@ spec:
                 message:
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -12138,25 +9534,19 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStoreUser represents a Ceph Object Store Gateway User
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
               properties:
                 capabilities:
-                  description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
                     amz-cache:
-                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12164,7 +9554,6 @@ spec:
                         - read, write
                       type: string
                     bilog:
-                      description: Add capabilities for user to change bucket index logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12172,7 +9561,6 @@ spec:
                         - read, write
                       type: string
                     bucket:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12180,7 +9568,6 @@ spec:
                         - read, write
                       type: string
                     buckets:
-                      description: Admin capabilities to read/write Ceph object store buckets. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12188,7 +9575,6 @@ spec:
                         - read, write
                       type: string
                     datalog:
-                      description: Add capabilities for user to change data logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12196,7 +9582,6 @@ spec:
                         - read, write
                       type: string
                     info:
-                      description: Admin capabilities to read/write information about the user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12204,7 +9589,6 @@ spec:
                         - read, write
                       type: string
                     mdlog:
-                      description: Add capabilities for user to change metadata logging. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12212,7 +9596,6 @@ spec:
                         - read, write
                       type: string
                     metadata:
-                      description: Admin capabilities to read/write Ceph object store metadata. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12220,7 +9603,6 @@ spec:
                         - read, write
                       type: string
                     oidc-provider:
-                      description: Add capabilities for user to change oidc provider. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12228,7 +9610,6 @@ spec:
                         - read, write
                       type: string
                     ratelimit:
-                      description: Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12236,7 +9617,6 @@ spec:
                         - read, write
                       type: string
                     roles:
-                      description: Admin capabilities to read/write roles for user. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12244,7 +9624,6 @@ spec:
                         - read, write
                       type: string
                     usage:
-                      description: Admin capabilities to read/write Ceph object store usage. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12252,7 +9631,6 @@ spec:
                         - read, write
                       type: string
                     user:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12260,7 +9638,6 @@ spec:
                         - read, write
                       type: string
                     user-policy:
-                      description: Add capabilities for user to change user policies. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12268,7 +9645,6 @@ spec:
                         - read, write
                       type: string
                     users:
-                      description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12276,7 +9652,6 @@ spec:
                         - read, write
                       type: string
                     zone:
-                      description: Admin capabilities to read/write Ceph object store zones. Documented in https://docs.ceph.
                       enum:
                         - '*'
                         - read
@@ -12285,21 +9660,16 @@ spec:
                       type: string
                   type: object
                 clusterNamespace:
-                  description: The namespace where the parent CephCluster and CephObjectStore are found
                   type: string
                 displayName:
-                  description: The display name for the ceph users
                   type: string
                 quotas:
-                  description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage.
                   nullable: true
                   properties:
                     maxBuckets:
-                      description: Maximum bucket limit for the ceph user
                       nullable: true
                       type: integer
                     maxObjects:
-                      description: Maximum number of objects across all the user's buckets
                       format: int64
                       nullable: true
                       type: integer
@@ -12307,17 +9677,14 @@ spec:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: Maximum size limit of all objects across all the user's buckets See https://pkg.go.dev/k8s.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                   type: object
                 store:
-                  description: The store the user will be created in
                   type: string
               type: object
             status:
-              description: ObjectStoreUserStatus represents the status Ceph Object Store Gateway User
               properties:
                 info:
                   additionalProperties:
@@ -12325,7 +9692,6 @@ spec:
                   nullable: true
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12364,31 +9730,24 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectZoneGroup represents a Ceph Object Store Gateway Zone Group
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
               properties:
                 realm:
-                  description: The display name for the ceph users
                   type: string
               required:
                 - realm
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12399,17 +9758,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12448,34 +9804,27 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectZone represents a Ceph Object Store Gateway Zone
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
               properties:
                 customEndpoints:
-                  description: If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint cre
                   items:
                     type: string
                   nullable: true
                   type: array
                 dataPool:
-                  description: The data pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12485,28 +9834,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12514,40 +9856,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -12555,40 +9886,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -12596,36 +9918,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -12634,14 +9948,12 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 metadataPool:
-                  description: The metadata pool settings
                   nullable: true
                   properties:
                     application:
                       description: The application name to set on the pool. Only expected to be set for rgw pools.
                       type: string
                     compressionMode:
-                      description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
                         - none
                         - passive
@@ -12651,28 +9963,21 @@ spec:
                       nullable: true
                       type: string
                     crushRoot:
-                      description: The root of the crush hierarchy utilized by the pool
                       nullable: true
                       type: string
                     deviceClass:
-                      description: The device class the OSD should set to for use in the pool
                       nullable: true
                       type: string
                     enableRBDStats:
-                      description: EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool
                       type: boolean
                     erasureCoded:
-                      description: The erasure code settings
                       properties:
                         algorithm:
-                          description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool t
                           minimum: 0
                           type: integer
                       required:
@@ -12680,40 +9985,29 @@ spec:
                         - dataChunks
                       type: object
                     failureDomain:
-                      description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush '
                       type: string
                     mirroring:
-                      description: The mirroring settings
                       properties:
                         enabled:
-                          description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
                           type: string
                         peers:
-                          description: Peers represents the peers spec
                           nullable: true
                           properties:
                             secretNames:
-                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                               items:
                                 type: string
                               type: array
                           type: object
                         snapshotSchedules:
-                          description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
-                            description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
                                 type: string
                               path:
-                                description: Path is the path to snapshot, only valid for CephFS
                                 type: string
                               startTime:
-                                description: StartTime indicates when to start the snapshot
                                 type: string
                             type: object
                           type: array
@@ -12721,40 +10015,31 @@ spec:
                     parameters:
                       additionalProperties:
                         type: string
-                      description: Parameters is a list of properties to enable on a given pool
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
                       nullable: true
                       properties:
                         maxBytes:
-                          description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
-                      description: The replication settings
                       properties:
                         hybridStorage:
-                          description: HybridStorage represents hybrid storage tier settings
                           nullable: true
                           properties:
                             primaryDeviceClass:
-                              description: PrimaryDeviceClass represents high performance tier (for example SSD or NVME) for Primary OSD
                               minLength: 1
                               type: string
                             secondaryDeviceClass:
-                              description: SecondaryDeviceClass represents low performance tier (for example HDDs) for remaining OSDs
                               minLength: 1
                               type: string
                           required:
@@ -12762,36 +10047,28 @@ spec:
                             - secondaryDeviceClass
                           type: object
                         replicasPerFailureDomain:
-                          description: ReplicasPerFailureDomain the number of replica in the specified failure domain
                           minimum: 1
                           type: integer
                         requireSafeReplicaSize:
-                          description: RequireSafeReplicaSize if false allows you to set replica 1
                           type: boolean
                         size:
-                          description: Size - Number of copies per object in a replicated storage pool, including the object itself (requir
                           minimum: 0
                           type: integer
                         subFailureDomain:
-                          description: SubFailureDomain the name of the sub-failure domain
                           type: string
                         targetSizeRatio:
-                          description: TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capac
                           type: number
                       required:
                         - size
                       type: object
                     statusCheck:
-                      description: The mirroring statusCheck
                       properties:
                         mirror:
-                          description: HealthCheckSpec represents the health check of an object store bucket
                           nullable: true
                           properties:
                             disabled:
                               type: boolean
                             interval:
-                              description: Interval is the internal in second or minute for the health check to run like 60s for 60 seconds
                               type: string
                             timeout:
                               type: string
@@ -12801,10 +10078,8 @@ spec:
                   type: object
                 preservePoolsOnDelete:
                   default: true
-                  description: Preserve pools on object zone deletion
                   type: boolean
                 zoneGroup:
-                  description: The display name for the ceph users
                   type: string
               required:
                 - dataPool
@@ -12812,11 +10087,9 @@ spec:
                 - zoneGroup
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -12827,17 +10100,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -12876,75 +10146,56 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephRBDMirror represents a Ceph RBD Mirror
           properties:
             apiVersion:
-              description: APIVersion defines the versioned schema of this representation of an object.
               type: string
             kind:
-              description: Kind is a string value representing the REST resource this object represents.
               type: string
             metadata:
               type: object
             spec:
-              description: RBDMirroringSpec represents the specification of an RBD mirror daemon
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description: The annotations-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 count:
-                  description: Count represents the number of rbd mirror instance to run
                   minimum: 1
                   type: integer
                 labels:
                   additionalProperties:
                     type: string
-                  description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 peers:
-                  description: Peers represents the peers spec
                   nullable: true
                   properties:
                     secretNames:
-                      description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
                       items:
                         type: string
                       type: array
                   type: object
                 placement:
-                  description: The affinity to place the rgw pods (default is to place on any available node)
                   nullable: true
                   properties:
                     nodeAffinity:
-                      description: NodeAffinity is a group of node affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
                             properties:
                               preference:
-                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12954,18 +10205,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -12977,7 +10223,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -12986,26 +10231,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           properties:
                             nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
                                 properties:
                                   matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -13015,18 +10252,13 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
                                       properties:
                                         key:
-                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
                                           items:
                                             type: string
                                           type: array
@@ -13044,32 +10276,22 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
-                      description: PodAffinity is a group of inter pod affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13081,38 +10303,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13124,23 +10337,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -13149,26 +10358,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13180,38 +10381,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13223,17 +10415,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -13241,32 +10430,22 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description: PodAntiAffinity is a group of inter pod anti affinity scheduling rules
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
                           items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
                             properties:
                               podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13278,38 +10457,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
                                               items:
                                                 type: string
                                               type: array
@@ -13321,23 +10491,19 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to.
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -13346,26 +10512,18 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
                           items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13377,38 +10535,29 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values.
                                           type: string
                                         values:
-                                          description: values is an array of string values.
                                           items:
                                             type: string
                                           type: array
@@ -13420,17 +10569,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to.
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
                                 type: string
                             required:
                               - topologyKey
@@ -13438,49 +10584,34 @@ spec:
                           type: array
                       type: object
                     tolerations:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to.
                             type: string
                         type: object
                       type: array
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology
                       items:
-                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
                                       items:
                                         type: string
                                       type: array
@@ -13492,35 +10623,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           matchLabelKeys:
-                            description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           maxSkew:
-                            description: MaxSkew describes the degree to which pods may be unevenly distributed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: MinDomains indicates a minimum number of eligible domains.
                             format: int32
                             type: integer
                           nodeAffinityPolicy:
-                            description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector when calculating pod '
                             type: string
                           nodeTaintsPolicy:
-                            description: NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew.
                             type: string
                           topologyKey:
-                            description: TopologyKey is the key of node labels.
                             type: string
                           whenUnsatisfiable:
-                            description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
                             type: string
                         required:
                           - maxSkew
@@ -13531,19 +10654,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 priorityClassName:
-                  description: PriorityClassName sets priority class on the rbd mirror pods
                   type: string
                 resources:
-                  description: The resource requirements for the rbd mirror pods
                   nullable: true
                   properties:
                     claims:
-                      description: Claims lists the names of resources, defined in spec.
                       items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.
                             type: string
                         required:
                           - name
@@ -13559,7 +10677,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
                       type: object
                     requests:
                       additionalProperties:
@@ -13568,7 +10685,6 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Requests describes the minimum amount of compute resources required.
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -13576,11 +10692,9 @@ spec:
                 - count
               type: object
             status:
-              description: Status represents the status of an object
               properties:
                 conditions:
                   items:
-                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
                     properties:
                       lastHeartbeatTime:
                         format: date-time
@@ -13591,17 +10705,14 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is a reason for a condition
                         type: string
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
                         type: string
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
                   type: integer
                 phase:
@@ -13614,118 +10725,5 @@ spec:
           type: object
       served: true
       storage: true
-      subresources:
-        status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: objectbucketclaims.objectbucket.io
-spec:
-  group: objectbucket.io
-  names:
-    kind: ObjectBucketClaim
-    listKind: ObjectBucketClaimList
-    plural: objectbucketclaims
-    singular: objectbucketclaim
-    shortNames:
-      - obc
-      - obcs
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                storageClassName:
-                  type: string
-                bucketName:
-                  type: string
-                generateBucketName:
-                  type: string
-                additionalConfig:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                objectBucketName:
-                  type: string
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-      subresources:
-        status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: objectbuckets.objectbucket.io
-spec:
-  group: objectbucket.io
-  names:
-    kind: ObjectBucket
-    listKind: ObjectBucketList
-    plural: objectbuckets
-    singular: objectbucket
-    shortNames:
-      - ob
-      - obs
-  scope: Cluster
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                storageClassName:
-                  type: string
-                endpoint:
-                  type: object
-                  nullable: true
-                  properties:
-                    bucketHost:
-                      type: string
-                    bucketPort:
-                      type: integer
-                      format: int32
-                    bucketName:
-                      type: string
-                    region:
-                      type: string
-                    subRegion:
-                      type: string
-                    additionalConfig:
-                      type: object
-                      nullable: true
-                      x-kubernetes-preserve-unknown-fields: true
-                authentication:
-                  type: object
-                  nullable: true
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                additionalState:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                reclaimPolicy:
-                  type: string
-                claimRef:
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}

--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -34,9 +34,25 @@ func (n *NetworkSpec) IsMultus() bool {
 
 // IsHost can be used to determine if pods should use host networking by
 // checking whether the cephCluster is configured to use the "host" network provider.
+// This  network mode only applies host networking to pods that require it in
+// order to limit the number of pods exposed to the host network, improving
+// cluster security.
 // This method also maintains compatibility with the old hostNetwork setting
 func (n *NetworkSpec) IsHost() bool {
 	return (n.HostNetwork && n.Provider == NetworkProviderDefault) || n.Provider == NetworkProviderHost || n.Provider == NetworkProviderHostStrict
+}
+
+// IsHostStrict determines whether the CephCluster is configured to use the use host
+// networking on all pods. This is achieved by checking whether the "host-strict" network provider
+// is set on the CephCluster.
+// This network mode applies host networking to all pods without caveat. This is
+// useful for clusters with no default CNI. This mode is less secure than "host"
+// The "host-strict"  network mode is needed rarely and so is supported on a best-effort
+// basis.
+// mode. Users  are advised use "host" mode instead of "host-strict" when possible.
+// The IsHostStrict  method does not preserve compatibility with the old HostNetwork setting
+func (n *NetworkSpec) IsHostStrict() bool {
+	return n.Provider == NetworkProviderHostStrict
 }
 
 func ValidateNetworkSpec(clusterNamespace string, spec NetworkSpec) error {

--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -32,10 +32,11 @@ func (n *NetworkSpec) IsMultus() bool {
 	return n.Provider == NetworkProviderMultus
 }
 
-// IsHost get whether to use host network provider. This method also preserve
-// compatibility with the old HostNetwork field.
+// IsHost can be used to determine if pods should use host networking by
+// checking whether the cephCluster is configured to use the "host" network provider.
+// This method also maintains compatibility with the old hostNetwork setting
 func (n *NetworkSpec) IsHost() bool {
-	return (n.HostNetwork && n.Provider == NetworkProviderDefault) || n.Provider == NetworkProviderHost
+	return (n.HostNetwork && n.Provider == NetworkProviderDefault) || n.Provider == NetworkProviderHost || n.Provider == NetworkProviderHostStrict
 }
 
 func ValidateNetworkSpec(clusterNamespace string, spec NetworkSpec) error {

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -73,8 +73,17 @@ func TestValidateNetworkSpec(t *testing.T) {
 }
 
 func TestNetworkCephIsHostLegacy(t *testing.T) {
-	net := NetworkSpec{HostNetwork: true}
+	net := NetworkSpec{HostNetwork: true,
+		Provider: "",
+	}
+	assert.True(t, net.IsHost())
+}
 
+func TestNetworkCephIsHost(t *testing.T) {
+	net := NetworkSpec{Provider: "host"}
+	assert.True(t, net.IsHost())
+
+	net = NetworkSpec{Provider: "host-strict"}
 	assert.True(t, net.IsHost())
 }
 

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -87,6 +87,13 @@ func TestNetworkCephIsHost(t *testing.T) {
 	assert.True(t, net.IsHost())
 }
 
+func TestNetworkCephIsHostStrict(t *testing.T) {
+	net := NetworkSpec{Provider: "host-strict"}
+	assert.True(t, net.IsHostStrict())
+	net = NetworkSpec{Provider: "host"}
+	assert.False(t, net.IsHostStrict())
+}
+
 func TestNetworkSpec(t *testing.T) {
 	netSpecYAML := []byte(`
 provider: host

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2391,13 +2391,14 @@ type NetworkSpec struct {
 }
 
 // NetworkProviderType defines valid network providers for Rook.
-// +kubebuilder:validation:Enum="";host;multus
+// +kubebuilder:validation:Enum="";host;host-strict;multus
 type NetworkProviderType string
 
 const (
-	NetworkProviderDefault = NetworkProviderType("")
-	NetworkProviderHost    = NetworkProviderType("host")
-	NetworkProviderMultus  = NetworkProviderType("multus")
+	NetworkProviderDefault    = NetworkProviderType("")
+	NetworkProviderHost       = NetworkProviderType("host")
+	NetworkProviderHostStrict = NetworkProviderType("host-strict")
+	NetworkProviderMultus     = NetworkProviderType("multus")
 )
 
 // CephNetworkType should be "public" or "cluster".

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -161,6 +161,7 @@ func (c *ClusterController) cleanUpJobTemplateSpec(cluster *cephv1.CephCluster, 
 			Volumes:           volumes,
 			RestartPolicy:     v1.RestartPolicyOnFailure,
 			PriorityClassName: cephv1.GetCleanupPriorityClassName(cluster.Spec.PriorityClassNames),
+			HostNetwork:       c.spec.Network.IsHostStrict(),
 		},
 	}
 

--- a/pkg/operator/ceph/object/cosi/spec.go
+++ b/pkg/operator/ceph/object/cosi/spec.go
@@ -97,11 +97,13 @@ func createCOSIPodSpec(cephCOSIDriver *cephv1.CephCOSIDriver) (corev1.PodTemplat
 
 	podTemplateSpec := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   CephCOSIDriverName,
-			Labels: getCOSILabels(cephCOSIDriver.Name, cephCOSIDriver.Namespace),
+			Name:        CephCOSIDriverName,
+			Labels:      getCOSILabels(cephCOSIDriver.Name, cephCOSIDriver.Namespace),
+			HostNetwork: CephCOSIDriver.Spec.Network.IsHostStrict(),
 		},
-		Spec: podSpec,
-	}
+			Spec:        podSpec,
+	,
+}
 
 	return podTemplateSpec, nil
 }

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -121,6 +121,7 @@ func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, disco
 							Image:           discoverImage,
 							Args:            discoveryParameters,
 							SecurityContext: controller.PrivilegedContext(true),
+							HostNetwork:     c.spec.Network.IsHostStrict(),
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "dev",


### PR DESCRIPTION
**description of changes:** 
This  change adds a new network provider "host-strict" to the cephCluster that behaves as a superset of the known  "host" provider. in that it lets rook configure *all* pods for host networking, not only those that were previously affected by "host". 

** ToDo:** 

* configure additional pods to use host networking if "host-strict" is set.

**Issue resolved by this Pull Request:**
Resolves #13571 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
