### PR TITLE
csi: Fix NetNamespaceFilePath generation with namespace instead of name

### DIFF
--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -299,7 +299,7 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) updateClusterConfig(cephFilesyst
 	// If the cluster has Multus enabled we need to append the network namespace of the driver's
 	// holder DaemonSet in the csi configmap
 	if cephCluster.Spec.Network.IsMultus() {
-		netNamespaceFilePath, err := csi.GenerateNetNamespaceFilePath(r.opManagerContext, r.client, cephCluster.Name, r.opConfig.OperatorNamespace, csi.CephFSDriverShortName)
+		netNamespaceFilePath, err := csi.GenerateNetNamespaceFilePath(r.opManagerContext, r.client, cephCluster.Namespace, r.opConfig.OperatorNamespace, csi.CephFSDriverShortName)
 		if err != nil {
 			return errors.Wrap(err, "failed to generate cephfs net namespace file path")
 		}

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -286,7 +286,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) updateClusterConfig(cephBlockPool
 
 	if cephCluster.Spec.Network.IsMultus() {
 		// Build the network namespace config to be injected into the csi config
-		netNamespaceFilePath, err := csi.GenerateNetNamespaceFilePath(r.opManagerContext, r.client, cephCluster.Name, r.opConfig.OperatorNamespace, csi.RBDDriverShortName)
+		netNamespaceFilePath, err := csi.GenerateNetNamespaceFilePath(r.opManagerContext, r.client, cephCluster.Namespace, r.opConfig.OperatorNamespace, csi.RBDDriverShortName)
 		if err != nil {
 			return errors.Wrap(err, "failed to generate rbd net namespace file path")
 		}


### PR DESCRIPTION
              Agreed, let's open a separate PR for this fix

_Originally posted by @travisn in https://github.com/rook/rook/pull/13613#discussion_r1473524760_
            
            
https://github.com/rook/rook/blob/ab31635d9b98e70eca042cda124cac5747d573da/pkg/operator/ceph/csi/spec.go#L911-L917

`GenerateNetNamespaceFilePath` func parameter tells to pass the clusterNamespace.
And also the holder template takes clusterNamespace.

https://github.com/rook/rook/blob/ab31635d9b98e70eca042cda124cac5747d573da/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-holder.yaml#L46-L52

This PR fixes the NetNamespaceFilePath generation in the subvolumegroup & radosnamespace controller by replacing the `cephCluster.Name` with `cephCluster.Namespace`.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
