### PR TITLE
core: Prevent unintentional deletion of service and service monitor during node reconciliation

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -207,10 +207,6 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			if err != nil {
 				return reconcile.Result{}, errors.Wrapf(err, "failed to list and delete deployments in namespace %q on node %q", namespace, request.Name)
 			}
-			result, err := r.cleanupExporterResources(cephCluster.Namespace, namespace, request.Name)
-			if err != nil {
-				return result, errors.Wrapf(err, "failed to cleanup exporter resources in namespace %q on node %q", namespace, request.Name)
-			}
 		}
 		// Cleanup exporter if the ceph version isn't supported
 		if !cephVersion.IsAtLeast(MinVersionForCephExporter) {


### PR DESCRIPTION

Previously, during the reconciliation of a node without a Ceph pod, the service and service monitor were erroneously deleted. This action resulted in the removal of the Ceph exporter service for the entire cluster. The manual clearing of resources is unnecessary due to the controller's ownership set on the service and service monitor.
