### PR TITLE
csi: remove CSI_ENABLE_READ_AFFINITY

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -115,8 +115,6 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.rbdPluginUpdateStrategy` | CSI RBD plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
 | `csi.rbdPluginUpdateStrategyMaxUnavailable` | A maxUnavailable parameter of CSI RBD plugin daemonset update strategy. | `1` |
 | `csi.rbdPodLabels` | Labels to add to the CSI RBD Deployments and DaemonSets Pods | `nil` |
-| `csi.readAffinity.crushLocationLabels` | Define which node labels to use as CRUSH location. This should correspond to the values set in the CRUSH map. | labels listed [here](../CRDs/Cluster/ceph-cluster-crd.md#osd-topology) |
-| `csi.readAffinity.enabled` | Enable read affinity for RBD volumes. Recommended to set to true if running kernel 5.8 or newer. | `false` |
 | `csi.registrar.image` | Kubernetes CSI registrar image | `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1` |
 | `csi.resizer.image` | Kubernetes CSI resizer image | `registry.k8s.io/sig-storage/csi-resizer:v1.9.2` |
 | `csi.serviceMonitor.enabled` | Enable ServiceMonitor for Ceph CSI drivers | `false` |

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,6 +1,7 @@
 # v1.14 Pending Release Notes
 
 ## Breaking Changes
-
+- The removal of `CSI_ENABLE_READ_AFFINITY` option and its replacement with per-cluster
+read affinity setting in cephCluster CR (CSIDriverOptions section) in [PR](https://github.com/rook/rook/pull/13665)
 
 ## Features

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -118,12 +118,6 @@ data:
   CSI_TOPOLOGY_DOMAIN_LABELS: {{ .Values.csi.topology.domainLabels | join "," }}
 {{- end }}
 {{- end }}
-{{- if .Values.csi.readAffinity }}
-  CSI_ENABLE_READ_AFFINITY: {{ .Values.csi.readAffinity.enabled | quote }}
-{{- if .Values.csi.readAffinity.crushLocationLabels }}
-  CSI_CRUSH_LOCATION_LABELS: {{ .Values.csi.readAffinity.crushLocationLabels | join "," }}
-{{- end }}
-{{- end }}
 {{- if .Values.csi.nfs }}
   ROOK_CSI_ENABLE_NFS: {{ .Values.csi.nfs.enabled | quote }}
 {{- end }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -557,17 +557,6 @@ csi:
     # - topology.kubernetes.io/zone
     # - topology.rook.io/rack
 
-  readAffinity:
-    # -- Enable read affinity for RBD volumes. Recommended to
-    # set to true if running kernel 5.8 or newer.
-    # @default -- `false`
-    enabled: false
-    # -- Define which node labels to use
-    # as CRUSH location. This should correspond to the values set
-    # in the CRUSH map.
-    # @default -- labels listed [here](../CRDs/Cluster/ceph-cluster-crd.md#osd-topology)
-    crushLocationLabels:
-
   # -- Whether to skip any attach operation altogether for CephFS PVCs. See more details
   # [here](https://kubernetes-csi.github.io/docs/skip-attach.html#skip-attach-with-csi-driver-object).
   # If cephFSAttachRequired is set to false it skips the volume attachments and makes the creation

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -584,16 +584,6 @@ data:
   # updated with node labels that define domains of interest
   # CSI_TOPOLOGY_DOMAIN_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
 
-  # Enable read affinity for RBD volumes. Recommended to
-  # set to true if running kernel 5.8 or newer.
-  CSI_ENABLE_READ_AFFINITY: "false"
-  # CRUSH location labels define which node labels to use
-  # as CRUSH location. This should correspond to the values set in
-  # the CRUSH map.
-  # Defaults to all the labels mentioned in
-  # https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/#osd-topology
-  # CSI_CRUSH_LOCATION_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
-
   # Whether to skip any attach operation altogether for CephCSI PVCs.
   # See more details [here](https://kubernetes-csi.github.io/docs/skip-attach.html#skip-attach-with-csi-driver-object).
   # If set to false it skips the volume attachments and makes the creation of pods using the CephCSI PVC fast.

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -526,16 +526,6 @@ data:
   # updated with node labels that define domains of interest
   # CSI_TOPOLOGY_DOMAIN_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
 
-  # Enable read affinity for RBD volumes. Recommended to
-  # set to true if running kernel 5.8 or newer.
-  CSI_ENABLE_READ_AFFINITY: "false"
-  # CRUSH location labels define which node labels to use
-  # as CRUSH location. This should correspond to the values set in
-  # the CRUSH map.
-  # Defaults to all the labels mentioned in
-  # https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/#osd-topology
-  # CSI_CRUSH_LOCATION_LABELS: "kubernetes.io/hostname,topology.kubernetes.io/zone,topology.rook.io/rack"
-
   # Whether to skip any attach operation altogether for CephCSI PVCs.
   # See more details [here](https://kubernetes-csi.github.io/docs/skip-attach.html#skip-attach-with-csi-driver-object).
   # If set to false it skips the volume attachments and makes the creation of pods using the CephCSI PVC fast.

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/pkg/errors"
@@ -83,11 +82,6 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 	if CSIParam.EnableCSIHostNetwork, err = strconv.ParseBool(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_HOST_NETWORK", "true")); err != nil {
 		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_HOST_NETWORK'")
 	}
-
-	if CSIParam.EnableReadAffinity, err = strconv.ParseBool(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_READ_AFFINITY", "false")); err != nil {
-		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_READ_AFFINITY'")
-	}
-	CSIParam.CrushLocationLabels = k8sutil.GetValue(r.opConfig.Parameters, "CSI_CRUSH_LOCATION_LABELS", topology.GetDefaultTopologyLabels())
 
 	// If not set or set to anything but "false", the kernel client will be enabled
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_FORCE_CEPHFS_KERNEL_CLIENT", "true"), "false") {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -65,7 +65,6 @@ type Param struct {
 	ImagePullPolicy                          string
 	CSIClusterName                           string
 	CSIDomainLabels                          string
-	CrushLocationLabels                      string
 	GRPCTimeout                              time.Duration
 	CSIEnableMetadata                        bool
 	EnablePluginSelinuxHostMount             bool
@@ -80,7 +79,6 @@ type Param struct {
 	EnableCSIEncryption                      bool
 	EnableCSITopology                        bool
 	EnableLiveness                           bool
-	EnableReadAffinity                       bool
 	CephFSAttachRequired                     bool
 	RBDAttachRequired                        bool
 	NFSAttachRequired                        bool

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -79,10 +79,6 @@ spec:
             {{- if .EnableCSITopology }}
             - "--domainlabels={{ .CSIDomainLabels }}"
             {{- end }}
-            {{- if .EnableReadAffinity }}
-            - "--enable-read-affinity=true"
-            - "--crush-location-labels={{ .CrushLocationLabels }}"
-            {{- end }}
           env:
             - name: POD_IP
               valueFrom:


### PR DESCRIPTION
                Since v1.13 was released with #13200 (which moved the read affinity to the cluster CR), has the "--enable-read- 
                affinity=true" flag been ignored by the CSI driver? Or has that flag still been honored even if there was a conflicting 
                setting in the cluster CR? If this flag is already broken or ignored in v1.13, then the backward compatibility is already 
                broken and we should go put a note in the v1.13 upgrade guide about this issue.
  
                If we could maintain backward compatibility it would be ideal. IMO this feature is not critical to maintain backward 
                compatibility, but if it's not broken yet and we're not going to maintain backward compatibility we should wait to 
                release it in v1.14 and include a note in the upgrade guide. 
  
                Please also split this out into a separate PR to give it more visibility.

_Originally posted by @travisn in https://github.com/rook/rook/pull/13613#discussion_r1473546989_
            
            
This PR removes the `CSI_ENABLE_READ_AFFINITY` since it is no longer utilised after addition of the read affinity option per cluster via CSIDriverSpec.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
