### PR TITLE
osd: correct counting the devices when metadataDevice is set

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -722,11 +722,16 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 	for md, conf := range metadataDevices {
 
 		mdArgs := batchArgs
+		osdsPerDevice := 1
 		if _, ok := conf["osdsperdevice"]; ok {
 			mdArgs = append(mdArgs, []string{
 				osdsPerDeviceFlag,
 				conf["osdsperdevice"],
 			}...)
+			v, _ := strconv.Atoi(conf["osdsperdevice"])
+			if v > 1 {
+				osdsPerDevice = v
+			}
 		}
 		if _, ok := conf["deviceclass"]; ok {
 			mdArgs = append(mdArgs, []string{
@@ -779,7 +784,7 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 			return errors.Wrap(err, "failed to unmarshal ceph-volume report json")
 		}
 
-		if len(strings.Split(conf["devices"], " ")) != len(cvReports) {
+		if len(strings.Split(conf["devices"], " "))*osdsPerDevice != len(cvReports) {
 			return errors.Errorf("failed to create enough required devices, required: %s, actual: %v", cvOut, cvReports)
 		}
 


### PR DESCRIPTION
The validation logic of checking the number of devices is wrong when `metadataDevice` is set and `osdsPerDevice` > 1. `len(cvReports)` is the expected number of OSDs and is the number of specified data devices multiplied by `osdsPerDevice`.

**Issue resolved by this Pull Request:**
Resolves #13637

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
