### PR TITLE
ci: disk in github action increased to 75G from 64G

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -303,7 +303,7 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: prepare loop devices for osds
@@ -370,7 +370,7 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: deploy cluster
@@ -416,7 +416,7 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -469,7 +469,7 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -516,13 +516,13 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: create LV on disk
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
 
       - name: deploy cluster
@@ -574,7 +574,7 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/loopDevicePV.sh 1
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
@@ -605,7 +605,7 @@ jobs:
           kubectl -n rook-ceph logs deploy/rook-ceph-operator
           tests/scripts/github-action-helper.sh wait_for_cleanup_pod
           lsblk
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           sudo head --bytes=60 ${BLOCK}1
           sudo head --bytes=60 ${BLOCK}2
           sudo head --bytes=60 /dev/loop1
@@ -770,7 +770,7 @@ jobs:
           kubectl -n rook-ceph delete cephcluster rook-ceph
           kubectl -n rook-ceph logs deploy/rook-ceph-operator
           tests/scripts/github-action-helper.sh wait_for_cleanup_pod
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           sudo head --bytes=60 ${BLOCK}1
           sudo head --bytes=60 ${BLOCK}2
           sudo lsblk
@@ -1065,7 +1065,7 @@ jobs:
 
       - name: create LV on disk
         run: |
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
           tests/scripts/localPathPV.sh /dev/test-rook-vg/test-rook-lv
 
@@ -1114,7 +1114,7 @@ jobs:
       - name: use local disk into two partitions
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
           sudo lsblk
 

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)1
+          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)1
           export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
           go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)1
+          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)1
           export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
           go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 

--- a/.github/workflows/rgw-multisite-test/action.yml
+++ b/.github/workflows/rgw-multisite-test/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: use local disk into two partitions
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        BLOCK=$(sudo lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+        BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
         tests/scripts/github-action-helper.sh use_local_disk
         tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
         sudo lsblk

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -19,7 +19,7 @@ set -xeEo pipefail
 #############
 # VARIABLES #
 #############
-: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ || /64G/ {print $1}' | head -1)}"
+: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)}"
 NETWORK_ERROR="connection reset by peer"
 SERVICE_UNAVAILABLE_ERROR="Service Unavailable"
 INTERNAL_ERROR="INTERNAL_ERROR"
@@ -397,7 +397,7 @@ function create_LV_on_disk() {
 }
 
 function deploy_first_rook_cluster() {
-  BLOCK=$(sudo lsblk | awk '/14G/ || /64G/ {print $1}' | head -1)
+  BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)
   create_cluster_prerequisites
   cd deploy/examples/
 
@@ -410,7 +410,7 @@ function deploy_first_rook_cluster() {
 }
 
 function deploy_second_rook_cluster() {
-  BLOCK=$(sudo lsblk | awk '/14G/ || /64G/ {print $1}' | head -1)
+  BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)
   cd deploy/examples/
   NAMESPACE=rook-ceph-secondary envsubst <common-second-cluster.yaml | kubectl create -f -
   sed -i 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g' cluster-test.yaml


### PR DESCRIPTION
the disk size in the github action machine has
increased from 64G to 75G.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
