### PR TITLE
Fix block device detection in github workflow

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -19,7 +19,7 @@ set -xeEo pipefail
 #############
 # VARIABLES #
 #############
-: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ || /64G/ {print $1}' | head -1)}"
+: "${BLOCK:=$(lsblk --paths --list | grep -P '\s+/mnt$' | grep -Po '^[/a-z]+')}"
 NETWORK_ERROR="connection reset by peer"
 SERVICE_UNAVAILABLE_ERROR="Service Unavailable"
 INTERNAL_ERROR="INTERNAL_ERROR"
@@ -75,6 +75,7 @@ function use_local_disk() {
 }
 
 function use_local_disk_for_integration_test() {
+  sudo lsblk --paths --list | grep -P '\s+/mnt$' | grep -Po '^[/a-z]+'
   sudo apt purge snapd -y
   sudo udevadm control --log-priority=debug
   sudo swapoff --all --verbose
@@ -397,7 +398,7 @@ function create_LV_on_disk() {
 }
 
 function deploy_first_rook_cluster() {
-  BLOCK=$(sudo lsblk | awk '/14G/ || /64G/ {print $1}' | head -1)
+  BLOCK=$(lsblk --paths --list | grep -P '\s+/mnt$' | grep -Po '^[/a-z]+')
   create_cluster_prerequisites
   cd deploy/examples/
 
@@ -410,7 +411,7 @@ function deploy_first_rook_cluster() {
 }
 
 function deploy_second_rook_cluster() {
-  BLOCK=$(sudo lsblk | awk '/14G/ || /64G/ {print $1}' | head -1)
+  BLOCK=$(lsblk --paths --list | grep -P '\s+/mnt$' | grep -Po '^[/a-z]+')
   cd deploy/examples/
   NAMESPACE=rook-ceph-secondary envsubst <common-second-cluster.yaml | kubectl create -f -
   sed -i 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g' cluster-test.yaml


### PR DESCRIPTION
The machine setup provided by the
CI changed such that the wipefs
command fails not finding the correct
block device to wipe.

This commit fixes the block device "detection"
by adding another possible disk size (75G).
As this is however the same size as the root
disk the "detection" has been adapted to use
the last disk/block device with a matching
size (14G/64G/75G).

Resolves #13684 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
