### PR TITLE
Disallow legacy hostNetwork  together with  non-default provider

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -28,6 +28,7 @@
         "mon",
         "monitoring",
         "multus",
+	"network",
         "nfs",
         "object",
         "operator",

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2282,6 +2282,8 @@ spec:
                   x-kubernetes-validations:
                     - message: at least one network selector must be specified when using multus
                       rule: '!has(self.provider) || (self.provider != ''multus'' || (self.provider == ''multus'' && size(self.selectors) > 0))'
+                    - message: the legacy hostNetwork setting can only be set if the network.provider is set to the empty string
+                      rule: '!has(self.hostNetwork) || self.hostNetwork == false || !has(self.provider) || self.provider == ""'
                 placement:
                   additionalProperties:
                     description: Placement is the placement for an object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2280,6 +2280,8 @@ spec:
                   x-kubernetes-validations:
                     - message: at least one network selector must be specified when using multus
                       rule: '!has(self.provider) || (self.provider != ''multus'' || (self.provider == ''multus'' && size(self.selectors) > 0))'
+                    - message: the legacy hostNetwork setting can only be set if the network.provider is set to the empty string
+                      rule: '!has(self.hostNetwork) || self.hostNetwork == false || !has(self.provider) || self.provider == ""'
                 placement:
                   additionalProperties:
                     description: Placement is the placement for an object

--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -39,6 +39,9 @@ func (n *NetworkSpec) IsHost() bool {
 }
 
 func ValidateNetworkSpec(clusterNamespace string, spec NetworkSpec) error {
+	if spec.HostNetwork && (spec.Provider != NetworkProviderDefault) {
+		return errors.Errorf(`the legacy hostNetwork setting is only valid with the default network provider ("") and not with '%q'`, spec.Provider)
+	}
 	if spec.IsMultus() {
 		if len(spec.Selectors) == 0 {
 			return errors.Errorf("at least one network selector must be specified when using the %q network provider", NetworkProviderMultus)

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -42,6 +42,36 @@ func TestNetworkCephSpecLegacy(t *testing.T) {
 	assert.Equal(t, expected, net)
 }
 
+func TestValidateNetworkSpec(t *testing.T) {
+	net := NetworkSpec{
+		HostNetwork: true,
+		Provider:    NetworkProviderDefault,
+	}
+	err := ValidateNetworkSpec("", net)
+	assert.NoError(t, err)
+
+	net = NetworkSpec{
+		HostNetwork: true,
+		Provider:    NetworkProviderHost,
+	}
+	err = ValidateNetworkSpec("", net)
+	assert.Error(t, err)
+
+	net = NetworkSpec{
+		HostNetwork: false,
+		Provider:    NetworkProviderDefault,
+	}
+	err = ValidateNetworkSpec("", net)
+	assert.NoError(t, err)
+
+	net = NetworkSpec{
+		HostNetwork: false,
+		Provider:    NetworkProviderHost,
+	}
+	err = ValidateNetworkSpec("", net)
+	assert.NoError(t, err)
+}
+
 func TestNetworkCephIsHostLegacy(t *testing.T) {
 	net := NetworkSpec{HostNetwork: true}
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2316,6 +2316,7 @@ type SSSDSidecarAdditionalFile struct {
 
 // NetworkSpec for Ceph includes backward compatibility code
 // +kubebuilder:validation:XValidation:message="at least one network selector must be specified when using multus",rule="!has(self.provider) || (self.provider != 'multus' || (self.provider == 'multus' && size(self.selectors) > 0))"
+// +kubebuilder:validation:XValidation:message=`the legacy hostNetwork setting can only be set if the network.provider is set to the empty string`,rule=`!has(self.hostNetwork) || self.hostNetwork == false || !has(self.provider) || self.provider == ""`
 type NetworkSpec struct {
 	// Provider is what provides network connectivity to the cluster e.g. "host" or "multus".
 	// If the Provider is updated from being empty to "host" on a running cluster, then the operator will automatically fail over all the mons to apply the "host" network settings.


### PR DESCRIPTION

**Description of changes:**

Since the introduction of the "host" network provider, the  legacy
    "hostNetwork" setting is intended to be used only in combination with
    the default network provider (""), but originally, the code did not enforce this.
    
    This change adds the required validation checks to throw errors
    in invalid constellations.





**Issue resolved by this Pull Request:**
Resolves #13692  

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
