### PR TITLE
ci: fix detection of GH actions extra disk

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -303,7 +303,7 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: prepare loop devices for osds
@@ -370,7 +370,7 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: deploy cluster
@@ -416,7 +416,7 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -469,7 +469,7 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -516,13 +516,13 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: create LV on disk
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
 
       - name: deploy cluster
@@ -574,7 +574,7 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/loopDevicePV.sh 1
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
@@ -605,7 +605,7 @@ jobs:
           kubectl -n rook-ceph logs deploy/rook-ceph-operator
           tests/scripts/github-action-helper.sh wait_for_cleanup_pod
           lsblk
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           sudo head --bytes=60 ${BLOCK}1
           sudo head --bytes=60 ${BLOCK}2
           sudo head --bytes=60 /dev/loop1
@@ -744,7 +744,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          tests/scripts/localPathPV.sh $(lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
       - name: deploy cluster
@@ -770,7 +771,7 @@ jobs:
           kubectl -n rook-ceph delete cephcluster rook-ceph
           kubectl -n rook-ceph logs deploy/rook-ceph-operator
           tests/scripts/github-action-helper.sh wait_for_cleanup_pod
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           sudo head --bytes=60 ${BLOCK}1
           sudo head --bytes=60 ${BLOCK}2
           sudo lsblk
@@ -920,7 +921,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          tests/scripts/localPathPV.sh $(lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
       - name: deploy vault
@@ -1002,7 +1004,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          tests/scripts/localPathPV.sh $(lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
       - name: deploy vault
@@ -1065,7 +1068,7 @@ jobs:
 
       - name: create LV on disk
         run: |
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
           tests/scripts/localPathPV.sh /dev/test-rook-vg/test-rook-lv
 
@@ -1114,7 +1117,7 @@ jobs:
       - name: use local disk into two partitions
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
           sudo lsblk
 

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: use local disk and create partitions for osds
         run: |
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 1
 
@@ -135,7 +136,7 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="quincy-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -175,7 +176,7 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="reef-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -215,7 +216,7 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=main go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -255,7 +256,7 @@ jobs:
 
       - name: TestCephObjectSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="quincy-devel" go test -v -timeout 1800s -failfast -run TestCephObjectSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -295,7 +296,7 @@ jobs:
 
       - name: TestCephObjectSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=main go test -v -timeout 1800s -failfast -run TestCephObjectSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -335,7 +336,7 @@ jobs:
 
       - name: TestCephUpgradeSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToReefDevel github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -375,7 +376,7 @@ jobs:
 
       - name: TestCephUpgradeSuite
         run: |
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToQuincyDevel github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
+++ b/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
@@ -35,7 +35,8 @@ runs:
     - name: create cluster prerequisites
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        tests/scripts/localPathPV.sh $(lsblk --paths|awk '/14G/ || /64G/ {print $1}'| head -1)
+        export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+        tests/scripts/localPathPV.sh "$BLOCK"
         tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
     - name: deploy cluster

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -50,7 +50,7 @@ jobs:
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           tests/scripts/github-action-helper.sh create_helm_tag
           tests/scripts/helm.sh up
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephHelmSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: TestCephMgrSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 1800s -failfast -run CephMgrSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -45,8 +45,9 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)1
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export TEST_SCRATCH_DEVICE="${BLOCK}1"
+          export DEVICE_FILTER="$BLOCK"
           go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: TestCephObjectSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: TestCephSmokeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: TestCephUpgradeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 2400s -failfast -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -92,7 +92,7 @@ jobs:
           tests/scripts/helm.sh up
 
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 1800s -failfast -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -35,7 +35,7 @@ jobs:
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           tests/scripts/github-action-helper.sh create_helm_tag
           tests/scripts/helm.sh up
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephHelmSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -73,8 +73,9 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)1
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export TEST_SCRATCH_DEVICE="/dev/${BLOCK}1"
+          export DEVICE_FILTER="$BLOCK"
           go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -112,7 +113,7 @@ jobs:
       - name: TestCephSmokeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -150,7 +151,7 @@ jobs:
       - name: TestCephUpgradeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 2400s -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -191,7 +192,7 @@ jobs:
           tests/scripts/helm.sh up
 
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           go test -v -timeout 1800s -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -229,7 +230,7 @@ jobs:
       - name: TestCephObjectSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/rgw-multisite-test/action.yml
+++ b/.github/workflows/rgw-multisite-test/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: use local disk into two partitions
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}'| head -1)
+        export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
         tests/scripts/github-action-helper.sh use_local_disk
         tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
         sudo lsblk

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -19,7 +19,27 @@ set -xeEo pipefail
 #############
 # VARIABLES #
 #############
-: "${BLOCK:=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)}"
+
+function find_extra_block_dev() {
+  # shellcheck disable=SC2005 # redirect doesn't work with sudo, so use echo
+  echo "$(sudo lsblk)" >/dev/stderr # print lsblk output to stderr for debugging in case of future errors
+  # relevant lsblk --pairs example: (MOUNTPOINT identifies boot partition)(PKNAME is Parent dev ID)
+  # NAME="sda15" SIZE="106M" TYPE="part" MOUNTPOINT="/boot/efi" PKNAME="sda"
+  # NAME="sdb"   SIZE="75G"  TYPE="disk" MOUNTPOINT=""          PKNAME=""
+  # NAME="sdb1"  SIZE="75G"  TYPE="part" MOUNTPOINT="/mnt"      PKNAME="sdb"
+  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
+  echo "  == find_extra_block_dev(): boot_dev='$boot_dev'" >/dev/stderr # debug in case of future errors
+  # --nodeps ignores partitions
+  extra_dev="$(sudo lsblk --noheading --list --nodeps --output KNAME | grep -v loop | grep -v "$boot_dev" | head -1)"
+  echo "  == find_extra_block_dev(): extra_dev='$extra_dev'" >/dev/stderr # debug in case of future errors
+  echo "$extra_dev" # output of function
+}
+
+: "${BLOCK:=$(find_extra_block_dev)}"
+# by definition, in this file, BLOCK should only contain the "sdX" portion of the block device name
+# some external scripts export BLOCK as the full "/dev/sdX" path, which this script must handle
+BLOCK="$(basename $BLOCK)"
+
 NETWORK_ERROR="connection reset by peer"
 SERVICE_UNAVAILABLE_ERROR="Service Unavailable"
 INTERNAL_ERROR="INTERNAL_ERROR"
@@ -57,7 +77,7 @@ function prepare_loop_devices() {
 }
 
 function use_local_disk() {
-  BLOCK_DATA_PART=${BLOCK}1
+  BLOCK_DATA_PART="/dev/${BLOCK}1"
   sudo apt purge snapd -y
   sudo dmsetup version || true
   sudo swapoff --all --verbose
@@ -67,9 +87,9 @@ function use_local_disk() {
     sudo wipefs --all --force "$BLOCK_DATA_PART"
   else
     # it's the hosted runner!
-    sudo sgdisk --zap-all -- "${BLOCK}"
-    sudo dd if=/dev/zero of="${BLOCK}" bs=1M count=10 oflag=direct,dsync
-    sudo parted -s "${BLOCK}" mklabel gpt
+    sudo sgdisk --zap-all -- "/dev/${BLOCK}"
+    sudo dd if=/dev/zero of="/dev/${BLOCK}" bs=1M count=10 oflag=direct,dsync
+    sudo parted -s "/dev/${BLOCK}" mklabel gpt
   fi
   sudo lsblk
 }
@@ -81,7 +101,7 @@ function use_local_disk_for_integration_test() {
   sudo umount /mnt
   sudo sed -i.bak '/\/mnt/d' /etc/fstab
   # search for the device since it keeps changing between sda and sdb
-  PARTITION="${BLOCK}1"
+  PARTITION="/dev/${BLOCK}1"
   sudo wipefs --all --force "$PARTITION"
   sudo dd if=/dev/zero of="${PARTITION}" bs=1M count=1
   sudo lsblk --bytes
@@ -90,8 +110,7 @@ function use_local_disk_for_integration_test() {
   # for more details see: https://github.com/rook/rook/issues/7405
   echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
   # for below, see: https://access.redhat.com/solutions/1465913
-  block_base="$(basename "${BLOCK}")"
-  echo "ACTION==\"add|change\", KERNEL==\"${block_base}\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
+  echo "ACTION==\"add|change\", KERNEL==\"${BLOCK}\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
   # The partition is still getting reloaded occasionally during operation. See https://github.com/rook/rook/issues/8975
   # Try issuing some disk-inspection commands to jog the system so it won't reload the partitions
   # during OSD provisioning.
@@ -99,31 +118,31 @@ function use_local_disk_for_integration_test() {
   sudo udevadm trigger || true
   time sudo udevadm settle || true
   sudo partprobe || true
-  sudo lsblk --noheadings --pairs "${BLOCK}" || true
-  sudo sgdisk --print "${BLOCK}" || true
-  sudo udevadm info --query=property "${BLOCK}" || true
+  sudo lsblk --noheadings --pairs "/dev/${BLOCK}" || true
+  sudo sgdisk --print "/dev/${BLOCK}" || true
+  sudo udevadm info --query=property "/dev/${BLOCK}" || true
   sudo lsblk --noheadings --pairs "${PARTITION}" || true
   journalctl -o short-precise --dmesg | tail -40 || true
   cat /etc/fstab || true
 }
 
 function create_partitions_for_osds() {
-  tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 2
+  tests/scripts/create-bluestore-partitions.sh --disk "/dev/$BLOCK" --osd-count 2
   sudo lsblk
 }
 
 function create_bluestore_partitions_and_pvcs() {
-  BLOCK_PART="$BLOCK"2
-  DB_PART="$BLOCK"1
-  tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --bluestore-type block.db --osd-count 1
+  BLOCK_PART="/dev/$BLOCK"2
+  DB_PART="/dev/$BLOCK"1
+  tests/scripts/create-bluestore-partitions.sh --disk "/dev/$BLOCK" --bluestore-type block.db --osd-count 1
   tests/scripts/localPathPV.sh "$BLOCK_PART" "$DB_PART"
 }
 
 function create_bluestore_partitions_and_pvcs_for_wal() {
-  BLOCK_PART="$BLOCK"3
-  DB_PART="$BLOCK"1
-  WAL_PART="$BLOCK"2
-  tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --bluestore-type block.wal --osd-count 1
+  BLOCK_PART="/dev/$BLOCK"3
+  DB_PART="/dev/$BLOCK"1
+  WAL_PART="/dev/$BLOCK"2
+  tests/scripts/create-bluestore-partitions.sh --disk "/dev/$BLOCK" --bluestore-type block.wal --osd-count 1
   tests/scripts/localPathPV.sh "$BLOCK_PART" "$DB_PART" "$WAL_PART"
 }
 
@@ -397,7 +416,8 @@ function create_LV_on_disk() {
 }
 
 function deploy_first_rook_cluster() {
-  BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)
+  BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+  export BLOCK
   create_cluster_prerequisites
   cd deploy/examples/
 
@@ -410,7 +430,8 @@ function deploy_first_rook_cluster() {
 }
 
 function deploy_second_rook_cluster() {
-  BLOCK=$(sudo lsblk --paths | awk '/14G/ || /64G/ || /75G/ {print $1}' | head -1)
+  BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+  export BLOCK
   cd deploy/examples/
   NAMESPACE=rook-ceph-secondary envsubst <common-second-cluster.yaml | kubectl create -f -
   sed -i 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g' cluster-test.yaml


### PR DESCRIPTION
The 'extra' block device attached to GH actions runners has changed size twice in 3 months. The previous strategy of detecting the disk by size is becoming harder to maintain. Additionally, the block size with recent changes (75G) is now the same as the boot device (also 75G), making the method inexact.

The method can now be summarized as, "find the boot disk and choose the disk that isn't the boot disk to be the 'extra' one used."

Prior to this, we used a one-liner based on `lsblk`. While we could still make this a one-liner, the method is now updated to 2 effective lines, plus debug text output to stderr to help if we need to debug further in the future.

Of note, the 'extra' disk has a mount point of "/mnt", but it is unclear whether this is a reliable heuristic for detecting the extra disk. For years now, GH action runners have had only 2 disks. Therefore, it seems slightly more likely that a heuristic to "choose the non-boot disk" will be a more robust long-term solution.

If this strategy proves to be unreliable in the future, it may be wise to consider whether "the device with a partition mounted to '/mnt'" would be a good alternative.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

Might fix #13684

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
