### PR TITLE
test: use mounter kernal instead of fuse

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -242,6 +242,14 @@ spec:
       databaseSizeMB: "1024"
 `
 	}
+
+	if m.settings.ConnectionsEncrypted {
+		clusterSpec += `
+  csi:
+    cephfs:
+      kernelMountOptions: ms_mode=secure
+  `
+	}
 	return clusterSpec + `
   priorityClassNames:
     mon: system-node-critical
@@ -349,9 +357,9 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: ` + m.settings.Namespace + `
 `
 	if m.settings.ConnectionsEncrypted {
-		// encryption requires either the 5.11 kernel or the fuse mounter. Until the newer
-		// kernel is available in minikube, we need to test with fuse.
-		sc += "  mounter: fuse"
+		// Encryption with kernel version <= 5.11 requires 'mounter: fuse'. For kernel version >= 5.12, it requires 'mounter: kernel'.
+		// Since the Github action Minikube has kernel version > 5.12, the setting is set to 'mounter: kernel'.
+		sc += "  mounter: kernel"
 	}
 	return sc
 }


### PR DESCRIPTION
this kernal version is greater than 5.11 let's
use mounter kernal instead of fuse.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13684 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
