### PR TITLE
helm: Remove cpu limits from all pods

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -667,7 +667,6 @@ spec:
     - name: "172.17.4.201"
       resources:
         limits:
-          cpu: "2"
           memory: "4096Mi"
         requests:
           cpu: "2"

--- a/Documentation/CRDs/Cluster/pvc-cluster.md
+++ b/Documentation/CRDs/Cluster/pvc-cluster.md
@@ -85,7 +85,6 @@ spec:
       portable: false
       resources:
         limits:
-          cpu: "500m"
           memory: "4Gi"
         requests:
           cpu: "500m"

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -58,7 +58,6 @@ spec:
     #  topologySpreadConstraints:
     resources:
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"

--- a/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
@@ -55,7 +55,6 @@ spec:
     #  topologySpreadConstraints:
     resources:
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"

--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -42,7 +42,6 @@ spec:
 
     resources:
       limits:
-        cpu: "3"
         memory: "8Gi"
       requests:
         cpu: "3"

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -84,7 +84,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `toolbox.enabled` | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md) | `false` |
 | `toolbox.image` | Toolbox image, defaults to the image used by the Ceph cluster | `nil` |
 | `toolbox.priorityClassName` | Set the priority class for the toolbox if desired | `nil` |
-| `toolbox.resources` | Toolbox resources | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
+| `toolbox.resources` | Toolbox resources | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
 | `toolbox.tolerations` | Toolbox tolerations | `[]` |
 
 ### **Ceph Cluster Spec**

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -151,7 +151,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `pspEnable` | If true, create & use PSP resources | `false` |
 | `rbacAggregate.enableOBCs` | If true, create a ClusterRole aggregated to [user facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) for objectbucketclaims | `false` |
 | `rbacEnable` | If true, create & use RBAC resources | `true` |
-| `resources` | Pod resource requests & limits | `{"limits":{"cpu":"1500m","memory":"512Mi"},"requests":{"cpu":"200m","memory":"128Mi"}}` |
+| `resources` | Pod resource requests & limits | `{"limits":{"memory":"512Mi"},"requests":{"cpu":"200m","memory":"128Mi"}}` |
 | `scaleDownOperator` | If true, scale down the rook operator. This is useful for administrative actions where the rook operator must be scaled down, while using gitops style tooling to deploy your helm charts. | `false` |
 | `tolerations` | List of Kubernetes [`tolerations`](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to add to the Deployment. | `[]` |
 | `unreachableNodeTolerationSeconds` | Delay to use for the `node.kubernetes.io/unreachable` pod failure toleration to override the Kubernetes default of 5 minutes | `5` |

--- a/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md
+++ b/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md
@@ -168,7 +168,6 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            cpu: 100m
             memory: 100Mi
         env:
         # Configuration reference: https://docs.docker.com/registry/configuration/

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -40,7 +40,6 @@ toolbox:
   # -- Toolbox resources
   resources:
     limits:
-      cpu: "500m"
       memory: "1Gi"
     requests:
       cpu: "100m"
@@ -281,21 +280,18 @@ cephClusterSpec:
   resources:
     mgr:
       limits:
-        cpu: "1000m"
         memory: "1Gi"
       requests:
         cpu: "500m"
         memory: "512Mi"
     mon:
       limits:
-        cpu: "2000m"
         memory: "2Gi"
       requests:
         cpu: "1000m"
         memory: "1Gi"
     osd:
       limits:
-        cpu: "2000m"
         memory: "4Gi"
       requests:
         cpu: "1000m"
@@ -314,35 +310,30 @@ cephClusterSpec:
         memory: "50Mi"
     mgr-sidecar:
       limits:
-        cpu: "500m"
         memory: "100Mi"
       requests:
         cpu: "100m"
         memory: "40Mi"
     crashcollector:
       limits:
-        cpu: "500m"
         memory: "60Mi"
       requests:
         cpu: "100m"
         memory: "60Mi"
     logcollector:
       limits:
-        cpu: "500m"
         memory: "1Gi"
       requests:
         cpu: "100m"
         memory: "100Mi"
     cleanup:
       limits:
-        cpu: "500m"
         memory: "1Gi"
       requests:
         cpu: "500m"
         memory: "100Mi"
     exporter:
       limits:
-        cpu: "250m"
         memory: "128Mi"
       requests:
         cpu: "50m"
@@ -522,7 +513,6 @@ cephFileSystems:
         activeStandby: true
         resources:
           limits:
-            cpu: "2000m"
             memory: "4Gi"
           requests:
             cpu: "1000m"
@@ -596,7 +586,6 @@ cephObjectStores:
         port: 80
         resources:
           limits:
-            cpu: "2000m"
             memory: "2Gi"
           requests:
             cpu: "1000m"

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -23,7 +23,6 @@ crds:
 # -- Pod resource requests & limits
 resources:
   limits:
-    cpu: 1500m
     memory: 512Mi
   requests:
     cpu: 200m
@@ -218,7 +217,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-resizer
       resource:
         requests:
@@ -226,7 +224,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-attacher
       resource:
         requests:
@@ -234,7 +231,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-snapshotter
       resource:
         requests:
@@ -242,15 +238,12 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-rbdplugin
       resource:
         requests:
           memory: 512Mi
-          cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : csi-omap-generator
       resource:
         requests:
@@ -258,7 +251,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : liveness-prometheus
       resource:
         requests:
@@ -266,7 +258,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
 
   # -- CEPH CSI RBD plugin resource requirement list
   # @default -- see values.yaml
@@ -278,7 +269,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
     - name : csi-rbdplugin
       resource:
         requests:
@@ -286,7 +276,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : liveness-prometheus
       resource:
         requests:
@@ -294,7 +283,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
 
   # -- CEPH CSI CephFS provisioner resource requirement list
   # @default -- see values.yaml
@@ -306,7 +294,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-resizer
       resource:
         requests:
@@ -314,7 +301,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-attacher
       resource:
         requests:
@@ -322,7 +308,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-snapshotter
       resource:
         requests:
@@ -330,7 +315,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-cephfsplugin
       resource:
         requests:
@@ -338,7 +322,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : liveness-prometheus
       resource:
         requests:
@@ -346,7 +329,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
 
   # -- CEPH CSI CephFS plugin resource requirement list
   # @default -- see values.yaml
@@ -358,7 +340,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
     - name : csi-cephfsplugin
       resource:
         requests:
@@ -366,7 +347,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : liveness-prometheus
       resource:
         requests:
@@ -374,7 +354,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
 
   # -- CEPH CSI NFS provisioner resource requirement list
   # @default -- see values.yaml
@@ -386,7 +365,6 @@ csi:
           cpu: 100m
         limits:
           memory: 256Mi
-          cpu: 200m
     - name : csi-nfsplugin
       resource:
         requests:
@@ -394,7 +372,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
     - name : csi-attacher
       resource:
         requests:
@@ -402,7 +379,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
 
   # -- CEPH CSI NFS plugin resource requirement list
   # @default -- see values.yaml
@@ -414,7 +390,6 @@ csi:
           cpu: 50m
         limits:
           memory: 256Mi
-          cpu: 100m
     - name : csi-nfsplugin
       resource:
         requests:
@@ -422,7 +397,6 @@ csi:
           cpu: 250m
         limits:
           memory: 1Gi
-          cpu: 500m
 
   # Set provisionerTolerations and provisionerNodeAffinity for provisioner pod.
   # The CSI provisioner would be best to start on the same nodes as other ceph daemons.
@@ -629,7 +603,6 @@ discover:
   # -- Add resources to discover daemon pods
   resources:
   #   - limits:
-  #       cpu: 500m
   #       memory: 512Mi
   #   - requests:
   #       cpu: 100m

--- a/deploy/examples/cluster-on-local-pvc.yaml
+++ b/deploy/examples/cluster-on-local-pvc.yaml
@@ -226,7 +226,6 @@ spec:
         resources:
         # These are the OSD daemon limits. For OSD prepare limits, see the separate section below for "prepareosd" resources
         #   limits:
-        #     cpu: "500m"
         #     memory: "4Gi"
         #   requests:
         #     cpu: "500m"
@@ -250,10 +249,7 @@ spec:
     onlyApplyOSDPlacement: false
   resources:
   #  prepareosd:
-  #    limits:
-  #      cpu: "200m"
-  #      memory: "200Mi"
-  #   requests:
+  #    requests:
   #      cpu: "200m"
   #      memory: "200Mi"
   priorityClassNames:

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -115,7 +115,6 @@ spec:
         resources:
         # These are the OSD daemon limits. For OSD prepare limits, see the separate section below for "prepareosd" resources
         #   limits:
-        #     cpu: "500m"
         #     memory: "4Gi"
         #   requests:
         #     cpu: "500m"
@@ -167,10 +166,7 @@ spec:
     onlyApplyOSDPlacement: false
   resources:
   #  prepareosd:
-  #    limits:
-  #      cpu: "200m"
-  #      memory: "200Mi"
-  #   requests:
+  #    requests:
   #      cpu: "200m"
   #      memory: "200Mi"
   priorityClassNames:

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -214,7 +214,6 @@ spec:
   #The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
   #   mgr:
   #     limits:
-  #       cpu: "500m"
   #       memory: "1024Mi"
   #     requests:
   #       cpu: "500m"

--- a/deploy/examples/csi/cephfs/kube-registry.yaml
+++ b/deploy/examples/csi/cephfs/kube-registry.yaml
@@ -36,7 +36,6 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              cpu: 100m
               memory: 100Mi
           env:
             # Configuration reference: https://docs.docker.com/registry/configuration/

--- a/deploy/examples/filesystem-ec.yaml
+++ b/deploy/examples/filesystem-ec.yaml
@@ -85,7 +85,6 @@ spec:
     resources:
     # The requests and limits set here, allow the filesystem MDS Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"
@@ -108,6 +107,6 @@ spec:
   # by default pinning is set with value: distributed=1
   # for disabling default values set (distributed=0)
   pinning:
-    distributed: 1            # distributed=<0, 1> (disabled=0)
+    distributed: 1 # distributed=<0, 1> (disabled=0)
     # export:                 # export=<0-256> (disabled=-1)
     # random:                 # random=[0.0, 1.0](disabled=0.0)

--- a/deploy/examples/filesystem-mirror.yaml
+++ b/deploy/examples/filesystem-mirror.yaml
@@ -28,9 +28,8 @@ spec:
   annotations:
   #  key: value
   resources:
-  # The requests and limits, for example to allow the cephfs-mirror pod(s) to use half of one CPU core and 1 gigabyte of memory
+    # The requests and limits, for example to allow the cephfs-mirror pod(s) to use half of one CPU core and 1 gigabyte of memory
     limits:
-      cpu: "500m"
       memory: "1Gi"
     requests:
       cpu: "500m"

--- a/deploy/examples/filesystem.yaml
+++ b/deploy/examples/filesystem.yaml
@@ -103,7 +103,6 @@ spec:
     # resources:
     # The requests and limits set here, allow the filesystem MDS Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"
@@ -115,27 +114,27 @@ spec:
       disabled: false
   # Filesystem mirroring settings
   # mirroring:
-    # enabled: true
-    # list of Kubernetes Secrets containing the peer token
-    # for more details see: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/#bootstrap-peers
-    # Add the secret name if it already exists else specify the empty list here.
-    # peers:
-      #secretNames:
-        #- secondary-cluster-peer
-    # specify the schedule(s) on which snapshots should be taken
-    # see the official syntax here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules
-    # snapshotSchedules:
-    #   - path: /
-    #     interval: 24h # daily snapshots
-        # The startTime should be mentioned in the format YYYY-MM-DDTHH:MM:SS
-        # If startTime is not specified, then by default the start time is considered as midnight UTC.
-        # see usage here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#usage
-        # startTime: 2022-07-15T11:55:00
-    # manage retention policies
-    # see syntax duration here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies
-    # snapshotRetention:
-    #   - path: /
-    #     duration: "h 24"
+  #   enabled: true
+  #   # list of Kubernetes Secrets containing the peer token
+  #   # for more details see: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/#bootstrap-peers
+  #   # Add the secret name if it already exists else specify the empty list here.
+  #   peers:
+  #     secretNames:
+  #     - secondary-cluster-peer
+  #   # specify the schedule(s) on which snapshots should be taken
+  #   # see the official syntax here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules
+  #   snapshotSchedules:
+  #     - path: /
+  #       interval: 24h # daily snapshots
+  #   # The startTime should be mentioned in the format YYYY-MM-DDTHH:MM:SS
+  #   # If startTime is not specified, then by default the start time is considered as midnight UTC.
+  #   # see usage here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#usage
+  #   # startTime: 2022-07-15T11:55:00
+  #   # manage retention policies
+  #   # see syntax duration here https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies
+  #   snapshotRetention:
+  #     - path: /
+  #       duration: "h 24"
 ---
 # create default csi subvolume group
 apiVersion: ceph.rook.io/v1
@@ -153,6 +152,6 @@ spec:
   # by default pinning is set with value: distributed=1
   # for disabling default values set (distributed=0)
   pinning:
-    distributed: 1            # distributed=<0, 1> (disabled=0)
+    distributed: 1 # distributed=<0, 1> (disabled=0)
     # export:                 # export=<0-256> (disabled=-1)
     # random:                 # random=[0.0, 1.0](disabled=0.0)

--- a/deploy/examples/nfs.yaml
+++ b/deploy/examples/nfs.yaml
@@ -47,7 +47,6 @@ spec:
     # Resource requests and limits to apply to NFS server pods
     resources:
       # limits:
-      #   cpu: "3"
       #   memory: "8Gi"
       # requests:
       #   cpu: "3"
@@ -101,7 +100,6 @@ spec:
     #     # debugLevel: 6
     #     resources:
     #       limits:
-    #         cpu: "2"
     #         memory: "1Gi"
     #       requests:
     #         cpu: "2"

--- a/deploy/examples/object-ec.yaml
+++ b/deploy/examples/object-ec.yaml
@@ -74,7 +74,6 @@ spec:
     resources:
     # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"

--- a/deploy/examples/object-openshift.yaml
+++ b/deploy/examples/object-openshift.yaml
@@ -83,7 +83,6 @@ spec:
     resources:
     # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -94,7 +94,6 @@ spec:
     resources:
     # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:
-    #    cpu: "500m"
     #    memory: "1024Mi"
     #  requests:
     #    cpu: "500m"

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -346,7 +346,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-resizer
   #    resource:
   #      requests:
@@ -354,7 +353,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -362,7 +360,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-snapshotter
   #    resource:
   #      requests:
@@ -370,7 +367,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-rbdplugin
   #    resource:
   #      requests:
@@ -378,7 +374,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : csi-omap-generator
   #    resource:
   #      requests:
@@ -386,7 +381,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -394,7 +388,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI RBD plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   #CSI_RBD_PLUGIN_RESOURCE: |
@@ -405,7 +398,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-rbdplugin
   #    resource:
   #      requests:
@@ -413,7 +405,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -421,7 +412,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI CephFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
   #CSI_CEPHFS_PROVISIONER_RESOURCE: |
@@ -432,7 +422,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-resizer
   #    resource:
   #      requests:
@@ -440,7 +429,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -448,7 +436,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-snapshotter
   #    resource:
   #      requests:
@@ -456,7 +443,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-cephfsplugin
   #    resource:
   #      requests:
@@ -464,7 +450,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -472,7 +457,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI CephFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   #CSI_CEPHFS_PLUGIN_RESOURCE: |
@@ -483,7 +467,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-cephfsplugin
   #    resource:
   #      requests:
@@ -491,7 +474,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -499,7 +481,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
 
   # (Optional) CEPH CSI NFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
@@ -511,7 +492,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-nfsplugin
   #    resource:
   #      requests:
@@ -519,7 +499,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -527,7 +506,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   # (Optional) CEPH CSI NFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   # CSI_NFS_PLUGIN_RESOURCE: |
@@ -538,7 +516,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-nfsplugin
   #    resource:
   #      requests:
@@ -546,7 +523,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
 
   # Configure CSI CephFS liveness metrics port
   # Set to true to enable Ceph CSI liveness container.
@@ -648,7 +624,6 @@ data:
   #   - name: DISCOVER_DAEMON_RESOURCES
   #     resources:
   #       limits:
-  #         cpu: 1500m
   #         memory: 512Mi
   #       requests:
   #         cpu: 200m
@@ -724,7 +699,6 @@ spec:
             #   value: |
             #     resources:
             #       limits:
-            #         cpu: 500m
             #         memory: 512Mi
             #       requests:
             #         cpu: 100m
@@ -763,7 +737,6 @@ spec:
           # Recommended resource requests and limits, if desired
           #resources:
           #  limits:
-          #    cpu: 500m
           #    memory: 512Mi
           #  requests:
           #    cpu: 100m

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -279,7 +279,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-resizer
   #    resource:
   #      requests:
@@ -287,7 +286,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -295,7 +293,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-snapshotter
   #    resource:
   #      requests:
@@ -303,7 +300,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-rbdplugin
   #    resource:
   #      requests:
@@ -311,7 +307,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : csi-omap-generator
   #    resource:
   #      requests:
@@ -319,7 +314,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -327,7 +321,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI RBD plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   #CSI_RBD_PLUGIN_RESOURCE: |
@@ -338,7 +331,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-rbdplugin
   #    resource:
   #      requests:
@@ -346,7 +338,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -354,7 +345,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI CephFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
   #CSI_CEPHFS_PROVISIONER_RESOURCE: |
@@ -365,7 +355,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-resizer
   #    resource:
   #      requests:
@@ -373,7 +362,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -381,7 +369,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-snapshotter
   #    resource:
   #      requests:
@@ -389,7 +376,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-cephfsplugin
   #    resource:
   #      requests:
@@ -397,7 +383,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -405,7 +390,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   # (Optional) CEPH CSI CephFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   #CSI_CEPHFS_PLUGIN_RESOURCE: |
@@ -416,7 +400,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-cephfsplugin
   #    resource:
   #      requests:
@@ -424,7 +407,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : liveness-prometheus
   #    resource:
   #      requests:
@@ -432,7 +414,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
 
   # (Optional) CEPH CSI NFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
@@ -444,7 +425,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   #  - name : csi-nfsplugin
   #    resource:
   #      requests:
@@ -452,7 +432,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
   #  - name : csi-attacher
   #    resource:
   #      requests:
@@ -460,7 +439,6 @@ data:
   #        cpu: 100m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 200m
   # (Optional) CEPH CSI NFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
   # CSI_NFS_PLUGIN_RESOURCE: |
@@ -471,7 +449,6 @@ data:
   #        cpu: 50m
   #      limits:
   #        memory: 256Mi
-  #        cpu: 100m
   #  - name : csi-nfsplugin
   #    resource:
   #      requests:
@@ -479,7 +456,6 @@ data:
   #        cpu: 250m
   #      limits:
   #        memory: 1Gi
-  #        cpu: 500m
 
   # Configure CSI CephFS liveness metrics port
   # Set to true to enable Ceph CSI liveness container.
@@ -574,7 +550,6 @@ data:
   #   - name: DISCOVER_DAEMON_RESOURCES
   #     resources:
   #       limits:
-  #         cpu: 500m
   #         memory: 512Mi
   #       requests:
   #         cpu: 100m
@@ -677,7 +652,6 @@ spec:
           # Recommended resource requests and limits, if desired
           #resources:
           #  limits:
-          #    cpu: 1500m
           #    memory: 512Mi
           #  requests:
           #    cpu: 200m

--- a/deploy/examples/rbdmirror.yaml
+++ b/deploy/examples/rbdmirror.yaml
@@ -14,8 +14,8 @@ spec:
   # list of Kubernetes Secrets containing the peer token
   # for more details see: https://docs.ceph.com/docs/master/rbd/rbd-mirroring/#bootstrap-peers
   #peers:
-    #secretNames:
-      #- secondary-cluster-peer
+  #  secretNames:
+  #  - secondary-cluster-peer
   # The affinity rules to apply to the rbd-mirror deployment
   placement:
   #  nodeAffinity:
@@ -35,9 +35,8 @@ spec:
   annotations:
   #  key: value
   resources:
-  # The requests and limits, for example to allow the rbd-mirror pod(s) to use half of one CPU core and 1 gigabyte of memory
+    # The requests and limits, for example to allow the rbd-mirror pod(s) to use half of one CPU core and 1 gigabyte of memory
     limits:
-      cpu: "500m"
       memory: "1Gi"
     requests:
       cpu: "500m"

--- a/design/ceph/ceph-nfs-ganesha.md
+++ b/design/ceph/ceph-nfs-ganesha.md
@@ -112,7 +112,6 @@ spec:
     # one CPU core and 1 gigabyte of memory
     resources:
     #  limits:
-    #    cpu: "3"
     #    memory: "8Gi"
     #  requests:
     #    cpu: "3"
@@ -142,7 +141,6 @@ spec:
           #   cpu: "2"
           #   memory: "1024Mi"
           # limits:
-          #   cpu: "2"
           #   memory: "1024Mi"
 
     kerberos:

--- a/design/ceph/object/ceph-cosi-driver.md
+++ b/design/ceph/object/ceph-cosi-driver.md
@@ -66,7 +66,6 @@ spec:
   #    cpu: "100m"
   #    memory: "128Mi"
   #  limits:
-  #    cpu: "100m"
   #    memory: "128Mi"
 ```
 

--- a/design/ceph/resource-constraints.md
+++ b/design/ceph/resource-constraints.md
@@ -92,28 +92,24 @@ spec:
           cpu: "500m"
           memory: "512Mi"
       limits:
-        cpu: "500m"
         memory: "512Mi"
     mgr:
       requests:
           cpu: "500m"
           memory: "512Mi"
       limits:
-        cpu: "500m"
         memory: "512Mi"
     mon:
       requests:
           cpu: "500m"
           memory: "512Mi"
       limits:
-        cpu: "500m"
         memory: "512Mi"
     osd:
       requests:
           cpu: "500m"
           memory: "512Mi"
       limits:
-        cpu: "500m"
         memory: "512Mi"
   storage:
     useAllNodes: true
@@ -142,6 +138,4 @@ spec:
         requests:
           memory: "512Mi"
           cpu: "1"
-        limits:
-          cpu: "2"
 ```

--- a/design/common/multiple-storage-types-support.md
+++ b/design/common/multiple-storage-types-support.md
@@ -377,7 +377,6 @@ spec:
   resources:
   - name: osd
     limits:
-      cpu: "500m"
       memory: "1024Mi"
     requests:
       cpu: "500m"


### PR DESCRIPTION
When CPU requests and limits are assigned to a pod, the pod will be guaranteed the requests, up to the limits. Even if there are spare CPU cycles, the pod cannot use them. Thus, pods can be unnecessarily denied compute when they need to burst if the limits are set.

Therefore, it is not recommended to set CPU limits since the CPU requests are already guaranteeing that no pod will be starved at least for its requests.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13117 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
