### PR TITLE
ci: Backport-13697: fix ci failure due to `/dev` prefix

### DIFF
--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -46,9 +46,10 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          export TEST_SCRATCH_DEVICE="${BLOCK}1"
-          export DEVICE_FILTER="$BLOCK"
+          DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK="/dev/${DEVICE_NAME}"
+          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}1"
+          export DEVICE_FILTER="$DEVICE_NAME"
           go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -75,9 +75,10 @@ jobs:
       - name: TestCephMultiClusterDeploySuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          export TEST_SCRATCH_DEVICE="/dev/${BLOCK}1"
-          export DEVICE_FILTER="$BLOCK"
+          DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK="$/dev/${DEVICE_NAME}"
+          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}1"
+          export DEVICE_FILTER="$DEVICE_NAME"
           go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -415,26 +415,26 @@ function create_LV_on_disk() {
 }
 
 function deploy_first_rook_cluster() {
-  BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-  export BLOCK
+  DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+  export BLOCK="/dev/${DEVICE_NAME}"
   create_cluster_prerequisites
   cd deploy/examples/
 
   deploy_manifest_with_local_build operator.yaml
   yq w -i -d1 cluster-test.yaml spec.dashboard.enabled false
   yq w -i -d1 cluster-test.yaml spec.storage.useAllDevices false
-  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"1
+  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${DEVICE_NAME}"1
   kubectl create -f cluster-test.yaml
   deploy_toolbox
 }
 
 function deploy_second_rook_cluster() {
-  BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-  export BLOCK
+  DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+  export BLOCK="/dev/${DEVICE_NAME}"
   cd deploy/examples/
   NAMESPACE=rook-ceph-secondary envsubst <common-second-cluster.yaml | kubectl create -f -
   sed -i 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g' cluster-test.yaml
-  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"2
+  yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter "${DEVICE_NAME}"2
   yq w -i -d1 cluster-test.yaml spec.dataDirHostPath "/var/lib/rook-external"
   kubectl create -f cluster-test.yaml
   yq w -i toolbox.yaml metadata.namespace rook-ceph-secondary


### PR DESCRIPTION
This PR fixes the failure while running multicluster mirroring CI tests caused by the extra `/dev` prefix on the device name

Signed-off-by: sp98 <sapillai@redhat.com>
(cherry picked from commit 45adae1931cb76639d4e1588240cf85f53ad975e)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
