### PR TITLE
pool: Allow setting the application on a pool

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
@@ -204,8 +204,10 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
 * `name`: The name of Ceph pools is based on the `metadata.name` of the CephBlockPool CR. Some built-in Ceph pools
   require names that are incompatible with K8s resource names. These special pools can be configured
   by setting this `name` to override the name of the Ceph pool that is created instead of using the `metadata.name` for the pool.
-  Only the following pool names are supported: `device_health_metrics`, `.nfs`, and `.mgr`. See the example
+  Only the following pool names are supported: `.nfs`, `.mgr`, and `.rgw.root`. See the example
   [builtin mgr pool](https://github.com/rook/rook/blob/master/deploy/examples/pool-builtin-mgr.yaml).
+* `application`: The type of application set on the pool. By default, Ceph pools for CephBlockPools will be `rbd`,
+  CephObjectStore pools will be `rgw`, and CephFilesystem pools will be `cephfs`.
 
 * `parameters`: Sets any [parameters](https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values) listed to the given pool
     * `target_size_ratio:` gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool, for more info see the [ceph documentation](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size)

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -10300,6 +10300,18 @@ QuotaSpec
 <p>The quota settings</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>application</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The application name to set on the pool. Only expected to be set for rgw pools.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.PriorityClassNamesSpec">PriorityClassNamesSpec

--- a/Documentation/Troubleshooting/ceph-csi-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-csi-common-issues.md
@@ -110,7 +110,7 @@ to exist in the toolbox:
 
 ```console
 $ ceph osd lspools
-1 device_health_metrics
+1 .mgr
 2 replicapool
 ```
 
@@ -132,7 +132,7 @@ Now verify the `pool` mentioned in the `storageclass.yaml` exists, such as the e
 
 ```console
 ceph osd lspools
-1 device_health_metrics
+1 .mgr
 2 replicapool
 3 myfs-metadata0
 4 myfs-data0

--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -39,19 +39,6 @@ to Rook v1.13.
 !!! warning
     Ceph v17.2.2 has a blocking issue when running with Rook. Use v17.2.3 or newer when possible.
 
-### Quincy Consideration
-
-In Ceph Quincy (v17), the `device_health_metrics` pool was renamed to `.mgr`. Ceph will perform this
-migration automatically. The pool rename will be automatically handled by Rook if the configuration
-of the `device_health_metrics` pool is not customized via CephBlockPool.
-
-If the configuration of the `device_health_metrics` pool is customized via CephBlockPool, two extra
-steps are required after the Ceph upgrade is complete. Once upgrade is complete:
-
-1. Create a new CephBlockPool to configure the `.mgr` built-in pool. For an example, see
-   [builtin mgr pool](https://github.com/rook/rook/blob/master/deploy/examples/pool-builtin-mgr.yaml).
-2. Delete the old CephBlockPool that represents the `device_health_metrics` pool.
-
 ### CephNFS User Consideration
 
 Ceph Quincy v17.2.1 has a potentially breaking regression with CephNFS. See the NFS documentation's

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,6 +4,7 @@
 
 - The removal of `CSI_ENABLE_READ_AFFINITY` option and its replacement with per-cluster
 read affinity setting in cephCluster CR (CSIDriverOptions section) in [PR](https://github.com/rook/rook/pull/13665)
+- Allow setting the Ceph `application` on a pool
 
 ## Features
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -107,6 +107,9 @@ spec:
             spec:
               description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
+                application:
+                  description: The application name to set on the pool. Only expected to be set for rgw pools.
+                  type: string
                 compressionMode:
                   description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
@@ -188,7 +191,7 @@ spec:
                 name:
                   description: The desired name of the pool if different from the CephBlockPool CR name.
                   enum:
-                    - device_health_metrics
+                    - .rgw.root
                     - .nfs
                     - .mgr
                   type: string
@@ -6773,6 +6776,9 @@ spec:
                   items:
                     description: NamedPoolSpec represents the named ceph pool spec
                     properties:
+                      application:
+                        description: The application name to set on the pool. Only expected to be set for rgw pools.
+                        type: string
                       compressionMode:
                         description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
@@ -6941,6 +6947,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -10700,6 +10709,9 @@ spec:
                   description: The data pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -11823,6 +11835,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -12468,6 +12483,9 @@ spec:
                   description: The data pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -12631,6 +12649,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -109,6 +109,9 @@ spec:
             spec:
               description: NamedBlockPoolSpec allows a block pool to be created with a non-default name.
               properties:
+                application:
+                  description: The application name to set on the pool. Only expected to be set for rgw pools.
+                  type: string
                 compressionMode:
                   description: 'DEPRECATED: use Parameters instead, e.g.'
                   enum:
@@ -190,7 +193,7 @@ spec:
                 name:
                   description: The desired name of the pool if different from the CephBlockPool CR name.
                   enum:
-                    - device_health_metrics
+                    - .rgw.root
                     - .nfs
                     - .mgr
                   type: string
@@ -6768,6 +6771,9 @@ spec:
                   items:
                     description: NamedPoolSpec represents the named ceph pool spec
                     properties:
+                      application:
+                        description: The application name to set on the pool. Only expected to be set for rgw pools.
+                        type: string
                       compressionMode:
                         description: 'DEPRECATED: use Parameters instead, e.g.'
                         enum:
@@ -6936,6 +6942,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -10691,6 +10700,9 @@ spec:
                   description: The data pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -11814,6 +11826,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -12456,6 +12471,9 @@ spec:
                   description: The data pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:
@@ -12619,6 +12637,9 @@ spec:
                   description: The metadata pool settings
                   nullable: true
                   properties:
+                    application:
+                      description: The application name to set on the pool. Only expected to be set for rgw pools.
+                      type: string
                     compressionMode:
                       description: 'DEPRECATED: use Parameters instead, e.g.'
                       enum:

--- a/deploy/examples/pool-builtin-mgr.yaml
+++ b/deploy/examples/pool-builtin-mgr.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
   # the pool name created in Ceph with this name property.
-  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
   name: .mgr
   failureDomain: host
   replicated:

--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -42,7 +42,7 @@ func (p *ReplicatedSpec) IsTargetRatioEnabled() bool {
 
 // ValidateCephBlockPool validates specifically a CephBlockPool's spec (not just any NamedPoolSpec)
 func ValidateCephBlockPool(p *CephBlockPool) error {
-	if p.Spec.Name == "device_health_metrics" || p.Spec.Name == ".mgr" || p.Spec.Name == ".nfs" {
+	if p.Spec.Name == ".rgw.root" || p.Spec.Name == ".mgr" || p.Spec.Name == ".nfs" {
 		if p.Spec.IsErasureCoded() {
 			return errors.Errorf("invalid CephBlockPool spec: ceph built-in pool %q cannot be erasure coded", p.Name)
 		}

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -757,6 +757,10 @@ type PoolSpec struct {
 	// +optional
 	// +nullable
 	Quotas QuotaSpec `json:"quotas,omitempty"`
+
+	// The application name to set on the pool. Only expected to be set for rgw pools.
+	// +optional
+	Application string `json:"application"`
 }
 
 // NamedBlockPoolSpec allows a block pool to be created with a non-default name.
@@ -764,7 +768,7 @@ type PoolSpec struct {
 // allowed pool names that can be specified.
 type NamedBlockPoolSpec struct {
 	// The desired name of the pool if different from the CephBlockPool CR name.
-	// +kubebuilder:validation:Enum=device_health_metrics;.nfs;.mgr
+	// +kubebuilder:validation:Enum=.rgw.root;.nfs;.mgr
 	// +optional
 	Name string `json:"name,omitempty"`
 	// The core pool configuration

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -95,7 +95,7 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := createECPoolForApp(context, AdminTestClusterInfo("mycluster"), "mypoolprofile", p, DefaultPGCount, "myapp", overwrite)
+	err := createECPoolForApp(context, AdminTestClusterInfo("mycluster"), "mypoolprofile", p, DefaultPGCount, overwrite)
 	assert.Nil(t, err)
 	if compressionMode != "" {
 		assert.True(t, compressionModeCreated)
@@ -236,7 +236,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 		p.CompressionMode = compressionMode
 	}
 	clusterSpec := &cephv1.ClusterSpec{Storage: cephv1.StorageScopeSpec{Config: map[string]string{CrushRootConfigKey: "cluster-crush-root"}}}
-	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, p, DefaultPGCount, "myapp")
+	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, p, DefaultPGCount)
 	assert.Nil(t, err)
 	assert.True(t, crushRuleCreated)
 	if compressionMode != "" {
@@ -536,7 +536,7 @@ func testCreatePoolWithReplicasPerFailureDomain(t *testing.T, failureDomain, cru
 	}
 	context := &clusterd.Context{Executor: executor}
 	clusterSpec := &cephv1.ClusterSpec{Storage: cephv1.StorageScopeSpec{Config: map[string]string{CrushRootConfigKey: "cluster-crush-root"}}}
-	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, poolSpec, DefaultPGCount, "myapp")
+	err := createReplicatedPoolForApp(context, AdminTestClusterInfo("mycluster"), clusterSpec, poolSpec, DefaultPGCount)
 	assert.Nil(t, err)
 	assert.True(t, poolRuleCreated)
 	assert.True(t, poolRuleSet)

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -259,6 +259,8 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 				return "{}", nil
 			} else if reflect.DeepEqual(args[0:5], []string{"osd", "crush", "rule", "create-replicated", fsName + "-data1"}) {
 				return "", nil
+			} else if reflect.DeepEqual(args[0:3], []string{"osd", "pool", "application"}) {
+				return "", nil
 			} else if reflect.DeepEqual(args[0:4], []string{"osd", "pool", "create", fsName + "-data1"}) {
 				*createDataPoolCount++
 				return "", nil

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -531,7 +531,7 @@ func TestCephObjectStoreController(t *testing.T) {
 					// ceph actually outputs this all on one line, but this parses the same
 					return `[
 						{"poolnum":1,"poolname":"replicapool"},
-						{"poolnum":2,"poolname":"device_health_metrics"},
+						{"poolnum":2,"poolname":".mgr"},
 						{"poolnum":3,"poolname":".rgw.root"},
 						{"poolnum":4,"poolname":"my-store.rgw.buckets.index"},
 						{"poolnum":5,"poolname":"my-store.rgw.buckets.non-ec"},

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -55,6 +55,7 @@ const (
 	rgwRadosPoolPgNum     = "8"
 	cosiUserName          = "cosi"
 	cosiUserCaps          = "buckets=*;users=*"
+	rgwApplication        = "rgw"
 )
 
 var (
@@ -817,11 +818,12 @@ func createSimilarPools(ctx *Context, pools []string, clusterSpec *cephv1.Cluste
 
 func createRGWPool(ctx *Context, clusterSpec *cephv1.ClusterSpec, poolSpec cephv1.PoolSpec, pgCount, requestedName string) error {
 	// create the pool if it doesn't exist yet
+	poolSpec.Application = rgwApplication
 	pool := cephv1.NamedPoolSpec{
 		Name:     poolName(ctx.Name, requestedName),
 		PoolSpec: poolSpec,
 	}
-	if err := cephclient.CreatePoolWithPGs(ctx.Context, ctx.clusterInfo, clusterSpec, pool, AppName, pgCount); err != nil {
+	if err := cephclient.CreatePoolWithPGs(ctx.Context, ctx.clusterInfo, clusterSpec, pool, pgCount); err != nil {
 		return errors.Wrapf(err, "failed to create pool %q", pool.Name)
 	}
 	// Set the pg_num_min if not the default so the autoscaler won't immediately increase the pg count

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -64,11 +64,7 @@ func TestCreatePool(t *testing.T) {
 					}
 					assert.Equal(t, "enable", args[3])
 					if args[5] != "rbd" {
-						if args[4] == "device_health_metrics" {
-							enabledMetricsApp = true
-							assert.Equal(t, "device_health_metrics", args[4])
-							assert.Equal(t, "mgr_devicehealth", args[5])
-						} else if args[4] == ".mgr" {
+						if args[4] == ".mgr" {
 							enabledMgrApp = true
 							assert.Equal(t, ".mgr", args[4])
 							assert.Equal(t, "mgr", args[5])
@@ -95,13 +91,6 @@ func TestCreatePool(t *testing.T) {
 		err := createPool(context, clusterInfo, clusterSpec, p)
 		assert.Nil(t, err)
 		assert.False(t, enabledMetricsApp)
-	})
-
-	t.Run("built-in metrics pool", func(t *testing.T) {
-		p.Name = "device_health_metrics"
-		err := createPool(context, clusterInfo, clusterSpec, p)
-		assert.Nil(t, err)
-		assert.True(t, enabledMetricsApp)
 	})
 
 	t.Run("built-in mgr pool", func(t *testing.T) {
@@ -131,11 +120,6 @@ func TestCephPoolName(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "metapool"}, Spec: cephv1.NamedBlockPoolSpec{Name: "metapool"}}
 		name := p.ToNamedPoolSpec().Name
 		assert.Equal(t, "metapool", name)
-	})
-	t.Run("override device metrics", func(t *testing.T) {
-		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "device-metrics"}, Spec: cephv1.NamedBlockPoolSpec{Name: "device_health_metrics"}}
-		name := p.ToNamedPoolSpec().Name
-		assert.Equal(t, "device_health_metrics", name)
 	})
 	t.Run("override mgr", func(t *testing.T) {
 		p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "default-mgr"}, Spec: cephv1.NamedBlockPoolSpec{Name: ".mgr"}}


### PR DESCRIPTION
Rook has been setting the application automatically on all pools to rbd for CephBlockPools, rook-ceph-rgw for CephObjectStores, mgr on the built-in .mgr pool,
and nfs on the built-in .nfs pool.

The legacy pool device_health_metrics is long gone from Pacific which is no longer supported, so we can remove special handling for that pool in the upgrade guide and in the code.

The application setting is now available on the pool spec although it is not expected to commonly need to override the default applications set by Rook.

Allow definition of the `.rgw.root` pool with a CephBlockPool CR.

The application for CephFilesystem pools is now being set to cephfs, where it was previously blank.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
