### PR TITLE
mgr: handle explicitly the flag AllowPrivilegeEscalation

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -726,9 +726,9 @@ func HostPathRequiresPrivileged() bool {
 // PodSecurityContext detects if the pod needs privileges to run
 func PodSecurityContext() *v1.SecurityContext {
 	privileged := HostPathRequiresPrivileged()
-
 	return &v1.SecurityContext{
-		Privileged: &privileged,
+		Privileged:               &privileged,
+		AllowPrivilegeEscalation: &privileged,
 	}
 }
 


### PR DESCRIPTION
k8s docs are not clear about the default value of AllowPrivilegeEscalation, although reading [the code](https://github.com/kubernetes/kubernetes/blob/8b2dae57d4169e7801c870aa86f5644085518c57/pkg/securitycontext/util.go#L175) suggests it to be false. There are [an issue](https://github.com/kubernetes/website/issues/30104) opened on k8s project related to this.

To avoid any confusion, let's explicitly initialize the value of this field. This way, it becomes clear how the container's security context is initialized, and users can see the current values of the privileged and AllowPrivilegeEscalation fields when inspecting the containers.

Fixes: https://github.com/rook/rook/issues/13749

**Manual testing:**

```
 get pod | grep mgr | awk '{print $1}' | (while read x; do echo "======= $x =====" ; k get pod $x -o=json | jq -r '.spec.containers[] | "\(.name) - \(.securityContext)"'; done)   
======= rook-ceph-mgr-a-657d7d6f49-zm56k =====
mgr - {"allowPrivilegeEscalation":false,"privileged":false}
watch-active - {"privileged":true,"runAsUser":0}
======= rook-ceph-mgr-b-64bc94849-wn5mr =====
mgr - {"allowPrivilegeEscalation":false,"privileged":false}
watch-active - {"privileged":true,"runAsUser":0}

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
