### PR TITLE
mgr: enable rook orchestrator mgr module by default

### DIFF
--- a/deploy/examples/cluster-on-pvc-minikube.yaml
+++ b/deploy/examples/cluster-on-pvc-minikube.yaml
@@ -140,6 +140,9 @@ spec:
             storage: 10Gi
   mgr:
     count: 1
+    modules:
+      - name: rook
+        enabled: true
   dashboard:
     enabled: true
     ssl: false

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -40,6 +40,9 @@ spec:
   mgr:
     count: 2
     allowMultiplePerNode: false
+    modules:
+      - name: rook
+        enabled: true
   dashboard:
     enabled: true
     ssl: true

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -23,6 +23,9 @@ spec:
   mgr:
     count: 1
     allowMultiplePerNode: true
+    modules:
+      - name: rook
+        enabled: true
   dashboard:
     enabled: true
   crashCollector:

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -59,8 +59,8 @@ spec:
     modules:
       # List of modules to optionally enable or disable.
       # Note the "dashboard" and "monitoring" modules are already configured by other settings in the cluster CR.
-      # - name: rook
-      #   enabled: true
+      - name: rook
+        enabled: true
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true

--- a/deploy/examples/common-second-cluster.yaml
+++ b/deploy/examples/common-second-cluster.yaml
@@ -288,3 +288,17 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-rgw
   namespace: rook-ceph-secondary # namespace:cluster
+---
+# Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr-secondary-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-cluster
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: rook-ceph-secondary # namespace:cluster


### PR DESCRIPTION
previously, we had kept the Rook orchestrator manager module disabled so far because it was causing a bunch of issues and errors on the dashboard. But with the recent changes made in the `cephv v18.2.1` release, we've fixed those issues and made some overall improvements to the dashboard user experience when Rook is enabled. With all that in mind, it's time to switch on the Rook orchestrator by default.

Fixes: https://github.com/rook/rook/issues/13760

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
