### PR TITLE
mgr: Remove remaining pg_autoscaler examples

### DIFF
--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -136,10 +136,10 @@ cephClusterSpec:
     count: 2
     allowMultiplePerNode: false
     modules:
-      # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
-      # are already enabled by other settings in the cluster CR.
-      - name: pg_autoscaler
-        enabled: true
+      # List of modules to optionally enable or disable.
+      # Note the "dashboard" and "monitoring" modules are already configured by other settings in the cluster CR.
+      # - name: rook
+      #   enabled: true
 
   # enable the ceph dashboard for viewing cluster status
   dashboard:

--- a/deploy/examples/cluster-on-local-pvc.yaml
+++ b/deploy/examples/cluster-on-local-pvc.yaml
@@ -179,9 +179,6 @@ spec:
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   mgr:
     count: 1
-    modules:
-      - name: pg_autoscaler
-        enabled: true
   dashboard:
     enabled: true
     ssl: true

--- a/deploy/examples/cluster-on-pvc-minikube.yaml
+++ b/deploy/examples/cluster-on-pvc-minikube.yaml
@@ -140,9 +140,6 @@ spec:
             storage: 10Gi
   mgr:
     count: 1
-    modules:
-      - name: pg_autoscaler
-        enabled: true
   dashboard:
     enabled: true
     ssl: false

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -38,10 +38,8 @@ spec:
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   mgr:
-    count: 1
-    modules:
-      - name: pg_autoscaler
-        enabled: true
+    count: 2
+    allowMultiplePerNode: false
   dashboard:
     enabled: true
     ssl: true

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -42,19 +42,18 @@ import (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mgr")
 
 const (
-	AppName                = "rook-ceph-mgr"
-	serviceAccountName     = "rook-ceph-mgr"
-	PrometheusModuleName   = "prometheus"
-	crashModuleName        = "crash"
-	PgautoscalerModuleName = "pg_autoscaler"
-	balancerModuleName     = "balancer"
-	balancerModuleMode     = "upmap"
-	mgrRoleLabelName       = "mgr_role"
-	activeMgrStatus        = "active"
-	standbyMgrStatus       = "standby"
-	monitoringPath         = "/etc/ceph-monitoring/"
-	serviceMonitorFile     = "service-monitor.yaml"
-	serviceMonitorPort     = "http-metrics"
+	AppName              = "rook-ceph-mgr"
+	serviceAccountName   = "rook-ceph-mgr"
+	PrometheusModuleName = "prometheus"
+	crashModuleName      = "crash"
+	balancerModuleName   = "balancer"
+	balancerModuleMode   = "upmap"
+	mgrRoleLabelName     = "mgr_role"
+	activeMgrStatus      = "active"
+	standbyMgrStatus     = "standby"
+	monitoringPath       = "/etc/ceph-monitoring/"
+	serviceMonitorFile   = "service-monitor.yaml"
+	serviceMonitorPort   = "http-metrics"
 	// minimum amount of memory in MB to run the pod
 	cephMgrPodMinimumMemory uint64 = 512
 	// DefaultMetricsPort prometheus exporter port
@@ -494,12 +493,6 @@ func (c *Cluster) configureMgrModules() error {
 
 			// Configure special settings for individual modules that are enabled
 			switch module.Name {
-			case PgautoscalerModuleName:
-				monStore := config.GetMonStore(c.context, c.clusterInfo)
-				err := monStore.Set("global", "mon_pg_warn_min_per_osd", "0")
-				if err != nil {
-					return errors.Wrap(err, "failed to set minimal number PGs per (in) osd before we warn the admin to")
-				}
 			case rookModuleName:
 				startModuleConfiguration("orchestrator modules", c.configureOrchestratorModules)
 			}
@@ -517,7 +510,7 @@ func (c *Cluster) configureMgrModules() error {
 func (c *Cluster) moduleMeetsMinVersion(name string) (*cephver.CephVersion, bool) {
 	minVersions := map[string]cephver.CephVersion{
 		// Put the modules here, example:
-		// pgautoscalerModuleName: {Major: 15},
+		// "moduleName": {Major: 15},
 	}
 	if ver, ok := minVersions[name]; ok {
 		// Check if the required min version is met

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -333,24 +333,6 @@ func TestConfigureModules(t *testing.T) {
 	assert.Equal(t, 0, modulesDisabled)
 	assert.Equal(t, "mymodule", lastModuleConfigured)
 
-	// one module that has a min version that is not met
-	c.spec.Mgr.Modules = []cephv1.Module{
-		{Name: "pg_autoscaler", Enabled: true},
-	}
-
-	// one module that has a min version that is met
-	c.spec.Mgr.Modules = []cephv1.Module{
-		{Name: "pg_autoscaler", Enabled: true},
-	}
-	c.clusterInfo.CephVersion = cephver.CephVersion{Major: 15}
-	modulesEnabled = 0
-	assert.NoError(t, c.configureMgrModules())
-	assert.Equal(t, 1, modulesEnabled)
-	assert.Equal(t, 0, modulesDisabled)
-	assert.Equal(t, "pg_autoscaler", lastModuleConfigured)
-	assert.Equal(t, 1, len(configSettings))
-	assert.Equal(t, "0", configSettings["mon_pg_warn_min_per_osd"])
-
 	// disable the module
 	modulesEnabled = 0
 	lastModuleConfigured = ""
@@ -359,7 +341,7 @@ func TestConfigureModules(t *testing.T) {
 	assert.NoError(t, c.configureMgrModules())
 	assert.Equal(t, 0, modulesEnabled)
 	assert.Equal(t, 1, modulesDisabled)
-	assert.Equal(t, "pg_autoscaler", lastModuleConfigured)
+	assert.Equal(t, "mymodule", lastModuleConfigured)
 	assert.Equal(t, 0, len(configSettings))
 }
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -163,9 +163,6 @@ spec:
   mgr:
     count: ` + strconv.Itoa(mgrCount) + `
     allowMultiplePerNode: true
-    modules:
-    - name: pg_autoscaler
-      enabled: true
   dashboard:
     enabled: true
   network:


### PR DESCRIPTION
The pg_autoscaler is always enabled by ceph and cannot be disabled. In #13588 the pg_autoscaler config was removed from the main example. Now the remaining config for the pg_autoscaler is removed as well since being missed in the previous PR.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13346

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
