### PR TITLE
core: Continue processing PVs for network fencing when no node IPs found

### DIFF
--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -438,8 +438,13 @@ func (c *clientCluster) fenceCephFSVolume(
 		return fmt.Errorf("failed to list watchers for cephfs pool/subvoumeName %s/%s. %v", cephFSPV.Spec.CSI.VolumeAttributes["pool"], cephFSPV.Spec.CSI.VolumeAttributes["subvolumeName"], err)
 	}
 	ips, err := cephFSMDSClientMarshal(buf, cephFSPV)
-	if err != nil || ips == nil {
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal cephfs mds  output. %v", err)
+	}
+
+	if len(ips) == 0 {
+		logger.Infof("no active mds clients found for cephfs volume %q", cephFSPV.Name)
+		return nil
 	}
 
 	err = c.createNetworkFence(ctx, cephFSPV, node, cluster, ips, cephfsDriver)

--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -419,7 +419,7 @@ func (c *clientCluster) fenceCephFSVolume(
 
 	status, err := cephclient.StatusWithUser(c.context, clusterInfo)
 	if err != nil {
-		return fmt.Errorf("failed to get ceph status for check active mds. %v", err)
+		return pkgerror.Wrapf(err, "failed to get ceph status for check active mds")
 	}
 
 	var activeMDS string
@@ -439,7 +439,7 @@ func (c *clientCluster) fenceCephFSVolume(
 	}
 	ips, err := cephFSMDSClientMarshal(buf, cephFSPV)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal cephfs mds  output. %v", err)
+		return pkgerror.Wrapf(err, "failed to unmarshal cephfs mds output")
 	}
 
 	if len(ips) == 0 {
@@ -449,7 +449,7 @@ func (c *clientCluster) fenceCephFSVolume(
 
 	err = c.createNetworkFence(ctx, cephFSPV, node, cluster, ips, cephfsDriver)
 	if err != nil {
-		return fmt.Errorf("failed to create network fence for node %q. %v", node.Name, err)
+		return pkgerror.Wrapf(err, "failed to create network fence for node %q", node.Name)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -179,7 +179,7 @@ func TestHandleNodeFailure(t *testing.T) {
 		case command == "ceph" && args[0] == "status":
 			return `{"entity":[{"addr": [{"addr": "10.244.0.12:0", "nonce":3247243972}]}], "client_metadata":{"root":"/"}}`, nil
 		case command == "ceph" && args[0] == "tell":
-			return `[{"entity":{"addr":{"addr":"10.244.0.12:0","nonce":3247243972}}, "client_metadata":{"root":"/"}}]`, nil
+			return `[{"entity":{"addr":{"addr":"10.244.0.12:0","nonce":3247243972}}, "client_metadata":{"root":"/volumes/csi/csi-vol-58469d41-f6c0-4720-b23a-0a0826b842ca"}}]`, nil
 
 		}
 		return "", errors.Errorf("unexpected rbd/ceph command %q", args)
@@ -250,6 +250,7 @@ func TestHandleNodeFailure(t *testing.T) {
 					VolumeHandle: "0001-0009-rook-ceph-0000000000000002-24862838-240d-4215-9183-abfc0e9e4001",
 					VolumeAttributes: map[string]string{
 						"fsName":        "myfs",
+						"subvolumePath": "/volumes/csi/csi-vol-58469d41-f6c0-4720-b23a-0a0826b842ca",
 						"subvolumeName": "csi-vol-58469d41-f6c0-4720-b23a-0a0826b842ca",
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

The cephfs PVC might exist on the kubernetes node object but due to some timing issues the ip might not be visible on the ceph cluster or the client might have already been evicted or disconnected from the ceph cluster. In this case, we will not be able to get IP details for the subvolume and we don't have any check for empty ip's in the code rook tries to create NetworkFence CR with an empty Ip's, and the NetworkFence will get moved to the Failed state. This PR adds the necessary checks and logging to prevent this one.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
