### PR TITLE
ci: reverting csi changes done in cephcluster cr

### DIFF
--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -63,6 +63,7 @@ func (h *CephInstaller) configureRookOperatorViaHelm(upgrade bool) error {
 		"csiRBDPluginResource":         nil,
 		"csiCephFSProvisionerResource": nil,
 		"csiCephFSPluginResource":      nil,
+		"csicephFSKernelMountOptions":  "ms_mode=secure",
 	}
 
 	// create the operator namespace before the admission controller is created

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -243,13 +243,6 @@ spec:
 `
 	}
 
-	if m.settings.ConnectionsEncrypted {
-		clusterSpec += `
-  csi:
-    cephfs:
-      kernelMountOptions: ms_mode=secure
-  `
-	}
 	return clusterSpec + `
   priorityClassNames:
     mon: system-node-critical

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -92,6 +92,9 @@ func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
 	manifest = strings.ReplaceAll(manifest, `CSI_ENABLE_VOLUME_REPLICATION: "false"`, fmt.Sprintf(`CSI_ENABLE_VOLUME_REPLICATION: "%t"`, s.EnableVolumeReplication))
 	manifest = strings.ReplaceAll(manifest, `ROOK_CSI_ENABLE_NFS: "false"`, fmt.Sprintf(`ROOK_CSI_ENABLE_NFS: "%t"`, s.TestNFSCSI))
 	manifest = strings.ReplaceAll(manifest, `ROOK_DISABLE_ADMISSION_CONTROLLER: "true"`, `ROOK_DISABLE_ADMISSION_CONTROLLER: "false"`)
+	if s.ConnectionsEncrypted {
+		manifest = strings.ReplaceAll(manifest, `# CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: "ms_mode=secure"`, `CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: "ms_mode=secure"`)
+	}
 	return manifest
 }
 


### PR DESCRIPTION
In 1.12, we don't csi settings in cephcluster cr and this is causing smoke and helm test to fail.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
