### PR TITLE
mon: set mon pdb max unavailable as 2 in case of 5 or more mons.

### DIFF
--- a/pkg/operator/ceph/cluster/mon/drain_test.go
+++ b/pkg/operator/ceph/cluster/mon/drain_test.go
@@ -102,7 +102,7 @@ func TestReconcileMonPDB(t *testing.T) {
 					},
 				},
 			},
-			expectedMaxUnAvailable: 1,
+			expectedMaxUnAvailable: 2,
 			errorExpected:          false,
 		},
 	}


### PR DESCRIPTION
If the spec.mon.count is 5 or more, then create
mon pdbs with maxUnavailable count as 2. We can
afford to have more than 1 mons down while
draining the nodes in this case.


Testing:

```
❯ oc get pods -n rook-ceph
NAME                                                 READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-provisioner-76f944cd99-xxxtx        5/5     Running     0          5m7s
csi-cephfsplugin-zk2n2                               2/2     Running     0          5m7s
csi-rbdplugin-provisioner-dc487db8-sww2g             5/5     Running     0          5m7s
csi-rbdplugin-wxxv9                                  2/2     Running     0          5m7s
rook-ceph-crashcollector-minikube-586487c89f-mlzpt   1/1     Running     0          101s
rook-ceph-exporter-minikube-86bcb9c88b-665q4         1/1     Running     0          94s
rook-ceph-mgr-a-8647c69b88-w6jvb                     3/3     Running     0          2m46s
rook-ceph-mgr-b-5bc4f5cc9-bp6cf                      3/3     Running     0          2m45s
rook-ceph-mon-a-6486bcc964-8l5w9                     2/2     Running     0          3m37s
rook-ceph-mon-b-67769db67f-hc4ns                     2/2     Running     0          3m13s
rook-ceph-mon-c-648b49c4bb-ghmkz                     2/2     Running     0          3m
rook-ceph-operator-b46f6698c-znzxt                   1/1     Running     0          5m17s
rook-ceph-osd-0-68c7dcd846-lnpzw                     2/2     Running     0          100s
rook-ceph-osd-1-6b86b7b8c9-slfg2                     2/2     Running     0          100s
rook-ceph-osd-2-7946d5d877-fgrxb                     2/2     Running     0          100s
rook-ceph-osd-3-766c78b758-chmxm                     2/2     Running     0          101s
rook-ceph-osd-4-5979654fd7-k7tsl                     2/2     Running     0          101s
rook-ceph-osd-5-7d59698fb5-wk2k6                     2/2     Running     0          100s
rook-ceph-osd-prepare-minikube-n9jjr                 0/1     Completed   0          34s
rook-ceph-tools-57f75fc4d5-7rjb9                     1/1     Running     0          5m10s
❯ oc get pdb -n rook-ceph
NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb   N/A             1                 1                     2m26s
rook-ceph-mon-pdb   N/A             1                 1                     2m53s
```

------------------------------

With 5 mons

```
❯ oc get pods -n rook-ceph
NAME                                                 READY   STATUS      RESTARTS   AGE
csi-cephfsplugin-provisioner-76f944cd99-xxxtx        5/5     Running     0          6m31s
csi-cephfsplugin-zk2n2                               2/2     Running     0          6m31s
csi-rbdplugin-provisioner-dc487db8-sww2g             5/5     Running     0          6m31s
csi-rbdplugin-wxxv9                                  2/2     Running     0          6m31s
rook-ceph-crashcollector-minikube-586487c89f-mlzpt   1/1     Running     0          3m5s
rook-ceph-exporter-minikube-86bcb9c88b-665q4         1/1     Running     0          2m58s
rook-ceph-mgr-a-8647c69b88-w6jvb                     3/3     Running     0          4m10s
rook-ceph-mgr-b-5bc4f5cc9-bp6cf                      3/3     Running     0          4m9s
rook-ceph-mon-a-6486bcc964-8l5w9                     2/2     Running     0          5m1s
rook-ceph-mon-b-67769db67f-hc4ns                     2/2     Running     0          4m37s
rook-ceph-mon-c-648b49c4bb-ghmkz                     2/2     Running     0          4m24s
rook-ceph-mon-d-545dbd6dbf-5v2gb                     2/2     Running     0          32s
rook-ceph-mon-e-8d95d9b5b-gfnnm                      1/2     Running     0          19s
rook-ceph-operator-b46f6698c-znzxt                   1/1     Running     0          6m41s
rook-ceph-osd-0-68c7dcd846-lnpzw                     2/2     Running     0          3m4s
rook-ceph-osd-1-6b86b7b8c9-slfg2                     2/2     Running     0          3m4s
rook-ceph-osd-2-7946d5d877-fgrxb                     2/2     Running     0          3m4s
rook-ceph-osd-3-766c78b758-chmxm                     2/2     Running     0          3m5s
rook-ceph-osd-4-5979654fd7-k7tsl                     2/2     Running     0          3m5s
rook-ceph-osd-5-7d59698fb5-wk2k6                     2/2     Running     0          3m4s
rook-ceph-osd-prepare-minikube-n9jjr                 0/1     Completed   0          118s
rook-ceph-tools-57f75fc4d5-7rjb9                     1/1     Running     0          6m34s
❯ oc get pdb -n rook-ceph
NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb   N/A             1                 1                     3m50s
rook-ceph-mon-pdb   N/A             2                 2                     4m17s

````


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
