### PR TITLE
mds: fix incorrect comment on crd resource requirements

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7470,7 +7470,7 @@ Kubernetes core/v1.ResourceRequirements
 </td>
 <td>
 <em>(Optional)</em>
-<p>The resource requirements for the rgw pods</p>
+<p>The resource requirements for the mds pods</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -6498,7 +6498,7 @@ spec:
                       description: PriorityClassName sets priority classes on components
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
+                      description: The resource requirements for the mds pods
                       nullable: true
                       properties:
                         claims:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -6493,7 +6493,7 @@ spec:
                       description: PriorityClassName sets priority classes on components
                       type: string
                     resources:
-                      description: The resource requirements for the rgw pods
+                      description: The resource requirements for the mds pods
                       nullable: true
                       properties:
                         claims:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1184,7 +1184,7 @@ type MetadataServerSpec struct {
 	// +optional
 	Labels Labels `json:"labels,omitempty"`
 
-	// The resource requirements for the rgw pods
+	// The resource requirements for the mds pods
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable
 	// +optional


### PR DESCRIPTION
mds: fix incorrect comment on crd resource requirements
    
The MDS resource requirements had an incorrect comment of the RGW component.
    
Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
