### PR TITLE
docs: Add squid and bucket DNS subdomains to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,8 +12,10 @@ See the [GitHub project boards](https://github.com/rook/rook/projects) for the m
 
 The following high level features are targeted for Rook v1.14 (April 2024). For more detailed project tracking see the [v1.14 board](https://github.com/rook/rook/projects/31).
 
+* Support for Ceph Squid (v19)
 * Allow setting the application name on a CephBlockPool [#13744](https://github.com/rook/rook/pull/13744)
 * Pool sharing for multiple object stores [#11411](https://github.com/rook/rook/issues/11411)
+* DNS subdomain style access to RGW buckets [#4780](https://github.com/rook/rook/issues/4780)
 * Replace a single OSD when a metadataDevice is configured with multiple OSDs [#13240](https://github.com/rook/rook/issues/13240)
 * Create a default service account for all Ceph daemons [#13362](https://github.com/rook/rook/pull/13362)
 * Enable the rook orchestrator mgr module by default for improved dashboard integration [#13760](https://github.com/rook/rook/issues/13760)


### PR DESCRIPTION
For 1.14 release supporting squid is planned as well as DNS subdomain style access to RGW buckets.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
