### PR TITLE
rgw: implement support for creating swift sub-users via the user CR

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2147,6 +2147,19 @@ string
 <p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>subUsers,omitemtpy</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.SubuserSpec">
+[]SubuserSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2640,6 +2653,30 @@ string
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="ceph.rook.io/v1.AccessSpec">AccessSpec
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.SubuserSpec">SubuserSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;full&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;read&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;readwrite&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;write&#34;</p></td>
+<td></td>
+</tr></tbody>
 </table>
 <h3 id="ceph.rook.io/v1.AddressRangesSpec">AddressRangesSpec
 </h3>
@@ -9642,6 +9679,19 @@ string
 <p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>subUsers,omitemtpy</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.SubuserSpec">
+[]SubuserSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ObjectStoreUserStatus">ObjectStoreUserStatus
@@ -12424,6 +12474,45 @@ string
 <td>
 <em>(Optional)</em>
 <p>Zones is the list of zones</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.SubuserSpec">SubuserSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreUserSpec">ObjectStoreUserSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>access</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.AccessSpec">
+AccessSpec
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1912,6 +1912,34 @@ GatewaySpec
 </tr>
 <tr>
 <td>
+<code>protocols</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ProtocolSpec">
+ProtocolSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The protocol specification</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.AuthSpec">
+AuthSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The authentication configuration</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>zone</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.ZoneSpec">
@@ -2674,6 +2702,38 @@ CIDRList
 <div>
 <p>AnnotationsSpec is the main spec annotation for all daemons</p>
 </div>
+<h3 id="ceph.rook.io/v1.AuthSpec">AuthSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreSpec">ObjectStoreSpec</a>)
+</p>
+<div>
+<p>AuthSpec represents the authentication protocol configuration of a Ceph Object Store Gateway</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>keystone</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.KeystoneSpec">
+KeystoneSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The spec for Keystone</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.BucketNotificationEvent">BucketNotificationEvent
 (<code>string</code> alias)</h3>
 <p>
@@ -7001,6 +7061,32 @@ string
 </td>
 </tr></tbody>
 </table>
+<h3 id="ceph.rook.io/v1.ImplicitTenantSetting">ImplicitTenantSetting
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.KeystoneSpec">KeystoneSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;false&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;s3&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;swift&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;true&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
 <h3 id="ceph.rook.io/v1.KafkaEndpointSpec">KafkaEndpointSpec
 </h3>
 <p>
@@ -7348,6 +7434,95 @@ string
 </tr><tr><td><p>&#34;keyrotation&#34;</p></td>
 <td></td>
 </tr></tbody>
+</table>
+<h3 id="ceph.rook.io/v1.KeystoneSpec">KeystoneSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.AuthSpec">AuthSpec</a>)
+</p>
+<div>
+<p>KeystoneSpec represents the Keystone authentication configuration of a Ceph Object Store Gateway</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The URL for the Keystone server.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceUserSecretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret containing the credentials for the service user account used by RGW. It has to be in the same namespace as the object store resource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>acceptedRoles</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The roles requires to serve requests.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>implicitTenants</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ImplicitTenantSetting">
+ImplicitTenantSetting
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tokenCacheSize</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The maximum number of entries in each Keystone token cache.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revocationInterval</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of seconds between token revocation checks.</p>
+</td>
+</tr>
+</tbody>
 </table>
 <h3 id="ceph.rook.io/v1.Labels">Labels
 (<code>map[string]string</code> alias)</h3>
@@ -9198,6 +9373,34 @@ GatewaySpec
 </tr>
 <tr>
 <td>
+<code>protocols</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ProtocolSpec">
+ProtocolSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The protocol specification</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.AuthSpec">
+AuthSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The authentication configuration</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>zone</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.ZoneSpec">
@@ -10538,6 +10741,52 @@ alive or ready to receive traffic.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="ceph.rook.io/v1.ProtocolSpec">ProtocolSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreSpec">ObjectStoreSpec</a>)
+</p>
+<div>
+<p>ProtocolSpec represents a Ceph Object Store protocol specification</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>s3</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.S3Spec">
+S3Spec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The spec for S3</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>swift</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.SwiftSpec">
+SwiftSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The spec for Swift</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.PullSpec">PullSpec
 </h3>
 <p>
@@ -10908,6 +11157,48 @@ HybridStorageSpec
 <div>
 <p>ResourceSpec is a collection of ResourceRequirements that describes the compute resource requirements</p>
 </div>
+<h3 id="ceph.rook.io/v1.S3Spec">S3Spec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ProtocolSpec">ProtocolSpec</a>)
+</p>
+<div>
+<p>S3Spec represents Ceph Object Store specification for the S3 API</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>authUseKeystone</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to use Keystone for authentication. This option maps directly to the rgw_s3_auth_use_keystone option. Enabling it allows generating S3 credentials via an OpenStack API call, see the docs. If not given, the defaults of the corresponding RGW option apply.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.SSSDSidecar">SSSDSidecar
 </h3>
 <p>
@@ -12133,6 +12424,60 @@ string
 <td>
 <em>(Optional)</em>
 <p>Zones is the list of zones</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.SwiftSpec">SwiftSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ProtocolSpec">ProtocolSpec</a>)
+</p>
+<div>
+<p>SwiftSpec represents Ceph Object Store specification for the Swift API</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>accountInUrl</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether or not the Swift account name should be included in the Swift API URL. If set to false (the default), then the Swift API will listen on a URL formed like <a href="http://host:port/">http://host:port/</a><rgw_swift_url_prefix>/v1. If set to true, the Swift API URL will be <a href="http://host:port/">http://host:port/</a><rgw_swift_url_prefix>/v1/AUTH_<account_name>. You must set this option to true (and update the Keystone service catalog) if you want radosgw to support publicly-readable containers and temporary URLs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>urlPrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The URL prefix for the Swift API, to distinguish it from the S3 API endpoint. The default is swift, which makes the Swift API available at the URL <a href="http://host:port/swift/v1">http://host:port/swift/v1</a> (or <a href="http://host:port/swift/v1/AUTH_%(tenant_id)s">http://host:port/swift/v1/AUTH_%(tenant_id)s</a> if rgw swift account in url is enabled).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>versioningEnabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enables the Object Versioning of OpenStack Object Storage API. This allows clients to put the X-Versions-Location attribute on containers that should be versioned.</p>
 </td>
 </tr>
 </tbody>

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,3 +22,4 @@ read affinity setting in cephCluster CR (CSIDriverOptions section) in [PR](https
 - Support for virtual style hosting for s3 buckets in the CephObjectStore.
 - Add option to specify prefix for the OBC provisioner.
 - Support Azure Key Vault for storing OSD encryption keys.
+- Support creating swift sub-users through Kubernetes CRs (see [#9088](https://github.com/rook/rook/issues/9088)).

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -10053,6 +10053,41 @@ spec:
                   items:
                     type: string
                   type: array
+                auth:
+                  description: The authentication configuration
+                  properties:
+                    keystone:
+                      description: The spec for Keystone
+                      nullable: true
+                      properties:
+                        acceptedRoles:
+                          description: The roles requires to serve requests.
+                          items:
+                            type: string
+                          type: array
+                        implicitTenants:
+                          description: Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.
+                          type: string
+                        revocationInterval:
+                          description: The number of seconds between token revocation checks.
+                          nullable: true
+                          type: integer
+                        serviceUserSecretName:
+                          description: The name of the secret containing the credentials for the service user account used by RGW. It has to be in the same namespace as the object store resource.
+                          type: string
+                        tokenCacheSize:
+                          description: The maximum number of entries in each Keystone token cache.
+                          nullable: true
+                          type: integer
+                        url:
+                          description: The URL for the Keystone server.
+                          type: string
+                      required:
+                        - acceptedRoles
+                        - serviceUserSecretName
+                        - url
+                      type: object
+                  type: object
                 dataPool:
                   description: The data pool settings
                   nullable: true
@@ -11344,6 +11379,40 @@ spec:
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
                   type: boolean
+                protocols:
+                  description: The protocol specification
+                  properties:
+                    s3:
+                      description: The spec for S3
+                      nullable: true
+                      properties:
+                        authUseKeystone:
+                          description: Whether to use Keystone for authentication. This option maps directly to the rgw_s3_auth_use_keystone option. Enabling it allows generating S3 credentials via an OpenStack API call, see the docs. If not given, the defaults of the corresponding RGW option apply.
+                          nullable: true
+                          type: boolean
+                        enabled:
+                          description: Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    swift:
+                      description: The spec for Swift
+                      nullable: true
+                      properties:
+                        accountInUrl:
+                          description: Whether or not the Swift account name should be included in the Swift API URL. If set to false (the default), then the Swift API will listen on a URL formed like http://host:port/<rgw_swift_url_prefix>/v1. If set to true, the Swift API URL will be http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>. You must set this option to true (and update the Keystone service catalog) if you want radosgw to support publicly-readable containers and temporary URLs.
+                          nullable: true
+                          type: boolean
+                        urlPrefix:
+                          description: The URL prefix for the Swift API, to distinguish it from the S3 API endpoint. The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1 (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is enabled).
+                          nullable: true
+                          type: string
+                        versioningEnabled:
+                          description: Enables the Object Versioning of OpenStack Object Storage API. This allows clients to put the X-Versions-Location attribute on containers that should be versioned.
+                          nullable: true
+                          type: boolean
+                      type: object
+                  type: object
                 security:
                   description: Security represents security settings
                   nullable: true

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11771,6 +11771,19 @@ spec:
                 store:
                   description: The store the user will be created in
                   type: string
+                subUsers:
+                  items:
+                    properties:
+                      access:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - access
+                      - name
+                    type: object
+                  nullable: true
+                  type: array
               type: object
             status:
               description: ObjectStoreUserStatus represents the status Ceph Object Store Gateway User

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11761,6 +11761,19 @@ spec:
                 store:
                   description: The store the user will be created in
                   type: string
+                subUsers:
+                  items:
+                    properties:
+                      access:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - access
+                      - name
+                    type: object
+                  nullable: true
+                  type: array
               type: object
             status:
               description: ObjectStoreUserStatus represents the status Ceph Object Store Gateway User

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -10044,6 +10044,41 @@ spec:
                   items:
                     type: string
                   type: array
+                auth:
+                  description: The authentication configuration
+                  properties:
+                    keystone:
+                      description: The spec for Keystone
+                      nullable: true
+                      properties:
+                        acceptedRoles:
+                          description: The roles requires to serve requests.
+                          items:
+                            type: string
+                          type: array
+                        implicitTenants:
+                          description: Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.
+                          type: string
+                        revocationInterval:
+                          description: The number of seconds between token revocation checks.
+                          nullable: true
+                          type: integer
+                        serviceUserSecretName:
+                          description: The name of the secret containing the credentials for the service user account used by RGW. It has to be in the same namespace as the object store resource.
+                          type: string
+                        tokenCacheSize:
+                          description: The maximum number of entries in each Keystone token cache.
+                          nullable: true
+                          type: integer
+                        url:
+                          description: The URL for the Keystone server.
+                          type: string
+                      required:
+                        - acceptedRoles
+                        - serviceUserSecretName
+                        - url
+                      type: object
+                  type: object
                 dataPool:
                   description: The data pool settings
                   nullable: true
@@ -11335,6 +11370,40 @@ spec:
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
                   type: boolean
+                protocols:
+                  description: The protocol specification
+                  properties:
+                    s3:
+                      description: The spec for S3
+                      nullable: true
+                      properties:
+                        authUseKeystone:
+                          description: Whether to use Keystone for authentication. This option maps directly to the rgw_s3_auth_use_keystone option. Enabling it allows generating S3 credentials via an OpenStack API call, see the docs. If not given, the defaults of the corresponding RGW option apply.
+                          nullable: true
+                          type: boolean
+                        enabled:
+                          description: Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    swift:
+                      description: The spec for Swift
+                      nullable: true
+                      properties:
+                        accountInUrl:
+                          description: Whether or not the Swift account name should be included in the Swift API URL. If set to false (the default), then the Swift API will listen on a URL formed like http://host:port/<rgw_swift_url_prefix>/v1. If set to true, the Swift API URL will be http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>. You must set this option to true (and update the Keystone service catalog) if you want radosgw to support publicly-readable containers and temporary URLs.
+                          nullable: true
+                          type: boolean
+                        urlPrefix:
+                          description: The URL prefix for the Swift API, to distinguish it from the S3 API endpoint. The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1 (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is enabled).
+                          nullable: true
+                          type: string
+                        versioningEnabled:
+                          description: Enables the Object Versioning of OpenStack Object Storage API. This allows clients to put the X-Versions-Location attribute on containers that should be versioned.
+                          nullable: true
+                          type: boolean
+                      type: object
+                  type: object
                 security:
                   description: Security represents security settings
                   nullable: true

--- a/deploy/examples/object-user.yaml
+++ b/deploy/examples/object-user.yaml
@@ -1,5 +1,5 @@
 #################################################################################################################
-# Create an object store user for access to the s3 endpoint.
+# Create an object store user for access to the s3/swift endpoint.
 #  kubectl create -f object-user.yaml
 #################################################################################################################
 
@@ -23,6 +23,10 @@ spec:
   #   metadata: "*"
   #   usage: "*"
   #   zone: "*"
+  # Create subusers for swift access to the object store
+  # subUsers:
+  # - name: swift
+  #   access: full # Possible values are: read, write, readwrite, full
   # If the CephObjectStoreUser is created in a namespace other than the Rook cluster namespace,
   # specify the namespace where the cluster and object store are found.
   # "allowUsersInNamespaces" must include this namespace to enable this feature.

--- a/design/ceph/object/swift-and-keystone-integration.md
+++ b/design/ceph/object/swift-and-keystone-integration.md
@@ -80,11 +80,11 @@ Annotations:
   options](https://docs.ceph.com/en/octopus/radosgw/config-ref/#keystone-settings),
   the corresponding RGW option is formed by prefixing it with
   `rgw_keystone_` and replacing upper case letters by their lower case
-  letter followed by an underscore. E.g. `tokenCacheSize` maps to
+  letter preceded by an underscore. E.g. `tokenCacheSize` maps to
   `rgw_keystone_token_cache_size`.
 * `[2]` These settings are required in the `keystone` section if
   present.
-* `[1]` The name of the secret containing the credentials for the
+* `[3]` The name of the secret containing the credentials for the
   service user account used by RGW. It has to be in the same namespace
   as the object store resource.
 
@@ -173,12 +173,12 @@ Annotations:
   options](https://docs.ceph.com/en/octopus/radosgw/config-ref/#swift-settings),
   the corresponding RGW option is formed by prefixing it with
   `rgw_swift_` and replacing upper case letters by their lower case
-  letter followed by an underscore. E.g. `urlPrefix` maps to
+  letter preceded by an underscore. E.g. `urlPrefix` maps to
   `rgw_swift_url_prefix`. They are optional. If not given, the defaults
   of the corresponding RGW option apply.
 
-The access to the Swift API is granted by creating a subuser of an RGW
-user. While commonly the access is granted via projects
+Access to the Swift API is granted by creating a subuser of an RGW
+user. While commonly access is granted via projects
 mapped from Keystone, explicit creation of subusers is supported by
 extending the `cephobjectstoreuser` resource with a new optional section
 `spec.subUsers`:

--- a/pkg/apis/ceph.rook.io/v1/spec_test.go
+++ b/pkg/apis/ceph.rook.io/v1/spec_test.go
@@ -92,3 +92,78 @@ storage:
 
 	assert.Equal(t, expectedSpec, clusterSpec)
 }
+
+func newTrue() *bool {
+	t := true
+	return &t
+}
+
+func newFalse() *bool {
+	t := false
+	return &t
+}
+
+func newInt(val int) *int {
+	return &val
+}
+
+func newString(val string) *string {
+	return &val
+}
+
+func TestObjectStoreSpecMarhsalSwiftAndKeystone(t *testing.T) {
+	// Assert that the new ObjectStoreSpec fields specified in <design/ceph/object/swift-and-keystone-integration.md> are correctly parsed
+	specYaml := []byte(`
+auth:
+  keystone:
+    url: https://keystone:5000/
+    acceptedRoles: ["_member_", "service", "admin"]
+    implicitTenants: swift
+    tokenCacheSize: 1000
+    revocationInterval: 1200
+    serviceUserSecretName: rgw-service-user
+protocols:
+  swift:
+    accountInUrl: true
+    urlPrefix: /example
+    versioningEnabled: false
+  s3:
+    enabled: false
+    authUseKeystone: true
+`)
+	rawJSON, err := yaml.ToJSON(specYaml)
+	assert.Nil(t, err)
+	fmt.Printf("rawJSON: %s\n", string(rawJSON))
+
+	// unmarshal the JSON into a strongly typed storage spec object
+	var objectStoreSpec ObjectStoreSpec
+	err = json.Unmarshal(rawJSON, &objectStoreSpec)
+	assert.Nil(t, err)
+
+	// the unmarshalled storage spec should equal the expected spec below
+	expectedSpec := ObjectStoreSpec{
+		Auth: AuthSpec{
+			Keystone: &KeystoneSpec{
+				Url:                   "https://keystone:5000/",
+				AcceptedRoles:         []string{"_member_", "service", "admin"},
+				ImplicitTenants:       "swift",
+				TokenCacheSize:        newInt(1000),
+				RevocationInterval:    newInt(1200),
+				ServiceUserSecretName: "rgw-service-user",
+			},
+		},
+		Protocols: ProtocolSpec{
+			S3: &S3Spec{
+				Enabled:         newFalse(),
+				AuthUseKeystone: newTrue(),
+			},
+			Swift: &SwiftSpec{
+				AccountInUrl:      newTrue(),
+				UrlPrefix:         newString("/example"),
+				VersioningEnabled: newFalse(),
+			},
+		},
+	}
+
+	assert.Equal(t, expectedSpec, objectStoreSpec)
+}

--- a/pkg/apis/ceph.rook.io/v1/spec_test.go
+++ b/pkg/apis/ceph.rook.io/v1/spec_test.go
@@ -167,3 +167,29 @@ protocols:
 
 	assert.Equal(t, expectedSpec, objectStoreSpec)
 }
+
+func TestObjectStoreUserSpecMarhsalSubuser(t *testing.T) {
+	// Assert that the new ObjectStoreUserSpec fields specified in <design/ceph/object/swift-and-keystone-integration.md> parse
+	specYaml := []byte(`
+subUsers:
+- name: swift
+  access: full
+`)
+	rawJSON, err := yaml.ToJSON(specYaml)
+	assert.Nil(t, err)
+	fmt.Printf("rawJSON: %s\n", string(rawJSON))
+
+	// unmarshal the JSON into a strongly typed storage spec object
+	var objectStoreUserSpec ObjectStoreUserSpec
+	err = json.Unmarshal(rawJSON, &objectStoreUserSpec)
+	assert.Nil(t, err)
+
+	// the unmarshalled storage spec should equal the expected spec below
+	expectedSpec := ObjectStoreUserSpec{
+		Subusers: []SubuserSpec{
+			{Name: "swift", Access: "full"},
+		},
+	}
+
+	assert.Equal(t, expectedSpec, objectStoreUserSpec)
+}

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1445,6 +1445,14 @@ type ObjectStoreSpec struct {
 	// +nullable
 	Gateway GatewaySpec `json:"gateway"`
 
+	// The protocol specification
+	// +optional
+	Protocols ProtocolSpec `json:"protocols,omitempty"`
+
+	// The authentication configuration
+	// +optional
+	Auth AuthSpec `json:"auth,omitempty"`
+
 	// The multisite info
 	// +optional
 	// +nullable
@@ -1612,6 +1620,86 @@ type EndpointAddress struct {
 	// +optional
 	Hostname string `json:"hostname,omitempty" protobuf:"bytes,3,opt,name=hostname"`
 }
+
+// ProtocolSpec represents a Ceph Object Store protocol specification
+type ProtocolSpec struct {
+	// The spec for S3
+	// +optional
+	// +nullable
+	S3 *S3Spec `json:"s3,omitempty"`
+
+	// The spec for Swift
+	// +optional
+	// +nullable
+	Swift *SwiftSpec `json:"swift"`
+}
+
+// S3Spec represents Ceph Object Store specification for the S3 API
+type S3Spec struct {
+	// Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.
+	// +nullable
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+	// Whether to use Keystone for authentication. This option maps directly to the rgw_s3_auth_use_keystone option. Enabling it allows generating S3 credentials via an OpenStack API call, see the docs. If not given, the defaults of the corresponding RGW option apply.
+	// +nullable
+	// +optional
+	AuthUseKeystone *bool `json:"authUseKeystone,omitempty"`
+}
+
+// SwiftSpec represents Ceph Object Store specification for the Swift API
+type SwiftSpec struct {
+	// Whether or not the Swift account name should be included in the Swift API URL. If set to false (the default), then the Swift API will listen on a URL formed like http://host:port/<rgw_swift_url_prefix>/v1. If set to true, the Swift API URL will be http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>. You must set this option to true (and update the Keystone service catalog) if you want radosgw to support publicly-readable containers and temporary URLs.
+	// +nullable
+	// +optional
+	AccountInUrl *bool `json:"accountInUrl,omitempty"`
+	// The URL prefix for the Swift API, to distinguish it from the S3 API endpoint. The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1 (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is enabled).
+	// +nullable
+	// +optional
+	UrlPrefix *string `json:"urlPrefix,omitempty"`
+	// Enables the Object Versioning of OpenStack Object Storage API. This allows clients to put the X-Versions-Location attribute on containers that should be versioned.
+	// +nullable
+	// +optional
+	VersioningEnabled *bool `json:"versioningEnabled,omitempty"`
+}
+
+// AuthSpec represents the authentication protocol configuration of a Ceph Object Store Gateway
+type AuthSpec struct {
+	// The spec for Keystone
+	// +optional
+	// +nullable
+	Keystone *KeystoneSpec `json:"keystone,omitempty"`
+}
+
+// KeystoneSpec represents the Keystone authentication configuration of a Ceph Object Store Gateway
+type KeystoneSpec struct {
+	// The URL for the Keystone server.
+	Url string `json:"url"`
+	// The name of the secret containing the credentials for the service user account used by RGW. It has to be in the same namespace as the object store resource.
+	ServiceUserSecretName string `json:"serviceUserSecretName"`
+	// The roles requires to serve requests.
+	AcceptedRoles []string `json:"acceptedRoles"`
+	// Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.
+	// +optional
+	ImplicitTenants ImplicitTenantSetting `json:"implicitTenants,omitempty"`
+	// The maximum number of entries in each Keystone token cache.
+	// +optional
+	// +nullable
+	TokenCacheSize *int `json:"tokenCacheSize,omitempty"`
+	// The number of seconds between token revocation checks.
+	// +optional
+	// +nullable
+	RevocationInterval *int `json:"revocationInterval,omitempty"`
+}
+
+type ImplicitTenantSetting string
+
+const (
+	ImplicitTenantSwift   ImplicitTenantSetting = "swift"
+	ImplicitTenantS3      ImplicitTenantSetting = "s3"
+	ImplicitTenantTrue    ImplicitTenantSetting = "true"
+	ImplicitTenantFalse   ImplicitTenantSetting = "false"
+	ImplicitTenantDefault ImplicitTenantSetting = ""
+)
 
 // ZoneSpec represents a Ceph Object Store Gateway Zone specification
 type ZoneSpec struct {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1800,6 +1800,9 @@ type ObjectStoreUserSpec struct {
 	// The namespace where the parent CephCluster and CephObjectStore are found
 	// +optional
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+	// +optional
+	// +nullable
+	Subusers []SubuserSpec `json:"subUsers,omitemtpy"`
 }
 
 // Additional admin-level capabilities for the Ceph object store user
@@ -1887,6 +1890,21 @@ type ObjectUserQuotaSpec struct {
 	MaxObjects *int64 `json:"maxObjects,omitempty"`
 }
 
+type SubuserSpec struct {
+	Name   string     `json:"name"`
+	Access AccessSpec `json:"access"`
+}
+
+type AccessSpec string
+
+const (
+	AccessSpecFull      AccessSpec = "full"
+	AccessSpecRead      AccessSpec = "read"
+	AccessSpecWrite     AccessSpec = "write"
+	AccessSpecReadWrite AccessSpec = "readwrite"
+)
+
+// CephObjectRealm represents a Ceph Object Store Gateway Realm
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -569,7 +569,7 @@ func (r *ReconcileCephObjectStore) reconcileCOSIUser(cephObjectStore *cephv1.Cep
 	}
 
 	// Create COSI user secret
-	return ReconcileCephUserSecret(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
+	return ReconcileCephUserSecrets(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
 }
 
 func generateCOSIUserConfig() *admin.User {

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -569,7 +569,7 @@ func (r *ReconcileCephObjectStore) reconcileCOSIUser(cephObjectStore *cephv1.Cep
 	}
 
 	// Create COSI user secret
-	return ReconcileCephUserSecrets(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
+	return ReconcileCephUserSecrets(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef, cephObjectStore.Spec.Protocols.Swift.UrlPrefix, cephObjectStore.Spec.Protocols.Swift.AccountInUrl)
 }
 
 func generateCOSIUserConfig() *admin.User {

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -62,6 +62,10 @@ type rgwConfig struct {
 	Realm        string
 	ZoneGroup    string
 	Zone         string
+
+	Auth           cephv1.AuthSpec
+	KeystoneSecret *v1.Secret
+	Protocols      cephv1.ProtocolSpec
 }
 
 var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
@@ -70,10 +74,10 @@ var (
 	insecureSkipVerify = "insecureSkipVerify"
 )
 
-func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName string) error {
+func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName string, keystoneSecret *v1.Secret) error {
 	logger.Infof("creating object store %q in namespace %q", c.store.Name, c.store.Namespace)
 
-	if err := c.startRGWPods(realmName, zoneGroupName, zoneName); err != nil {
+	if err := c.startRGWPods(realmName, zoneGroupName, zoneName, keystoneSecret); err != nil {
 		return errors.Wrap(err, "failed to start rgw pods")
 	}
 
@@ -95,7 +99,7 @@ func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName s
 	return nil
 }
 
-func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) error {
+func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string, keystoneSecret *v1.Secret) error {
 	// backward compatibility, triggered during updates
 	if c.store.Spec.Gateway.Instances < 1 {
 		// Set the minimum of at least one instance
@@ -127,11 +131,13 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 		resourceName := fmt.Sprintf("%s-%s-%s", AppName, c.store.Name, daemonLetterID)
 
 		rgwConfig := &rgwConfig{
-			ResourceName: resourceName,
-			DaemonID:     daemonName,
-			Realm:        realmName,
-			ZoneGroup:    zoneGroupName,
-			Zone:         zoneName,
+			ResourceName:   resourceName,
+			DaemonID:       daemonName,
+			Realm:          realmName,
+			ZoneGroup:      zoneGroupName,
+			Zone:           zoneName,
+			Auth:           c.store.Spec.Auth,
+			KeystoneSecret: keystoneSecret,
 		}
 
 		// We set the owner reference of the Secret to the Object controller instead of the replicaset
@@ -151,6 +157,8 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 		if err != nil {
 			// Getting EPERM typically happens when the flag may not be modified at runtime
 			// This is fine to ignore
+			// No it is not: As errors in the mapKeystoneSecretToConfig function are returned
+			// directly and the situation may occur, that only part of the configuration is set
 			code, ok := exec.ExitStatus(err)
 			if ok && code != int(syscall.EPERM) {
 				return errors.Wrap(err, "failed to set default rgw config options")

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -82,7 +82,7 @@ func TestStartRGW(t *testing.T) {
 
 	t.Run("Deployment is created", func(t *testing.T) {
 		store.Spec.Gateway.Instances = 1
-		err := c.startRGWPods(store.Name, store.Name, store.Name)
+		err := c.startRGWPods(store.Name, store.Name, store.Name, nil)
 		assert.Nil(t, err)
 
 		validateStart(ctx, t, c, clientset)
@@ -95,7 +95,7 @@ func TestStartRGW(t *testing.T) {
 		// Purge store of configurations applied to gateways
 		appliedRgwConfigurations = make(map[string]string)
 
-		err := c.startRGWPods(store.Name, store.Name, store.Name)
+		err := c.startRGWPods(store.Name, store.Name, store.Name, nil)
 		assert.Nil(t, err)
 
 		assert.Contains(t, appliedRgwConfigurations, "rgw_run_sync_thread")
@@ -109,7 +109,7 @@ func TestStartRGW(t *testing.T) {
 		// Purge store of configurations applied to gateways
 		appliedRgwConfigurations = make(map[string]string)
 
-		err := c.startRGWPods(store.Name, store.Name, store.Name)
+		err := c.startRGWPods(store.Name, store.Name, store.Name, nil)
 		assert.Nil(t, err)
 
 		assert.Contains(t, appliedRgwConfigurations, "rgw_run_sync_thread")
@@ -157,7 +157,7 @@ func TestCreateObjectStore(t *testing.T) {
 	r := &ReconcileCephObjectStore{client: cl, scheme: s}
 	ownerInfo := client.NewMinimumOwnerInfoWithOwnerRef()
 	c := &clusterConfig{context, info, store, "1.2.3.4", &cephv1.ClusterSpec{}, ownerInfo, data, r.client}
-	err := c.createOrUpdateStore(store.Name, store.Name, store.Name)
+	err := c.createOrUpdateStore(store.Name, store.Name, store.Name, nil)
 	assert.Nil(t, err)
 }
 

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -89,6 +89,25 @@ func updateStatus(ctx context.Context, observedGeneration int64, client client.C
 	logger.Debugf("object store %q status updated to %q", namespacedName.String(), status)
 }
 
+func buildSwiftUrl(swiftUrlPrefix *string, swiftAccountInUrl *bool) string {
+	swiftApiVersion := "v1"
+
+	swiftUrl := ""
+
+	if swiftUrlPrefix == nil {
+		swiftUrl += "/swift"
+	} else {
+		swiftUrl += "/" + *swiftUrlPrefix
+	}
+
+	swiftUrl += "/" + swiftApiVersion
+
+	if swiftAccountInUrl != nil && *swiftAccountInUrl == true {
+		swiftUrl += "/AUTH_%(tenant_id)s"
+	}
+	return swiftUrl
+}
+
 func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string {
 	m := make(map[string]string)
 
@@ -99,6 +118,10 @@ func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string 
 		m["endpoint"] = BuildDNSEndpoint(GetStableDomainName(cephObjectStore), cephObjectStore.Spec.Gateway.SecurePort, true)
 	} else {
 		m["endpoint"] = BuildDNSEndpoint(GetStableDomainName(cephObjectStore), cephObjectStore.Spec.Gateway.Port, false)
+	}
+
+	if cephObjectStore.Spec.Protocols.Swift != nil {
+		m["swiftUrl"] = buildSwiftUrl(cephObjectStore.Spec.Protocols.Swift.UrlPrefix, cephObjectStore.Spec.Protocols.Swift.AccountInUrl)
 	}
 
 	return m

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -277,7 +277,7 @@ func generateCephSubuserSecret(userConfig *admin.User, endpoint, namespace, stor
 	secrets := map[string]string{
 		"SWIFT_USER":          subuser.User,
 		"SWIFT_SECRET_KEY":    subuser.SecretKey,
-		"SWIFT_AUTH_ENDPOINT": "TODO", // TODO
+		"SWIFT_AUTH_ENDPOINT": endpoint + "/swift/v1",
 	}
 	splitSubUserName := strings.SplitN(subuser.User, ":", 2)
 	secret := &corev1.Secret{

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -363,7 +363,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 	}
 
 	// Set access and secret key
-	if r.userConfig.Keys == nil {
+	if r.userConfig.Keys == nil || len(r.userConfig.Keys) == 0 {
 		r.userConfig.Keys = make([]admin.UserKeySpec, 1)
 	}
 	r.userConfig.Keys[0].AccessKey = user.Keys[0].AccessKey
@@ -438,6 +438,7 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) admin.User {
 	userConfig := admin.User{
 		ID:          user.Name,
 		DisplayName: displayName,
+		Keys:        make([]admin.UserKeySpec, 0),
 	}
 
 	defaultMaxBuckets := 1000

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
@@ -263,7 +264,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	}
 
 	tlsSecretName := store.Spec.Gateway.SSLCertificateRef
-	reconcileResponse, err = object.ReconcileCephUserSecret(r.opManagerContext, r.client, r.scheme, cephObjectStoreUser, r.userConfig, r.objContext.Endpoint, cephObjectStoreUser.Namespace, cephObjectStoreUser.Spec.Store, tlsSecretName)
+	reconcileResponse, err = object.ReconcileCephUserSecrets(r.opManagerContext, r.client, r.scheme, cephObjectStoreUser, r.userConfig, r.objContext.Endpoint, cephObjectStoreUser.Namespace, cephObjectStoreUser.Spec.Store, tlsSecretName)
 	if err != nil {
 		r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, k8sutil.ReconcileFailedStatus)
 		return reconcileResponse, *cephObjectStoreUser, err
@@ -362,15 +363,121 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		return errors.Wrapf(err, "failed to set quotas for user %q", u.Name)
 	}
 
+	// Reconcile subusers
+	user, err = r.reconcileSubusers(user, u)
+	if err != nil {
+		return err
+	}
+
 	// Set access and secret key
 	if r.userConfig.Keys == nil || len(r.userConfig.Keys) == 0 {
 		r.userConfig.Keys = make([]admin.UserKeySpec, 1)
 	}
 	r.userConfig.Keys[0].AccessKey = user.Keys[0].AccessKey
 	r.userConfig.Keys[0].SecretKey = user.Keys[0].SecretKey
+
+	// Copy the subuser keys – XXX: should this be a deep copy for safety?
+	r.userConfig.SwiftKeys = append([]admin.SwiftKeySpec{}, user.SwiftKeys...)
+
 	logger.Info(logCreateOrUpdate)
 
 	return nil
+}
+
+var accessLevelMap = map[admin.SubuserAccess]admin.SubuserAccess{
+	admin.SubuserAccessReplyNone:      admin.SubuserAccessNone,
+	admin.SubuserAccessReplyRead:      admin.SubuserAccessRead,
+	admin.SubuserAccessReplyWrite:     admin.SubuserAccessWrite,
+	admin.SubuserAccessReplyReadWrite: admin.SubuserAccessReadWrite,
+	admin.SubuserAccessReplyFull:      admin.SubuserAccessFull,
+}
+
+func mapAccessLevel(outputAccessLevel admin.SubuserAccess) (admin.SubuserAccess, error) {
+	level, ok := accessLevelMap[outputAccessLevel]
+	if !ok {
+		return admin.SubuserAccessNone, fmt.Errorf("invalid access level returned by RGW %s", outputAccessLevel)
+	}
+	return level, nil
+}
+
+func (r *ReconcileObjectStoreUser) reconcileSubusers(userIs admin.User, userSpec *cephv1.CephObjectStoreUser) (admin.User, error) {
+	var err error
+
+	mustRefreshUser := false
+
+	subusersSpec := append([]cephv1.SubuserSpec{}, userSpec.Spec.Subusers...)
+	subusersIs := append([]admin.SubuserSpec{}, userIs.Subusers...)
+
+	sort.Slice(subusersSpec, func(i, j int) bool {
+		return subusersSpec[i].Name < subusersSpec[j].Name
+	})
+	sort.Slice(subusersIs, func(i, j int) bool {
+		return subusersIs[i].Name < subusersIs[j].Name
+	})
+
+	toCreate := make([]cephv1.SubuserSpec, 0)
+	toDelete := make([]admin.SubuserSpec, 0)
+	for len(subusersSpec) > 0 && len(subusersIs) > 0 {
+		subuserFullNameSpec := fmt.Sprintf("%s:%s", userIs.ID, subusersSpec[0].Name)
+
+		if subuserFullNameSpec < subusersIs[0].Name {
+			toCreate = append(toCreate, subusersSpec[0])
+			subusersSpec = subusersSpec[1:]
+		} else if subuserFullNameSpec > subusersIs[0].Name {
+			toDelete = append(toDelete, subusersIs[0])
+			subusersIs = subusersIs[1:]
+		} else { // subusersSpec[0].Name == subusersIs[0].Name
+			accessLevelIs, err := mapAccessLevel(subusersIs[0].Access)
+			if err != nil {
+				return userIs, errors.Wrapf(err, "failed to reconcile subusers")
+			}
+			if string(subusersSpec[0].Access) != string(accessLevelIs) {
+				modifiedSubuser := admin.SubuserSpec{
+					Name:   subuserFullNameSpec,
+					Access: admin.SubuserAccess(subusersSpec[0].Access),
+				}
+				mustRefreshUser = true
+				err = r.objContext.AdminOpsClient.ModifySubuser(r.opManagerContext, userIs, modifiedSubuser)
+				if err != nil {
+					return userIs, errors.Wrapf(err, "failed to modify subuser %q", modifiedSubuser.Name)
+				}
+			}
+
+			subusersSpec = subusersSpec[1:]
+			subusersIs = subusersIs[1:]
+		}
+	}
+	toCreate = append(toCreate, subusersSpec...)
+	toDelete = append(toDelete, subusersIs...)
+
+	for _, subuserToCreate := range toCreate {
+		err = r.objContext.AdminOpsClient.CreateSubuser(r.opManagerContext, userIs, admin.SubuserSpec{
+			Name:   fmt.Sprintf("%s:%s", userIs.ID, subuserToCreate.Name),
+			Access: admin.SubuserAccess(subuserToCreate.Access),
+		})
+		mustRefreshUser = true
+		if err != nil {
+			return userIs, errors.Wrapf(err, "failed to create subuser %q", subuserToCreate.Name)
+		}
+	}
+
+	for _, subuserToDelete := range toDelete {
+		mustRefreshUser = true
+		err = r.objContext.AdminOpsClient.RemoveSubuser(r.opManagerContext, userIs, subuserToDelete)
+		if err != nil {
+			return userIs, errors.Wrapf(err, "failed to delete subuser %q", subuserToDelete.Name)
+		}
+	}
+
+	if mustRefreshUser {
+		// As the subuser commands don't give us the full user object, we need to get it here to have an accurate representation of the user state after the reconcile
+		userIs, err = r.objContext.AdminOpsClient.GetUser(r.opManagerContext, userIs)
+		if err != nil {
+			return userIs, errors.Wrapf(err, "failed to reconcile subusers during refresh")
+		}
+	}
+
+	return userIs, nil
 }
 
 func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephObjectStoreUser) error {


### PR DESCRIPTION
This PR implements using k8s custom resources to create swift sub-users as described in the already existing design document [swift-and-keystone-integration](https://github.com/rook/rook/blob/459604a3bd383ded82d62463b963f19869331216/design/ceph/object/swift-and-keystone-integration.md) (see https://github.com/rook/rook/pull/9444 for the design request and https://github.com/rook/rook/issues/9088 for the general issue).
                                                                                
The design document describes another feature namely the authentication using keystone of swift and s3 which is implemented in a #13807.                                                          
                                                                                
**Checklist:**                                                                  
                                                                                
- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.                       
- [X] Unit tests have been added, if necessary.                                 
- [x] Integration tests have been added, if necessary.