### PR TITLE
docs: note that changing encryption option settings for existing clusters is not dangerous

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -220,8 +220,9 @@ Configure the network that will be enabled for the cluster and services.
       See the kernel requirements above for encryption.
 
 !!! caution
-    Changing networking configuration after a Ceph cluster has been deployed is NOT
-    supported and will result in a non-functioning cluster.
+    Changing networking configuration after a Ceph cluster has been deployed is only supported for
+    the network encryption settings. Changing other network settings is *NOT* supported and will
+    likely result in a non-functioning cluster.
 
 #### Provider
 


### PR DESCRIPTION
We have prohibited changing all network-related configurations after cluster creation. However, as a result of #13584, we found that the connections.encryption flag can be regarded as an exception.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
