### PR TITLE
osd: fix removing key file timing

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -224,7 +224,6 @@ dmsetup version
 function open_encrypted_block {
 	echo "Opening encrypted device $BLOCK_PATH at $DM_PATH"
 	cryptsetup luksOpen --verbose --disable-keyring --allow-discards --key-file "$KEY_FILE_PATH" "$BLOCK_PATH" "$DM_NAME"
-	rm -f "$KEY_FILE_PATH"
 }
 
 # This is done for upgraded clusters that did not have the subsystem and label set by the prepare job


### PR DESCRIPTION
[The key file deletion process is in the shell script](https://github.com/rook/rook/blob/f6509e10f63f67879d9954f6465e0ef62cd28d1e/pkg/operator/ceph/cluster/osd/spec.go#L227) commonly used by all of `encryption-open`, `encryption-open-metadata`, and `encryption-open-wal` init containers. The key file is deleted at the `encryption-open` init container and `encryption-open-metadata` and `encryption-open-wal` init containers are failed to open the key file.

The key file is in the `/etc/ceph` folder. Unless that folder is shared, the key file anyway won't be available in the other init containers even if it is not deleted by these init containers. And it will naturally anyway be deleted after the init containers are completed. So The key file deletion process in shell scripts is unnecessary. 

Fixes: #13737

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
