### PR TITLE
doc: fix broken links

### DIFF
--- a/Documentation/.pages
+++ b/Documentation/.pages
@@ -6,3 +6,15 @@ nav:
     - Troubleshooting
     - Upgrade
     - Contributing
+    - Getting Started:
+          - Rook: intro.md
+          - Glossary: Getting-Started/glossary
+          - Prerequisites:
+                - Prerequisites: Getting-Started/Prerequisites/prerequisites.md
+                - Authenticated Container Registries: Getting-Started/Prerequisites/authenticated-registry
+          - Quick Start: Getting-Started/quickstart
+          - Storage Architecture: Getting-Started/storage-architecture
+          - Example Configurations: Getting-Started/example-configurations
+          - OpenShift: Getting-Started/ceph-openshift
+          - Cleanup: Getting-Started/ceph-teardown
+          - Release: Getting-Started/release-cycle

--- a/Documentation/Getting-Started/.pages
+++ b/Documentation/Getting-Started/.pages
@@ -1,5 +1,5 @@
 nav:
-    - intro.md
+    - Rook: ../intro
     - glossary.md
     - Prerequisites
     - quickstart.md

--- a/Documentation/Getting-Started/intro.md
+++ b/Documentation/Getting-Started/intro.md
@@ -1,1 +1,0 @@
-../README.md

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -18,11 +18,11 @@ Rook is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF
 ## Quick Start Guide
 
 Starting Ceph in your cluster is as simple as a few `kubectl` commands.
-See our [Quickstart](quickstart.md) guide to get started with the Ceph operator!
+See our [Quickstart](Getting-Started/quickstart.md) guide to get started with the Ceph operator!
 
 ## Designs
 
-[Ceph](https://docs.ceph.com/en/latest/) is a highly scalable distributed storage solution for block storage, object storage, and shared filesystems with years of production deployments. See the [Ceph overview](storage-architecture.md).
+[Ceph](https://docs.ceph.com/en/latest/) is a highly scalable distributed storage solution for block storage, object storage, and shared filesystems with years of production deployments. See the [Ceph overview](Getting-Started/storage-architecture.md).
 
 For detailed design documentation, see also the [design docs](https://github.com/rook/rook/tree/master/design).
 

--- a/Documentation/intro.md
+++ b/Documentation/intro.md
@@ -1,0 +1,1 @@
+README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,7 @@ plugins:
       #js_files: []
   - redirects:
       redirect_maps:
-        README.md: Getting-Started/intro.md
+        README.md: intro.md
   - mike:
       # these fields are all optional; the defaults are as below...
       version_selector: true # set to false to leave out the version selector


### PR DESCRIPTION
This patch fixes the broken links in the non rendered documents on github and keeps the structre of the rendered documents on the website intact as well.