### PR TITLE
build: use 'baseos' as repo for iproute install

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -20,7 +20,7 @@ ARG S5CMD_VERSION
 ARG S5CMD_ARCH
 
 # install 'ip' tool for Multus
-RUN dnf install -y --setopt=install_weak_deps=False iproute && dnf clean all
+RUN dnf install -y --repo baseos --setopt=install_weak_deps=False iproute && dnf clean all
 
 # Install the s5cmd package to interact with s3 gateway
 RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \


### PR DESCRIPTION
The rook/ceph Dockerfile uses dnf to ensure iproute (containing the 'ip' CLI tool) is installed in the Rook image for Multus usage. This comes from the 'baseos' repo, but if any other repos are unavailable temporarily, it can cause the container build to fail.

Use the '--repo baseos' flag to help prevent these kinds of failures. Additionally, this will speed up the build slightly since it does not attempt to load any non-necessary repos.

This change may make the container build slightly fragile in the future if CentOS changes the name of its baseos repo, or if the Ceph image switches to a non-CentOS base image.

Resolves #13864 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
