### PR TITLE
exporter: applying labels from monitoring section to ceph-exporter

### DIFF
--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -206,6 +206,8 @@ spec:
   #   cleanup:
   #   mgr:
   #   prepareosd:
+  # These labels are applied to ceph-exporter servicemonitor only
+  #   exporter:
   # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
   # These labels can be passed as LabelSelector to Prometheus
   #   monitoring:

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -262,6 +262,7 @@ func EnableCephExporterServiceMonitor(context *clusterd.Context, cephCluster cep
 
 func applyCephExporterLabels(cephCluster cephv1.CephCluster, serviceMonitor *monitoringv1.ServiceMonitor) {
 	if cephCluster.Spec.Labels != nil {
+		cephv1.GetMonitoringLabels(cephCluster.Spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 		if cephExporterLabels, ok := cephCluster.Spec.Labels["exporter"]; ok {
 			if managedBy, ok := cephExporterLabels["rook.io/managedBy"]; ok {
 				relabelConfig := monitoringv1.RelabelConfig{


### PR DESCRIPTION
the labels listed under the 'monitoring' section are currently only being applied to the rook-ceph-mgr ServiceMonitor. This change extends those labels to also include the rook-ceph-exporter ServiceMonitor.

Fixes: https://github.com/rook/rook/issues/13774

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
