### PR TITLE
core: disable mirroring on pool with "image" mode

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -332,32 +332,7 @@ func setCommonPoolProperties(context *clusterd.Context, clusterInfo *ClusterInfo
 				return errors.Wrapf(err, "failed to enable snapshot scheduling for pool %q", pool.Name)
 			}
 		}
-	} else {
-		if pool.Mirroring.Mode == "pool" {
-			// Remove storage cluster peers
-			mirrorInfo, err := GetPoolMirroringInfo(context, clusterInfo, pool.Name)
-			if err != nil {
-				return errors.Wrapf(err, "failed to get mirroring info for the pool %q", pool.Name)
-			}
-			for _, peer := range mirrorInfo.Peers {
-				if peer.UUID != "" {
-					err := removeClusterPeer(context, clusterInfo, pool.Name, peer.UUID)
-					if err != nil {
-						return errors.Wrapf(err, "failed to remove cluster peer with UUID %q for the pool %q", peer.UUID, pool.Name)
-					}
-				}
-			}
-
-			// Disable mirroring
-			err = disablePoolMirroring(context, clusterInfo, pool.Name)
-			if err != nil {
-				return errors.Wrapf(err, "failed to disable mirroring for pool %q", pool.Name)
-			}
-		} else if pool.Mirroring.Mode == "image" {
-			logger.Warningf("manually disable mirroring on images in the pool %q", pool.Name)
-		}
 	}
-
 	// set maxSize quota
 	if pool.Quotas.MaxSize != nil {
 		// check for format errors

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -541,6 +541,13 @@ func TestCephObjectStoreController(t *testing.T) {
 						{"poolnum":9,"poolname":"my-store.rgw.buckets.data"}
 					]`, nil
 				}
+				if args[0] == "mirror" && args[2] == "info" {
+					return "{}", nil
+				}
+				if args[0] == "mirror" && args[2] == "disable" {
+					return "", nil
+				}
+
 				return "", nil
 			},
 			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -75,7 +75,14 @@ func TestCreatePool(t *testing.T) {
 				}
 			}
 			if command == "rbd" {
-				assert.Equal(t, []string{"pool", "init", p.Name}, args[0:3])
+				if args[0] == "mirror" && args[2] == "info" {
+					return "{}", nil
+				} else if args[0] == "mirror" && args[2] == "disable" {
+					return "", nil
+				} else {
+					assert.Equal(t, []string{"pool", "init", p.Name}, args[0:3])
+				}
+
 			}
 			return "", nil
 		},
@@ -335,8 +342,11 @@ func TestCephBlockPoolController(t *testing.T) {
 				if args[0] == "config" && args[2] == "mgr" && args[3] == "mgr/prometheus/rbd_stats_pools" {
 					return "", nil
 				}
-
+				if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
+					return "{}", nil
+				}
 				return "", nil
+
 			},
 		}
 		c.Executor = executor
@@ -425,6 +435,9 @@ func TestCephBlockPoolController(t *testing.T) {
 			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "peer" && args[3] == "bootstrap" && args[4] == "create" {
 					return `eyJmc2lkIjoiYzZiMDg3ZjItNzgyOS00ZGJiLWJjZmMtNTNkYzM0ZTBiMzVkIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFBV1lsWmZVQ1Q2RGhBQVBtVnAwbGtubDA5YVZWS3lyRVV1NEE9PSIsIm1vbl9ob3N0IjoiW3YyOjE5Mi4xNjguMTExLjEwOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTA6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjEyOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTI6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjExOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTE6Njc4OV0ifQ==`, nil
+				}
+				if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
+					return "{}", nil
 				}
 				return "", nil
 			},


### PR DESCRIPTION
For `image` mode mirroring, if `cephBlockPool.Pool.Spec.Mirroring.Enable` is set to false, then remove the peer cluster and disable mirroring on all the pool if the user has disabled mirroring on all the pool images. 

if mirroring is not disabled on all the pool images, then reconcile will fail asking the users to manually disable mirroring on those images. 

Some initial Testing: 

``` 
When mirroring is enabled:
--------------------

runner@fv-az1017-987:~/work/rook/rook$ oc get cephblockpool replicapool -o yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  creationTimestamp: "2024-03-15T04:35:27Z"
  finalizers:
  - cephblockpool.ceph.rook.io
  generation: 3
  name: replicapool
  namespace: rook-ceph
  resourceVersion: "6053"
  uid: ee1db641-1657-47cd-a031-d08c44f492ca
spec:
  application: ""
  erasureCoded:
    codingChunks: 0
    dataChunks: 0
  failureDomain: osd
  mirroring:
    enabled: true
    mode: image
    peers:
      secretNames:
      - pool-peer-token-replicapool-config
  quotas: {}
  replicated:
    size: 1
  statusCheck:
    mirror: {}
status:
  info:
    rbdMirrorBootstrapPeerSecretName: pool-peer-token-replicapool
  mirroringInfo:
    lastChanged: "2024-03-15T04:54:23Z"
    lastChecked: "2024-03-15T04:55:23Z"
    mode: image
    peers:
    - client_name: client.rbd-mirror-peer
      direction: rx-tx
      mirror_uuid: 910ebd07-140c-4415-8cde-de715efcc35a
      site_name: b6a29137-eaa6-4a7a-a5a5-b9577d63309c
      uuid: 5221e1e2-38f2-49a6-8d08-0e47a1937655
    site_name: 357462f6-0c53-4b02-8c5a-763b1f500cff
  mirroringStatus:
    lastChecked: "2024-03-15T04:55:23Z"
    summary:
      daemon_health: OK
      health: OK
      image_health: OK
      states:
        replaying: 1
  observedGeneration: 1
  phase: Ready
  snapshotScheduleStatus: {}
  
  
  
  After disabling mirroring on each pool image and then disabling mirroring on cephCluster spec.
  ---------------------------
  
  runner@fv-az1017-987:~/work/rook/rook$ oc get cephblockpool replicapool -o yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  creationTimestamp: "2024-03-15T04:35:27Z"
  finalizers:
  - cephblockpool.ceph.rook.io
  generation: 4
  name: replicapool
  namespace: rook-ceph
  resourceVersion: "6232"
  uid: ee1db641-1657-47cd-a031-d08c44f492ca
spec:
  application: ""
  erasureCoded:
    codingChunks: 0
    dataChunks: 0
  failureDomain: osd
  quotas: {}
  replicated:
    size: 1
  statusCheck:
    mirror: {}
status:
  mirroringInfo:
    lastChanged: "2024-03-15T04:57:23Z"
  mirroringStatus: {}
  observedGeneration: 4
  phase: Ready
  snapshotScheduleStatus: {}
runner@fv-az1017-987:~/work/rook/rook$ 


-------------

runner@fv-az1017-987:~/work/rook/rook$ oc exec -it rook-ceph-tools-848bb44cb-w44zh sh 
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
sh-4.4$ ceph status  
  cluster:
    id:     357462f6-0c53-4b02-8c5a-763b1f500cff
    health: HEALTH_OK
 
  services:
    mon:           1 daemons, quorum a (age 28m)
    mgr:           a(active, since 22m)
    mds:           1/1 daemons up, 1 hot standby
    osd:           1 osds: 1 up (since 27m), 1 in (since 28m)
    cephfs-mirror: 1 daemon active (1 hosts)
    rbd-mirror:    1 daemon active (1 hosts)
 
  data:
    volumes: 1/1 healthy
    pools:   5 pools, 144 pgs
    objects: 42 objects, 1.2 MiB
    usage:   50 MiB used, 6.0 GiB / 6 GiB avail
    pgs:     144 active+clean
 
  io:
    client:   853 B/s rd, 1 op/s rd, 0 op/s wr
 
sh-4.4$ rbd mirror pool status replicapool
rbd: mirroring not enabled on the pool
sh-4.4$ 

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
