### PR TITLE
Support Object Store Deployment with operator hostNetwork

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -108,6 +108,7 @@ spec:
 {{- end }}
 {{- if .Values.useOperatorHostNetwork }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
We need to explicitly tell the rook-ceph-operator pod to use the dnsPolicy: ClusterFirstWithHostNet, when using host network, otherwise, the ceph object store deployments will fail on user creation because it cannot talk to the gateway witht the following error:

`2024-03-13 15:15:18.359104 E | ceph-object-controller: failed to reconcile CephObjectStore "rook-ceph/ceph-objectstore". failed to create object store deployments: failed to get COSI user "cosi": Get "http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc:80/admin/user?format=json&uid=cosi": dial tcp: lookup rook-ceph-rgw-ceph-objectstore.rook-ceph.svc on 8.8.8.8:53: no such host`

