### PR TITLE
csi: preserve csi if not owned by rook

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -59,7 +59,7 @@ func (r *ReconcileCSI) validateAndConfigureDrivers(serverVersion *version.Info, 
 	}
 
 	// Check whether RBD or CephFS needs to be disabled
-	return r.stopDrivers(serverVersion)
+	return r.stopDrivers(serverVersion, ownerInfo)
 }
 
 func (r *ReconcileCSI) setParams(ver *version.Info) error {

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -147,6 +147,11 @@ func (info *OwnerInfo) GetUID() types.UID {
 	return info.owner.GetUID()
 }
 
+// GetOwnerReference gets the owner references of the owner
+func (info *OwnerInfo) OwnerReference() *metav1.OwnerReference {
+	return info.ownerRef
+}
+
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {
 	// if the first has no limits set, apply the second limits if any are specified
 	if len(first.Limits) == 0 {


### PR DESCRIPTION
currently rook deleted the csi driver
if even the it was installed externally,
so add a check to donot delete
if it is installed externally

closes: https://github.com/rook/rook/issues/13942

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
