### PR TITLE
object: Set non-ec shared pool to metadata pool

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -931,7 +931,9 @@ func applyExpectedRadosNamespaceSettings(zoneConfig map[string]interface{}, meta
 		return fmt.Errorf("failed to parse placement_pools[0].val")
 	}
 	placementVals["index_pool"] = metadataPrefix + "buckets.index"
-	placementVals["data_extra_pool"] = dataPrefix + "buckets.non-ec"
+	// The extra pool is for omap data for multi-part uploads, so we use
+	// the metadata pool instead of the data pool.
+	placementVals["data_extra_pool"] = metadataPrefix + "buckets.non-ec"
 	storageClasses, ok := placementVals["storage_classes"].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("failed to parse storage_classes")

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -103,7 +103,7 @@ const (
 							"data_pool": "rgw-data-pool:store-a.buckets.data"
 						}
 					},
-					"data_extra_pool": "rgw-data-pool:store-a.buckets.non-ec",
+					"data_extra_pool": "rgw-meta-pool:store-a.buckets.non-ec",
 					"index_type": 0,
 					"inline_data": true
 				}


### PR DESCRIPTION
The omap data for multipart uploads is stored in an additional data pool, which cannot be an EC pool.
So the extra data pool is set to the metadata pool for object stores with shared pools.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13990 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
