### PR TITLE
object: add support for user s3 key for cephobjectstoreuser

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -93,45 +93,55 @@ type: kubernetes.io/rook
 
 AccessKey, SecretKey, and Credentials can be specified before CephObjectStore creation or modified afterwards to support user-specified keys and key rotation. Endpoint cannot be overridden by users and will always be updated by Rook to match the latest CephObjectStore information.
 
-Create or update the Kubernetes secret with name, `rook-ceph-object-user-<store-name>-<user-name>` in the same namespace of cephobjectUser,
+1) Update the cephObjectStoreUser spec with secretName.
 
-Steps:
+    ```
+    spec:
+      inputCredentials:
+        secretName: user-secret
+    ```
 
-i) Specify the annotations as `rook.io/source-of-truth: secret` and type as `type: "kubernetes.io/rook"`.
+2) Create or update the Kubernetes secret with user specified name, in the same namespace of cephobjectUser,
 
-ii) Specify the user defined `AccessKey` and `SecretKey`.
+    Steps:
 
-iii) (optional) The array of `Credentials` which contains all the trusted access and secret keys. Make sure to also add the user defined `AccessKey` and `SecretKey` of step ii).
+    i) Specify the type as `type: "kubernetes.io/rook"`.
 
-`Credentials`
-```console
-[{"access_key":"IE58RNT71Y2F1EQE80RA","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}, {"access_key":"IE58RNT71Y2F1EQE80RC","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}]
-```
+    ii) Specify the user defined `AccessKey` and `SecretKey`.
 
-If any key is present in the ceph user and not present in the `Credentials`, it will be removed from the ceph user too.
-If `Credentials` is left empty, it will be auto updated by the latest AccessKey and SecretKey and will remove all the other keys from the ceph user.
+    iii) (optional) The array of `Credentials` which contains all the trusted access and secret keys. Make sure to also add the user defined `AccessKey` and `SecretKey` of step ii).
 
-!!! note
-    Secret data usually needs to be converted to base64 format.
+    `Credentials`
+    ```console
+    [{"access_key":"IE58RNT71Y2F1EQE80RA","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}, {"access_key":"IE58RNT71Y2F1EQE80RC","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}]
+    ```
 
-Example Secret:
+    If any key is present in the ceph user and not present in the `Credentials`, it will be removed from the ceph user too.
+    If `Credentials` is left empty, it will be auto updated by the latest AccessKey and SecretKey and will remove all the other keys from the ceph user.
 
-```console
-kubectl create -f
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rook-ceph-object-user-my-store-my-user
-  namespace: rook-ceph
-  annotations:
-    rook.io/source-of-truth: secret
-data:
-  AccessKey: ***
-  SecretKey: ***
-  Endpoint: ***
-  Credentials: ***
-type: "kubernetes.io/rook"
-```
+    !!! note
+        Secret data usually needs to be converted to base64 format.
 
-!!! note
-    Be careful when updating Kubernetes secret values. Mistakes entering info can cause errors reconciling the CephObjectStore.
+    Example Secret:
+
+    ```console
+    kubectl create -f
+    apiVersion: v1
+    kind: Secret
+    metadata:
+    name: user-secret
+    namespace: rook-ceph
+    annotations:
+        rook.io/source-of-truth: secret
+    data:
+    AccessKey: ***
+    SecretKey: ***
+    Endpoint: ***
+    Credentials: ***
+    type: "kubernetes.io/rook"
+    ```
+
+    !!! note
+        Be careful when updating Kubernetes secret values. Mistakes entering info can cause errors reconciling the CephObjectStore.
+
+Validate looking the cephObjectStoreUser status if the User-Specified Reference Secret is updated successful to the rgw/s3 user backend.

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -60,3 +60,78 @@ spec:
     * `user-policy`
     * `odic-provider`
     * `ratelimit`
+
+### CephObjectStoreUser Reference Secret
+
+A Kubernetes secret is created by Rook with the name, `rook-ceph-object-user-<store-name>-<user-name>` in the same namespace of cephobjectUser, where:
+
+* `store-name`: The object store name in which the user will be created. This matches the name of the objectstore CRD.
+* `user-name`: The metadata name of the cephObjectStoreUser
+
+Application pods can use the secret to configure access to the object store.
+
+```yaml
+apiVersion: v1
+data:
+  AccessKey: ***       # [1]
+  Credentials: ***     # [2]
+  Endpoint: ***        # [3]
+  SecretKey: ***       # [4]
+kind: Secret
+...
+...
+type: kubernetes.io/rook
+
+```
+
+1. `AccessKey`: User access key for ceph S3.
+2. `SecretKey`: User secret key for ceph S3.
+3. `Credentials`: Comma separated values of all access and secret keys.
+4. `Endpoint`: Endpoint for ceph S3.
+
+#### User-Specified Reference Secret
+
+AccessKey, SecretKey, and Credentials can be specified before CephObjectStore creation or modified afterwards to support user-specified keys and key rotation. Endpoint cannot be overridden by users and will always be updated by Rook to match the latest CephObjectStore information.
+
+Create or update the Kubernetes secret with name, `rook-ceph-object-user-<store-name>-<user-name>` in the same namespace of cephobjectUser,
+
+Steps:
+
+i) Specify the annotations as `rook.io/source-of-truth: secret` and type as `type: "kubernetes.io/rook"`.
+
+ii) Specify the user defined `AccessKey` and `SecretKey`.
+
+iii) (optional) The array of `Credentials` which contains all the trusted access and secret keys. Make sure to also add the user defined `AccessKey` and `SecretKey` of step ii).
+
+`Credentials`
+```console
+[{"access_key":"IE58RNT71Y2F1EQE80RA","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}, {"access_key":"IE58RNT71Y2F1EQE80RC","secret_key":"cULyMz5dCpX18dPsJhpIKay7vcDNRNJWJPu8VqUA"}]
+```
+
+If any key is present in the ceph user and not present in the `Credentials`, it will be removed from the ceph user too.
+If `Credentials` is left empty, it will be auto updated by the latest AccessKey and SecretKey and will remove all the other keys from the ceph user.
+
+!!! note
+    Secret data usually needs to be converted to base64 format.
+
+Example Secret:
+
+```console
+kubectl create -f
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rook-ceph-object-user-my-store-my-user
+  namespace: rook-ceph
+  annotations:
+    rook.io/source-of-truth: secret
+data:
+  AccessKey: ***
+  SecretKey: ***
+  Endpoint: ***
+  Credentials: ***
+type: "kubernetes.io/rook"
+```
+
+!!! note
+    Be careful when updating Kubernetes secret values. Mistakes entering info can cause errors reconciling the CephObjectStore.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2054,6 +2054,20 @@ string
 <p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>inputCredentials</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ObjectUserInputCredentials">
+ObjectUserInputCredentials
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Input Credentials for the cephObjectUser</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -9508,6 +9522,20 @@ string
 <p>The namespace where the parent CephCluster and CephObjectStore are found</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>inputCredentials</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ObjectUserInputCredentials">
+ObjectUserInputCredentials
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Input Credentials for the cephObjectUser</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ObjectStoreUserStatus">ObjectStoreUserStatus
@@ -9558,6 +9586,20 @@ int64
 <td>
 <em>(Optional)</em>
 <p>ObservedGeneration is the latest generation observed by the controller.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>inputCredentialsStatus</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.ObjectUserInputCredentialsStatus">
+ObjectUserInputCredentialsStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Input Credentials for the cephObjectUser</p>
 </td>
 </tr>
 </tbody>
@@ -9768,6 +9810,76 @@ string
 <td>
 <em>(Optional)</em>
 <p>Add capabilities for user to set rate limiter for user and bucket. Documented in <a href="https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities">https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.ObjectUserInputCredentials">ObjectUserInputCredentials
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreUserSpec">ObjectStoreUserSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretName for input Credentials for the cephObjectUser</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ceph.rook.io/v1.ObjectUserInputCredentialsStatus">ObjectUserInputCredentialsStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreUserStatus">ObjectStoreUserStatus</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretName for input Credentials for the cephObjectUser</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretGeneration</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The generation of the above secret Rook last used to apply creds</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11765,6 +11765,13 @@ spec:
                 displayName:
                   description: The display name for the ceph users
                   type: string
+                inputCredentials:
+                  description: Input Credentials for the cephObjectUser
+                  properties:
+                    secretName:
+                      description: SecretName for input Credentials for the cephObjectUser
+                      type: string
+                  type: object
                 quotas:
                   description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
                   nullable: true
@@ -11800,6 +11807,17 @@ spec:
                   additionalProperties:
                     type: string
                   nullable: true
+                  type: object
+                inputCredentialsStatus:
+                  description: Input Credentials for the cephObjectUser
+                  properties:
+                    secretGeneration:
+                      description: The generation of the above secret Rook last used to apply creds
+                      format: int64
+                      type: integer
+                    secretName:
+                      description: SecretName for input Credentials for the cephObjectUser
+                      type: string
                   type: object
                 observedGeneration:
                   description: ObservedGeneration is the latest generation observed by the controller.

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11755,6 +11755,13 @@ spec:
                 displayName:
                   description: The display name for the ceph users
                   type: string
+                inputCredentials:
+                  description: Input Credentials for the cephObjectUser
+                  properties:
+                    secretName:
+                      description: SecretName for input Credentials for the cephObjectUser
+                      type: string
+                  type: object
                 quotas:
                   description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
                   nullable: true
@@ -11790,6 +11797,17 @@ spec:
                   additionalProperties:
                     type: string
                   nullable: true
+                  type: object
+                inputCredentialsStatus:
+                  description: Input Credentials for the cephObjectUser
+                  properties:
+                    secretGeneration:
+                      description: The generation of the above secret Rook last used to apply creds
+                      format: int64
+                      type: integer
+                    secretName:
+                      description: SecretName for input Credentials for the cephObjectUser
+                      type: string
                   type: object
                 observedGeneration:
                   description: ObservedGeneration is the latest generation observed by the controller.

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -42,6 +42,9 @@ spec:
       #target_size_ratio: ".5"
   # Whether to preserve metadata and data pools on object store deletion
   preservePoolsOnDelete: false
+  # If need to update/rotate the rgw user creds
+  # inputCredentials:
+  #   secretName: xyz
   # The gateway service configuration
   gateway:
     # A reference to the secret in the rook namespace where the ssl certificate is stored

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1701,6 +1701,18 @@ type ObjectStoreUserStatus struct {
 	// ObservedGeneration is the latest generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Input Credentials for the cephObjectUser
+	// +optional
+	InputCredentials *ObjectUserInputCredentialsStatus `json:"inputCredentialsStatus,omitempty"`
+}
+
+type ObjectUserInputCredentialsStatus struct {
+	// SecretName for input Credentials for the cephObjectUser
+	// +optional
+	SecretName string `json:"secretName,omitempty"`
+	// The generation of the above secret Rook last used to apply creds
+	// +optional
+	SecretGeneration int64 `json:"secretGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -1729,6 +1741,15 @@ type ObjectStoreUserSpec struct {
 	// The namespace where the parent CephCluster and CephObjectStore are found
 	// +optional
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+	// Input Credentials for the cephObjectUser
+	// +optional
+	InputCredentials *ObjectUserInputCredentials `json:"inputCredentials,omitempty"`
+}
+
+type ObjectUserInputCredentials struct {
+	// SecretName for input Credentials for the cephObjectUser
+	// +optional
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // Additional admin-level capabilities for the Ceph object store user

--- a/pkg/operator/ceph/object/secret/secret.go
+++ b/pkg/operator/ceph/object/secret/secret.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/pkg/errors"
+)
+
+const (
+	//#nosec G101 -- This is the name of an annotation key, not a secret
+	UpdateObjectUserSecretAnnotation = "rook.io/source-of-truth"
+	SourceOfTruthSecret              = "secret"
+)
+
+// Credential is the user credential values
+type Credential struct {
+	AccessKey string `json:"access_key" url:"access-key"`
+	SecretKey string `json:"secret_key" url:"secret-key"`
+}
+
+func ValidateCredentials(accessKey, secretKey string, credentials []Credential) ([]Credential, error) {
+	// if len is 0 just update the credentials array with the accessKey and secretKey key
+	if len(credentials) == 0 {
+		credentials = []Credential{
+			{AccessKey: accessKey,
+				SecretKey: secretKey}}
+		return credentials, nil
+	}
+	// match if the credentials array contains the accessKey and secretKey key
+	for i := range credentials {
+		if credentials[i].AccessKey == accessKey && credentials[0].SecretKey == secretKey {
+			return credentials, nil
+		}
+	}
+
+	return credentials, errors.Errorf("secret keys data is invalid, please update the secret with valid format")
+}
+
+func UnmarshalKeys(credentials []byte) ([]Credential, error) {
+	var userKeys []Credential
+	err := json.Unmarshal(credentials, &userKeys)
+	if err != nil {
+		return userKeys, errors.Wrapf(err, "unable to unmarshal credentials from the object secret")
+	}
+	return userKeys, nil
+}
+
+func GetUserDefinedSecretAnnotations(annotations map[string]string) bool {
+	if value, found := annotations[UpdateObjectUserSecretAnnotation]; found {
+		if strings.EqualFold(value, SourceOfTruthSecret) {
+			return true
+		}
+	}
+	return false
+}
+
+func UpdatecredentialsUserId(uid, displayName string, credentials []Credential) []admin.UserKeySpec {
+	var updatedCredentials []admin.UserKeySpec
+	for i := range credentials {
+		userSpec := admin.UserKeySpec{User: displayName, UID: uid, AccessKey: credentials[i].AccessKey, SecretKey: credentials[i].SecretKey}
+		updatedCredentials = append(updatedCredentials, userSpec)
+	}
+
+	return updatedCredentials
+}

--- a/pkg/operator/ceph/object/secret/secret.go
+++ b/pkg/operator/ceph/object/secret/secret.go
@@ -18,16 +18,9 @@ package secret
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
-)
-
-const (
-	//#nosec G101 -- This is the name of an annotation key, not a secret
-	UpdateObjectUserSecretAnnotation = "rook.io/source-of-truth"
-	SourceOfTruthSecret              = "secret"
 )
 
 // Credential is the user credential values
@@ -61,15 +54,6 @@ func UnmarshalKeys(credentials []byte) ([]Credential, error) {
 		return userKeys, errors.Wrapf(err, "unable to unmarshal credentials from the object secret")
 	}
 	return userKeys, nil
-}
-
-func GetUserDefinedSecretAnnotations(annotations map[string]string) bool {
-	if value, found := annotations[UpdateObjectUserSecretAnnotation]; found {
-		if strings.EqualFold(value, SourceOfTruthSecret) {
-			return true
-		}
-	}
-	return false
 }
 
 func UpdatecredentialsUserId(uid, displayName string, credentials []Credential) []admin.UserKeySpec {

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/ceph/object/secret"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	corev1 "k8s.io/api/core/v1"
@@ -246,9 +245,9 @@ func generateCephUserSecret(userConfig *admin.User, endpoint, namespace, storeNa
 	secretName := GenerateCephUserSecretName(storeName, userConfig.ID)
 	accessKey := userConfig.Keys[0].AccessKey
 	secretKey := userConfig.Keys[0].SecretKey
-	credentials := []secret.Credential{
-		{AccessKey: accessKey,
-			SecretKey: secretKey}}
+	// TODO
+	//marshal []admin.UserKeySpec to []secret.Credential
+	credentials := userConfig.Keys
 	credentialsKeys, err := json.Marshal(credentials)
 	if err != nil {
 		return &corev1.Secret{}, err


### PR DESCRIPTION
CephObjectStoreUser should optionally be able to reference a secret where S3 key is defined. This enables us to specify the accesskey and accesssecret rather than those values being randomly generated.

Closes: https://github.com/rook/rook/issues/11563

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
