### PR TITLE
helm: Separate repository and tags for csi images in the operator chart

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -53,18 +53,21 @@ The following table lists the configurable parameters of the rook-operator chart
 | `containerSecurityContext` | Set the container security context for the operator | `{"capabilities":{"drop":["ALL"]},"runAsGroup":2016,"runAsNonRoot":true,"runAsUser":2016}` |
 | `crds.enabled` | Whether the helm chart should create and update the CRDs. If false, the CRDs must be managed independently with deploy/examples/crds.yaml. **WARNING** Only set during first deployment. If later disabled the cluster may be DESTROYED. If the CRDs are deleted in this case, see [the disaster recovery guide](https://rook.io/docs/rook/latest/Troubleshooting/disaster-recovery/#restoring-crds-after-deletion) to restore them. | `true` |
 | `csi.allowUnsupportedVersion` | Allow starting an unsupported ceph-csi image | `false` |
-| `csi.attacher.image` | Kubernetes CSI Attacher image | `registry.k8s.io/sig-storage/csi-attacher:v4.5.0` |
+| `csi.attacher.repository` | Kubernetes CSI Attacher image repository | `"registry.k8s.io/sig-storage/csi-attacher"` |
+| `csi.attacher.tag` | Attacher image tag | `"v4.5.0"` |
 | `csi.cephFSAttachRequired` | Whether to skip any attach operation altogether for CephFS PVCs. See more details [here](https://kubernetes-csi.github.io/docs/skip-attach.html#skip-attach-with-csi-driver-object). If cephFSAttachRequired is set to false it skips the volume attachments and makes the creation of pods using the CephFS PVC fast. **WARNING** It's highly discouraged to use this for CephFS RWO volumes. Refer to this [issue](https://github.com/kubernetes/kubernetes/issues/103305) for more details. | `true` |
 | `csi.cephFSFSGroupPolicy` | Policy for modifying a volume's ownership or permissions when the CephFS PVC is being mounted. supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html | `"File"` |
 | `csi.cephFSKernelMountOptions` | Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options. Set to "ms_mode=secure" when connections.encrypted is enabled in CephCluster CR | `nil` |
 | `csi.cephFSPluginUpdateStrategy` | CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
 | `csi.cephFSPluginUpdateStrategyMaxUnavailable` | A maxUnavailable parameter of CSI cephFS plugin daemonset update strategy. | `1` |
-| `csi.cephcsi.image` | Ceph CSI image | `quay.io/cephcsi/cephcsi:v3.11.0` |
+| `csi.cephcsi.repository` | Ceph CSI image repository | `"quay.io/cephcsi/cephcsi"` |
+| `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.11.0"` |
 | `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port | `9081` |
 | `csi.cephfsPodLabels` | Labels to add to the CSI CephFS Deployments and DaemonSets Pods | `nil` |
 | `csi.clusterName` | Cluster name identifier to set as metadata on the CephFS subvolume and RBD images. This will be useful in cases like for example, when two container orchestrator clusters (Kubernetes/OCP) are using a single ceph cluster | `nil` |
 | `csi.csiAddons.enabled` | Enable CSIAddons | `false` |
-| `csi.csiAddons.image` | CSIAddons Sidecar image | `"quay.io/csiaddons/k8s-sidecar:v0.8.0"` |
+| `csi.csiAddons.repository` | CSIAddons sidecar image repository | `"quay.io/csiaddons/k8s-sidecar"` |
+| `csi.csiAddons.tag` | CSIAddons sidecar image tag | `"v0.8.0"` |
 | `csi.csiAddonsPort` | CSI Addons server port | `9070` |
 | `csi.csiCephFSPluginResource` | CEPH CSI CephFS plugin resource requirement list | see values.yaml |
 | `csi.csiCephFSPluginVolume` | The volume of the CephCSI CephFS plugin DaemonSet | `nil` |
@@ -107,7 +110,8 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.pluginNodeAffinity` | The node labels for affinity of the CephCSI RBD plugin DaemonSet [^1] | `nil` |
 | `csi.pluginPriorityClassName` | PriorityClassName to be set on csi driver plugin pods | `"system-node-critical"` |
 | `csi.pluginTolerations` | Array of tolerations in YAML format which will be added to CephCSI plugin DaemonSet | `nil` |
-| `csi.provisioner.image` | Kubernetes CSI provisioner image | `registry.k8s.io/sig-storage/csi-provisioner:v4.0.0` |
+| `csi.provisioner.repository` | Kubernetes CSI provisioner image repository | `"registry.k8s.io/sig-storage/csi-provisioner"` |
+| `csi.provisioner.tag` | Provisioner image tag | `"v4.0.0"` |
 | `csi.provisionerNodeAffinity` | The node labels for affinity of the CSI provisioner deployment [^1] | `nil` |
 | `csi.provisionerPriorityClassName` | PriorityClassName to be set on csi driver provisioner pods | `"system-cluster-critical"` |
 | `csi.provisionerReplicas` | Set replicas for csi provisioner deployment | `2` |
@@ -118,14 +122,17 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.rbdPluginUpdateStrategy` | CSI RBD plugin daemonset update strategy, supported values are OnDelete and RollingUpdate | `RollingUpdate` |
 | `csi.rbdPluginUpdateStrategyMaxUnavailable` | A maxUnavailable parameter of CSI RBD plugin daemonset update strategy. | `1` |
 | `csi.rbdPodLabels` | Labels to add to the CSI RBD Deployments and DaemonSets Pods | `nil` |
-| `csi.registrar.image` | Kubernetes CSI registrar image | `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0` |
-| `csi.resizer.image` | Kubernetes CSI resizer image | `registry.k8s.io/sig-storage/csi-resizer:v1.10.0` |
+| `csi.registrar.repository` | Kubernetes CSI registrar image repository | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` |
+| `csi.registrar.tag` | Registrar image tag | `"v2.10.0"` |
+| `csi.resizer.repository` | Kubernetes CSI resizer image repository | `"registry.k8s.io/sig-storage/csi-resizer"` |
+| `csi.resizer.tag` | Resizer image tag | `"v1.10.0"` |
 | `csi.serviceMonitor.enabled` | Enable ServiceMonitor for Ceph CSI drivers | `false` |
 | `csi.serviceMonitor.interval` | Service monitor scrape interval | `"10s"` |
 | `csi.serviceMonitor.labels` | ServiceMonitor additional labels | `{}` |
 | `csi.serviceMonitor.namespace` | Use a different namespace for the ServiceMonitor | `nil` |
 | `csi.sidecarLogLevel` | Set logging level for Kubernetes-csi sidecar containers. Supported values from 0 to 5. 0 for general useful logs (the default), 5 for trace level verbosity. | `0` |
-| `csi.snapshotter.image` | Kubernetes CSI snapshotter image | `registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1` |
+| `csi.snapshotter.repository` | Kubernetes CSI snapshotter image repository | `"registry.k8s.io/sig-storage/csi-snapshotter"` |
+| `csi.snapshotter.tag` | Snapshotter image tag | `"v7.0.1"` |
 | `csi.topology.domainLabels` | domainLabels define which node labels to use as domains for CSI nodeplugins to advertise their domains | `nil` |
 | `csi.topology.enabled` | Enable topology based provisioning | `false` |
 | `currentNamespaceOnly` | Whether the operator should watch cluster CRD in its own namespace or not | `false` |

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -60,6 +60,10 @@ those releases.
   If there are pods named `csi-*plugin-holder-*` in the Rook operator namespace, see the
   [detailed documentation](../CRDs/Cluster/network-providers.md#holder-pod-deprecation)
   to disable them. This is optional for v1.14, but will be required in a future release.
+* In the operator helm chart, the images for the CSI driver are now specified with separate
+  `repository` and `tag` values. If the CSI images have been customized, convert them from the
+  `image` value to the separated `repository` and `tag` values.
+
 
 ## Considerations
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -23,3 +23,4 @@
 - Support for virtual style hosting for s3 buckets in the CephObjectStore.
 - Add option to specify prefix for the OBC provisioner.
 - Support Azure Key Vault for storing OSD encryption keys.
+- Separate image repository and tag values in the helm chart for the CSI images.

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -80,33 +80,33 @@ data:
   CSI_LEADER_ELECTION_RETRY_PERIOD: {{ .Values.csi.csiLeaderElectionRetryPeriod | quote }}
 {{- end }}
 {{- if .Values.csi.cephcsi }}
-{{- if .Values.csi.cephcsi.image }}
-  ROOK_CSI_CEPH_IMAGE: {{ .Values.csi.cephcsi.image | quote }}
+{{- if and .Values.csi.cephcsi.repository .Values.csi.cephcsi.tag }}
+  ROOK_CSI_CEPH_IMAGE: "{{ .Values.csi.cephcsi.repository }}:{{ .Values.csi.cephcsi.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.registrar }}
-{{- if .Values.csi.registrar.image }}
-  ROOK_CSI_REGISTRAR_IMAGE: {{ .Values.csi.registrar.image | quote }}
+{{- if and .Values.csi.registrar.repository .Values.csi.registrar.tag }}
+  ROOK_CSI_REGISTRAR_IMAGE: "{{ .Values.csi.registrar.repository }}:{{ .Values.csi.registrar.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.provisioner }}
-{{- if .Values.csi.provisioner.image }}
-  ROOK_CSI_PROVISIONER_IMAGE: {{ .Values.csi.provisioner.image | quote }}
+{{- if and .Values.csi.provisioner.repository .Values.csi.provisioner.tag }}
+  ROOK_CSI_PROVISIONER_IMAGE: "{{ .Values.csi.provisioner.repository }}:{{ .Values.csi.provisioner.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.snapshotter }}
-{{- if .Values.csi.snapshotter.image }}
-  ROOK_CSI_SNAPSHOTTER_IMAGE: {{ .Values.csi.snapshotter.image | quote }}
+{{- if and .Values.csi.snapshotter.repository .Values.csi.snapshotter.tag }}
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .Values.csi.snapshotter.repository }}:{{ .Values.csi.snapshotter.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.attacher }}
-{{- if .Values.csi.attacher.image }}
-  ROOK_CSI_ATTACHER_IMAGE: {{ .Values.csi.attacher.image | quote }}
+{{- if and .Values.csi.attacher.repository .Values.csi.attacher.tag }}
+  ROOK_CSI_ATTACHER_IMAGE: "{{ .Values.csi.attacher.repository }}:{{ .Values.csi.attacher.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.resizer }}
-{{- if .Values.csi.resizer.image }}
-  ROOK_CSI_RESIZER_IMAGE: {{ .Values.csi.resizer.image | quote }}
+{{- if and .Values.csi.resizer.repository .Values.csi.resizer.tag }}
+  ROOK_CSI_RESIZER_IMAGE: "{{ .Values.csi.resizer.repository }}:{{ .Values.csi.resizer.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.imagePullPolicy }}
@@ -114,8 +114,8 @@ data:
 {{- end }}
 {{- if .Values.csi.csiAddons }}
   CSI_ENABLE_CSIADDONS: {{ .Values.csi.csiAddons.enabled | quote }}
-{{- if .Values.csi.csiAddons.image }}
-  ROOK_CSIADDONS_IMAGE: {{ .Values.csi.csiAddons.image | quote }}
+{{- if and .Values.csi.csiAddons.repository .Values.csi.csiAddons.tag }}
+  ROOK_CSIADDONS_IMAGE: "{{ .Values.csi.csiAddons.repository }}:{{ .Values.csi.csiAddons.tag }}"
 {{- end }}
 {{- end }}
 {{- if .Values.csi.topology }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -478,34 +478,40 @@ csi:
   csiLeaderElectionRetryPeriod:
 
   cephcsi:
-    # -- Ceph CSI image
-    # @default -- `quay.io/cephcsi/cephcsi:v3.11.0`
-    image:
+    # -- Ceph CSI image repository
+    repository: quay.io/cephcsi/cephcsi
+    # -- Ceph CSI image tag
+    tag: v3.11.0
 
   registrar:
-    # -- Kubernetes CSI registrar image
-    # @default -- `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0`
-    image:
+    # -- Kubernetes CSI registrar image repository
+    repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    # -- Registrar image tag
+    tag: v2.10.0
 
   provisioner:
-    # -- Kubernetes CSI provisioner image
-    # @default -- `registry.k8s.io/sig-storage/csi-provisioner:v4.0.0`
-    image:
+    # -- Kubernetes CSI provisioner image repository
+    repository: registry.k8s.io/sig-storage/csi-provisioner
+    # -- Provisioner image tag
+    tag: v4.0.0
 
   snapshotter:
-    # -- Kubernetes CSI snapshotter image
-    # @default -- `registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1`
-    image:
+    # -- Kubernetes CSI snapshotter image repository
+    repository: registry.k8s.io/sig-storage/csi-snapshotter
+    # -- Snapshotter image tag
+    tag: v7.0.1
 
   attacher:
-    # -- Kubernetes CSI Attacher image
-    # @default -- `registry.k8s.io/sig-storage/csi-attacher:v4.5.0`
-    image:
+    # -- Kubernetes CSI Attacher image repository
+    repository: registry.k8s.io/sig-storage/csi-attacher
+    # -- Attacher image tag
+    tag: v4.5.0
 
   resizer:
-    # -- Kubernetes CSI resizer image
-    # @default -- `registry.k8s.io/sig-storage/csi-resizer:v1.10.0`
-    image:
+    # -- Kubernetes CSI resizer image repository
+    repository: registry.k8s.io/sig-storage/csi-resizer
+    # -- Resizer image tag
+    tag: v1.10.0
 
   # -- Image pull policy
   imagePullPolicy: IfNotPresent
@@ -522,8 +528,10 @@ csi:
   csiAddons:
     # -- Enable CSIAddons
     enabled: false
-    # -- CSIAddons Sidecar image
-    image: "quay.io/csiaddons/k8s-sidecar:v0.8.0"
+    # -- CSIAddons sidecar image repository
+    repository: quay.io/csiaddons/k8s-sidecar
+    # -- CSIAddons sidecar image tag
+    tag: v0.8.0
 
   nfs:
     # -- Enable the nfs csi driver


### PR DESCRIPTION
The csi images in the operator helm chart previously were a single image name including the repository and tag in a single string. Now the repository and tag values are separated to allow for greater customization of the repository from the version tags.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13585

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
