### PR TITLE
rgw: fix typo on crd endpoint address

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5556,7 +5556,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.</p>
+<p>The IP of this endpoint. As a legacy behavior, this supports being given a DNS-addressable hostname as well.</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -10313,7 +10313,7 @@ spec:
                             description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
                             type: string
                           ip:
-                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
+                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-addressable hostname as well.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -10304,7 +10304,7 @@ spec:
                             description: The DNS-addressable Hostname of this endpoint. This field will be preferred over IP if both are given.
                             type: string
                           ip:
-                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
+                            description: The IP of this endpoint. As a legacy behavior, this supports being given a DNS-addressable hostname as well.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1613,7 +1613,7 @@ type GatewaySpec struct {
 // Kubernetes's v1.EndpointAddress.
 // +structType=atomic
 type EndpointAddress struct {
-	// The IP of this endpoint. As a legacy behavior, this supports being given a DNS-adressable hostname as well.
+	// The IP of this endpoint. As a legacy behavior, this supports being given a DNS-addressable hostname as well.
 	// +optional
 	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
 


### PR DESCRIPTION
The rgw endpoint address had a typo

Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
