### PR TITLE
doc: make CSI host netowrking required

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -108,7 +108,7 @@ The upgrade steps in this guide will clarify what Helm handles automatically.
 
 !!! important
     If there are pods named `csi-*plugin-holder-*` in the Rook operator namespace, set the new
-    config `disableHolderPods: false` in the values.yaml before upgrading to v1.14.
+    config `csi.disableHolderPods: false` in the values.yaml before upgrading to v1.14.
 
 The `rook-ceph` helm chart upgrade performs the Rook upgrade.
 The `rook-ceph-cluster` helm chart upgrade performs a [Ceph upgrade](#ceph-version-upgrades) if the Ceph image is updated.


### PR DESCRIPTION
The network providers doc, including the holder pod migration sections, were developed with the understanding that CSI could be placed into pod networking mode if desired by users. In reality, this hasn't been supported due to bugs.

This allows streamlining the holder pod migration sections to no longer need to document for users what to do if they use CSI in pod network mode.

Rook will continue to have the `CSI_ENABLE_HOST_NETWORK` config available as an undocumented value. This can allow users who desperately cannot use host networking to still use pod networking, though this will mean any CSI node plugin updates could stall mounts for running apps. Thus we do not support it.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
