### PR TITLE
object: virtulhostnames is not required in the endpoint for rgw

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -348,9 +348,6 @@ func getDomainName(s *cephv1.CephObjectStore, returnRandomDomainIfMultiple bool)
 		for _, e := range s.Spec.Gateway.ExternalRgwEndpoints {
 			endpoints = append(endpoints, e.String())
 		}
-	} else if s.Spec.Hosting != nil && len(s.Spec.Hosting.DNSNames) > 0 {
-		// if the store is internal and has DNS names, pick a random DNS name to use
-		endpoints = s.Spec.Hosting.DNSNames
 	} else {
 		return domainNameOfService(s)
 	}


### PR DESCRIPTION
The endpoint of cephobjectstore is populated with help of `BuildDNSEndpoint` which combines domain name from `getDomainName` and `port` in the `objectstore.spec.gateway`. This approach is used in most of the Rook code base and even for adminsops api for Rook to communicate with RGW.
In case  vhost feature is enabled it returns the domain from rgw DNS name list, but the domain picked may not have the same port as the rgw internal port which is failing for adminsops use case. So the populated endpoint in this case is wrong.
Even if the feature is enabled by default rgw service endpoint will be part of the rgw DNS names so we can pick RGW service endpoint for all the internal communications
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
