### PR TITLE
Cleanup RADOS namespace with forced deletion annotation

### DIFF
--- a/Documentation/Storage-Configuration/ceph-teardown.md
+++ b/Documentation/Storage-Configuration/ceph-teardown.md
@@ -200,6 +200,7 @@ Once the cleanup job is completed successfully, Rook will remove the finalizers 
 
 This cleanup is supported only for the following custom resources:
 
-| Custom Resource                                | Ceph Resources to be cleaned up |
-| --------                                       | ------- |
-| CephFilesystemSubVolumeGroup                   | CSI stored RADOS OMAP details for pvc/volumesnapshots, subvolume snapshots, subvolume clones, subvolumes |
+| Custom Resource                      | Ceph Resources to be cleaned up |
+| --------                             | ------- |
+| CephFilesystemSubVolumeGroup         | CSI stored RADOS OMAP details for pvc/volumesnapshots, subvolume snapshots, subvolume clones, subvolumes |
+| CephBlockPoolRadosNamespace          | Images and snapshots in the RADOS namespace|

--- a/pkg/daemon/ceph/cleanup/radosnamespace.go
+++ b/pkg/daemon/ceph/cleanup/radosnamespace.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+)
+
+func RadosNamespaceCleanup(context *clusterd.Context, clusterInfo *client.ClusterInfo, poolName, radosNamespace string) error {
+	logger.Infof("starting clean up of CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+
+	images, err := cephclient.ListImagesInRadosNamespace(context, clusterInfo, poolName, radosNamespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list images in cephblockpool %q in rados namespace %q", poolName, radosNamespace)
+	}
+
+	var retErr error
+	for _, image := range images {
+		snaps, err := cephclient.ListSnapshotsInRadosNamespace(context, clusterInfo, poolName, image.Name, radosNamespace)
+		if err != nil {
+			retErr = errors.Wrapf(err, "failed to list snapshots for the image %q in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			logger.Error(retErr)
+		}
+
+		for _, snap := range snaps {
+			err := cephclient.DeleteSnapshotInRadosNamespace(context, clusterInfo, poolName, image.Name, snap.Name, radosNamespace)
+			if err != nil {
+				retErr = errors.Wrapf(err, "failed to delete snapshot %q of the image %q in cephblockpool %q in rados namespace %q.", snap.Name, image.Name, poolName, radosNamespace)
+				logger.Error(retErr)
+			} else {
+				logger.Infof("successfully deleted snapshot %q of image %q in cephblockpool %q in rados namespace %q", snap.Name, image.Name, poolName, radosNamespace)
+			}
+		}
+
+		err = cephclient.MoveImageToTrashInRadosNamespace(context, clusterInfo, poolName, image.Name, radosNamespace)
+		if err != nil {
+			retErr = errors.Wrapf(err, "failed to move image %q to trash in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			logger.Error(retErr)
+		}
+		err = cephclient.DeleteImageFromTrashInRadosNamespace(context, clusterInfo, poolName, image.ID, radosNamespace)
+		if err != nil {
+			retErr = errors.Wrapf(err, "failed to add task to remove image %q from trash in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			logger.Error(retErr)
+		}
+	}
+
+	if retErr != nil {
+		logger.Errorf("failed to clean up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+		return retErr
+	}
+
+	logger.Infof("successfully cleaned up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+	return nil
+}

--- a/pkg/daemon/ceph/cleanup/radosnamespace_test.go
+++ b/pkg/daemon/ceph/cleanup/radosnamespace_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	mockImageLSResponse   = `[{"image":"csi-vol-136268e8-5386-4453-a6bd-9dca381d187d","id":"16e35cfa56a7","size":1073741824,"format":2}]`
+	mockSnapshotsResponse = `[{"id":5,"name":"snap1","size":1073741824,"protected":"false","timestamp":"Fri Apr 12 13:39:28 2024"}]`
+)
+
+func TestRadosNamespace(t *testing.T) {
+	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
+	poolName := "test-pool"
+	radosNamespace := "test-namespace"
+
+	t.Run("no images in rados namespace", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			if args[0] == "ls" && args[1] == "-l" {
+				assert.Equal(t, poolName, args[2])
+				return "", nil
+			}
+			return "", errors.New("unknown command")
+		}
+		context := &clusterd.Context{Executor: executor}
+		err := RadosNamespaceCleanup(context, clusterInfo, poolName, radosNamespace)
+		assert.NoError(t, err)
+	})
+
+	t.Run("images with snapshots available in rados namespace", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			// list all subvolumes in subvolumegroup
+			if args[0] == "ls" && args[1] == "-l" {
+				assert.Equal(t, poolName, args[2])
+				return mockImageLSResponse, nil
+			}
+			if args[0] == "snap" && args[1] == "ls" {
+				assert.Equal(t, "test-pool/csi-vol-136268e8-5386-4453-a6bd-9dca381d187d", args[2])
+				assert.Equal(t, "--namespace", args[3])
+				assert.Equal(t, radosNamespace, args[4])
+				return mockSnapshotsResponse, nil
+			}
+			if args[0] == "snap" && args[1] == "rm" {
+				assert.Equal(t, "test-pool/csi-vol-136268e8-5386-4453-a6bd-9dca381d187d@snap1", args[2])
+				assert.Equal(t, "--namespace", args[3])
+				assert.Equal(t, radosNamespace, args[4])
+				return "", nil
+			}
+			if args[0] == "trash" && args[1] == "mv" {
+				assert.Equal(t, "test-pool/csi-vol-136268e8-5386-4453-a6bd-9dca381d187d", args[2])
+				assert.Equal(t, "--namespace", args[3])
+				assert.Equal(t, radosNamespace, args[4])
+				return "", nil
+			}
+			if args[0] == "rbd" && args[1] == "task" && args[2] == "add" && args[3] == "trash" {
+				// pool-name/rados-namespace/image-id
+				assert.Equal(t, "test-pool/test-namespace/16e35cfa56a7", args[5])
+				return "", nil
+			}
+			return "", errors.New("unknown command")
+		}
+		context := &clusterd.Context{Executor: executor}
+		err := RadosNamespaceCleanup(context, clusterInfo, poolName, radosNamespace)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -187,7 +187,7 @@ func TestListImageLogLevelInfo(t *testing.T) {
 	}
 
 	clusterInfo := AdminTestClusterInfo("mycluster")
-	images, err = ListImages(context, clusterInfo, "pool1")
+	images, err = ListImagesInPool(context, clusterInfo, "pool1")
 	assert.Nil(t, err)
 	assert.NotNil(t, images)
 	assert.True(t, len(images) == 3)
@@ -195,7 +195,7 @@ func TestListImageLogLevelInfo(t *testing.T) {
 	listCalled = false
 
 	emptyListResult = true
-	images, err = ListImages(context, clusterInfo, "pool1")
+	images, err = ListImagesInPool(context, clusterInfo, "pool1")
 	assert.Nil(t, err)
 	assert.NotNil(t, images)
 	assert.True(t, len(images) == 0)
@@ -251,7 +251,7 @@ func TestListImageLogLevelDebug(t *testing.T) {
 	}
 
 	clusterInfo := AdminTestClusterInfo("mycluster")
-	images, err = ListImages(context, clusterInfo, "pool1")
+	images, err = ListImagesInPool(context, clusterInfo, "pool1")
 	assert.Nil(t, err)
 	assert.NotNil(t, images)
 	assert.True(t, len(images) == 3)
@@ -259,7 +259,7 @@ func TestListImageLogLevelDebug(t *testing.T) {
 	listCalled = false
 
 	emptyListResult = true
-	images, err = ListImages(context, clusterInfo, "pool1")
+	images, err = ListImagesInPool(context, clusterInfo, "pool1")
 	assert.Nil(t, err)
 	assert.NotNil(t, images)
 	assert.True(t, len(images) == 0)

--- a/pkg/operator/ceph/controller/cleanup.go
+++ b/pkg/operator/ceph/controller/cleanup.go
@@ -40,6 +40,10 @@ const (
 	CephFSNameEnv               = "FILESYSTEM_NAME"
 	CSICephFSRadosNamesaceEnv   = "CSI_CEPHFS_RADOS_NAMESPACE"
 	CephFSMetaDataPoolNameEnv   = "METADATA_POOL_NAME"
+
+	// cephblockpoolradosnamespace env resources
+	CephBlockPoolNameEnv           = "BLOCKPOOL_NAME"
+	CephBlockPoolRadosNamespaceEnv = "RADOS_NAMESPACE"
 )
 
 // ResourceCleanup defines an rook ceph resource to be cleaned up

--- a/pkg/operator/ceph/controller/cleanup_test.go
+++ b/pkg/operator/ceph/controller/cleanup_test.go
@@ -55,10 +55,7 @@ func TestJobTemplateSpec(t *testing.T) {
 	cleanup := NewResourceCleanup(svgObj, cluster, rookImage, testConfig)
 	podTemplateSpec := cleanup.jobTemplateSpec()
 	assert.Equal(t, "CephFSSubvolumeGroup", podTemplateSpec.Spec.Containers[0].Args[2])
-	assert.Equal(t, "config1", podTemplateSpec.Spec.Containers[0].Env[3].Name)
-	assert.Equal(t, "value1", podTemplateSpec.Spec.Containers[0].Env[3].Value)
-	assert.Equal(t, "config2", podTemplateSpec.Spec.Containers[0].Env[4].Name)
-	assert.Equal(t, "value2", podTemplateSpec.Spec.Containers[0].Env[4].Value)
+	assert.Equal(t, 5, len(podTemplateSpec.Spec.Containers[0].Env))
 }
 
 func TestForceDeleteRequested(t *testing.T) {

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -161,7 +161,7 @@ func (b *BlockOperation) ListAllImages(clusterInfo *client.ClusterInfo) ([]Block
 func (b *BlockOperation) ListImagesInPool(clusterInfo *client.ClusterInfo, poolName string) ([]BlockImage, error) {
 	// for each pool, get further details about all the images in the pool
 	images := []BlockImage{}
-	cephImages, err := client.ListImages(b.k8sClient.MakeContext(), clusterInfo, poolName)
+	cephImages, err := client.ListImagesInPool(b.k8sClient.MakeContext(), clusterInfo, poolName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from pool %s: %+v", poolName, err)
 	}
@@ -182,7 +182,7 @@ func (b *BlockOperation) ListImagesInPool(clusterInfo *client.ClusterInfo, poolN
 // DeleteBlockImage Function to list all the blocks created/being managed by rook
 func (b *BlockOperation) DeleteBlockImage(clusterInfo *client.ClusterInfo, image BlockImage) error {
 	context := b.k8sClient.MakeContext()
-	return client.DeleteImage(context, clusterInfo, image.Name, image.PoolName)
+	return client.DeleteImageInPool(context, clusterInfo, image.Name, image.PoolName)
 }
 
 // CreateClientPod starts a pod that should have a block PVC.


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
If RadosNamespace CR is deleted with `rook.io/force-deletion` annotation then start a clean up job that will delete the images and snapshots on the radosnamespace. 
Steps followed for cleanup:

- List images in pool
- List snapshots for each image.
- Delete snapshots for each image. 
- Move Image to trash
- Start a task to delete the trash. 

Operator logs  after deleting radosNamespace CR with annotation
[operator-logs.txt](https://github.com/rook/rook/files/14959940/operator-logs.txt)


<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:*
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
