### PR TITLE
object: declare object store `hosting` section experimental

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -155,6 +155,9 @@ The [zone](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.
 
 ## Hosting Settings
 
+!!! warning
+    The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
+
 The hosting settings allow you to host buckets in the object store on a custom DNS name, enabling virtual-hosted-style access to buckets similar to AWS S3 (https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
 
 * `dnsNames`: a list of DNS names to host buckets on. These names need to valid according RFC-1123. Otherwise it will fail. Each endpoint requires wildcard support like [ingress loadbalancer](https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards). Do not include the wildcard itself in the list of hostnames (e.g., use "mystore.example.com" instead of "*.mystore.example.com"). Add all the hostnames like openshift routes otherwise access will be denied, but if the hostname does not support wild card then virtual host style won't work those hostname. By default cephobjectstore service endpoint and custom endpoints from cephobjectzone is included. The feature is supported only for Ceph v18 and later versions.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1980,7 +1980,8 @@ ObjectStoreHostingSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Hosting settings for the object store</p>
+<p>Hosting settings for the object store
+The features provided by the <code>hosting</code> configuration section are experimental. APIs may be subject to change.</p>
 </td>
 </tr>
 </table>
@@ -9038,7 +9039,8 @@ bool
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ObjectStoreSpec">ObjectStoreSpec</a>)
 </p>
 <div>
-<p>ObjectStoreHostingSpec represents the hosting settings for the object store</p>
+<p>ObjectStoreHostingSpec represents the hosting settings for the object store
+The features provided by the <code>hosting</code> configuration section are experimental. APIs may be subject to change.</p>
 </div>
 <table>
 <thead>
@@ -9266,7 +9268,8 @@ ObjectStoreHostingSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Hosting settings for the object store</p>
+<p>Hosting settings for the object store
+The features provided by the <code>hosting</code> configuration section are experimental. APIs may be subject to change.</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11193,7 +11193,9 @@ spec:
                       type: object
                   type: object
                 hosting:
-                  description: Hosting settings for the object store
+                  description: |-
+                    Hosting settings for the object store
+                    The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
                   properties:
                     dnsNames:
                       description: |-

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11184,7 +11184,9 @@ spec:
                       type: object
                   type: object
                 hosting:
-                  description: Hosting settings for the object store
+                  description: |-
+                    Hosting settings for the object store
+                    The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
                   properties:
                     dnsNames:
                       description: |-

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -108,6 +108,7 @@ spec:
       disabled: false
     readinessProbe:
       disabled: false
+  # # The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
   # hosting:
   #   The list of subdomain names for virtual hosting of buckets.
   #   dnsNames:

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -34,10 +34,11 @@ spec:
     port: 80
     securePort: 443
     instances: 3
-    hosting:
-      dnsNames:
-      - "my-ingress.mydomain.com"
-      - "rook-ceph-rgw-my-store.rook-ceph.svc"
+  # The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
+  hosting:
+    dnsNames:
+    - "my-ingress.mydomain.com"
+    - "rook-ceph-rgw-my-store.rook-ceph.svc"
 ```
 
 Now create the object store.
@@ -343,6 +344,7 @@ For accessing the bucket point user need to configure wildcard dns in the cluste
 
 ```yaml
 spec:
+  # The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
   hosting:
     dnsNames:
     - "my-ingress.mydomain.com"

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1479,6 +1479,7 @@ type ObjectStoreSpec struct {
 	AllowUsersInNamespaces []string `json:"allowUsersInNamespaces,omitempty"`
 
 	// Hosting settings for the object store
+	// The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
 	// +optional
 	Hosting *ObjectStoreHostingSpec `json:"hosting,omitempty"`
 }
@@ -1655,6 +1656,7 @@ type ObjectEndpoints struct {
 }
 
 // ObjectStoreHostingSpec represents the hosting settings for the object store
+// The features provided by the `hosting` configuration section are experimental. APIs may be subject to change.
 type ObjectStoreHostingSpec struct {
 	// A list of DNS names in which bucket can be accessed via virtual host path. These names need to valid according RFC-1123.
 	// Each domain requires wildcard support like ingress loadbalancer.


### PR DESCRIPTION
Declare the CephObjectStore `hosting` section experimental in CRDs and docs. Early user feedback is showing that there may be issues getting the feature to work with OBCs/COSI, possibly involving port changes between wildcard-capable endpoints and the RGW. hosting.dnsNames may need to have its API changed to allow port specs, and declaring the API experimental will allow us to do so without causing unexpected stress on users.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
