### PR TITLE
mon: Disable the msgr v1 port if msgr2 is required

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -656,26 +656,21 @@ func (c *cluster) configureMsgr2() error {
 		}
 	}
 	// Set network compression
-	if c.ClusterInfo.CephVersion.IsAtLeastQuincy() {
-		if c.Spec.Network.Connections == nil || c.Spec.Network.Connections.Compression == nil || !c.Spec.Network.Connections.Compression.Enabled {
-			encryptionConfig := []config.Option{
-				{Who: "global", Option: "ms_osd_compress_mode"},
-			}
-			if err := monStore.DeleteAll(encryptionConfig...); err != nil {
-				return errors.Wrap(err, "failed to delete msgr2 compression settings")
-			}
-		} else {
-			globalConfigSettings := map[string]string{
-				"ms_osd_compress_mode": "force",
-			}
-			logger.Infof("setting msgr2 compression mode to %q", "force")
-			if err := monStore.SetAll("global", globalConfigSettings); err != nil {
-				return err
-			}
+	if c.Spec.Network.Connections == nil || c.Spec.Network.Connections.Compression == nil || !c.Spec.Network.Connections.Compression.Enabled {
+		encryptionConfig := []config.Option{
+			{Who: "global", Option: "ms_osd_compress_mode"},
 		}
-
+		if err := monStore.DeleteAll(encryptionConfig...); err != nil {
+			return errors.Wrap(err, "failed to delete msgr2 compression settings")
+		}
 	} else {
-		logger.Warningf("network compression requires Ceph Quincy (v17) or newer, skipping for current ceph %q", c.ClusterInfo.CephVersion.String())
+		globalConfigSettings := map[string]string{
+			"ms_osd_compress_mode": "force",
+		}
+		logger.Infof("setting msgr2 compression mode to %q", "force")
+		if err := monStore.SetAll("global", globalConfigSettings); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The mon was listening on both v1 and v2 ports inside the daemon even though the service endpoint would not redirect any traffic to the v1 port. When msgr2 is required, disable the mon from listening on the v1 port for reduced security footprint.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
