### PR TITLE
ci: add multus canary test without holder pods

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1526,7 +1526,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-name: ${{ github.job }}-${{ matrix.ceph-image }}
 
-  multus-cluster-network:
+  multus-cluster-network-with-holder:
     runs-on: ubuntu-22.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     strategy:
@@ -1587,13 +1587,13 @@ jobs:
         run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
-        run: IS_POD_NETWORK=true IS_MULTUS=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+        run: IS_POD_NETWORK=true IS_MULTUS_WITH_HOLDER=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
 
       - name: wait for ceph-csi configmap to be updated with network namespace
         run: tests/scripts/github-action-helper.sh wait_for_ceph_csi_configmap_to_be_updated
 
       - name: wait for cephnfs to be ready
-        run: IS_POD_NETWORK=true IS_MULTUS=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready nfs 1
+        run: IS_POD_NETWORK=true IS_MULTUS_WITH_HOLDER=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready nfs 1
 
       - name: check multus connections
         run: tests/scripts/github-action-helper.sh test_multus_connections
@@ -1614,7 +1614,7 @@ jobs:
           name: ${{ github.job }}-${{ matrix.ceph-image }}
           additional-namespace: kube-system
 
-  csi-hostnetwork-disabled:
+  multus-cluster-network-without-holder:
     runs-on: ubuntu-22.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     strategy:
@@ -1631,31 +1631,57 @@ jobs:
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
 
+      - name: setup golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config
 
-      - name: allow holder pod deployment
-        run: sed -i "s|CSI_DISABLE_HOLDER_PODS|# CSI_DISABLE_HOLDER_PODS|g" "deploy/examples/operator.yaml"
-
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ github.event.inputs.ceph-image }}"
+
+      - name: install deps
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+        run: tests/scripts/github-action-helper.sh install_deps
+
+      - name: print k8s cluster status
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+        run: tests/scripts/github-action-helper.sh print_k8s_cluster_status
+
+      - name: build rook
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+        run: tests/scripts/github-action-helper.sh build_rook
+
+      - name: validate-yaml
+        run: tests/scripts/github-action-helper.sh validate_yaml
 
       - name: use local disk and create partitions for osds
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/github-action-helper.sh create_partitions_for_osds
 
-      - name: deploy CSI hostNetworking disabled cluster
-        run: tests/scripts/github-action-helper.sh deploy_csi_hostnetwork_disabled_cluster
+      - name: deploy multus
+        run: tests/scripts/github-action-helper.sh deploy_multus
+
+      - name: deploy multus cluster
+        run: tests/scripts/github-action-helper.sh deploy_multus_cluster
 
       - name: wait for prepare pod
         run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
-        run: IS_POD_NETWORK=true tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
 
       - name: wait for ceph-csi configmap to be updated with network namespace
         run: tests/scripts/github-action-helper.sh wait_for_ceph_csi_configmap_to_be_updated
+
+      - name: wait for cephnfs to be ready
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready nfs 1
+
+      - name: check multus connections
+        run: tests/scripts/github-action-helper.sh test_multus_connections
 
       - name: test ceph-csi-rbd plugin restart
         run: tests/scripts/github-action-helper.sh test_csi_rbd_workload
@@ -1671,3 +1697,4 @@ jobs:
         uses: ./.github/workflows/collect-logs
         with:
           name: ${{ github.job }}-${{ matrix.ceph-image }}
+          additional-namespace: kube-system

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -104,7 +104,7 @@ function test_demo_pool {
 function test_csi {
   timeout 360 bash -x <<-'EOF'
     echo $IS_POD_NETWORK
-    echo $IS_MULTUS
+    echo $IS_MULTUS_WITH_HOLDER
     if [ -z "$IS_POD_NETWORK" ]; then
       until [[ "$(kubectl -n rook-ceph get pods --field-selector=status.phase=Running|grep -c ^csi-)" -eq 6 ]]; do
         echo "waiting for csi pods to be ready"
@@ -116,7 +116,7 @@ function test_csi {
         sleep 5
       done
     fi
-    if [ -n "$IS_MULTUS" ]; then
+    if [ -n "$IS_MULTUS_WITH_HOLDER" ]; then
       echo "verifying csi holder interfaces (multus ones must be present)"
       kubectl -n rook-ceph exec -t ds/csi-rbdplugin-holder-my-cluster -- grep eth0 /proc/net/dev
       kubectl -n rook-ceph exec -t ds/csi-cephfsplugin-holder-my-cluster -- grep eth0 /proc/net/dev


### PR DESCRIPTION
this commit adds changes to deploy multus with
holder pods disabled and also remove ci test
csi-hostnetwork-disabled as this not really not
supported in rook.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13922 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
