### PR TITLE
docs: document how to have StorageClass consume Rados Namespace

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-rados-namespace-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-rados-namespace-crd.md
@@ -49,3 +49,35 @@ If any setting is unspecified, a suitable default will be used automatically.
 ### Spec
 
 - `blockPoolName`: The metadata name of the CephBlockPool CR where the rados namespace will be created.
+
+## Creating a Storage Class
+
+Once the RADOS namespace is created, an RBD-based StorageClass can be created to
+create PVs in this RADOS namespace. For this purpose, the `clusterID` value from the
+CephBlockPoolRadosNamespace status needs to be put into the `clusterID` field of the StorageClass
+spec. 
+
+Extract the clusterID from the CephBlockPoolRadosNamespace CR:
+
+```console
+$ kubectl -n rook-ceph  get cephblockpoolradosnamespace/namespace-a -o jsonpath='{.status.info.clusterID}'
+80fc4f4bacc064be641633e6ed25ba7e
+```
+
+In this example, replace `namespace-a` by the actual name of the radosnamespace
+created before.
+Now set the `clusterID` retrieved from the previous step into the `clusterID` of the storage class.
+
+Example:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block-rados-ns
+provisioner: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
+parameters:
+  clusterID: 80fc4f4bacc064be641633e6ed25ba7e
+  pool: replicapool
+  ...
+```


### PR DESCRIPTION
## description

This change expands the documentation to describe how to create a storageclass that consumes a `CephBlockPoolRadodNamespace`.



**Issue resolved by this Pull Request:**
Resolves #13214 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
