### PR TITLE
ci: add missing markdownlint CI step

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           python-version: 3.9
 
+      - uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: |
+            Documentation/**/*.md
+            !Documentation/Helm-Charts
+
       - name: Check helm-docs
         run: make check-helm-docs
       - name: Check docs


### PR DESCRIPTION
The CI step that runs markdown lint accidentally got removed as part of PR updates. Add the CI step back in.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
