### PR TITLE
Toolbox image value causes chart to fail

### DIFF
--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -25,7 +25,7 @@ toolbox:
   # -- Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md)
   enabled: false
   # -- Toolbox image, defaults to the image used by the Ceph cluster
-  image: #quay.io/ceph/ceph:v18.2.2
+  # image: quay.io/ceph/ceph:v18.2.2
   # -- Toolbox tolerations
   tolerations: []
   # -- Toolbox affinity


### PR DESCRIPTION
Currently the toolbox image sets no value - either toolbox.image needs to be unset to default to the ceph value or the value should not be commented. I've commented the whole line here as the template shows this is the desired behaviour:

          image: {{ default .Values.cephClusterSpec.cephVersion.image .Values.toolbox.image }}



<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14180 

**Checklist:**

- [ x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x ] Documentation has been updated, if necessary.
- [ x] Unit tests have been added, if necessary.
- [ x] Integration tests have been added, if necessary.
