### PR TITLE
core: do not watch resourceversion and heartbeat node updates

### DIFF
--- a/pkg/operator/ceph/cluster/predicate_test.go
+++ b/pkg/operator/ceph/cluster/predicate_test.go
@@ -18,10 +18,12 @@ package cluster
 
 import (
 	"testing"
+	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsHotPlugCM(t *testing.T) {
@@ -39,4 +41,29 @@ func TestIsHotPlugCM(t *testing.T) {
 
 	cm.Labels["app"] = "rook-discover"
 	assert.True(t, isHotPlugCM(cm))
+}
+
+func TestCompareNodes(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldobj    corev1.Node
+		newobj    corev1.Node
+		reconcile bool
+	}{
+		{"if no changes", corev1.Node{}, corev1.Node{}, false},
+		{"if only Resourceversion got changed", corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "123"}}, corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "145"}}, false},
+		{"if only heartbeat got changed", corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(time.Now())}}}}, corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(<-time.After(5))}}}}, false},
+		{"if both Resourceversion and heartbeat change", corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "123"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(time.Now())}}}}, corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "145"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(<-time.After(5))}}}}, false},
+		{"if only a field changes", corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "123"}}, corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "145"}}, true},
+		{"if a field and the Resourceversion change", corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "123"}, ObjectMeta: metav1.ObjectMeta{ResourceVersion: "123"}}, corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "145"}, ObjectMeta: metav1.ObjectMeta{ResourceVersion: "145"}}, true},
+		{"if a field and the hertbeat change", corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "123"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(time.Now())}}}}, corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "145"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(<-time.After(5))}}}}, true},
+		{"if a field, Resourceversion and the hertbeat change", corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "123"}, Spec: corev1.NodeSpec{PodCIDR: "123"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(time.Now())}}}}, corev1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "145"}, Spec: corev1.NodeSpec{PodCIDR: "145"}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{LastHeartbeatTime: metav1.NewTime(<-time.After(5))}}}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//#nosec G601 -- since nothing is modifying the tests slic
+			assert.Equal(t, tt.reconcile, shouldReconcileChangedNode(&tt.oldobj, &tt.newobj))
+		})
+	}
 }


### PR DESCRIPTION
currently node predicate watches for resourceVersion and heartbeat changes, which are not critical things.
So with the PR we will add a early-exit condition for the predicate as an optimization and to ignore considering for a reconcile of cephcluster if updates are not crucial

closes: https://github.com/rook/rook/issues/14070

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
