### PR TITLE
osd: skip upgrade if migration is pending

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -19,7 +19,6 @@ package osd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -728,7 +727,7 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 			},
 		}
 		c := New(context, clusterInfo, spec, "myversion")
-		err := c.replaceOSDForNewStore()
+		_, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
 		assert.Nil(t, c.replaceOSD)
 	})
@@ -743,7 +742,7 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 			},
 		}
 		c := New(context, clusterInfo, spec, "myversion")
-		err := c.replaceOSDForNewStore()
+		_, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
 		assert.Nil(t, c.replaceOSD)
 	})
@@ -761,8 +760,9 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 		d := getDummyDeploymentOnNode(clientset, c, "node2", 0)
 		d.Labels[osdStore] = "bluestore-rdr"
 		createDeploymentOrPanic(clientset, d)
-		err := c.replaceOSDForNewStore()
+		osdsToBeReplaced, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
+		assert.Equal(t, 0, len(osdsToBeReplaced))
 		assert.Nil(t, c.replaceOSD)
 	})
 
@@ -779,7 +779,7 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 		// create osd deployment with `bluestore` backend store
 		d := getDummyDeploymentOnNode(clientset, c, "node2", 1)
 		createDeploymentOrPanic(clientset, d)
-		err := c.replaceOSDForNewStore()
+		_, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
 		assert.NotNil(t, c.replaceOSD)
 		assert.Equal(t, 1, c.replaceOSD.ID)
@@ -816,9 +816,9 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 		c := New(context, clusterInfo, spec, "myversion")
 		d := getDummyDeploymentOnPVC(clientset, c, "pvc1", 2)
 		createDeploymentOrPanic(clientset, d)
-		err := c.replaceOSDForNewStore()
+		osdsToBeReplaced, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
-		fmt.Printf("%+v", c.replaceOSD)
+		assert.Equal(t, 1, len(osdsToBeReplaced))
 		assert.NotNil(t, c.replaceOSD)
 		assert.Equal(t, 2, c.replaceOSD.ID)
 		assert.Equal(t, "pvc1", c.replaceOSD.Path)
@@ -862,8 +862,9 @@ func TestReplaceOSDForNewStore(t *testing.T) {
 		}
 		context.Executor = executor
 		c := New(context, clusterInfo, spec, "myversion")
-		err := c.replaceOSDForNewStore()
+		osdsToBeReplaced, err := c.replaceOSDForNewStore()
 		assert.NoError(t, err)
+		assert.Equal(t, 0, len(osdsToBeReplaced))
 		assert.Nil(t, c.replaceOSD)
 	})
 }

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -21,12 +21,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/k8sutil"
-	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -161,127 +158,5 @@ func TestGetOSDWithNonMatchingStoreOnPVCs(t *testing.T) {
 		assert.Equal(t, 1, len(osdList))
 		assert.Equal(t, 0, osdList[0].ID)
 		assert.Equal(t, "pvc0", osdList[0].Path)
-	})
-}
-
-func TestGetOSDReplaceInfo(t *testing.T) {
-	namespace := "rook-ceph"
-	clientset := fake.NewSimpleClientset()
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-			logger.Infof("Command: %s %v", command, args)
-			if args[0] == "status" {
-				return healthyCephStatus, nil
-			}
-			return "", errors.Errorf("unexpected ceph command '%v'", args)
-		},
-	}
-	ctx := &clusterd.Context{
-		Clientset: clientset,
-		Executor:  executor,
-	}
-	clusterInfo := &cephclient.ClusterInfo{
-		Namespace: namespace,
-		Context:   context.TODO(),
-	}
-	clusterInfo.SetName("mycluster")
-	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
-
-	spec := cephv1.ClusterSpec{}
-	c := New(ctx, clusterInfo, spec, "rook/rook:master")
-
-	t.Run("no OSD replace info available", func(t *testing.T) {
-		actualOSDInfo, err := c.getOSDReplaceInfo()
-		assert.NoError(t, err)
-		assert.Nil(t, actualOSDInfo)
-	})
-
-	t.Run("ensure no OSD to replace if pgs are not healthy", func(t *testing.T) {
-		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-				logger.Infof("Command: %s %v", command, args)
-				if args[0] == "status" {
-					return unHealthyCephStatus, nil
-				}
-				return "", errors.Errorf("unexpected ceph command '%v'", args)
-			},
-		}
-
-		ctx.Executor = executor
-		c := New(ctx, clusterInfo, spec, "rook/rook:master")
-		actualOSDInfo, err := c.getOSDReplaceInfo()
-		assert.NoError(t, err)
-		assert.Nil(t, actualOSDInfo)
-	})
-
-	t.Run("read OSD 0 replace info from config map", func(t *testing.T) {
-		actualOSDInfo := &OSDReplaceInfo{ID: 0, Path: "/dev/sda", Node: "node1"}
-		err := actualOSDInfo.saveAsConfig(c.context, c.clusterInfo)
-		assert.NoError(t, err)
-		expectedOSDInfo, err := c.getOSDReplaceInfo()
-		assert.NoError(t, err)
-		assert.NotNil(t, expectedOSDInfo)
-		assert.Equal(t, 0, expectedOSDInfo.ID)
-		err = k8sutil.DeleteConfigMap(clusterInfo.Context, ctx.Clientset, OSDReplaceConfigName, namespace, &k8sutil.DeleteOptions{})
-		assert.NoError(t, err)
-	})
-
-	t.Run("ensure no OSD replace info if all OSDs using expected OSD store", func(t *testing.T) {
-		spec := cephv1.ClusterSpec{
-			Storage: cephv1.StorageScopeSpec{
-				Store: cephv1.OSDStore{
-					Type:        "bluestore-rdr",
-					UpdateStore: "yes-really-update-store",
-				},
-			},
-		}
-		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-				logger.Infof("Command: %s %v", command, args)
-				if args[0] == "status" {
-					return healthyCephStatus, nil
-				}
-				return "", errors.Errorf("unexpected ceph command '%v'", args)
-			},
-		}
-
-		ctx.Executor = executor
-		c := New(ctx, clusterInfo, spec, "myversion")
-		d := getDummyDeploymentOnNode(clientset, c, "node2", 1)
-		d.Labels[osdStore] = "bluestore-rdr"
-		createDeploymentOrPanic(clientset, d)
-		expectedOSDInfo, err := c.getOSDReplaceInfo()
-		assert.NoError(t, err)
-		assert.Nil(t, expectedOSDInfo)
-	})
-
-	t.Run("ensure OSD replace info if OSD store is not up to date", func(t *testing.T) {
-		spec := cephv1.ClusterSpec{
-			Storage: cephv1.StorageScopeSpec{
-				Store: cephv1.OSDStore{
-					Type:        "bluestore-rdr",
-					UpdateStore: "yes-really-update-store",
-				},
-			},
-		}
-		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-				logger.Infof("Command: %s %v", command, args)
-				if args[0] == "status" {
-					return healthyCephStatus, nil
-				}
-				return "", errors.Errorf("unexpected ceph command '%v'", args)
-			},
-		}
-
-		ctx.Executor = executor
-		c := New(ctx, clusterInfo, spec, "myversion")
-		d := getDummyDeploymentOnNode(clientset, c, "node3", 2)
-		createDeploymentOrPanic(clientset, d)
-		expectedOSDInfo, err := c.getOSDReplaceInfo()
-		assert.NoError(t, err)
-		assert.NotNil(t, expectedOSDInfo)
-		assert.Equal(t, 2, expectedOSDInfo.ID)
-		assert.Equal(t, "node3", expectedOSDInfo.Node)
 	})
 }


### PR DESCRIPTION
Currently we allow upgrade of other OSDs while migration of OSD, due to change in backing store, is pending. This will not work if the updated OSD ceph version does not support the currently applied backing store. So rook will skip any OSD upgrade if the OSD migration is pending.


Testing: 
- Tested the changing the backing store from bluestore to bluestore-rdr and vice versa multiple times. OSDs are getting migrated without any issues. 
- Also verified the OSDs pods that are pending migration are not getting upgraded by updating the `ceph` image and the `store` type in the cephCluster CR at the same time. 

[operator-logs.txt](https://github.com/rook/rook/files/15332702/operator-logs.txt)


cephCluster CR status before upgrade:
```
status:
  ceph:
    capacity:
      bytesAvailable: 32146395136
      bytesTotal: 32212254720
      bytesUsed: 65859584
      lastUpdated: "2024-05-16T09:05:49Z"
    fsid: 07ce7de3-e339-4c1e-9092-2d8cab527c13
    health: HEALTH_OK
    lastChanged: "2024-05-16T09:04:45Z"
    lastChecked: "2024-05-16T09:05:49Z"
    previousHealth: HEALTH_WARN
    versions:
      mgr:
        ceph version 17.2.6-373-g5406f4b1 (5406f4b1729bf4f476338ad344cc86b126e0c5b3) quincy (stable): 2
      mon:
        ceph version 17.2.6-373-g5406f4b1 (5406f4b1729bf4f476338ad344cc86b126e0c5b3) quincy (stable): 3
      osd:
        ceph version 17.2.6-373-g5406f4b1 (5406f4b1729bf4f476338ad344cc86b126e0c5b3) quincy (stable): 3
      overall:
        ceph version 17.2.6-373-g5406f4b1 (5406f4b1729bf4f476338ad344cc86b126e0c5b3) quincy (stable): 8
  conditions:
  - lastHeartbeatTime: "2024-05-16T09:05:49Z"
    lastTransitionTime: "2024-05-16T08:54:40Z"
    message: Cluster created successfully
    reason: ClusterCreated
    status: "True"
    type: Ready
  message: Cluster created successfully
  observedGeneration: 3
  phase: Ready
  state: Created
  storage:
    deviceClasses:
    - name: hdd
    osd:
      storeType:
        bluestore-rdr: 3
  version:
    image: quay.io/guits/ceph-volume:bs-rdr
    version: 17.2.6-373
```

cephCluster CR status after upgrade.
```
status:
    ceph:
      capacity:
        bytesAvailable: 32126930944
        bytesTotal: 32212254720
        bytesUsed: 85323776
        lastUpdated: "2024-05-16T09:23:40Z"
      details:
        OSD_UPGRADE_FINISHED:
          message: all OSDs are running squid or later but require_osd_release < squid
          severity: HEALTH_WARN
        PG_DEGRADED:
          message: 'Degraded data redundancy: 2/6 objects degraded (33.333%), 1 pg
            degraded'
          severity: HEALTH_WARN
      fsid: 07ce7de3-e339-4c1e-9092-2d8cab527c13
      health: HEALTH_WARN
      lastChanged: "2024-05-16T09:23:40Z"
      lastChecked: "2024-05-16T09:23:40Z"
      previousHealth: HEALTH_OK
      versions:
        mgr:
          ceph version 19.0.0-1778-g5062c03f (5062c03f723d4318b100d525eeb7e0a85d579243) squid (dev): 2
        mon:
          ceph version 19.0.0-1778-g5062c03f (5062c03f723d4318b100d525eeb7e0a85d579243) squid (dev): 3
        osd:
          ceph version 19.0.0-1778-g5062c03f (5062c03f723d4318b100d525eeb7e0a85d579243) squid (dev): 3
        overall:
          ceph version 19.0.0-1778-g5062c03f (5062c03f723d4318b100d525eeb7e0a85d579243) squid (dev): 8
    conditions:
    - lastHeartbeatTime: "2024-05-16T09:24:39Z"
      lastTransitionTime: "2024-05-16T08:54:40Z"
      message: Cluster created successfully
      reason: ClusterCreated
      status: "True"
      type: Ready
    - lastHeartbeatTime: "2024-05-16T09:24:44Z"
      lastTransitionTime: "2024-05-16T09:24:44Z"
      message: Configuring Ceph Mons
      reason: ClusterProgressing
      status: "True"
      type: Progressing
    message: Configuring Ceph Mons
    observedGeneration: 4
    phase: Progressing
    state: Creating
    storage:
      deviceClasses:
      - name: hdd
      osd:
        storeType:
          bluestore: 3
    version:
      image: quay.ceph.io/ceph-ci/ceph:wip-aclamk-bs-compression-recompression-test
      version: 19.0.0-1778
kind: List
```

Ceph status 
```
sh-4.4$ ceph status  
  cluster:
    id:     07ce7de3-e339-4c1e-9092-2d8cab527c13
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum a,b,c (age 14m)
    mgr: a(active, since 6m), standbys: b
    osd: 3 osds: 3 up (since 9m), 3 in (since 38m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   83 MiB used, 30 GiB / 30 GiB avail
    pgs:     1 active+clean
 
sh-4.4$ 
```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
