### PR TITLE
ci: bump github actions dependency setup-go

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -12,7 +12,7 @@ runs:
         tool-cache: true
 
     - name: setup golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: "1.21"
 

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -16,7 +16,7 @@ runs:
         tool-cache: true
 
     - name: setup golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: "1.21"
 


### PR DESCRIPTION
The version v2 was deprecated and was causing warnings.

Saw that the version v2 was deprecated and thought I would give it a bump :)
Not sure why dependabot has missed this though

fixes: #14197 