### PR TITLE
ci: fix pylint errors

### DIFF
--- a/.docs/macros/includes/main.py
+++ b/.docs/macros/includes/main.py
@@ -12,6 +12,7 @@ subst = "\\1/%s/"
 
 
 def define_env(env):
+    target = None
     repo = Repository(".")
     if repo is not None:
         target = repo.head.shorthand

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+# pylint: disable=E0606
+
 import errno
 import sys
 import json


### PR DESCRIPTION
Afte pylint was updated to version 3.2.0 a set of new errors appeared that breaks ci. 
This change makes ci passing by either fixing the problem or ignoring it in the check

I propose starting with this to get ci passing, then in a follow-up PR remove the python2 support from `deploy/examples/create-external-cluster-resources.py` which will make fixing the lint error there much more trivial and also allow for so more refactoring of the code

fixes: #14203 