### PR TITLE
core: remove pacific specific code

### DIFF
--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/util/exec"
 )
 
@@ -215,12 +214,8 @@ func GetFSMirrorDaemonStatus(context *clusterd.Context, clusterInfo *ClusterInfo
 	// Using Debug level since this is called in a recurrent go routine
 	logger.Debugf("retrieving filesystem mirror status for filesystem %q", fsName)
 
-	args := []string{"fs", "snapshot", "mirror", "daemon", "status"} // for Ceph v16.2.7 and above
-	if !clusterInfo.CephVersion.IsAtLeast(cephver.CephVersion{Major: 16, Minor: 2, Extra: 7}) {
-		// fs-name needed for Ceph v16.2.6 and earlier
-		args = append(args, fsName)
-	}
 	// Build command
+	args := []string{"fs", "snapshot", "mirror", "daemon", "status"}
 	cmd := NewCephCommand(context, clusterInfo, args)
 
 	// Run command

--- a/pkg/daemon/ceph/client/filesystem_mirror_test.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,10 +30,6 @@ var (
 	// response of "ceph fs snapshot mirror peer_bootstrap create myfs2 client.mirror test"
 	//nolint:gosec // since this is not leaking any credentials
 	fsMirrorToken = `{"token": "eyJmc2lkIjogIjgyYjdlZDkyLTczYjAtNGIyMi1hOGI3LWVkOTQ4M2UyODc1NiIsICJmaWxlc3lzdGVtIjogIm15ZnMyIiwgInVzZXIiOiAiY2xpZW50Lm1pcnJvciIsICJzaXRlX25hbWUiOiAidGVzdCIsICJrZXkiOiAiQVFEVVAxSmdqM3RYQVJBQWs1cEU4cDI1ZUhld2lQK0ZXRm9uOVE9PSIsICJtb25faG9zdCI6ICJbdjI6MTAuOTYuMTQyLjIxMzozMzAwLHYxOjEwLjk2LjE0Mi4yMTM6Njc4OV0sW3YyOjEwLjk2LjIxNy4yMDc6MzMwMCx2MToxMC45Ni4yMTcuMjA3OjY3ODldLFt2MjoxMC45OS4xMC4xNTc6MzMwMCx2MToxMC45OS4xMC4xNTc6Njc4OV0ifQ=="}`
-
-	// response of "ceph fs snapshot mirror daemon status myfs"
-	// fsMirrorDaemonStatus    = `{ "daemon_id": "444607", "filesystems": [ { "filesystem_id": "1", "name": "myfs", "directory_count": 0, "peers": [ { "uuid": "4a6983c0-3c9d-40f5-b2a9-2334a4659827", "remote": { "client_name": "client.mirror_remote", "cluster_name": "site-remote", "fs_name": "backup_fs" }, "stats": { "failure_count": 0, "recovery_count": 0 } } ] } ] }`
-	fsMirrorDaemonStatus = `[{"daemon_id":25103, "filesystems": [{"filesystem_id": 1, "name": "myfs", "directory_count": 0, "peers": []}]}]`
 
 	// response of "ceph fs snapshot mirror daemon status"
 	fsMirrorDaemonStatusNew = `[{"daemon_id":23102, "filesystems": [{"filesystem_id": 2, "name": "myfsNew", "directory_count": 0, "peers": []}]}]`
@@ -146,27 +141,7 @@ func TestRemoveFilesystemMirrorPeer(t *testing.T) {
 func TestFSMirrorDaemonStatus(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
-	t.Run("snapshot status command with fsName - test for Ceph v16.2.6 and earlier", func(t *testing.T) {
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-			if args[0] == "fs" {
-				assert.Equal(t, "snapshot", args[1])
-				assert.Equal(t, "mirror", args[2])
-				assert.Equal(t, "daemon", args[3])
-				assert.Equal(t, "status", args[4])
-				assert.Equal(t, fs, args[5]) // fs-name needed for Ceph v16.2.6 and earlier
-				return fsMirrorDaemonStatus, nil
-			}
-			return "", errors.New("unknown command")
-		}
-		context := &clusterd.Context{Executor: executor}
-		clusterInfo := AdminTestClusterInfo("mycluster")
-		clusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}
-		s, err := GetFSMirrorDaemonStatus(context, clusterInfo, fs)
-		assert.NoError(t, err)
-		assert.Equal(t, 25103, s[0].DaemonID)
-		assert.Equal(t, "myfs", s[0].Filesystems[0].Name)
-	})
-	t.Run("snapshot status command without fsName - test for Ceph v16.2.7 and above", func(t *testing.T) {
+	t.Run("snapshot status command", func(t *testing.T) {
 		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			if args[0] == "fs" {
 				assert.Equal(t, "snapshot", args[1])
@@ -180,7 +155,6 @@ func TestFSMirrorDaemonStatus(t *testing.T) {
 		}
 		context := &clusterd.Context{Executor: executor}
 		clusterInfo := AdminTestClusterInfo("mycluster")
-		clusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 7}
 		s, err := GetFSMirrorDaemonStatus(context, clusterInfo, fs)
 		assert.NoError(t, err)
 		assert.Equal(t, 23102, s[0].DaemonID)

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -251,13 +251,6 @@ func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
 	// Set the value of isUpgrade based on the image discovery done by detectAndValidateCephVersion()
 	cluster.isUpgrade = isUpgrade
 
-	if cluster.Spec.IsStretchCluster() {
-		stretchVersion := cephver.CephVersion{Major: 16, Minor: 2, Build: 5}
-		if !cephVersion.IsAtLeast(stretchVersion) {
-			return errors.Errorf("stretch clusters minimum ceph version is %q, but is running %s", stretchVersion.String(), cephVersion.String())
-		}
-	}
-
 	if cluster.Spec.Network.MultiClusterService.Enabled {
 		serviceExportVersion := cephver.CephVersion{Major: 17, Minor: 2, Extra: 6}
 		if !cephVersion.IsAtLeast(serviceExportVersion) {

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -73,7 +73,7 @@ func createNewCluster(t *testing.T) *Cluster {
 		Client:    cl,
 	}
 	ownerInfo := cephclient.NewMinimumOwnerInfo(t)
-	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo, CephVersion: cephver.CephVersion{Major: 16, Minor: 2, Build: 5}, Context: context.TODO()}
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo, CephVersion: cephver.CephVersion{Major: 17, Minor: 2, Build: 0}, Context: context.TODO()}
 	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Annotations:        map[cephv1.KeyType]cephv1.Annotations{cephv1.KeyMgr: {"my": "annotation"}},

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -29,7 +29,6 @@ import (
 	cephutil "github.com/rook/rook/pkg/daemon/ceph/util"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,8 +46,6 @@ var (
 	timeZero                       = time.Duration(0)
 	// Check whether mons are on the same node once per operator restart since it's a rare scheduling condition
 	needToCheckMonsOnSameNode = true
-	// Version of Ceph where the arbiter failover is supported
-	arbiterFailoverSupportedCephVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 7}
 )
 
 // HealthChecker aggregates the mon/cluster info needed to check the health of the monitors
@@ -552,13 +549,9 @@ func (c *Cluster) allowFailover(name string) error {
 		// failover if it's a non-arbiter
 		return nil
 	}
-	if c.ClusterInfo.CephVersion.IsAtLeast(arbiterFailoverSupportedCephVersion) {
-		// failover the arbiter if at least v16.2.7
-		return nil
-	}
 
 	// Ceph does not support updating the arbiter mon in older versions
-	return errors.Errorf("refusing to failover arbiter mon %q on a stretched cluster until upgrading to ceph version %s", name, arbiterFailoverSupportedCephVersion.String())
+	return errors.Errorf("refusing to failover arbiter mon %q on a stretched cluster", name)
 }
 
 func (c *Cluster) removeOrphanMonResources() {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -30,7 +30,6 @@ import (
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/ceph/version"
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -274,16 +273,6 @@ func TestSkipMonFailover(t *testing.T) {
 		assert.NoError(t, c.allowFailover(monName))
 	})
 
-	t.Run("skip failover for arbiter if an older version of ceph", func(t *testing.T) {
-		c.arbiterMon = monName
-		c.ClusterInfo.CephVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 6}
-		assert.Error(t, c.allowFailover(monName))
-	})
-
-	t.Run("don't skip failover for arbiter if a newer version of ceph", func(t *testing.T) {
-		c.ClusterInfo.CephVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 7}
-		assert.NoError(t, c.allowFailover(monName))
-	})
 }
 
 func TestEvictMonOnSameNode(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -360,12 +360,6 @@ func (c *Cluster) ConfigureArbiter() error {
 	if err != nil {
 		logger.Warningf("attempting to enable arbiter after failed to detect if already enabled. %v", err)
 	} else if monDump.StretchMode {
-		// only support arbiter failover if at least v16.2.7
-		if !c.ClusterInfo.CephVersion.IsAtLeast(arbiterFailoverSupportedCephVersion) {
-			logger.Info("stretch mode is already enabled")
-			return nil
-		}
-
 		if monDump.TiebreakerMon == c.arbiterMon {
 			logger.Infof("stretch mode is already enabled with tiebreaker %q", c.arbiterMon)
 			return nil

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -507,23 +507,14 @@ func TestConfigureArbiter(t *testing.T) {
 	c.context = &clusterd.Context{Clientset: test.New(t, 5), Executor: executor}
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(5)
 
-	t.Run("no arbiter failover for old ceph version", func(t *testing.T) {
-		c.arbiterMon = "changed"
-		c.ClusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}
-		err := c.ConfigureArbiter()
-		assert.NoError(t, err)
-		assert.False(t, setNewTiebreaker)
-	})
 	t.Run("stretch mode already configured - new", func(t *testing.T) {
 		c.arbiterMon = currentArbiter
-		c.ClusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 7}
 		err := c.ConfigureArbiter()
 		assert.NoError(t, err)
 		assert.False(t, setNewTiebreaker)
 	})
 	t.Run("tiebreaker changed", func(t *testing.T) {
 		c.arbiterMon = "changed"
-		c.ClusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 7}
 		err := c.ConfigureArbiter()
 		assert.NoError(t, err)
 		assert.True(t, setNewTiebreaker)

--- a/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash_test.go
@@ -50,7 +50,7 @@ func TestCreateOrUpdateCephCrash(t *testing.T) {
 	}
 	cephCluster.Spec.Labels = cephv1.LabelsSpec{}
 	cephCluster.Spec.PriorityClassNames = cephv1.PriorityClassNamesSpec{}
-	cephVersion := &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
+	cephVersion := &cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
 	ctx := context.TODO()
 	context := &clusterd.Context{
 		Clientset:     test.New(t, 1),

--- a/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestCreateOrUpdateCephCron(t *testing.T) {
 	cephCluster := cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph"}}
-	cephVersion := &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
+	cephVersion := &cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
 	ctx := context.TODO()
 	context := &clusterd.Context{
 		Clientset:     test.New(t, 1),

--- a/pkg/operator/ceph/file/mirror/config.go
+++ b/pkg/operator/ceph/file/mirror/config.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
-	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
@@ -36,11 +35,6 @@ const (
 `
 	user   = "client.fs-mirror"
 	userID = "fs-mirror"
-)
-
-var (
-	// PeerAdditionMinVersion This version includes a number of fixes for snapshots and mirror status
-	PeerAdditionMinVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 5}
 )
 
 // daemonConfig for a single rbd-mirror

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -70,8 +70,7 @@ chown --recursive --verbose ceph:ceph $VAULT_TOKEN_NEW_PATH
 )
 
 var (
-	cephVersionMinRGWSSES3     = cephver.CephVersion{Major: 17, Minor: 2, Extra: 3}
-	cephVersionMinRGWSSEKMSTLS = cephver.CephVersion{Major: 16, Minor: 2, Extra: 6}
+	cephVersionMinRGWSSES3 = cephver.CephVersion{Major: 17, Minor: 2, Extra: 3}
 
 	//go:embed rgw-probe.sh
 	rgwProbeScriptTemplate string
@@ -394,8 +393,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 		if c.store.Spec.Security.KeyManagementService.IsTokenAuthEnabled() {
 			container.Args = append(container.Args, c.sseKMSVaultTokenOptions(kmsEnabled)...)
 		}
-		if c.store.Spec.Security.KeyManagementService.IsTLSEnabled() &&
-			c.clusterInfo.CephVersion.IsAtLeast(cephVersionMinRGWSSEKMSTLS) {
+		if c.store.Spec.Security.KeyManagementService.IsTLSEnabled() {
 			container.Args = append(container.Args, c.sseKMSVaultTLSOptions(kmsEnabled)...)
 		}
 	}

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -162,27 +162,27 @@ func TestIsInferior(t *testing.T) {
 
 func TestValidateCephVersionsBetweenLocalAndExternalClusters(t *testing.T) {
 	// TEST 1: versions are identical
-	localCephVersion := CephVersion{Major: 15, Minor: 2, Extra: 1}
-	externalCephVersion := CephVersion{Major: 15, Minor: 2, Extra: 1}
+	localCephVersion := CephVersion{Major: 17, Minor: 2, Extra: 1}
+	externalCephVersion := CephVersion{Major: 17, Minor: 2, Extra: 1}
 	err := ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.NoError(t, err)
 
 	// TEST 2: local cluster version major is lower than external cluster version
-	localCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 1}
-	externalCephVersion = CephVersion{Major: 16, Minor: 2, Extra: 1}
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 18, Minor: 2, Extra: 1}
 	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.NoError(t, err)
 
 	// TEST 3: local cluster version major is higher than external cluster version
-	localCephVersion = CephVersion{Major: 16, Minor: 2, Extra: 1}
-	externalCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 1}
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 16, Minor: 2, Extra: 1}
 	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.Error(t, err)
 
 	// TEST 4: local version is > but from a minor release
 	// local version must never be higher
-	localCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 2}
-	externalCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 1}
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 2}
+	externalCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1}
 	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.Error(t, err)
 


### PR DESCRIPTION
Since pacific is no longer supported, we can remove pacific specific code.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
