### PR TITLE
core: remove owner refs in resource cleanup jobs

### DIFF
--- a/pkg/operator/ceph/controller/cleanup.go
+++ b/pkg/operator/ceph/controller/cleanup.go
@@ -69,9 +69,8 @@ func (c *ResourceCleanup) StartJob(ctx context.Context, clientset kubernetes.Int
 	podSpec := c.jobTemplateSpec()
 	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            jobName,
-			Namespace:       c.resource.GetNamespace(),
-			OwnerReferences: c.resource.GetOwnerReferences(),
+			Name:      jobName,
+			Namespace: c.resource.GetNamespace(),
 		},
 		Spec: batch.JobSpec{
 			Template: podSpec,


### PR DESCRIPTION
Removed owner reference from Radosnamespace and
subVolumeGroup cleanup resources.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
--->
Resolves  #14233

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
