### PR TITLE
network: improve  the IsHost() function

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -32,8 +32,13 @@ func (n *NetworkSpec) IsMultus() bool {
 	return n.Provider == NetworkProviderMultus
 }
 
-// IsHost get whether to use host network provider. This method also preserve
-// compatibility with the old HostNetwork field.
+// IsHost is intended to be used to determine if the rook operator should configure
+// managed pods to use host networking.
+// This behavior is enabled by configuring the cephCluster with the "host" network provider.
+// This method also maintains compatibility with the old HostNetwork setting
+// which is incompatible with other network providers: HostNetwork set to true
+// together with an empty or unset network provider has the same effect as
+// network.Provider set to "host"
 func (n *NetworkSpec) IsHost() bool {
 	return (n.HostNetwork && n.Provider == NetworkProviderDefault) || n.Provider == NetworkProviderHost
 }

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -72,10 +72,40 @@ func TestValidateNetworkSpec(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNetworkCephIsHostLegacy(t *testing.T) {
-	net := NetworkSpec{HostNetwork: true}
+// test the NetworkSpec.IsHost method with different network providers
+// Also test it in combination with the legacy
+// "HostNetwork" setting.
+func TestNetworkCephIsHost(t *testing.T) {
+	net := NetworkSpec{HostNetwork: false}
 
+	net.Provider = NetworkProviderHost
 	assert.True(t, net.IsHost())
+
+	net.Provider = NetworkProviderDefault
+	net.HostNetwork = true
+	assert.True(t, net.IsHost())
+
+	net = NetworkSpec{}
+	net.Provider = NetworkProviderDefault
+	net.HostNetwork = false
+	assert.False(t, net.IsHost())
+
+	net = NetworkSpec{}
+	net.Provider = NetworkProviderMultus
+	net.HostNetwork = false
+	assert.False(t, net.IsHost())
+
+	net = NetworkSpec{}
+	net.Provider = NetworkProviderMultus
+	net.HostNetwork = true
+	assert.False(t, net.IsHost())
+
+	// test with  nonempty but invalid provider
+	net = NetworkSpec{}
+	net.HostNetwork = true
+	net.Provider = "foo"
+	assert.False(t, net.IsHost())
+
 }
 
 func TestNetworkSpec(t *testing.T) {


### PR DESCRIPTION

This change is a follow-up to PR  https://github.com/rook/rook/pull/13693 .
It is also  meant to provide a continuation of the closed, stale PR https://github.com/rook/rook/pull/13878 .

Finally, it is  intended as a preparation for the introduction of a way to enforce host networking in the next round of updates to PR
 https://github.com/rook/rook/pull/13651 .

This change improves the documentation comment and the unit testing for the `IsHost()`  method of the `CephCluster.Network` spec.

The implementation of IsHost() is changed to validate the Network Spec and return error if the spec is invalid.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
