### PR TITLE
osd: reduce safe-to-destroy retry timeout to 15s

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -84,7 +84,7 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 		logger.Errorf("failed to exclude osd.%d out of the crush map. %v", osdID, err)
 	}
 
-	// Check we can remove the OSD
+	// Check if we can safely remove the OSD
 	// Loop forever until the osd is safe-to-destroy
 	for {
 		isSafeToDestroy, err := client.OsdSafeToDestroy(clusterdContext, clusterInfo, osdID)
@@ -112,8 +112,8 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 				break
 			}
 			// Else we wait until the OSD can be removed
-			logger.Warningf("osd.%d is NOT ok to destroy, retrying in 1m until success", osdID)
-			time.Sleep(1 * time.Minute)
+			logger.Warningf("osd.%d is NOT ok to destroy, retrying in 15s until success", osdID)
+			time.Sleep(15 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
This reduces the safe-to-remove retry interval from 1m to 15s.

Closes #14247

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14247

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
