### PR TITLE
docs: Add a note for NixOS and containerd

### DIFF
--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -129,3 +129,11 @@ ConfigMap found in operator.yaml:
 * `CSI_CEPHFS_PLUGIN_VOLUME_MOUNT`
 * `CSI_RBD_PLUGIN_VOLUME`
 * `CSI_RBD_PLUGIN_VOLUME_MOUNT`
+
+If using containerd, remove `LimitNOFILE` from containerd service config to avoid issues like slow ceph commands or mons falling out of quorum.
+
+```nix
+systemd.services.containerd.serviceConfig = {
+  LimitNOFILE = lib.mkForce null;
+};
+```


### PR DESCRIPTION
Add a note to remove LimitNOFILE setting in containerd service configuration.

This setting causes multiple issues such as slow `ceph status` commands (and failing healthchecks), various timeouts, and mons failing/timing out.

Upstream containerd already removed the setting. NixOS hasn't incorporated the change.

This note can be removed once https://github.com/NixOS/nixpkgs/pull/313507 makes it to a stable release.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
