### PR TITLE
pool: get the exact deviceClass name instead of crushroot+deviceClass

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -529,7 +529,12 @@ func extractPoolDetails(rule ruleSpec) (string, string) {
 			failureDomain = step.Type
 		}
 		if step.ItemName != "" {
-			deviceClass = step.ItemName
+			// we are not using crushRoot currently, but in future improve
+			// this part to improve advanced crushrule support
+			crushRootAndDeviceClass := step.ItemName
+			parts := strings.SplitN(crushRootAndDeviceClass, "~", 2)
+			deviceClass = parts[1]
+			logger.Debugf("Using deviceClass as %q ", deviceClass)
 		}
 		// We expect the rule to be found by the second step, or else it is a more
 		// complex rule that would not be supported for updating the failure domain


### PR DESCRIPTION
this lead to creation of 2 crush rules because of difference in deviceClass names:
eg:
creating a new crush rule for changed deviceClass
("default~hdd"-->"hdd") on crush rule "test-crush-bug-az-ab-4"

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
