### PR TITLE
multus: add and test ipv6 support for validation tool

### DIFF
--- a/pkg/daemon/multus/nginx-config.yaml
+++ b/pkg/daemon/multus/nginx-config.yaml
@@ -7,7 +7,10 @@ metadata:
 data:
   server.conf: |
     server {
+        # listen on all IPv4 addrs
         listen       8080;
+        # listen on all IPv6 addrs
+        listen       [::]:8080;
         server_name  localhost;
 
         # return the client ip upon connect

--- a/pkg/daemon/multus/templates.go
+++ b/pkg/daemon/multus/templates.go
@@ -113,6 +113,12 @@ func (vt *ValidationTest) generateClientTemplateConfig(
 	if attachCluster && serverClusterAddr != "" {
 		netNamesAndAddresses["cluster"] = serverClusterAddr
 	}
+	for name, addr := range netNamesAndAddresses {
+		if strings.Contains(addr, ":") {
+			// it's an IPv6 address and needs square brackets around it to support :<port> addition
+			netNamesAndAddresses[name] = "[" + addr + "]"
+		}
+	}
 	return clientTemplateConfig{
 		NodeType:                 nodeType,
 		ClientType:               clientType,

--- a/tests/scripts/multus/default-public-cluster-nads.yaml
+++ b/tests/scripts/multus/default-public-cluster-nads.yaml
@@ -17,4 +17,4 @@ metadata:
   labels:
   annotations:
 spec:
-  config: '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "eth0", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.30.0/24" } }'
+  config: '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "eth0", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "fc00::/96" } }'


### PR DESCRIPTION
Add IPv6 support for multus validation tool. Also test that IPv6 support works by specifying one of the NetAttachDefs with an IPv6 address range.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
