### PR TITLE
object: consider virtulhostnames only for OBC endpoints

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -139,7 +139,7 @@ func UpdateEndpoint(objContext *Context, store *cephv1.CephObjectStore) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get port for object store %q", nsName)
 	}
-	objContext.Endpoint = BuildDNSEndpoint(GetDomainName(store), port, store.Spec.IsTLSEnabled())
+	objContext.Endpoint = BuildDNSEndpoint(GetDomainName(store, false), port, store.Spec.IsTLSEnabled())
 
 	return nil
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -559,8 +559,10 @@ func (r *ReconcileCephObjectStore) reconcileCOSIUser(cephObjectStore *cephv1.Cep
 		}
 	}
 
+	// if vhost is enabled then select from dnsNames
+	endpointForCOSIBucket := GetDomainName(cephObjectStore, true)
 	// Create COSI user secret
-	return ReconcileCephUserSecret(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
+	return ReconcileCephUserSecret(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, endpointForCOSIBucket, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
 }
 
 func generateCOSIUserConfig() *admin.User {

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -332,15 +332,15 @@ func EmptyPool(pool cephv1.PoolSpec) bool {
 }
 
 // GetDomainName build the dns name to reach out the service endpoint
-func GetDomainName(s *cephv1.CephObjectStore) string {
-	return getDomainName(s, true)
+func GetDomainName(s *cephv1.CephObjectStore, forVirtualHostBuckets bool) string {
+	return getDomainName(s, true, forVirtualHostBuckets)
 }
 
 func GetStableDomainName(s *cephv1.CephObjectStore) string {
-	return getDomainName(s, false)
+	return getDomainName(s, false, false)
 }
 
-func getDomainName(s *cephv1.CephObjectStore, returnRandomDomainIfMultiple bool) string {
+func getDomainName(s *cephv1.CephObjectStore, returnRandomDomainIfMultiple, forVirtualHostBuckets bool) string {
 	endpoints := []string{}
 	if s.Spec.IsExternal() {
 		// if the store is external, pick a random endpoint to use. if the endpoint is down, this
@@ -348,8 +348,8 @@ func getDomainName(s *cephv1.CephObjectStore, returnRandomDomainIfMultiple bool)
 		for _, e := range s.Spec.Gateway.ExternalRgwEndpoints {
 			endpoints = append(endpoints, e.String())
 		}
-	} else if s.Spec.Hosting != nil && len(s.Spec.Hosting.DNSNames) > 0 {
-		// if the store is internal and has DNS names, pick a random DNS name to use
+	} else if s.Spec.Hosting != nil && len(s.Spec.Hosting.DNSNames) > 0 && forVirtualHostBuckets {
+		// if the store is internal and has DNS names, pick a random DNS name to use for Buckets
 		endpoints = s.Spec.Hosting.DNSNames
 	} else {
 		return domainNameOfService(s)

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -208,7 +208,7 @@ func TestBuildDomainNameAndEndpoint(t *testing.T) {
 			Namespace: "rook-ceph",
 		},
 	}
-	dns := GetDomainName(s)
+	dns := GetDomainName(s, false)
 	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph.svc", dns)
 
 	// non-secure endpoint


### PR DESCRIPTION
The virtualhostnames for rgw is added to possible endpoint list, this endpoint is mainly used by rook operator for communicating with RGW server. If enable the virtualhostname feature for rgw, those domains is used, but requried only for Buckets.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
