### PR TITLE
build: Update to use the latest version of go-junit-report

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -201,7 +201,7 @@ $(GOFMT):
 $(GOJUNIT):
 	@echo === installing go-junit-report
 	@mkdir -p $(TOOLS_DIR)/tmp
-	@curl -sL https://github.com/jstemmer/go-junit-report/releases/download/v2.0.0/go-junit-report-v2.0.0-$(GOOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_DIR)/tmp
+	@curl -sL https://github.com/jstemmer/go-junit-report/releases/download/v2.1.0/go-junit-report-v2.1.0-$(GOOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_DIR)/tmp
 	@mv $(TOOLS_DIR)/tmp/go-junit-report $(TOOLS_DIR)
 	@rm -fr $(TOOLS_DIR)/tmp
 


### PR DESCRIPTION
**description of changes:**
`make test` failed for me on MacOS with this error:

```console
$ make test

...

=== installing go-junit-report
tar: Error opening archive: Unrecognized archive format
make[2]: ***
$ 
```

So it seems the version v2.0.0 of go-junit-report has a broken source
tarball

Going to the latest version v2.1.0 fixes the problem for me.




**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
