### PR TITLE
csi: add log rotation for csi rbd pod containers

### DIFF
--- a/pkg/operator/ceph/csi/template/csi-logrotate-sidecar.yaml
+++ b/pkg/operator/ceph/csi/template/csi-logrotate-sidecar.yaml
@@ -1,0 +1,35 @@
+args:
+  - |
+    echo "Starting the csi-logrotate-sidecar"
+    mkdir -p {{ .CsiLogDirPath }}/cephcsi/logrotate-config/{{ .CSILogFolder }};
+    echo '{{ .CsiLogDirPath }}cephcsi/log/{{ .CSILogFolder }}/*.log {
+        {{ .CSILogRotationPeriod }}
+        missingok
+        rotate 7
+        compress
+        copytruncate
+        notifempty
+    }' >  {{ .CsiLogDirPath }}/cephcsi/logrotate-config/{{ .CSILogFolder }}/csi;
+    echo "File creation container completed";
+
+    LOG_ROTATE_CEPH_CSI_FILE={{ .CsiLogDirPath }}/cephcsi/logrotate-config/{{ .CSILogFolder }}/csi
+    LOG_MAX_SIZE={{ .CSILogRotationMaxSize }}
+    if [ "$LOG_MAX_SIZE" != "0" ]; then
+      sed --in-place "4i \ \ \ \ maxsize $LOG_MAX_SIZE" "$LOG_ROTATE_CEPH_CSI_FILE"
+    fi
+
+    while true; do
+      logrotate --verbose "$LOG_ROTATE_CEPH_CSI_FILE"
+      sleep 15m
+    done
+command:
+  - /bin/sh
+  - -c
+image: {{ .CSIPluginImage }}
+imagePullPolicy: IfNotPresent
+name: log-collector
+volumeMounts:
+  - mountPath: {{ .CsiLogDirPath }}/cephcsi/logrotate-config/{{ .CSILogFolder }}
+    name: csi-logs-logrotate
+  - mountPath: {{ .CsiLogDirPath }}/cephcsi/log/{{ .CSILogFolder }}
+    name: csi-log

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -38,9 +38,9 @@ spec:
             - "--extra-create-metadata=true"
             - "--prevent-volume-mode-conversion=true"
             - "--feature-gates=HonorPVReclaimPolicy=true"
-            {{- if .EnableCSITopology }}
+            {{ if .EnableCSITopology }}
             - "--feature-gates=Topology=true"
-            {{- end }}
+            {{ end }}
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
@@ -116,7 +116,7 @@ spec:
         {{ if .EnableOMAPGenerator }}
         - name: csi-omap-generator
           image: {{ .CSIPluginImage }}
-          args :
+          args:
             - "--type=controller"
             - "--drivernamespace=$(DRIVER_NAMESPACE)"
             - "--v={{ .LogLevel }}"
@@ -142,7 +142,7 @@ spec:
         {{ if .EnableCSIAddonsSideCar }}
         - name: csi-addons
           image: {{ .CSIAddonsImage }}
-          args :
+          args:
             - "--node-id=$(NODE_ID)"
             - "--v={{ .LogLevel }}"
             - "--csi-addons-address=$(CSIADDONS_ENDPOINT)"
@@ -155,6 +155,11 @@ spec:
             - "--leader-election-lease-duration={{ .LeaderElectionLeaseDuration }}"
             - "--leader-election-renew-deadline={{ .LeaderElectionRenewDeadline }}"
             - "--leader-election-retry-period={{ .LeaderElectionRetryPeriod }}"
+            {{ if .CSILogRotation }}
+            - "--logtostderr=false"
+            - "--alsologtostderr=true"
+            - "--log_file={{ .CsiLogDirPath }}/cephcsi/log/rbd-provisioner/csi-addons.log"
+            {{ end }}
           ports:
             - containerPort: {{ .CSIAddonsPort }}
           env:
@@ -180,10 +185,14 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            {{ if .CSILogRotation }}
+            - mountPath: {{ .CsiLogDirPath }}/cephcsi/log/rbd-provisioner
+              name: csi-log
+            {{ end }}
         {{ end }}
         - name: csi-rbdplugin
           image: {{ .CSIPluginImage }}
-          args :
+          args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v={{ .LogLevel }}"
@@ -191,6 +200,11 @@ spec:
             - "--controllerserver=true"
             - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
             - "--pidlimit=-1"
+            {{ if .CSILogRotation }}
+            - "--logtostderr=false"
+            - "--alsologtostderr=true"
+            - "--log_file={{ .CsiLogDirPath }}/cephcsi/log/rbd-provisioner/csi-rbdplugin.log"
+            {{ end }}
             {{ if .EnableCSIAddonsSideCar }}
             - "--csi-addons-endpoint=$(CSIADDONS_ENDPOINT)"
             {{ end }}
@@ -225,6 +239,10 @@ spec:
               mountPath: /csi
             - mountPath: /dev
               name: host-dev
+            {{ if .CSILogRotation }}
+            - mountPath: {{ .CsiLogDirPath }}/cephcsi/log/rbd-provisioner
+              name: csi-log
+            {{ end }}
             - mountPath: /sys
               name: host-sys
             - mountPath: /lib/modules
@@ -272,6 +290,13 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: csi-log
+          hostPath:
+            path: {{ .CsiLogDirPath }}/cephcsi/log/rbd-provisioner
+            type: DirectoryOrCreate
+        - name: csi-logs-logrotate
+          emptyDir:
+            type: DirectoryOrCreate
         - name: host-sys
           hostPath:
             path: /sys

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -73,6 +73,11 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
             - "--pidlimit=-1"
             - "--stagingpath={{ .KubeletDirPath }}/plugins/kubernetes.io/csi/"
+            {{ if .CSILogRotation }}
+            - "--logtostderr=false"
+            - "--alsologtostderr=true"
+            - "--log_file={{ .CsiLogDirPath }}/cephcsi/log/rbd-plugin/csi-rbdplugin.log"
+            {{ end }}
             {{ if .EnableCSIAddonsSideCar }}
             - "--csi-addons-endpoint=$(CSIADDONS_ENDPOINT)"
             {{ end }}
@@ -121,6 +126,10 @@ spec:
               mountPath: /tmp/csi/keys
             - name: host-run-mount
               mountPath: /run/mount
+            {{ if .CSILogRotation }}
+            - mountPath: {{ .CsiLogDirPath }}/cephcsi/log/rbd-plugin
+              name: csi-log
+            {{ end }}
             {{ if .EnablePluginSelinuxHostMount }}
             - name: etc-selinux
               mountPath: /etc/selinux
@@ -154,6 +163,11 @@ spec:
             - "--namespace=$(POD_NAMESPACE)"
             - "--pod-uid=$(POD_UID)"
             - "--stagingpath={{ .KubeletDirPath }}/plugins/kubernetes.io/csi/"
+            {{ if .CSILogRotation }}
+            - "--logtostderr=false"
+            - "--alsologtostderr=true"
+            - "--log_file={{ .CsiLogDirPath }}/cephcsi/log/rbd-plugin/csi-addons.log"
+            {{ end }}
           ports:
             - containerPort: {{ .CSIAddonsPort }}
           env:
@@ -179,6 +193,10 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+            {{ if .CSILogRotation }}
+            - mountPath: {{ .CsiLogDirPath }}/cephcsi/log/rbd-plugin
+              name: csi-log
+            {{ end }}
         {{ end }}
         {{ if .EnableLiveness }}
         - name: liveness-prometheus
@@ -210,6 +228,13 @@ spec:
         - name: plugin-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com"
+            type: DirectoryOrCreate
+        - name: csi-log
+          hostPath:
+            path: {{ .CsiLogDirPath }}/cephcsi/log/rbd-plugin
+            type: DirectoryOrCreate
+        - name: csi-logs-logrotate
+          emptyDir:
             type: DirectoryOrCreate
         - name: plugin-mount-dir
           hostPath:

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -84,6 +84,20 @@ func templateToDeployment(name, templateData string, p templateParam) (*apps.Dep
 	return &dep, nil
 }
 
+func applyLogrotateSidecar(specTemplate *corev1.PodTemplateSpec, name, templateData string, p templateParam) {
+	var logrotateSidecarContainer corev1.Container
+	t, err := loadTemplate(name, templateData, p)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to load logrotate container template"))
+	}
+
+	err = yaml.Unmarshal(t, &logrotateSidecarContainer)
+	if err != nil {
+		panic(errors.Wrap(err, "failed to unmarshal logrotate container template"))
+	}
+	specTemplate.Spec.Containers = append(specTemplate.Spec.Containers, logrotateSidecarContainer)
+}
+
 func applyResourcesToContainers(opConfig map[string]string, key string, podspec *corev1.PodSpec) {
 	resource := getComputeResource(opConfig, key)
 

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -120,8 +120,8 @@ func Test_applyVolumeToPodSpec(t *testing.T) {
 		Param:     CSIParam,
 		Namespace: "foo",
 	}
-	// rbdplugin has 11 volumes by default
-	defaultVolumes := 11
+	// rbdplugin has 13 volumes by default
+	defaultVolumes := 13
 	ds, err := templateToDaemonSet(dsName, RBDPluginTemplatePath, tp)
 	assert.Nil(t, err)
 	applyVolumeToPodSpec(config, configKey, &ds.Spec.Template.Spec)


### PR DESCRIPTION
1) Make the csi rbd container logs persisted in a file
   (csi plugin, csi provisioner, csi addons sidecar)

2) Use the cephcluster api specs to configure the log rotate

3) Add log rotation to rotate the log file and  
   Add a sidecar log collector container

part-of: https://github.com/rook/rook/issues/12809

Updates: 
- --logtostderr=false
- --alsologtostderr=true
- --log_file=/var/lib/cephcsi/log/rbdprov.log

```
sh-4.4# cat csi
/dev/*.log {
  rotate 3
  daily
  size 1M
  copytruncate
  start 1
}
```

When you mount a volume to a directory in a container, it effectively overrides the contents of that directory with the contents of the volume. This can cause issues if there are existing configurations or files in that directory that you want to preserve while adding new files or configurations.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
