### PR TITLE
monitoring: fix exporter service monitor selector

### DIFF
--- a/deploy/examples/monitoring/exporter-service-monitor.yaml
+++ b/deploy/examples/monitoring/exporter-service-monitor.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: rook-ceph-exporter
       rook_cluster: rook-ceph # namespace:cluster
-      ceph_daemon_id: exporter
   endpoints:
     - port: ceph-exporter-http-metrics
       path: /metrics


### PR DESCRIPTION
Exporter service created by rook operator contains the following labels: `app=rook-ceph-exporter,rook_cluster=<cluster-name>`

Label `ceph_daemon_id=exporter` is not there and therefore the service monitor selector can not discover the exporter service.

This fix removes the `ceph_daemon_id=exporter` label from the exporter service monitor selector.

See rook-ceph-exporter service labels:
```bash
$ kubectl -n rook-ceph get service rook-ceph-exporter --show-labels
NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE   LABELS
rook-ceph-exporter   ClusterIP   10.43.233.37   <none>        9926/TCP   23h   app=rook-ceph-exporter,rook_cluster=rook-cep
```
An alternative approach could be adding the missing label to the service. 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
