### PR TITLE
helm: allow custom labels and annotations for storage classes

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -80,6 +80,8 @@ The `cephBlockPools` array in the values file will define a list of CephBlockPoo
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephBlockPool | `true` |
 | `storageClass.isDefault` | Whether the storage class will be the default storage class for PVCs. See [PersistentVolumeClaim documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) for details. | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-block` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.parameters` | See [Block Storage](../Storage-Configuration/Block-Storage-RBD/block-storage.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
@@ -96,6 +98,8 @@ The `cephFileSystems` array in the values file will define a list of CephFileSys
 | `spec` | The CephFileSystem spec, see the [CephFilesystem CRD](../CRDs/Shared-Filesystem/ceph-filesystem-crd.md) documentation. | see values.yaml |
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephFileSystem | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-filesystem` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.pool` | The name of [Data Pool](../CRDs/Shared-Filesystem/ceph-filesystem-crd.md#pools), without the filesystem name prefix | `data0` |
 | `storageClass.parameters` | See [Shared Filesystem](../Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
@@ -111,6 +115,8 @@ The `cephObjectStores` array in the values file will define a list of CephObject
 | `spec` | The CephObjectStore spec, see the [CephObjectStore CRD](../CRDs/Object-Storage/ceph-object-store-crd.md) documentation. | see values.yaml |
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephObjectStore | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-bucket` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.parameters` | See [Object Store storage class](../Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `ingress.enabled` | Enable an ingress for the object store | `false` |

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -109,6 +109,8 @@ The `cephBlockPools` array in the values file will define a list of CephBlockPoo
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephBlockPool | `true` |
 | `storageClass.isDefault` | Whether the storage class will be the default storage class for PVCs. See [PersistentVolumeClaim documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) for details. | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-block` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.parameters` | See [Block Storage](../Storage-Configuration/Block-Storage-RBD/block-storage.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
@@ -125,6 +127,8 @@ The `cephFileSystems` array in the values file will define a list of CephFileSys
 | `spec` | The CephFileSystem spec, see the [CephFilesystem CRD](../CRDs/Shared-Filesystem/ceph-filesystem-crd.md) documentation. | see values.yaml |
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephFileSystem | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-filesystem` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.pool` | The name of [Data Pool](../CRDs/Shared-Filesystem/ceph-filesystem-crd.md#pools), without the filesystem name prefix | `data0` |
 | `storageClass.parameters` | See [Shared Filesystem](../Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
@@ -140,6 +144,8 @@ The `cephObjectStores` array in the values file will define a list of CephObject
 | `spec` | The CephObjectStore spec, see the [CephObjectStore CRD](../CRDs/Object-Storage/ceph-object-store-crd.md) documentation. | see values.yaml |
 | `storageClass.enabled` | Whether a storage class is deployed alongside the CephObjectStore | `true` |
 | `storageClass.name` | The name of the storage class | `ceph-bucket` |
+| `storageClass.annotations` | Additional storage class annotations | `{}` |
+| `storageClass.labels` | Additional storage class labels | `{}` |
 | `storageClass.parameters` | See [Object Store storage class](../Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 | `ingress.enabled` | Enable an ingress for the object store | `false` |

--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -14,8 +14,15 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ $blockpool.storageClass.name }}
+{{- if $blockpool.storageClass.labels }}
+  labels:
+{{ toYaml $blockpool.storageClass.labels | indent 4 }}
+{{- end }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "{{ if default false $blockpool.storageClass.isDefault }}true{{ else }}false{{ end }}"
+{{- if $blockpool.storageClass.annotations }}
+{{ toYaml $blockpool.storageClass.annotations | indent 4 }}
+{{- end }}
 {{- if $root.Values.csiDriverNamePrefix }}
 provisioner: {{ $root.Values.csiDriverNamePrefix }}.rbd.csi.ceph.com
 {{- else }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
@@ -22,10 +22,16 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ $ecblockpool.storageClass.name }}
-  {{- if $ecblockpool.storageClass.isDefault }}
+{{- if $ecblockpool.storageClass.labels }}
+  labels:
+{{ toYaml $ecblockpool.storageClass.labels | indent 4 }}
+{{- end }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  {{end}}
+    storageclass.kubernetes.io/is-default-class: "{{ if default false $ecblockpool.storageClass.isDefault }}true{{ else }}false{{ end }}"
+{{- if $ecblockpool.storageClass.annotations }}
+{{ toYaml $ecblockpool.storageClass.annotations | indent 4 }}
+{{- end }}
+
 {{- if $root.Values.csiDriverNamePrefix }}
 provisioner: {{ $root.Values.csiDriverNamePrefix }}.rbd.csi.ceph.com
 {{- else }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -33,8 +33,15 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ $filesystem.storageClass.name }}
+{{- if $filesystem.storageClass.labels }}
+  labels:
+{{ toYaml $filesystem.storageClass.labels | indent 4 }}
+{{- end }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "{{ if default false $filesystem.storageClass.isDefault }}true{{ else }}false{{ end }}"
+{{- if $filesystem.storageClass.annotations }}
+{{ toYaml $filesystem.storageClass.annotations | indent 4 }}
+{{- end }}
 {{- if $root.Values.csiDriverNamePrefix }}
 provisioner: {{ $root.Values.csiDriverNamePrefix }}.cephfs.csi.ceph.com
 {{- else }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -14,6 +14,14 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ $objectstore.storageClass.name }}
+{{- if $objectstore.storageClass.labels }}
+  labels:
+{{ toYaml $objectstore.storageClass.labels | indent 4 }}
+{{- end }}
+{{- if $objectstore.storageClass.annotations }}
+  annotations:
+{{ toYaml $objectstore.storageClass.annotations | indent 4 }}
+{{- end }}
 provisioner: {{ $root.Release.Namespace }}.ceph.rook.io/bucket
 reclaimPolicy: {{ default "Delete" $objectstore.storageClass.reclaimPolicy }}
 volumeBindingMode: {{ default "Immediate" $objectstore.storageClass.volumeBindingMode }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -452,6 +452,8 @@ cephBlockPools:
     storageClass:
       enabled: true
       name: ceph-block
+      annotations: { }
+      labels: { }
       isDefault: true
       reclaimPolicy: Delete
       allowVolumeExpansion: true
@@ -534,6 +536,8 @@ cephFileSystems:
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       volumeBindingMode: "Immediate"
+      annotations: { }
+      labels: { }
       mountOptions: []
       # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md#provision-storage for available configuration
       parameters:
@@ -606,6 +610,8 @@ cephObjectStores:
       name: ceph-bucket
       reclaimPolicy: Delete
       volumeBindingMode: "Immediate"
+      annotations: { }
+      labels: { }
       # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md#storageclass for available configuration
       parameters:
         # note: objectStoreNamespace and objectStoreName are configured by the chart
@@ -669,8 +675,10 @@ cephObjectStores:
 #    storageClass:
 #      provisioner: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
 #      enabled: true
-#      name:  rook-ceph-block
+#      name: rook-ceph-block
 #      isDefault: false
+#      annotations: { }
+#      labels: { }
 #      allowVolumeExpansion: true
 #      reclaimPolicy: Delete
 


### PR DESCRIPTION
Storage classes were missing the possilbilty to attach custom labels and annotations. This change brings it on par with VolumeSnapshotClass objects.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
