### PR TITLE
pool: get the exact deviceClass name instead of crushroot+deviceClass

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -529,7 +529,15 @@ func extractPoolDetails(rule ruleSpec) (string, string) {
 			failureDomain = step.Type
 		}
 		if step.ItemName != "" {
-			deviceClass = step.ItemName
+			// we are not using crushRoot currently, remove it
+			// from crush rule
+			if strings.Contains(step.ItemName, "~") {
+				crushRootAndDeviceClass := step.ItemName
+				parts := strings.SplitN(crushRootAndDeviceClass, "~", 2)
+				deviceClass = parts[1]
+			} else {
+				deviceClass = step.ItemName
+			}
 		}
 		// We expect the rule to be found by the second step, or else it is a more
 		// complex rule that would not be supported for updating the failure domain

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -339,6 +339,16 @@ func TestExtractPoolDetails(t *testing.T) {
 		assert.Equal(t, "zone", failureDomain)
 		assert.Equal(t, "ssd", deviceClass)
 	})
+
+	t.Run("valid crush rule with crushroot combined", func(t *testing.T) {
+		rule := ruleSpec{Steps: []stepSpec{
+			{Type: ""},
+			{Type: "zone", ItemName: "default~ssd"},
+		}}
+		failureDomain, deviceClass := extractPoolDetails(rule)
+		assert.Equal(t, "zone", failureDomain)
+		assert.Equal(t, "ssd", deviceClass)
+	})
 }
 
 func TestGetPoolStatistics(t *testing.T) {


### PR DESCRIPTION
this lead to creation of 2 crush rules because of difference in deviceClass names:
eg:
creating a new crush rule for changed deviceClass
("default~hdd"-->"hdd") on crush rule "test-crush-bug-az-ab-4"
```
            "rule_id": 3,
            "rule_name": "test-bug-pool_host_hdd",
            "type": 1,
            "steps": [
                {
                    "op": "take",
                    "item": -2,
                    "item_name": "default~hdd"
                },
                {
                    "op": "chooseleaf_firstn",
                    "num": 0,
                    "type": "host"
                },
                {
                    "op": "emit"
                }
            ]
        }
```
tested locally on changing device class hdd to nvme

```
2024-06-11 20:34:10.028094 D | cephclient: checking that pool "test-bug-pool" has the failure domain "host" and deviceClass "nvme"
```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
