### PR TITLE
monitoring: Set honor labels on the service monitor

### DIFF
--- a/deploy/examples/monitoring/service-monitor.yaml
+++ b/deploy/examples/monitoring/service-monitor.yaml
@@ -17,3 +17,4 @@ spec:
     - port: http-metrics
       path: /metrics
       interval: 10s
+      honorLabels: true

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -61,9 +61,10 @@ func GetServiceMonitor(name string, namespace string, portName string) *monitori
 			},
 			Endpoints: []monitoringv1.Endpoint{
 				{
-					Port:     portName,
-					Path:     "/metrics",
-					Interval: "10s",
+					Port:        portName,
+					Path:        "/metrics",
+					Interval:    "10s",
+					HonorLabels: true,
 				},
 			},
 		},


### PR DESCRIPTION
The endpoint property honorLabels: true should be set so that different rgw instances can show separate prometheus values instead of being aggregated.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14169 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
