### PR TITLE
monitoring: fix CephPoolGrowthWarning expression

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -533,7 +533,7 @@ groups:
         annotations:
           description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
           summary: "Pool growth rate may soon exceed capacity"
-        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
           severity: "warning"

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -537,7 +537,7 @@ spec:
           annotations:
             description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
             summary: "Pool growth rate may soon exceed capacity"
-          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
             severity: "warning"


### PR DESCRIPTION
Prometheus found duplicate series for the match group `pool_id` and `instance` when evaluating the CephPoolGrowthWarning alert expression. This alert has an evaluation interval of 2 days and did not consider the changing POD names during the Rook migration process.

This PR adds the `pod` label to the set of considered labels.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
**Issue resolved by this Pull Request:**
Resolves #14338 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
