### PR TITLE
osd: Use old passphrase to kill the LUKS slot

### DIFF
--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -272,10 +272,10 @@ func addEncryptionKey(context *clusterd.Context, disk, passphrase, newPassphrase
 		if err != nil {
 			return errors.Wrapf(err, "failed to ensure passphrase in slot %q of encrypted device %q", slot, disk)
 		}
-		// if newPassphrase is not one in the slot, then remove the key slot and
-		// add add the newPassphrase to it.
+		// if newPassphrase is not one in the slot, then remove the key slot using current passphrase and then
+		// add the newPassphrase to it.
 		if !matched {
-			err = removeEncryptionKeySlot(context, disk, newPassphrase, slot)
+			err = removeEncryptionKeySlot(context, disk, passphrase, slot)
 			if err != nil {
 				return errors.Wrapf(err, "failed to remove key slot %q of encrypted device %q", slot, disk)
 			}


### PR DESCRIPTION
While adding a new encryption key to slot 1
if there exists a key in slot 1 which is not
equal to the one we want to update it with,
we kill the slot and then add the new key to it.

While killing the slot, the existing code uses
the new key, which is not valid in such cases.

This patch modifies the code to use the key in
slot 0 (the one that we know works) to kill the slot.