### PR TITLE
csi: add securityContext to csi containers

### DIFF
--- a/Documentation/Getting-Started/ceph-openshift.md
+++ b/Documentation/Getting-Started/ceph-openshift.md
@@ -59,7 +59,7 @@ There are some Rook settings that also need to be adjusted to work in OpenShift.
 
 There is an environment variable that needs to be set in the operator spec that will allow Rook to run in OpenShift clusters.
 
-* `ROOK_HOSTPATH_REQUIRES_PRIVILEGED`: Must be set to `true`. Writing to the hostPath is required for the Ceph mon and osd pods. Given the restricted permissions in OpenShift with SELinux, the pod must be running privileged in order to write to the hostPath volume.
+* `ROOK_HOSTPATH_REQUIRES_PRIVILEGED`: Must be set to `true`. Writing to the hostPath is required for the Ceph mon, osd pods and csi provisioners(if logrotation is on). Given the restricted permissions in OpenShift with SELinux, the pod must be running privileged in order to write to the hostPath volume.
 
 ```yaml
 - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -682,7 +682,7 @@ spec:
             - name: ROOK_CURRENT_NAMESPACE_ONLY
               value: "false"
 
-            # Whether to start pods as privileged that mount a host path, which includes the Ceph mon and osd pods.
+            # Whether to start pods as privileged that mount a host path, which includes the Ceph mon, osd pods and csi provisioners(if logrotation is on).
             # Set this to true if SELinux is enabled (e.g. OpenShift) to workaround the anyuid issues.
             # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641
             - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -610,7 +610,7 @@ spec:
             - name: ROOK_CURRENT_NAMESPACE_ONLY
               value: "false"
 
-            # Whether to start pods as privileged that mount a host path, which includes the Ceph mon and osd pods.
+            # Whether to start pods as privileged that mount a host path, which includes the Ceph mon, osd pods and csi provisioners(if logrotation is on).
             # Set this to true if SELinux is enabled (e.g. OpenShift) to workaround the anyuid issues.
             # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641
             - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -317,6 +317,7 @@ func setCSILogrotateParams(cephClustersItems []cephv1.CephCluster) {
 	if spec.DataDirHostPath == "" {
 		CSIParam.CsiLogDirPath = k8sutil.DataDir
 	}
+
 	CSIParam.CSILogRotation = spec.LogCollector.Enabled
 	if spec.LogCollector.Enabled {
 		maxSize, period := opcontroller.GetLogRotateConfig(spec)

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/pkg/errors"
@@ -123,6 +124,8 @@ func (r *ReconcileCSI) setParams(ver *version.Info) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_LIVENESS'")
 	}
+
+	CSIParam.Privileged = controller.HostPathRequiresPrivileged()
 
 	// default value `system-node-critical` is the highest available priority
 	CSIParam.PluginPriorityClassName = k8sutil.GetValue(r.opConfig.Parameters, "CSI_PLUGIN_PRIORITY_CLASSNAME", "")

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -102,6 +102,7 @@ type Param struct {
 	CSILogRotationMaxSize                    string
 	CSILogRotationPeriod                     string
 	CSILogFolder                             string
+	Privileged                               bool
 }
 
 type templateParam struct {

--- a/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -148,6 +148,10 @@ spec:
               value: unix:///csi/csi-addons.sock
             {{ end }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          {{ if and .Privileged .CSILogRotation }}
+          securityContext:
+            privileged: true
+          {{ end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -209,6 +213,10 @@ spec:
             - name: CSIADDONS_ENDPOINT
               value: unix:///csi/csi-addons.sock
           imagePullPolicy: {{ .ImagePullPolicy }}
+          {{ if and .Privileged .CSILogRotation }}
+          securityContext:
+            privileged: true
+          {{ end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/nfs/csi-nfsplugin-provisioner-dep.yaml
@@ -129,6 +129,10 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: {{ .ImagePullPolicy }}
+          {{ if and .Privileged .CSILogRotation }}
+          securityContext:
+            privileged: true
+          {{ end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/pkg/operator/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -182,6 +182,10 @@ spec:
             - name: CSIADDONS_ENDPOINT
               value: unix:///csi/csi-addons.sock
           imagePullPolicy: {{ .ImagePullPolicy }}
+          {{ if and .Privileged .CSILogRotation }}
+          securityContext:
+            privileged: true
+          {{ end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -234,6 +238,10 @@ spec:
               value: unix:///csi/csi-addons.sock
             {{ end }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          {{ if and .Privileged .CSILogRotation }}
+          securityContext:
+            privileged: true
+          {{ end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
With the recent enhancements csi containers for using logrotate, they need to run with securityContext to privileged, on platform like openshift.
Used the ROOK_HOSTPATH_REQUIRES_PRIVILEGED flag
wich is set with operator deployment to see
if the securityCOntext is needed or not

Closes: https://github.com/rook/rook/issues/14400

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
