### PR TITLE
external: add final args used to the upgrade configmap

### DIFF
--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -174,14 +174,20 @@ function createInputCommadConfigMap() {
       create \
       configmap \
       "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
-      --from-literal=command="$EXTERNAL_CLUSTER_USER_COMMAND"
+      --from-literal=command="$EXTERNAL_CLUSTER_USER_COMMAND" \
+      --from-literal=args="$ARGS"
   else
     echo "configmap $EXTERNAL_COMMAND_CONFIGMAP_NAME already exists, updating it"
     $KUBECTL -n "$NAMESPACE" \
       patch \
       configmap \
       "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
-      -p "{'data':{'command':$EXTERNAL_COMMAND_CONFIGMAP_NAME}}"
+      -p "{\"data\":{\"command\":\"$EXTERNAL_CLUSTER_USER_COMMAND\"}}"
+    $KUBECTL -n "$NAMESPACE" \
+      patch \
+      configmap \
+      "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
+      -p "{\"data\":{\"args\":\"$ARGS\"}}"
   fi
 }
 


### PR DESCRIPTION
Recently we have introuced `external-cluster-user-command` cm Which help user to look at the previous command run, So with this PR we will add another data field `arg` on this confimap which will have the final processed flags that are being used
So user can use them directly either in config.ini or cmd line args

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
