### PR TITLE
build: upgrade to go 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21","1.22"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1570,7 +1570,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: setup cluster resources
         uses: ./.github/workflows/canary-test-config

--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: setup golang
       uses: actions/setup-go@v5
       with:
-        go-version: "1.21"
+        go-version: "1.22"
 
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: run codegen
         run: GOPATH=$(go env GOPATH) make codegen

--- a/.github/workflows/crds-gen.yml
+++ b/.github/workflows/crds-gen.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: run crds-gen
         run: GOPATH=$(go env GOPATH) make crds

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Install Docker
         run: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-         go-version: "1.22"
+         go-version: "1.22.5"
          check-latest: true
       - name: govulncheck
         uses: golang/govulncheck-action@v1

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -18,7 +18,7 @@ runs:
     - name: setup golang
       uses: actions/setup-go@v5
       with:
-        go-version: "1.21"
+        go-version: "1.22"
 
     - name: Setup Minikube
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/mod-check.yml
+++ b/.github/workflows/mod-check.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: run mod check
         run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check

--- a/.github/workflows/multus.yaml
+++ b/.github/workflows/multus.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go version
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Create KinD Cluster
         uses: helm/kind-action@v1.10.0

--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
         # docker/setup-qemu action installs QEMU static binaries, which are used to run builders for architectures other than the host.
       - name: set up QEMU

--- a/.github/workflows/rbac-gen.yaml
+++ b/.github/workflows/rbac-gen.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: run gen-rbac
         run: GOPATH=$(go env GOPATH) make gen-rbac

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Setup jq
         uses: dcarbone/install-jq-action@v2.1.0

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -7,7 +7,7 @@ don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev 
 
 ## Prerequisites
 
-1. [GO 1.21](https://golang.org/dl/) or greater installed
+1. [GO 1.22](https://golang.org/dl/) or greater installed
 2. Git client installed
 3. GitHub account
 

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -48,7 +48,7 @@ GO_TEST_FLAGS ?=
 # ====================================================================================
 # Setup go environment
 
-GO_SUPPORTED_VERSIONS ?= 1.21|1.22
+GO_SUPPORTED_VERSIONS ?= 1.22
 
 GO_PACKAGES := $(foreach t,$(GO_SUBDIRS),$(GO_PROJECT)/$(t)/...)
 GO_INTEGRATION_TEST_PACKAGES := $(foreach t,$(GO_INTEGRATION_TESTS_SUBDIRS),$(GO_PROJECT)/$(t)/integration)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rook/rook/pkg/apis
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
this commit upgrade to go 1.22 in go mod file and ci related files. Also remove go 1.21 support

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
