### PR TITLE
osd: reweight osd while resizing

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -82,6 +82,9 @@ For more details on the mons and when to choose a number other than `3`, see the
     * `config`: Config settings applied to all OSDs on the node unless overridden by `devices`. See the [config settings](#osd-configuration-settings) below.
     * `allowDeviceClassUpdate`: Whether to allow changing the device class of an OSD after it is created. The default is false
         to prevent unintentional data movement or CRUSH changes if the device class is changed accidentally.
+    * `allowOsdCrushWeightUpdate`: Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.
+        This allows cluster data to be rebalanced to make most effective use of new OSD space.
+        The default is false since data rebalancing can cause temporary cluster slowdown.
     * [storage selection settings](#storage-selection-settings)
     * [Storage Class Device Sets](#storage-class-device-sets)
     * `onlyApplyOSDPlacement`: Whether the placement specific for OSDs is merged with the `all` placement. If `false`, the OSD placement will be merged with the `all` placement. If true, the `OSD placement will be applied` and the `all` placement will be ignored. The placement for OSDs is computed from several different places depending on the type of OSD:

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -12230,6 +12230,20 @@ bool
 <p>Whether to allow updating the device class after the OSD is initially provisioned</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>allowOsdCrushWeightUpdate</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.
+This allows cluster data to be rebalanced to make most effective use of new OSD space.
+The default is false since data rebalancing can cause temporary cluster slowdown.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.StoreType">StoreType

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -3207,6 +3207,12 @@ spec:
                     allowDeviceClassUpdate:
                       description: Whether to allow updating the device class after the OSD is initially provisioned
                       type: boolean
+                    allowOsdCrushWeightUpdate:
+                      description: |-
+                        Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.
+                        This allows cluster data to be rebalanced to make most effective use of new OSD space.
+                        The default is false since data rebalancing can cause temporary cluster slowdown.
+                      type: boolean
                     backfillFullRatio:
                       description: BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
                       maximum: 1

--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -54,6 +54,7 @@ spec:
     maxLogSize: 500M # SUFFIX may be 'M' or 'G'. Must be at least 1M.
   storage:
     allowDeviceClassUpdate: false # whether to allow changing the device class of an OSD after it is created
+    allowOsdCrushWeightUpdate: true # whether to allow resizing the OSD crush weight after osd pvc is increased
     storageClassDeviceSets:
       - name: set1
         # The number of OSDs to create from this device set

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -34,6 +34,7 @@ spec:
     useAllNodes: true
     useAllDevices: true
     allowDeviceClassUpdate: true
+    allowOsdCrushWeightUpdate: false
     #deviceFilter:
     #config:
     #  deviceClass: testclass

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -257,6 +257,7 @@ spec:
       # encryptedDevice: "true" # the default value for this option is "false"
       # deviceClass: "myclass" # specify a device class for OSDs in the cluster
     allowDeviceClassUpdate: false # whether to allow changing the device class of an OSD after it is created
+    allowOsdCrushWeightUpdate: false # whether to allow resizing the OSD crush weight after osd pvc is increased
     # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
     # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
     # nodes:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -3205,6 +3205,12 @@ spec:
                     allowDeviceClassUpdate:
                       description: Whether to allow updating the device class after the OSD is initially provisioned
                       type: boolean
+                    allowOsdCrushWeightUpdate:
+                      description: |-
+                        Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.
+                        This allows cluster data to be rebalanced to make most effective use of new OSD space.
+                        The default is false since data rebalancing can cause temporary cluster slowdown.
+                      type: boolean
                     backfillFullRatio:
                       description: BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.
                       maximum: 1

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2864,6 +2864,11 @@ type StorageScopeSpec struct {
 	// Whether to allow updating the device class after the OSD is initially provisioned
 	// +optional
 	AllowDeviceClassUpdate bool `json:"allowDeviceClassUpdate,omitempty"`
+	// Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.
+	// This allows cluster data to be rebalanced to make most effective use of new OSD space.
+	// The default is false since data rebalancing can cause temporary cluster slowdown.
+	// +optional
+	AllowOsdCrushWeightUpdate bool `json:"allowOsdCrushWeightUpdate,omitempty"`
 }
 
 // OSDStore is the backend storage type used for creating the OSDs

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -141,6 +141,18 @@ func TestOSDDeviceClasses(t *testing.T) {
 	})
 }
 
+func TestConvertKibibytesToTebibytes(t *testing.T) {
+	kib := "1024"
+	terabyte, err := convertKibibytesToTebibytes(kib)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(9.5367431640625e-07), terabyte)
+
+	kib = "1073741824"
+	terabyte, err = convertKibibytesToTebibytes(kib)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), terabyte)
+}
+
 func TestOSDOkToStop(t *testing.T) {
 	returnString := ""
 	returnOkResult := true


### PR DESCRIPTION
osd got resized by cryptsetup bluestore cmd
but it should also be reweight to balance the pgs properly

closes: https://github.com/rook/rook/issues/14430

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
