### PR TITLE
external: fix the output of user config

### DIFF
--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -174,7 +174,6 @@ function createInputCommadConfigMap() {
       create \
       configmap \
       "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
-      --from-literal=command="$EXTERNAL_CLUSTER_USER_COMMAND" \
       --from-literal=args="$ARGS"
   else
     echo "configmap $EXTERNAL_COMMAND_CONFIGMAP_NAME already exists, updating it"
@@ -182,12 +181,7 @@ function createInputCommadConfigMap() {
       patch \
       configmap \
       "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
-      -p "{\"data\":{\"command\":\"$EXTERNAL_CLUSTER_USER_COMMAND\"}}"
-    $KUBECTL -n "$NAMESPACE" \
-      patch \
-      configmap \
-      "$EXTERNAL_COMMAND_CONFIGMAP_NAME" \
-      -p "{\"data\":{\"args\":\"$ARGS\"}}"
+      -p "$(jq -n --arg args "$ARGS" '{"data": {"args": $args}}')"
   fi
 }
 


### PR DESCRIPTION
currently the output in the cm was not human readable and can not easily used to create a config.ini file

Also for now removed the support of printing arg in upstream

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
