### PR TITLE
core: set min-compat-client to reef for upmap-read

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1601,6 +1601,7 @@ spec:
                                   - ""
                                   - crush-compat
                                   - upmap
+                                  - read
                                   - upmap-read
                                 type: string
                             type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1599,6 +1599,7 @@ spec:
                                   - ""
                                   - crush-compat
                                   - upmap
+                                  - read
                                   - upmap-read
                                 type: string
                             type: object

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -679,7 +679,7 @@ type Module struct {
 
 type ModuleSettings struct {
 	// BalancerMode sets the `balancer` module with different modes like `upmap`, `crush-compact` etc
-	// +kubebuilder:validation:Enum="";crush-compat;upmap;upmap-read
+	// +kubebuilder:validation:Enum="";crush-compat;upmap;read;upmap-read
 	BalancerMode string `json:"balancerMode,omitempty"`
 }
 

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -22,10 +22,16 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 )
 
 var (
 	moduleEnableWaitTime = 5 * time.Second
+)
+
+const (
+	readBalancerMode      = "read"
+	upmapReadBalancerMode = "upmap-read"
 )
 
 func CephMgrMap(context *clusterd.Context, clusterInfo *ClusterInfo) (*MgrMap, error) {
@@ -132,12 +138,12 @@ func setBalancerMode(context *clusterd.Context, clusterInfo *ClusterInfo, mode s
 	return nil
 }
 
-// setMinCompatClientLuminous set the minimum compatibility for clients to Luminous
-func setMinCompatClientLuminous(context *clusterd.Context, clusterInfo *ClusterInfo) error {
-	args := []string{"osd", "set-require-min-compat-client", "luminous", "--yes-i-really-mean-it"}
+// setMinCompatClient set the minimum compatibility for clients
+func setMinCompatClient(context *clusterd.Context, clusterInfo *ClusterInfo, version string) error {
+	args := []string{"osd", "set-require-min-compat-client", version, "--yes-i-really-mean-it"}
 	_, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
-		return errors.Wrap(err, "failed to set set-require-min-compat-client to luminous")
+		return errors.Wrapf(err, "failed to set set-require-min-compat-client to %q", version)
 	}
 
 	return nil
@@ -165,8 +171,12 @@ func mgrSetBalancerMode(context *clusterd.Context, clusterInfo *ClusterInfo, bal
 
 // ConfigureBalancerModule configures the balancer module
 func ConfigureBalancerModule(context *clusterd.Context, clusterInfo *ClusterInfo, balancerModuleMode string) error {
-	// Set min compat client to luminous before enabling the balancer mode "upmap"
-	err := setMinCompatClientLuminous(context, clusterInfo)
+	minCompatClientVersion, err := desiredMinCompatClientVersion(clusterInfo, balancerModuleMode)
+	if err != nil {
+		return errors.Wrap(err, "failed to get minimum compatibility client version")
+	}
+
+	err = setMinCompatClient(context, clusterInfo, minCompatClientVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to set minimum compatibility client")
 	}
@@ -178,4 +188,18 @@ func ConfigureBalancerModule(context *clusterd.Context, clusterInfo *ClusterInfo
 	}
 
 	return nil
+}
+
+func desiredMinCompatClientVersion(clusterInfo *ClusterInfo, balancerModuleMode string) (string, error) {
+	// Set min compat client to luminous before enabling the balancer mode "upmap"
+	minCompatClientVersion := "luminous"
+	if balancerModuleMode == readBalancerMode || balancerModuleMode == upmapReadBalancerMode {
+		if !clusterInfo.CephVersion.IsAtLeast(cephver.CephVersion{Major: 19}) {
+			return "", errors.New("minimum ceph v19 (Squid) is required for upmap-read or read balancer modes")
+		}
+		// Set min compat client to reef before enabling the balancer mode "upmap-read" or "read"
+		minCompatClientVersion = "reef"
+	}
+
+	return minCompatClientVersion, nil
 }


### PR DESCRIPTION
If `upmap-read` or `read` balancer mode is used, then set
min-compat-client to reef

Able to set `upmap-read` mode :
```
❯ oc rsh -n openshift-storage $(oc get pods -o wide -n openshift-storage|grep rook-ceph-operator|awk '{print$1}') ceph --conf=/var/lib/rook/openshift-storage/openshift-storage.config balancer status
{
    "active": true,
    "last_optimize_duration": "0:00:00.002488",
    "last_optimize_started": "Wed Jul 24 01:25:28 2024",
    "mode": "upmap-read",
    "no_optimization_needed": true,
    "optimize_result": "Unable to find further optimization, or pool(s) pg_num is decreasing, or distribution is already perfect",
    "plans": []
}

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
