### PR TITLE
ci: fix the permissions of the assign action

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -10,7 +10,7 @@ jobs:
   assign:
     permissions:
       # write permissions are needed to assign the issue.
-      contents: write
+    issues: write
     name: Run self assign job
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Resolves: #14518 

A recent change seems to have broken the permissions of the auto-assign action.

This  change tries to fix this by making permissions more generous.



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
