### PR TITLE
docs: fix affinity docs in operator chart

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/operator-chart.gotmpl.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters of the rook-operator chart
 
 {{ template "chart.valuesTable" . }}
 
-[^1]: `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
+[^1]: `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage;role=rook-example` or `storage;` (_checks only for presence of key_)
 
 ### **Development Build**
 

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -168,7 +168,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `unreachableNodeTolerationSeconds` | Delay to use for the `node.kubernetes.io/unreachable` pod failure toleration to override the Kubernetes default of 5 minutes | `5` |
 | `useOperatorHostNetwork` | If true, run rook operator on the host network | `nil` |
 
-[^1]: `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
+[^1]: `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage;role=rook-example` or `storage;` (_checks only for presence of key_)
 
 ### **Development Build**
 


### PR DESCRIPTION
It turns out that using `storage=;` for the field `*NodeAffinity` results in the following affinity:
```yaml
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: storage
            operator: In
            values:
            - ""
```

Which is not checking for existence. To create the affinity that check for existence, it should be `storage;`, which results in this:
```yaml
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: storage
            operator: Exists

```

This is corroborated by reading [the code](https://github.com/rook/rook/blob/89f29a427a8ce2eedccc38bf7fb7727ec666477e/pkg/operator/k8sutil/node.go#L351-L352).

