### PR TITLE
ci: fix failing multus validation tool test

### DIFF
--- a/.github/workflows/multus.yaml
+++ b/.github/workflows/multus.yaml
@@ -11,6 +11,7 @@ on:
       - cmd/rook/userfacing/**
       - pkg/daemon/multus/**
       - .github/workflows/multus.yaml
+      - tests/scripts/multus/**
 
 defaults:
   run:

--- a/tests/scripts/multus/host-cfg-ds.yaml
+++ b/tests/scripts/multus/host-cfg-ds.yaml
@@ -29,12 +29,12 @@ spec:
       terminationGracePeriodSeconds: 0 # allow updating/deleting immediately
       containers:
         - name: test
-          image: quay.io/ceph/ceph:v18
+          image: jonlabelle/network-tools
           env:
             - name: IFACE_NAME
               value: eth0 # IFACE_NAME
           command:
-            - bash
+            - sh
             - -x
             - -c
           args:


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

Ceph image no longer has `ip` tool installed. Use a different container
image for the daemonset which sets host IPs and routes for multus hosts.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
