### PR TITLE
core: Add annotations and labels to detect version jobs

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7482,6 +7482,8 @@ string
 <td></td>
 </tr><tr><td><p>&#34;clusterMetadata&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;cmdreporter&#34;</p></td>
+<td></td>
 </tr><tr><td><p>&#34;crashcollector&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;dashboard&#34;</p></td>

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -194,9 +194,14 @@ spec:
   annotations:
   #   all:
   #   mon:
+  #   mgr:
   #   osd:
+  #   exporter:
+  #   crashcollector:
   #   cleanup:
   #   prepareosd:
+  # cmdreporter is for jobs to detect ceph and csi versions, and check network status
+  #   cmdreporter:
   # clusterMetadata annotations will be applied to only `rook-ceph-mon-endpoints` configmap and the `rook-ceph-mon` and `rook-ceph-admin-keyring` secrets.
   # And clusterMetadata annotations will not be merged with `all` annotations.
   #    clusterMetadata:

--- a/pkg/apis/ceph.rook.io/v1/annotations.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations.go
@@ -72,6 +72,11 @@ func GetCephExporterAnnotations(a AnnotationsSpec) Annotations {
 	return mergeAllAnnotationsWithKey(a, KeyCephExporter)
 }
 
+// GetCmdReporterAnnotations returns the Annotations for jobs detecting versions
+func GetCmdReporterAnnotations(a AnnotationsSpec) Annotations {
+	return mergeAllAnnotationsWithKey(a, KeyCmdReporter)
+}
+
 func GetClusterMetadataAnnotations(a AnnotationsSpec) Annotations {
 	return a[KeyClusterMetadata]
 }

--- a/pkg/apis/ceph.rook.io/v1/annotations_test.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations_test.go
@@ -58,8 +58,9 @@ func TestCephAnnotationsMerge(t *testing.T) {
 
 	// Merge with "all"
 	testAnnotations = AnnotationsSpec{
-		"all": {"allkey1": "allval1", "allkey2": "allval2"},
-		"mgr": {"mgrkey": "mgrval"},
+		"all":         {"allkey1": "allval1", "allkey2": "allval2"},
+		"mgr":         {"mgrkey": "mgrval"},
+		"cmdreporter": {"myversions": "detect"},
 	}
 	a = GetMonAnnotations(testAnnotations)
 	assert.Equal(t, "allval1", a["allkey1"])
@@ -70,6 +71,10 @@ func TestCephAnnotationsMerge(t *testing.T) {
 	assert.Equal(t, "allval1", a["allkey1"])
 	assert.Equal(t, "allval2", a["allkey2"])
 	assert.Equal(t, 3, len(a))
+	b := GetCmdReporterAnnotations(testAnnotations)
+	assert.Equal(t, "detect", b["myversions"])
+	assert.Equal(t, "allval1", b["allkey1"])
+	assert.Equal(t, "allval2", b["allkey2"])
 }
 
 func TestAnnotationsSpec(t *testing.T) {

--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -32,4 +32,5 @@ const (
 	KeyCrashCollector  KeyType = "crashcollector"
 	KeyClusterMetadata KeyType = "clusterMetadata"
 	KeyCephExporter    KeyType = "exporter"
+	KeyCmdReporter     KeyType = "cmdreporter"
 )

--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -87,6 +87,10 @@ func GetCephExporterLabels(a LabelsSpec) Labels {
 	return mergeAllLabelsWithKey(a, KeyCephExporter)
 }
 
+func GetCmdReporterLabels(a LabelsSpec) Labels {
+	return mergeAllLabelsWithKey(a, KeyCmdReporter)
+}
+
 func mergeAllLabelsWithKey(a LabelsSpec, name KeyType) Labels {
 	all := a.All()
 	if all != nil {

--- a/pkg/apis/ceph.rook.io/v1/labels_test.go
+++ b/pkg/apis/ceph.rook.io/v1/labels_test.go
@@ -58,8 +58,9 @@ func TestCephLabelsMerge(t *testing.T) {
 
 	// Merge with "all"
 	testLabels = LabelsSpec{
-		"all": {"allkey1": "allval1", "allkey2": "allval2"},
-		"mgr": {"mgrkey": "mgrval"},
+		"all":         {"allkey1": "allval1", "allkey2": "allval2"},
+		"mgr":         {"mgrkey": "mgrval"},
+		"cmdreporter": {"detect": "myversion"},
 	}
 	a = GetMonLabels(testLabels)
 	assert.Equal(t, "allval1", a["allkey1"])
@@ -67,6 +68,11 @@ func TestCephLabelsMerge(t *testing.T) {
 	assert.Equal(t, 2, len(a))
 	a = GetMgrLabels(testLabels)
 	assert.Equal(t, "mgrval", a["mgrkey"])
+	assert.Equal(t, "allval1", a["allkey1"])
+	assert.Equal(t, "allval2", a["allkey2"])
+	assert.Equal(t, 3, len(a))
+	a = GetCmdReporterLabels(testLabels)
+	assert.Equal(t, "myversion", a["detect"])
 	assert.Equal(t, "allval1", a["allkey1"])
 	assert.Equal(t, "allval2", a["allkey2"])
 	assert.Equal(t, 3, len(a))

--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -264,6 +264,8 @@ func discoverAddressRanges(
 	job.Spec.Template.Annotations = map[string]string{
 		nadv1.NetworkAttachmentAnnot: netSelectionValue,
 	}
+	cephv1.GetCmdReporterAnnotations(clusterSpec.Annotations).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
+	cephv1.GetCmdReporterLabels(clusterSpec.Labels).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
 
 	// use osd placement for net canaries b/c osd pods are present on both public and cluster nets
 	cephv1.GetOSDPlacement(clusterSpec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -86,6 +86,9 @@ func DetectCephVersion(ctx context.Context, rookImage, namespace, jobName string
 	cephv1.GetMonPlacement(cephClusterSpec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)
 	job.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
 
+	cephv1.GetCmdReporterAnnotations(cephClusterSpec.Annotations).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
+	cephv1.GetCmdReporterLabels(cephClusterSpec.Labels).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
+
 	stdout, stderr, retcode, err := versionReporter.Run(ctx, detectCephVersionTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to complete ceph version job")

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -58,6 +58,8 @@ type ReconcileCSI struct {
 	opManagerContext   context.Context
 	opConfig           opcontroller.OperatorConfig
 	clustersWithHolder []ClusterDetail
+	// the first cluster CR which will determine some settings for the csi driver
+	firstCephCluster *cephv1.ClusterSpec
 }
 
 // ClusterDetail is a struct that holds the information of a cluster, it knows its internals (like
@@ -274,6 +276,10 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 		if !cluster.Spec.External.Enable && cluster.Spec.CleanupPolicy.HasDataDirCleanPolicy() {
 			logger.Debugf("ceph cluster %q has cleanup policy, the cluster will soon go away, no need to reconcile the csi driver", cluster.Name)
 			return reconcile.Result{}, nil
+		}
+
+		if r.firstCephCluster == nil {
+			r.firstCephCluster = &cephClusters.Items[i].Spec
 		}
 
 		// Load cluster info for later use in updating the ceph-csi configmap

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/telemetry"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -873,6 +874,10 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 	job.Spec.Template.Spec.Tolerations = getToleration(r.opConfig.Parameters, provisionerTolerationsEnv, []corev1.Toleration{})
 	job.Spec.Template.Spec.Affinity = &corev1.Affinity{
 		NodeAffinity: getNodeAffinity(r.opConfig.Parameters, provisionerNodeAffinityEnv, &corev1.NodeAffinity{}),
+	}
+	if r.firstCephCluster != nil {
+		cephv1.GetCmdReporterAnnotations(r.firstCephCluster.Annotations).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
+		cephv1.GetCmdReporterLabels(r.firstCephCluster.Labels).ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
 	}
 
 	stdout, _, retcode, err := versionReporter.Run(r.opManagerContext, timeout)


### PR DESCRIPTION
The jobs to detect the ceph and csi versions now can have custom annotations and labels added to them. They are very short-lived jobs, but they may need custom annotations in some environments to run.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14575 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
