### PR TITLE
docs: missing slack link

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -3,7 +3,7 @@ title: Development Flow
 ---
 
 Thank you for your time and effort to help us improve Rook! Here are a few steps to get started. If you have any questions,
-don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev channel.
+don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev channel. Sign up for the Rook Slack [here](https://slack.rook.io).
 
 ## Prerequisites
 


### PR DESCRIPTION
It is missing in https://rook.io/docs/rook/latest-release/Contributing/development-flow/