### PR TITLE
build: Generate the local build tag with docker io

### DIFF
--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rook/rook/tests/framework/utils"
 )
 
-var imageMatch = regexp.MustCompile(`image: rook\/ceph:[a-z0-9.-]+`)
+var imageMatch = regexp.MustCompile(`image: docker.io/rook\/ceph:[a-z0-9.-]+`)
 
 func readManifest(filename string) string {
 	rootDir, err := utils.FindRookRoot()
@@ -39,7 +39,7 @@ func readManifest(filename string) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to read manifest at %s", manifest))
 	}
-	return imageMatch.ReplaceAllString(string(contents), "image: rook/ceph:"+LocalBuildTag)
+	return imageMatch.ReplaceAllString(string(contents), "image: docker.io/rook/ceph:"+LocalBuildTag)
 }
 
 func buildURL(rookVersion, filename string) string {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -380,7 +380,7 @@ func (s *UpgradeSuite) verifyOperatorImage(expectedImage string) {
 	// verify that the operator spec is updated
 	version, err := k8sutil.GetDeploymentImage(context.TODO(), s.k8sh.Clientset, systemNamespace, operatorContainer, operatorContainer)
 	assert.NoError(s.T(), err)
-	assert.Contains(s.T(), version, "rook/ceph:"+expectedImage)
+	assert.Contains(s.T(), "docker.io/rook/ceph:"+expectedImage, version)
 }
 
 func (s *UpgradeSuite) verifyRookUpgrade(numOSDs int) {

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -204,7 +204,7 @@ function build_rook() {
   tests/scripts/validate_modified_files.sh build
   docker images
   if [[ "$build_type" == "build" ]]; then
-    docker tag "$(docker images | awk '/build-/ {print $1}')" rook/ceph:local-build
+    docker tag "$(docker images | awk '/build-/ {print $1}')" docker.io/rook/ceph:local-build
   fi
 }
 
@@ -246,7 +246,7 @@ function create_cluster_prerequisites() {
 function deploy_manifest_with_local_build() {
   sed -i 's/.*ROOK_CSI_ENABLE_NFS:.*/  ROOK_CSI_ENABLE_NFS: \"true\"/g' $1
   if [[ "$USE_LOCAL_BUILD" != "false" ]]; then
-    sed -i "s|image: rook/ceph:.*|image: rook/ceph:local-build|g" $1
+    sed -i "s|image: docker.io/rook/ceph:.*|image: docker.io/rook/ceph:local-build|g" $1
   fi
   if [[ "$ALLOW_LOOP_DEVICES" = "true" ]]; then
     sed -i "s|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"false\"|ROOK_CEPH_ALLOW_LOOP_DEVICES: \"true\"|g" $1
@@ -640,7 +640,7 @@ function test_multus_connections() {
 
 function create_operator_toolbox() {
   cd deploy/examples
-  sed -i "s|image: rook/ceph:.*|image: rook/ceph:local-build|g" toolbox-operator-image.yaml
+  sed -i "s|image: docker.io/rook/ceph:.*|image: docker.io/rook/ceph:local-build|g" toolbox-operator-image.yaml
   kubectl create -f toolbox-operator-image.yaml
 }
 


### PR DESCRIPTION
The docker.io image prefix is expected to be prepended to the image names in the test images. This was missed in 14550 related to some CI tests, which was now causing the CI failures in the 1.15 branch where the search and replace was missing the new docker.io prefix.

This was already done in the release-1.15 branch with #14165 since the CI failure was only observed in the release branch, not the master branch. This PR is just to port it back to master.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
