### PR TITLE
csi: use specific tag instead of latest image

### DIFF
--- a/deploy/examples/csi-operator.yaml
+++ b/deploy/examples/csi-operator.yaml
@@ -15802,7 +15802,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: CSI_SERVICE_ACCOUNT_PREFIX
               value: ceph-csi-
-          image: quay.io/cephcsi/ceph-csi-operator:latest
+          image: quay.io/cephcsi/ceph-csi-operator:v0.1.0
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
when I was pusing the new changes in older pr I missed updating the latest tag to v0.1.0 in csi-operator.yaml file. Updating now.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
