### PR TITLE
test: Use registry in dev-env when using multi node setup

### DIFF
--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -113,7 +113,11 @@ setup_minikube_env() {
     echo "Setting up minikube env for profile '$ROOK_PROFILE_NAME' (using $minikube_driver driver)"
     $MINIKUBE delete
     $MINIKUBE start --disk-size="$MINIKUBE_DISK_SIZE" --extra-disks="$MINIKUBE_EXTRA_DISKS" --driver "$minikube_driver" -n "$MINIKUBE_NODES" $ROOK_MINIKUBE_EXTRA_ARGS
-    eval "$($MINIKUBE docker-env)"
+    if [ "$MINIKUBE_NODES" -eq 1 ]; then
+        eval "$($MINIKUBE docker-env)"
+    elif [ "$MINIKUBE_NODES" -gt 1 ]; then
+        $MINIKUBE addons enable registry
+    fi
 }
 
 create_rook_cluster() {


### PR DESCRIPTION
When having more than one node in your minikube cluster the command `eval "$($MINIKUBE docker-env)"` won't work since each node has it's own docker context. It will throw the following error:

```
❌  Exiting due to ENV_MULTINODE_CONFLICT: The docker-env command is incompatible with multi-node clusters. Use the 'registry' add-on: https://minikube.sigs.k8s.io/docs/handbook/registry/
```

So sweet and simple I think we should enable the registry instead when using multi node setups

If this is something that is wanted in the `create-dev-cluster.sh` and it is felt that there is a need how to use this with local built images, I can add a part about that to the dev-env documentation

Resolves #14352
