### PR TITLE
tests: fix unit test failure on macOS due to temp directory path

### DIFF
--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -239,7 +239,7 @@ var fakeMultiPeerCephBlockPool = cephv1.CephBlockPool{
 }
 
 func saveMockDataInTempFile(data, filePattern string) error {
-	matches, _ := filepath.Glob(fmt.Sprintf("/tmp/%s*", filePattern))
+	matches, _ := filepath.Glob(fmt.Sprintf("%s/%s*", os.TempDir(), filePattern))
 	for _, m := range matches {
 		file, err := os.OpenFile(m, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {


### PR DESCRIPTION
Fixed a couple of unit test failures on macOS.