### PR TITLE
core: fix Ceph monitor deployment in separate zones

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -79,7 +79,7 @@ func GetFailureDomainLabel(spec cephv1.ClusterSpec) string {
 	}
 
 	if spec.ZonesRequired() && spec.Mon.FailureDomainLabel != "" {
-		return spec.Mon.StretchCluster.FailureDomainLabel
+		return spec.Mon.FailureDomainLabel
 	}
 	// The default topology label is for a zone
 	return corev1.LabelZoneFailureDomainStable


### PR DESCRIPTION
Previously, Rook would fail to create monitors for a `CephCluster` spec that required them to be located in distinct failure domains:

```yaml
spec:
  mon:
    count: 3
    failureDomainLabel: topology.kubernetes.io/zone
    zones:
    - eu-central-1a
    - eu-central-1b
    - eu-central-1c
```

This was due to the fact that Rook was mistakenly getting the `failureDomainLabel` from `spec.mon.stretchCluster.failureDomainLabel`.

This commit ensures `spec.mon.failureDomainLabel` is being used instead, which fixes the cluster deployment for the spec above.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
