### PR TITLE
helm: reorder volumes in rook-ceph-csi scc for argocd diff to show no changes

### DIFF
--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -72,9 +72,9 @@ supplementalGroups:
 # The type of volumes which are mounted to csi pods
 volumes:
   - configMap
-  - projected
   - emptyDir
   - hostPath
+  - projected
 users:
   # A user needs to be added for each rook service account.
   - system:serviceaccount:{{ .Release.Namespace }}:rook-csi-rbd-plugin-sa

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -83,9 +83,9 @@ supplementalGroups:
 # The type of volumes which are mounted to csi pods
 volumes:
   - configMap
-  - projected
   - emptyDir
   - hostPath
+  - projected
 users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.


### PR DESCRIPTION
Fixes the order of the volumes in the rook-ceph-csi csi to avoid the diff error shown in the screenshot below:

![image](https://github.com/user-attachments/assets/daf890ff-3c6b-4d4a-8d6c-02b76cbd4d25)


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
