### PR TITLE
csi: stop deleting csi-operator resources

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -176,20 +176,3 @@ func (r *ReconcileCSI) createImageSetConfigmap() (string, error) {
 
 	return cm.Name, nil
 }
-
-func (r *ReconcileCSI) deleteImageSetConfigMap() error {
-	cm := &v1.ConfigMap{}
-	err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: cm.Name, Namespace: r.opConfig.OperatorNamespace}, cm)
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return nil
-		}
-	}
-	err = r.client.Delete(r.opManagerContext, cm)
-	if nil != err {
-		return errors.Wrapf(err, "failed to delete imageSet configMap %v", cm.Name)
-	}
-	logger.Infof("deleted imageSet configMap %q", cm.Name)
-
-	return nil
-}

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 
-	csiopv1a1 "github.com/ceph/ceph-csi-operator/api/v1alpha1"
 	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
@@ -757,48 +756,6 @@ func (r *ReconcileCSI) stopDrivers(ver *version.Info) error {
 	}
 
 	return nil
-}
-
-func (r *ReconcileCSI) deleteCSIOperatorResources(clusterNamespace string, deleteOp bool) {
-	csiCephConnection := &csiopv1a1.CephConnection{}
-
-	err := r.client.DeleteAllOf(r.opManagerContext, csiCephConnection, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{Namespace: clusterNamespace}})
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Errorf("failed to delete CSI-operator Ceph Connection %q. %v", csiCephConnection.Name, err)
-	} else {
-		logger.Infof("deleted CSI-operator Ceph Connection %q", csiCephConnection.Name)
-	}
-
-	csiOpClientProfile := &csiopv1a1.ClientProfile{}
-	err = r.client.DeleteAllOf(r.opManagerContext, csiOpClientProfile, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{Namespace: clusterNamespace}})
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Errorf("failed to delete CSI-operator client profile %q. %v", csiOpClientProfile.Name, err)
-	} else {
-		logger.Infof("deleted CSI-operator client profile %q", csiOpClientProfile.Name)
-	}
-
-	err = r.deleteImageSetConfigMap()
-	if err != nil && !kerrors.IsNotFound(err) {
-		logger.Error("failed to delete imageSetConfigMap", err)
-	}
-
-	if deleteOp {
-		csiDriver := &csiopv1a1.Driver{}
-		err = r.client.DeleteAllOf(r.opManagerContext, csiDriver, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{Namespace: r.opConfig.OperatorNamespace}})
-		if err != nil && !kerrors.IsNotFound(err) {
-			logger.Errorf("failed to delete CSI-operator driver config %q. %v", csiDriver.Name, err)
-		} else {
-			logger.Infof("deleted CSI-operator driver config %q", csiDriver.Name)
-		}
-
-		opConfig := &csiopv1a1.OperatorConfig{}
-		err = r.client.DeleteAllOf(r.opManagerContext, opConfig, &client.DeleteAllOfOptions{ListOptions: client.ListOptions{Namespace: r.opConfig.OperatorNamespace}})
-		if err != nil && !kerrors.IsNotFound(err) {
-			logger.Errorf("failed to delete CSI-operator operator config %q. %v", opConfig.Name, err)
-		} else {
-			logger.Infof("deleted CSI-operator operator config %q", opConfig.Name)
-		}
-	}
 }
 
 func (r *ReconcileCSI) deleteCSIDriverResources(ver *version.Info, daemonset, deployment, service, driverName string) error {


### PR DESCRIPTION
to keep it simple we'll not delete the csi-operator resources we'll only document this for users who want to switch to csi-drivers. Anyways by next release we'll only support csi-operator only.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14688 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
