### PR TITLE
CI: extract more check make targets from workflows.

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -44,12 +44,5 @@ jobs:
           mkdir -p $(go env GOPATH)/src/github.com/rook/rook/
           cp -R . $(go env GOPATH)/src/github.com/rook/rook/
 
-      - name: run codegen
-        run: |
-          cd $(go env GOPATH)/src/github.com/rook/rook
-          GOPATH=$(go env GOPATH) make codegen
-
       - name: validate codegen
-        run: |
-          cd $(go env GOPATH)/src/github.com/rook/rook
-          tests/scripts/validate_modified_files.sh codegen
+        run: GOPATH=$(go env GOPATH) make check.codegen

--- a/.github/workflows/crds-gen.yml
+++ b/.github/workflows/crds-gen.yml
@@ -37,8 +37,6 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: run crds-gen
-        run: GOPATH=$(go env GOPATH) make crds
-
       - name: validate crds-gen
-        run: tests/scripts/validate_modified_files.sh crd
+        run: GOPATH=$(go env GOPATH) make check.crds
+

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,8 @@ check.docs:
 	@$(MAKE) docs
 	@tests/scripts/validate_modified_files.sh docs
 
+check.crds: crds
+	@tests/scripts/validate_modified_files.sh crd
 
 docs-preview: ## Preview the documentation through mkdocs
 	mkdocs serve

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,9 @@ check.docs:
 check.crds: crds
 	@tests/scripts/validate_modified_files.sh crd
 
+check.codegen: codegen
+	@tests/scripts/validate_modified_files.sh codegen
+
 docs-preview: ## Preview the documentation through mkdocs
 	mkdocs serve
 

--- a/tests/scripts/validate_modified_files.sh
+++ b/tests/scripts/validate_modified_files.sh
@@ -6,7 +6,7 @@ set -ex
 #############
 CODEGEN_ERR="found codegen files! please run 'make codegen' and update your PR"
 MOD_ERR="changes found by mod.check. You may need to run make clean"
-CRD_ERR="changes found by 'make crds'. please run 'make crds' locally and update your PR"
+CRD_ERR="changes found by 'make check.crds'. please run 'make crds' locally and update your PR"
 BUILD_ERR="changes found by make build', please commit your go.sum or other changed files"
 HELM_ERR="changes found by 'make gen-rbac'. please run 'make gen-rbac' locally and update your PR"
 DOCS_ERR="changes found by 'make docs'. please run 'make docs' locally and update your PR"


### PR DESCRIPTION
***Description of changes:***

Continuing  the work started in #14672  and #14674  and discussed in #14686 , this PR extracts two more make targets from the github CI workflows: `check.crds`and `check.godegen`

The general motivation is to make it more easy and consistent for developers to run validating checks locally before pushing to a PR.

This PR currently purposefully  consists  of two commits -- one for each target -- instead of just one. The intention here is to keep the git history a bit more verbose and explicit.




<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
