### PR TITLE
pool: Allow negative step num in crush rule

### DIFF
--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -75,7 +75,7 @@ type ruleSpec struct {
 
 type stepSpec struct {
 	Operation string `json:"op"`
-	Number    uint   `json:"num"`
+	Number    int    `json:"num"`
 	Item      int    `json:"item"`
 	ItemName  string `json:"item_name"`
 	Type      string `json:"type"`

--- a/pkg/daemon/ceph/client/crush_rule.go
+++ b/pkg/daemon/ceph/client/crush_rule.go
@@ -150,7 +150,7 @@ func buildTwoStepCrushSteps(pool cephv1.PoolSpec) []stepSpec {
 	// Step three
 	stepTakeSubFailureDomain := &stepSpec{
 		Operation: "chooseleaf_firstn",
-		Number:    pool.Replicated.ReplicasPerFailureDomain,
+		Number:    int(pool.Replicated.ReplicasPerFailureDomain),
 		Type:      pool.Replicated.SubFailureDomain,
 	}
 	steps = append(steps, *stepTakeSubFailureDomain)

--- a/pkg/daemon/ceph/client/crush_rule_test.go
+++ b/pkg/daemon/ceph/client/crush_rule_test.go
@@ -56,7 +56,7 @@ func TestBuildCrushSteps(t *testing.T) {
 	assert.Equal(t, 4, len(steps))
 	assert.Equal(t, cephv1.DefaultCRUSHRoot, steps[0].ItemName)
 	assert.Equal(t, "datacenter", steps[1].Type)
-	assert.Equal(t, uint(2), steps[2].Number)
+	assert.Equal(t, 2, steps[2].Number)
 }
 
 func TestCompileCRUSHMap(t *testing.T) {


### PR DESCRIPTION
The crush rules may have a negative step num. Rook had assumed negative values were not possible, but just had not been encountered previously in a custom crush rule.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14685 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
