### PR TITLE
Configure prio-limit for ceph exporter container

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -52,6 +52,9 @@ If this value is empty, each pod will get an ephemeral directory to store their 
     * `externalMgrPrometheusPort`: external prometheus manager module port. See [external cluster configuration](./external-cluster/external-cluster.md) for more details.
     * `port`: The internal prometheus manager module port where the prometheus mgr module listens. The port may need to be configured when host networking is enabled.
     * `interval`: The interval for the prometheus module to to scrape targets.
+    * `exporter`: Ceph exporter metrics config.
+        * `perfCountersPrioLimit`: Specifies which performance counters are exported. Corresponds to `--prio-limit` Ceph exporter flag. `0` - all counters are exported, default is `5`.
+        * `statsPeriodSeconds`: Time to wait before sending requests again to exporter server (seconds). Corresponds to `--stats-period` Ceph exporter flag. Default is `5`.
 * `network`: For the network settings for the cluster, refer to the [network configuration settings](#network-configuration-settings)
 * `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health doc](../../Storage-Configuration/Advanced/ceph-mon-health.md).

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -3686,6 +3686,45 @@ map[string]int
 </tr>
 </tbody>
 </table>
+<h3 id="ceph.rook.io/v1.CephExporterSpec">CephExporterSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.MonitoringSpec">MonitoringSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>perfCountersPrioLimit</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>Only performance counters greater than or equal to this option are fetched</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statsPeriodSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>Time to wait before sending requests again to exporter server (seconds)</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus
 </h3>
 <p>
@@ -8525,6 +8564,20 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>Interval determines prometheus scrape interval</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>exporter</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CephExporterSpec">
+CephExporterSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ceph exporter configuration</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2341,6 +2341,20 @@ spec:
                         Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
                         types must exist or the creation will fail. Default is false.
                       type: boolean
+                    exporter:
+                      description: Ceph exporter configuration
+                      properties:
+                        perfCountersPrioLimit:
+                          default: 5
+                          description: Only performance counters greater than or equal to this option are fetched
+                          format: int64
+                          type: integer
+                        statsPeriodSeconds:
+                          default: 5
+                          description: Time to wait before sending requests again to exporter server (seconds)
+                          format: int64
+                          type: integer
+                      type: object
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
                       items:

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -85,6 +85,15 @@ spec:
     # Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
     # If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
     metricsDisabled: false
+    # Ceph exporter metrics config.
+    exporter:
+      # Specifies which performance counters are exported.
+      # Corresponds to --prio-limit Ceph exporter flag
+      # 0 - all counters are exported
+      perfCountersPrioLimit: 5
+      # Time to wait before sending requests again to exporter server (seconds)
+      # Corresponds to --stats-period Ceph exporter flag
+      statsPeriodSeconds: 5
   network:
     connections:
       # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2339,6 +2339,20 @@ spec:
                         Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
                         types must exist or the creation will fail. Default is false.
                       type: boolean
+                    exporter:
+                      description: Ceph exporter configuration
+                      properties:
+                        perfCountersPrioLimit:
+                          default: 5
+                          description: Only performance counters greater than or equal to this option are fetched
+                          format: int64
+                          type: integer
+                        statsPeriodSeconds:
+                          default: 5
+                          description: Time to wait before sending requests again to exporter server (seconds)
+                          format: int64
+                          type: integer
+                      type: object
                     externalMgrEndpoints:
                       description: ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
                       items:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -406,6 +406,20 @@ type MonitoringSpec struct {
 	// Interval determines prometheus scrape interval
 	// +optional
 	Interval *metav1.Duration `json:"interval,omitempty"`
+
+	// Ceph exporter configuration
+	// +optional
+	Exporter *CephExporterSpec `json:"exporter,omitempty"`
+}
+
+type CephExporterSpec struct {
+	// Only performance counters greater than or equal to this option are fetched
+	// +kubebuilder:default=5
+	PerfCountersPrioLimit int64 `json:"perfCountersPrioLimit,omitempty"`
+
+	// Time to wait before sending requests again to exporter server (seconds)
+	// +kubebuilder:default=5
+	StatsPeriodSeconds int64 `json:"statsPeriodSeconds,omitempty"`
 }
 
 // ClusterStatus represents the status of a Ceph cluster

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -42,8 +42,8 @@ const (
 	monitoringPath                   = "/etc/ceph-monitoring/"
 	serviceMonitorFile               = "exporter-service-monitor.yaml"
 	sockDir                          = "/run/ceph"
-	perfCountersPrioLimit            = "5"
-	statsPeriod                      = "5"
+	defaultPrioLimit                 = "5"
+	defaultStatsPeriod               = "5"
 	DefaultMetricsPort        uint16 = 9926
 	exporterServiceMetricName        = "ceph-exporter-http-metrics"
 	exporterKeyringUsername          = "client.ceph-exporter"
@@ -179,10 +179,15 @@ func getCephExporterDaemonContainer(cephCluster cephv1.CephCluster, cephVersion 
 	exporterEnvVar := generateExporterEnvVar()
 	envVars := append(controller.DaemonEnvVars(&cephCluster.Spec), exporterEnvVar)
 
+	prioLimit, statsPeriod := defaultPrioLimit, defaultStatsPeriod
+	if cephCluster.Spec.Monitoring.Exporter != nil {
+		prioLimit = strconv.Itoa(int(cephCluster.Spec.Monitoring.Exporter.PerfCountersPrioLimit))
+		statsPeriod = strconv.Itoa(int(cephCluster.Spec.Monitoring.Exporter.StatsPeriodSeconds))
+	}
 	args := []string{
 		"--sock-dir", sockDir,
 		"--port", strconv.Itoa(int(DefaultMetricsPort)),
-		"--prio-limit", perfCountersPrioLimit,
+		"--prio-limit", prioLimit,
 		"--stats-period", statsPeriod,
 	}
 


### PR DESCRIPTION
Closes #14710 

Allows to set `--prio-limit` and `--stats-period` options to Ceph exporter from CephCluster CRD.