### PR TITLE
core: Enable annotations on crash collector

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/annotations.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations.go
@@ -77,6 +77,11 @@ func GetCmdReporterAnnotations(a AnnotationsSpec) Annotations {
 	return mergeAllAnnotationsWithKey(a, KeyCmdReporter)
 }
 
+// GetCrashCollectorAnnotations returns the Annotations for the crash collector
+func GetCrashCollectorAnnotations(a AnnotationsSpec) Annotations {
+	return mergeAllAnnotationsWithKey(a, KeyCrashCollector)
+}
+
 func GetClusterMetadataAnnotations(a AnnotationsSpec) Annotations {
 	return a[KeyClusterMetadata]
 }

--- a/pkg/apis/ceph.rook.io/v1/annotations_test.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations_test.go
@@ -58,9 +58,10 @@ func TestCephAnnotationsMerge(t *testing.T) {
 
 	// Merge with "all"
 	testAnnotations = AnnotationsSpec{
-		"all":         {"allkey1": "allval1", "allkey2": "allval2"},
-		"mgr":         {"mgrkey": "mgrval"},
-		"cmdreporter": {"myversions": "detect"},
+		"all":            {"allkey1": "allval1", "allkey2": "allval2"},
+		"mgr":            {"mgrkey": "mgrval"},
+		"cmdreporter":    {"myversions": "detect"},
+		"crashcollector": {"crash": "crashval"},
 	}
 	a = GetMonAnnotations(testAnnotations)
 	assert.Equal(t, "allval1", a["allkey1"])
@@ -75,6 +76,10 @@ func TestCephAnnotationsMerge(t *testing.T) {
 	assert.Equal(t, "detect", b["myversions"])
 	assert.Equal(t, "allval1", b["allkey1"])
 	assert.Equal(t, "allval2", b["allkey2"])
+	c := GetCrashCollectorAnnotations(testAnnotations)
+	assert.Equal(t, "crashval", c["crash"])
+	assert.Equal(t, "allval1", c["allkey1"])
+	assert.Equal(t, "allval2", c["allkey2"])
 }
 
 func TestAnnotationsSpec(t *testing.T) {

--- a/pkg/operator/ceph/cluster/nodedaemon/crash.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash.go
@@ -124,6 +124,7 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 				ServiceAccountName: k8sutil.DefaultServiceAccount,
 			},
 		}
+		cephv1.GetCrashCollectorAnnotations(cephCluster.Spec.Annotations).ApplyToObjectMeta(&deploy.Spec.Template.ObjectMeta)
 
 		return nil
 	}


### PR DESCRIPTION
The crash collector daemon had missed the ability to add custom annotations via the cephcluster CR, as already supported for all the other daemons.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14729 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
