### PR TITLE
docs: Declare cephconfig settings stable

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -825,9 +825,6 @@ set the `allowUninstallWithVolumes` to true under `spec.CleanupPolicy`.
 
 ## Ceph Config
 
-!!! attention
-    This feature is experimental.
-
 The Ceph config options are applied after the MONs are all in quorum and running.
 To set Ceph config options, you can add them to your `CephCluster` spec as shown below.
 See the [Ceph config reference](https://docs.ceph.com/en/latest/rados/configuration/general-config-ref/)
@@ -847,6 +844,17 @@ spec:
     "osd.*":
       osd_max_scrubs: "10"
 ```
+
+The Rook operator will actively apply these values, whereas the
+[ceph.conf settings](../../Storage-Configuration/Advanced/ceph-configuration/#custom-cephconf-settings)
+only take effect after the Ceph daemon pods are restarted.
+
+If both these `cephConfig` and [ceph.conf settings](../../Storage-Configuration/Advanced/ceph-configuration/#custom-cephconf-settings)
+are applied, the `cephConfig` settings will take higher precedence if there is an overlap.
+
+If Ceph settings need to be applied to mons before quorum is initially created, the
+[ceph.conf settings](../../Storage-Configuration/Advanced/ceph-configuration/#custom-cephconf-settings)
+should be used instead.
 
 !!! warning
     Rook performs no direct validation on these config options, so the validity of the settings is the

--- a/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
@@ -208,7 +208,7 @@ ceph osd pool set rbd pg_num 512
 
 ## Custom `ceph.conf` Settings
 
-!!! warning
+!!! info
     The advised method for controlling Ceph configuration is to use the [`cephConfig:` structure](../../CRDs/Cluster/ceph-cluster-crd.md#ceph-config)
     in the `CephCluster` CRD.
     <br><br>It is highly recommended that this only be used when absolutely necessary and that the `config` be


### PR DESCRIPTION
The cephConfig settings in the CephCluster CR have been stable and there are no planned changes, so remove the experimental documentation indicator. Also, clarify the usage and the precedence of the ceph config
options.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14736

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
