### PR TITLE
[chart][rook-ceph] Allows extending configmap to contain other envs for Operator

### DIFF
--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -260,3 +260,4 @@ data:
 {{- if .Values.csi.kubeApiQPS }}
   CSI_KUBE_API_QPS: {{ .Values.csi.kubeApiQPS | quote }}
 {{- end }}
+{{ .Values.configExtra | nindent 2 }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -654,3 +654,5 @@ monitoring:
   # -- Enable monitoring. Requires Prometheus to be pre-installed.
   # Enabling will also create RBAC rules to allow Operator to create ServiceMonitors
   enabled: false
+
+configExtra:


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

While reading Rook, we needed to improve Discover to support some of our special Device types. I accidentally found that helm doesn't allow adding extended envs to Rook, and it might be necessary for someone

Some DISCOVER_DAEMON_RESOURCES flags are supported in code, but there is no way to do it via helm except when you run `kubectl patch`. Adding this PR will support future cases of missing envs or custom env additions

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
