### PR TITLE
rgw: fix CephObjectZone failing with pre-existing pools

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2180,6 +2180,7 @@ PoolSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The metadata pool settings</p>
 </td>
 </tr>
@@ -2193,6 +2194,7 @@ PoolSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The data pool settings</p>
 </td>
 </tr>
@@ -10367,6 +10369,7 @@ PoolSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The metadata pool settings</p>
 </td>
 </tr>
@@ -10380,6 +10383,7 @@ PoolSpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The data pool settings</p>
 </td>
 </tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -13323,8 +13323,6 @@ spec:
                   description: The display name for the ceph users
                   type: string
               required:
-                - dataPool
-                - metadataPool
                 - zoneGroup
               type: object
             status:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -13311,8 +13311,6 @@ spec:
                   description: The display name for the ceph users
                   type: string
               required:
-                - dataPool
-                - metadataPool
                 - zoneGroup
               type: object
             status:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2128,10 +2128,12 @@ type ObjectZoneSpec struct {
 	ZoneGroup string `json:"zoneGroup"`
 
 	// The metadata pool settings
+	// +optional
 	// +nullable
 	MetadataPool PoolSpec `json:"metadataPool"`
 
 	// The data pool settings
+	// +optional
 	// +nullable
 	DataPool PoolSpec `json:"dataPool"`
 


### PR DESCRIPTION
These fields must be optional in order to allow usage of pre-existing pools managed by CephBlockPool CR(s).

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
