### PR TITLE
object: add bucketMaxObjects & bucketMaxSize to obc

### DIFF
--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
@@ -32,6 +32,8 @@ spec:
   additionalConfig: [6]
     maxObjects: "1000"
     maxSize: "2G"
+    bucketMaxObjects: "3000"
+    bucketMaxSize: "4G"
 ```
 
 1. `name` of the `ObjectBucketClaim`. This name becomes the name of the Secret and ConfigMap.
@@ -45,8 +47,10 @@ If both `bucketName` and `generateBucketName` are blank or omitted then the stor
 5. `storageClassName` which defines the StorageClass which contains the names of the bucket provisioner, the object-store and specifies the bucket retention policy.
 6. `additionalConfig` is an optional list of key-value pairs used to define attributes specific to the bucket being provisioned by this OBC. This information is typically tuned to a particular bucket provisioner and may limit application portability. Options supported:
 
-    * `maxObjects`: The maximum number of objects in the bucket
-    * `maxSize`: The maximum size of the bucket, please note minimum recommended value is 4K.
+    * `maxObjects`: The maximum number of objects in the bucket as a quota on the user account automatically created for the bucket.
+    * `maxSize`: The maximum size of the bucket as a quota on the user account automatically created for the bucket. Please note minimum recommended value is 4K.
+    * `bucketMaxObjects`: The maximum number of objects in the bucket as an individual bucket quota. This is useful when the bucket is shared among multiple users.
+    * `bucketMaxSize`: The maximum size of the bucket as an individual bucket quota.
 
 ### OBC Custom Resource after Bucket Provisioning
 

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -57,8 +57,10 @@ type Provisioner struct {
 }
 
 type additionalConfigSpec struct {
-	maxObjects *int64
-	maxSize    *int64
+	maxObjects       *int64
+	maxSize          *int64
+	bucketMaxObjects *int64
+	bucketMaxSize    *int64
 }
 
 var _ apibkt.Provisioner = &Provisioner{}
@@ -578,6 +580,20 @@ func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error
 		return errors.Wrap(err, "failed to process additionalConfig")
 	}
 
+	err = p.setUserQuota(additionalConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to set user quota")
+	}
+
+	err = p.setBucketQuota(additionalConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to set bucket quota")
+	}
+
+	return nil
+}
+
+func (p *Provisioner) setUserQuota(additionalConfig *additionalConfigSpec) error {
 	liveQuota, err := p.adminOpsClient.GetUserQuota(p.clusterInfo.Context, admin.QuotaSpec{UID: p.cephUserName})
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch user %q", p.cephUserName)
@@ -622,6 +638,59 @@ func (p *Provisioner) setAdditionalSettings(options *apibkt.BucketOptions) error
 		err = p.adminOpsClient.SetUserQuota(p.clusterInfo.Context, targetQuota)
 		if err != nil {
 			return errors.Wrapf(err, "failed to set user %q quota enabled=%v %+v", p.cephUserName, quotaEnabled, additionalConfig)
+		}
+	}
+
+	return nil
+}
+
+func (p *Provisioner) setBucketQuota(additionalConfig *additionalConfigSpec) error {
+	bucket, err := p.adminOpsClient.GetBucketInfo(p.clusterInfo.Context, admin.Bucket{Bucket: p.bucketName})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch bucket %q", p.bucketName)
+	}
+	liveQuota := bucket.BucketQuota
+
+	// Copy only the fields that are actively managed by the provisioner to
+	// prevent passing back undesirable combinations of fields.  It is
+	// known to be problematic to set both MaxSize and MaxSizeKB.
+	currentQuota := admin.QuotaSpec{
+		Enabled:    liveQuota.Enabled,
+		MaxObjects: liveQuota.MaxObjects,
+		MaxSize:    liveQuota.MaxSize,
+	}
+	targetQuota := currentQuota
+
+	// enable or disable quota for user
+	quotaEnabled := (additionalConfig.bucketMaxObjects != nil) || (additionalConfig.bucketMaxSize != nil)
+
+	targetQuota.Enabled = &quotaEnabled
+
+	if additionalConfig.bucketMaxObjects != nil {
+		targetQuota.MaxObjects = additionalConfig.bucketMaxObjects
+	} else if currentQuota.MaxObjects != nil && *currentQuota.MaxObjects >= 0 {
+		// if the existing value is already negative, we don't want to change it
+		var objects int64 = -1
+		targetQuota.MaxObjects = &objects
+	}
+
+	if additionalConfig.bucketMaxSize != nil {
+		targetQuota.MaxSize = additionalConfig.bucketMaxSize
+	} else if currentQuota.MaxSize != nil && *currentQuota.MaxSize >= 0 {
+		// if the existing value is already negative, we don't want to change it
+		var size int64 = -1
+		targetQuota.MaxSize = &size
+	}
+
+	diff := cmp.Diff(currentQuota, targetQuota)
+	if diff != "" {
+		logger.Debugf("Quota for bucket %q has changed. diff:%s", p.bucketName, diff)
+		// UID & Bucket are not set in the QuotaSpec returned by GetBucketInfo()
+		targetQuota.UID = p.cephUserName
+		targetQuota.Bucket = p.bucketName
+		err = p.adminOpsClient.SetIndividualBucketQuota(p.clusterInfo.Context, targetQuota)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set bucket %q quota enabled=%v %+v", p.bucketName, quotaEnabled, additionalConfig)
 		}
 	}
 

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -40,6 +40,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	userPath   = "rgw.test/admin/user"
+	bucketPath = "rgw.test/admin/bucket"
+)
+
 func TestPopulateDomainAndPort(t *testing.T) {
 	ctx := context.TODO()
 	store := "test-store"
@@ -142,40 +147,42 @@ func TestQuanityToInt64(t *testing.T) {
 }
 
 func TestProvisioner_setAdditionalSettings(t *testing.T) {
-	newProvisioner := func(t *testing.T, getUserResult string, putValsSeen *[]string) *Provisioner {
+	newProvisioner := func(t *testing.T, getResult *map[string]string, getSeen, putSeen *map[string][]string) *Provisioner {
 		mockClient := &object.MockClient{
 			MockDo: func(req *http.Request) (*http.Response, error) {
+				path := req.URL.Path
+
 				// t.Logf("HTTP req: %#v", req)
-				t.Logf("HTTP %s: %s %s", req.Method, req.URL.Path, req.URL.RawQuery)
+				t.Logf("HTTP %s: %s %s", req.Method, path, req.URL.RawQuery)
 
-				assert.Contains(t, req.URL.RawQuery, "&uid=bob")
+				statusCode := 200
+				if _, ok := (*getResult)[path]; !ok {
+					// path not configured
+					statusCode = 500
+				}
+				responseBody := []byte(`[]`)
 
-				if req.Method == http.MethodGet {
-					if req.URL.Path == "my.endpoint.net/admin/user" {
-						statusCode := 200
-						if getUserResult == "" {
-							statusCode = 500
-						}
-						return &http.Response{
-							StatusCode: statusCode,
-							Body:       io.NopCloser(bytes.NewReader([]byte(getUserResult))),
-						}, nil
+				switch method := req.Method; method {
+				case http.MethodGet:
+					(*getSeen)[path] = append((*getSeen)[path], req.URL.RawQuery)
+					responseBody = []byte((*getResult)[path])
+				case http.MethodPut:
+					if (*putSeen)[path] == nil {
+						(*putSeen)[path] = []string{}
 					}
+					(*putSeen)[path] = append((*putSeen)[path], req.URL.RawQuery)
+				default:
+					panic(fmt.Sprintf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, path))
 				}
-				if req.Method == http.MethodPut {
-					if req.URL.Path == "my.endpoint.net/admin/user" {
-						*putValsSeen = append(*putValsSeen, req.URL.RawQuery)
-						return &http.Response{
-							StatusCode: 200,
-							Body:       io.NopCloser(bytes.NewReader([]byte(`[]`))),
-						}, nil
-					}
-				}
-				panic(fmt.Sprintf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path))
+
+				return &http.Response{
+					StatusCode: statusCode,
+					Body:       io.NopCloser(bytes.NewReader(responseBody)),
+				}, nil
 			},
 		}
 
-		adminClient, err := admin.New("my.endpoint.net", "accesskey", "secretkey", mockClient)
+		adminClient, err := admin.New("rgw.test", "accesskey", "secretkey", mockClient)
 		assert.NoError(t, err)
 
 		p := &Provisioner{
@@ -189,30 +196,16 @@ func TestProvisioner_setAdditionalSettings(t *testing.T) {
 		return p
 	}
 
-	t.Run("quota should remain disabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
-			&putValsSeen,
-		)
+	t.Run("user and bucket quota should remain disabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
 
-		err := p.setAdditionalSettings(&apibkt.BucketOptions{
-			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
-				Spec: v1alpha1.ObjectBucketClaimSpec{
-					AdditionalConfig: map[string]string{},
-				},
-			},
-		})
-		assert.NoError(t, err)
-		assert.Len(t, putValsSeen, 0)
-	})
-
-	t.Run("quota should be disabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":true,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":2}`,
-			&putValsSeen,
-		)
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
 
 		err := p.setAdditionalSettings(&apibkt.BucketOptions{
 			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
@@ -223,17 +216,56 @@ func TestProvisioner_setAdditionalSettings(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		// quota should be disabled, and that's it
-		assert.Len(t, putValsSeen, 1)
-		assert.Equal(t, 1, numberOfPutsWithValue(`enabled=false`, putValsSeen))
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
+
+		assert.Len(t, putSeen[userPath], 0)   // user quota should not be touched
+		assert.Len(t, putSeen[bucketPath], 0) // bucket quota should not be touched
 	})
 
-	t.Run("maxSize quota should be enabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
-			&putValsSeen,
-		)
+	t.Run("user and bucket quota should be disabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":true,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":2}`,
+			bucketPath: `{"owner": "bob","bucket_quota":{"enabled":true,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":3}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
+
+		err := p.setAdditionalSettings(&apibkt.BucketOptions{
+			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
+
+		assert.Len(t, putSeen[userPath], 1)
+		assert.Equal(t, 1, numberOfCallsWithValue("enabled=false", putSeen[userPath]))
+		assert.Len(t, putSeen[bucketPath], 1)
+		assert.Equal(t, 1, numberOfCallsWithValue("enabled=false", putSeen[bucketPath]))
+	})
+
+	t.Run("user maxSize quota should be enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
 
 		err := p.setAdditionalSettings(&apibkt.BucketOptions{
 			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
@@ -246,22 +278,27 @@ func TestProvisioner_setAdditionalSettings(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		assert.Zero(t, numberOfPutsWithValue(`enabled=false`, putValsSeen)) // no puts should disable
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
 
-		assert.NotEmpty(t, putWithValue(`enabled=true`, putValsSeen)) // at least one put enables
-
-		// there is only one time that max-size is set, and it's to the right value
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-size`, putValsSeen))
-		assert.NotEmpty(t, putWithValue(`max-size=2`, putValsSeen))
-
+		assert.Len(t, putSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-size=2", putSeen[userPath]), 1)
+		assert.Len(t, putSeen[bucketPath], 0) // bucket quota should not be touched
 	})
 
-	t.Run("maxObjects quota should be enabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
-			&putValsSeen,
-		)
+	t.Run("user maxObjects quota should be enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
 
 		err := p.setAdditionalSettings(&apibkt.BucketOptions{
 			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
@@ -274,76 +311,186 @@ func TestProvisioner_setAdditionalSettings(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		assert.Zero(t, numberOfPutsWithValue(`enabled=false`, putValsSeen)) // no puts should disable
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
 
-		assert.NotEmpty(t, putWithValue(`enabled=true`, putValsSeen)) // at least one put enables
-
-		// there is only one time max-objects is set, and it's to the right value
-		assert.NotEmpty(t, putWithValue(`max-objects=2`, putValsSeen))
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-objects`, putValsSeen))
-
+		assert.Len(t, putSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-objects=2", putSeen[userPath]), 1)
+		assert.Len(t, putSeen[bucketPath], 0) // bucket quota should not be touched
 	})
 
-	t.Run("maxObjects and maxSize quotas should be enabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
-			&putValsSeen,
-		)
+	t.Run("user maxObjects and maxSize quotas should be enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
 
 		err := p.setAdditionalSettings(&apibkt.BucketOptions{
 			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
 				Spec: v1alpha1.ObjectBucketClaimSpec{
 					AdditionalConfig: map[string]string{
-						"maxSize":    "2",
-						"maxObjects": "3",
+						"maxObjects": "2",
+						"maxSize":    "3",
 					},
 				},
 			},
 		})
 		assert.NoError(t, err)
 
-		assert.Zero(t, numberOfPutsWithValue(`enabled=false`, putValsSeen)) // no puts should disable
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
 
-		assert.NotEmpty(t, putWithValue(`enabled=true`, putValsSeen)) // at least one put enables
-
-		// there is only one time that max-size is set, and it's to the right value
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-size`, putValsSeen))
-		assert.NotEmpty(t, putWithValue(`max-size=2`, putValsSeen))
-
-		// there is only one time max-objects is set, and it's to the right value
-		assert.NotEmpty(t, putWithValue(`max-objects=3`, putValsSeen))
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-objects`, putValsSeen))
+		assert.Len(t, putSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-objects=2", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-size=3", putSeen[userPath]), 1)
+		assert.Len(t, putSeen[bucketPath], 0) // bucket quota should not be touched
 	})
 
-	t.Run("quotas are enabled and need updated enabled", func(t *testing.T) {
-		putValsSeen := []string{}
-		p := newProvisioner(t,
-			`{"enabled":true,"check_on_raw":false,"max_size":1,"max_size_kb":0,"max_objects":1}`,
-			&putValsSeen,
-		)
+	t.Run("user quotas are enabled and need updated enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":true,"check_on_raw":false,"max_size":1,"max_size_kb":0,"max_objects":1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
 
 		err := p.setAdditionalSettings(&apibkt.BucketOptions{
 			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
 				Spec: v1alpha1.ObjectBucketClaimSpec{
 					AdditionalConfig: map[string]string{
-						"maxSize":    "2",
-						"maxObjects": "3",
+						"maxObjects": "12",
+						"maxSize":    "13",
 					},
 				},
 			},
 		})
 		assert.NoError(t, err)
 
-		assert.Zero(t, numberOfPutsWithValue(`enabled=false`, putValsSeen)) // no puts should disable
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
 
-		// there is only one time that max-size is set, and it's to the right value
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-size`, putValsSeen))
-		assert.NotEmpty(t, putWithValue(`max-size=2`, putValsSeen))
+		assert.Len(t, putSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-objects=12", putSeen[userPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-size=13", putSeen[userPath]), 1)
+		assert.Len(t, putSeen[bucketPath], 0) // bucket quota should not be touched
+	})
 
-		// there is only one time max-objects is set, and it's to the right value
-		assert.NotEmpty(t, putWithValue(`max-objects=3`, putValsSeen))
-		assert.Equal(t, 1, numberOfPutsWithValue(`max-objects`, putValsSeen))
+	t.Run("bucket maxObjects quota should be enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
+
+		err := p.setAdditionalSettings(&apibkt.BucketOptions{
+			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketMaxObjects": "4",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
+
+		assert.Len(t, putSeen[userPath], 0) // user quota should not be touched
+		assert.Len(t, putSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[bucketPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-objects=4", putSeen[bucketPath]), 1)
+	})
+
+	t.Run("bucket maxSize quota should be enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
+
+		err := p.setAdditionalSettings(&apibkt.BucketOptions{
+			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketMaxSize": "5",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
+
+		assert.Len(t, putSeen[userPath], 0) // user quota should not be touched
+		assert.Len(t, putSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[bucketPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-size=5", putSeen[bucketPath]), 1)
+	})
+
+	t.Run("bucket quotas are enabled and need updated enabled", func(t *testing.T) {
+		getResult := map[string]string{
+			userPath:   `{"enabled":false,"check_on_raw":false,"max_size":-1024,"max_size_kb":0,"max_objects":-1}`,
+			bucketPath: `{"bucket_quota":{"enabled":true,"check_on_raw":false,"max_size":5,"max_size_kb":0,"max_objects":4}}`,
+		}
+		getSeen := map[string][]string{}
+		putSeen := map[string][]string{}
+
+		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
+		p.setBucketName("bob")
+
+		err := p.setAdditionalSettings(&apibkt.BucketOptions{
+			ObjectBucketClaim: &v1alpha1.ObjectBucketClaim{
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					AdditionalConfig: map[string]string{
+						"bucketMaxObjects": "14",
+						"bucketMaxSize":    "15",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.Len(t, getSeen[userPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("uid=bob", getSeen[userPath]), 1)
+		assert.Len(t, getSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("bucket=bob", getSeen[bucketPath]), 1)
+
+		assert.Len(t, putSeen[userPath], 0) // user quota should not be touched
+		assert.Len(t, putSeen[bucketPath], 1)
+		assert.Equal(t, numberOfCallsWithValue("enabled=true", putSeen[bucketPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-objects=14", putSeen[bucketPath]), 1)
+		assert.Equal(t, numberOfCallsWithValue("max-size=15", putSeen[bucketPath]), 1)
 	})
 }
 
@@ -367,9 +514,21 @@ func TestProvisioner_additionalConfigSpecFromMap(t *testing.T) {
 		var i int64 = 3
 		assert.Equal(t, additionalConfigSpec{maxSize: &i}, *spec)
 	})
+
+	t.Run("bucketMaxObjects field should be set", func(t *testing.T) {
+		spec, err := additionalConfigSpecFromMap(map[string]string{"bucketMaxObjects": "4"})
+		assert.NoError(t, err)
+		assert.Equal(t, additionalConfigSpec{bucketMaxObjects: &(&struct{ i int64 }{4}).i}, *spec)
+	})
+
+	t.Run("bucketMaxSize field should be set", func(t *testing.T) {
+		spec, err := additionalConfigSpecFromMap(map[string]string{"bucketMaxSize": "5"})
+		assert.NoError(t, err)
+		assert.Equal(t, additionalConfigSpec{bucketMaxSize: &(&struct{ i int64 }{5}).i}, *spec)
+	})
 }
 
-func numberOfPutsWithValue(substr string, strs []string) int {
+func numberOfCallsWithValue(substr string, strs []string) int {
 	count := 0
 	for _, s := range strs {
 		if strings.Contains(s, substr) {
@@ -377,13 +536,4 @@ func numberOfPutsWithValue(substr string, strs []string) int {
 		}
 	}
 	return count
-}
-
-func putWithValue(substr string, strs []string) string {
-	for _, s := range strs {
-		if strings.Contains(s, substr) {
-			return s
-		}
-	}
-	return ""
 }

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -106,6 +106,20 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 		}
 	}
 
+	if _, ok := config["bucketMaxObjects"]; ok {
+		spec.bucketMaxObjects, err = quanityToInt64(config["bucketMaxObjects"])
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse bucketMaxObjects quota")
+		}
+	}
+
+	if _, ok := config["bucketMaxSize"]; ok {
+		spec.bucketMaxSize, err = quanityToInt64(config["bucketMaxSize"])
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse bucketMaxSize quota")
+		}
+	}
+
 	return &spec, nil
 }
 


### PR DESCRIPTION
Two new keys are added to ObjectBucketClaim.spec.additionalConfig to
support the configuration of bucket scope quota(s). This differs from
the existing maxObjects & maxSize keys, which manage a user scope
quota(s) on the automatically generated rgw user.

Related to #14764 & #14815
Based on #14827
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
