### PR TITLE
core: Remove obsolete creation of v1beta1 pruner cron jobs

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/pruner.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner.go
@@ -24,29 +24,19 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/version"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) error {
+func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv1.CephCluster) error {
 	if cephCluster.Spec.CrashCollector.Disable {
 		logger.Debugf("crash collector is disabled in namespace %q so skipping crash retention reconcile", namespace)
 		return nil
 	}
-
-	k8sVersion, err := k8sutil.GetK8SVersion(r.context.Clientset)
-	if err != nil {
-		return errors.Wrap(err, "failed to get k8s version")
-	}
-	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(MinVersionForCronV1))
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      prunerName,
@@ -56,13 +46,7 @@ func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv
 	if cephCluster.Spec.CrashCollector.DaysToRetain == 0 {
 		logger.Debug("deleting cronjob if it exists...")
 
-		var cronJob client.Object
-		// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
-		if useCronJobV1 {
-			cronJob = &v1.CronJob{ObjectMeta: objectMeta}
-		} else {
-			cronJob = &v1beta1.CronJob{ObjectMeta: objectMeta}
-		}
+		cronJob := &v1.CronJob{ObjectMeta: objectMeta}
 
 		err := r.client.Delete(r.opManagerContext, cronJob)
 		if err != nil {
@@ -76,7 +60,7 @@ func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv
 		}
 	} else {
 		logger.Debugf("daysToRetain set to: %d", cephCluster.Spec.CrashCollector.DaysToRetain)
-		op, err := r.createOrUpdateCephCron(cephCluster, cephVersion, useCronJobV1)
+		op, err := r.createOrUpdateCephCron(cephCluster)
 		if err != nil {
 			return errors.Wrapf(err, "node reconcile failed on op %q", op)
 		}
@@ -84,7 +68,7 @@ func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv
 	}
 	return nil
 }
-func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion, useCronJobV1 bool) (controllerutil.OperationResult, error) {
+func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster) (controllerutil.OperationResult, error) {
 	objectMeta := metav1.ObjectMeta{
 		Name:      prunerName,
 		Namespace: cephCluster.GetNamespace(),
@@ -105,7 +89,7 @@ func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, c
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				getCrashPruneContainer(cephCluster, *cephVersion),
+				getCrashPruneContainer(cephCluster),
 			},
 			RestartPolicy:      corev1.RestartPolicyNever,
 			HostNetwork:        cephCluster.Spec.Network.IsHost(),
@@ -118,33 +102,11 @@ func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, c
 	// To avoid this, the cronjob is configured to only count the failures
 	// that occurred in the last hour.
 	deadline := int64(60)
-
-	// minimum k8s version required for v1 cronJob is 'v1.21.0'. Apply v1 if k8s version is at least 'v1.21.0', else apply v1beta1 cronJob.
-	if useCronJobV1 {
-		r.deletev1betaJob(objectMeta)
-
-		cronJob := &v1.CronJob{ObjectMeta: objectMeta}
-		err := controllerutil.SetControllerReference(&cephCluster, cronJob, r.scheme)
-		if err != nil {
-			return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of deployment %q", cronJob.Name)
-		}
-		mutateFunc := func() error {
-			cronJob.ObjectMeta.Labels = cronJobLabels
-			cronJob.Spec.JobTemplate.Spec.Template = podTemplateSpec
-			cronJob.Spec.Schedule = pruneSchedule
-			cronJob.Spec.StartingDeadlineSeconds = &deadline
-
-			return nil
-		}
-
-		return controllerutil.CreateOrUpdate(r.opManagerContext, r.client, cronJob, mutateFunc)
-	}
-	cronJob := &v1beta1.CronJob{ObjectMeta: objectMeta}
+	cronJob := &v1.CronJob{ObjectMeta: objectMeta}
 	err := controllerutil.SetControllerReference(&cephCluster, cronJob, r.scheme)
 	if err != nil {
 		return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of deployment %q", cronJob.Name)
 	}
-
 	mutateFunc := func() error {
 		cronJob.ObjectMeta.Labels = cronJobLabels
 		cronJob.Spec.JobTemplate.Spec.Template = podTemplateSpec
@@ -157,19 +119,7 @@ func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, c
 	return controllerutil.CreateOrUpdate(r.opManagerContext, r.client, cronJob, mutateFunc)
 }
 
-func (r *ReconcileNode) deletev1betaJob(objectMeta metav1.ObjectMeta) {
-	// delete v1beta1 cronJob on an update to v1 job,only if v1 job is not created yet
-	if _, err := r.context.Clientset.BatchV1().CronJobs(objectMeta.Namespace).Get(r.opManagerContext, prunerName, metav1.GetOptions{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			err = r.client.Delete(r.opManagerContext, &v1beta1.CronJob{ObjectMeta: objectMeta})
-			if err != nil && !kerrors.IsNotFound(err) {
-				logger.Debugf("could not delete CronJob v1Beta1 %q. %v", prunerName, err)
-			}
-		}
-	}
-}
-
-func getCrashPruneContainer(cephCluster cephv1.CephCluster, cephVersion cephver.CephVersion) corev1.Container {
+func getCrashPruneContainer(cephCluster cephv1.CephCluster) corev1.Container {
 	envVars := append(controller.DaemonEnvVars(&cephCluster.Spec), generateCrashEnvVar())
 	dataPathMap := config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath)
 	volumeMounts := controller.DaemonVolumeMounts(dataPathMap, "", cephCluster.Spec.DataDirHostPath)

--- a/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner_test.go
@@ -24,12 +24,9 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +35,6 @@ import (
 
 func TestCreateOrUpdateCephCron(t *testing.T) {
 	cephCluster := cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "rook-ceph"}}
-	cephVersion := &cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
 	ctx := context.TODO()
 	context := &clusterd.Context{
 		Clientset:     test.New(t, 1),
@@ -47,10 +43,6 @@ func TestCreateOrUpdateCephCron(t *testing.T) {
 
 	s := scheme.Scheme
 	err := v1.AddToScheme(s)
-	if err != nil {
-		assert.Fail(t, "failed to build scheme")
-	}
-	err = v1beta1.AddToScheme(s)
 	if err != nil {
 		assert.Fail(t, "failed to build scheme")
 	}
@@ -68,34 +60,11 @@ func TestCreateOrUpdateCephCron(t *testing.T) {
 		},
 	}
 
-	cronV1Beta1 := &v1beta1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      prunerName,
-			Namespace: "rook-ceph",
-		},
-	}
-
-	// check if v1beta1 cronJob is present and v1 cronJob is not
-	cntrlutil, err := r.createOrUpdateCephCron(cephCluster, cephVersion, false)
-	assert.NoError(t, err)
-	assert.Equal(t, cntrlutil, controllerutil.OperationResult("created"))
-
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1Beta1)
-	assert.NoError(t, err)
-
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1)
-	assert.Error(t, err)
-	assert.True(t, kerrors.IsNotFound(err))
-
-	// check if v1 cronJob is present and v1beta1 cronJob is not
-	cntrlutil, err = r.createOrUpdateCephCron(cephCluster, cephVersion, true)
+	// check if cronJob is created
+	cntrlutil, err := r.createOrUpdateCephCron(cephCluster)
 	assert.NoError(t, err)
 	assert.Equal(t, cntrlutil, controllerutil.OperationResult("created"))
 
 	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1)
 	assert.NoError(t, err)
-
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: "rook-ceph", Name: prunerName}, cronV1Beta1)
-	assert.Error(t, err)
-	assert.True(t, kerrors.IsNotFound(err))
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -59,10 +59,6 @@ var (
 	waitForRequeueIfSecretNotCreated = reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}
 )
 
-const (
-	MinVersionForCronV1 = "1.21.0"
-)
-
 // ReconcileNode reconciles ReplicaSets
 type ReconcileNode struct {
 	// client can be used to retrieve objects from the APIServer.
@@ -223,7 +219,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 
-		if err := r.reconcileCrashPruner(namespace, cephCluster, cephVersion); err != nil {
+		if err := r.reconcileCrashPruner(namespace, cephCluster); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -34,8 +34,6 @@ import (
 	"github.com/pkg/errors"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/nodedaemon"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1604,18 +1602,8 @@ func (k8sh *K8sHelper) WaitForLabeledDeploymentsToBeReadyWithRetries(label, name
 }
 
 func (k8sh *K8sHelper) WaitForCronJob(name, namespace string) error {
-	k8sVersion, err := k8sutil.GetK8SVersion(k8sh.Clientset)
-	if err != nil {
-		return errors.Wrap(err, "failed to get k8s version")
-	}
-	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(nodedaemon.MinVersionForCronV1))
 	for i := 0; i < RetryLoop; i++ {
-		var err error
-		if useCronJobV1 {
-			_, err = k8sh.Clientset.BatchV1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		} else {
-			_, err = k8sh.Clientset.BatchV1beta1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		}
+		_, err := k8sh.Clientset.BatchV1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				logger.Infof("waiting for CronJob named %s in namespace %s", name, namespace)


### PR DESCRIPTION
The v1beta1 cron jobs have been obsolete since K8s 1.21, and Rook has not supported that version of K8s
for many moons, so we can remove the obsolete code for the handling of v1beta1 cron jobs for crash pruning.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
