### PR TITLE
core: Skip counting exporter pods as a ceph pod

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/add.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/add.go
@@ -177,7 +177,8 @@ func isCephPod(labels map[string]string, podName string) bool {
 	// will be empty since the monitors don't exist yet
 	isCanaryPod := strings.Contains(podName, "-canary-")
 	isCrashCollectorPod := strings.Contains(podName, "-crashcollector-")
-	if ok && !isCanaryPod && !isCrashCollectorPod {
+	isExporterPod := strings.Contains(podName, "-exporter-")
+	if ok && !isCanaryPod && !isCrashCollectorPod && !isExporterPod {
 		logger.Debugf("%q is a ceph pod!", podName)
 		return true
 	}


### PR DESCRIPTION
The exporter pods were being counted as a ceph pod, so once an exporter pod was added to a node, it would never be removed since the controller thinks the exporter pod itself is a ceph pod for which the exporter must be present.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14265 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
