### PR TITLE
test: add additionalConfig param to CephManifestsMaster.GetOBC

### DIFF
--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -47,28 +47,28 @@ func (b *BucketOperation) DeleteBucketStorageClass(namespace string, storeName s
 	return err
 }
 
-func (b *BucketOperation) CreateObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("create", b.manifests.GetOBC(obcName, storageClassName, bucketName, maxObject, createBucket))
+func (b *BucketOperation) CreateObc(obcName, storageClassName, bucketName string, additionalConfig map[string]string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("create", b.manifests.GetOBC(obcName, storageClassName, bucketName, additionalConfig, createBucket))
 }
 
 func (b *BucketOperation) CreateObcNotification(obcName string, storageClassName string, bucketName string, notification string, createBucket bool) error {
 	return b.k8sh.ResourceOperation("create", b.manifests.GetOBCNotification(obcName, storageClassName, bucketName, notification, createBucket))
 }
 
-func (b *BucketOperation) DeleteObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("delete", b.manifests.GetOBC(obcName, storageClassName, bucketName, maxObject, createBucket))
+func (b *BucketOperation) DeleteObc(obcName, storageClassName, bucketName string, additionalConfig map[string]string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("delete", b.manifests.GetOBC(obcName, storageClassName, bucketName, additionalConfig, createBucket))
 }
 
-func (b *BucketOperation) UpdateObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("apply", b.manifests.GetOBC(obcName, storageClassName, bucketName, maxObject, createBucket))
+func (b *BucketOperation) UpdateObc(obcName, storageClassName, bucketName string, additionalConfig map[string]string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("apply", b.manifests.GetOBC(obcName, storageClassName, bucketName, additionalConfig, createBucket))
 }
 
 func (b *BucketOperation) UpdateObcNotificationAdd(obcName string, storageClassName string, bucketName string, notification string, createBucket bool) error {
 	return b.k8sh.ResourceOperation("apply", b.manifests.GetOBCNotification(obcName, storageClassName, bucketName, notification, createBucket))
 }
 
-func (b *BucketOperation) UpdateObcNotificationRemove(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("apply", b.manifests.GetOBC(obcName, storageClassName, bucketName, maxObject, createBucket))
+func (b *BucketOperation) UpdateObcNotificationRemove(obcName, storageClassName, bucketName string, additionalConfig map[string]string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("apply", b.manifests.GetOBC(obcName, storageClassName, bucketName, additionalConfig, createBucket))
 }
 
 // CheckOBC, returns true if the obc, secret and configmap are all in the "check" state,

--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -148,8 +148,8 @@ func (m *CephManifestsPreviousVersion) GetBucketStorageClass(storeName, storageC
 }
 
 // GetOBC returns the manifest to create object bucket claim
-func (m *CephManifestsPreviousVersion) GetOBC(claimName, storageClassName, objectBucketName, maxObject string, varBucketName bool) string {
-	return m.latest.GetOBC(claimName, storageClassName, objectBucketName, maxObject, varBucketName)
+func (m *CephManifestsPreviousVersion) GetOBC(claimName, storageClassName, objectBucketName string, additionalConfig map[string]string, varBucketName bool) string {
+	return m.latest.GetOBC(claimName, storageClassName, objectBucketName, additionalConfig, varBucketName)
 }
 
 // GetOBCNotification returns the manifest to create object bucket claim

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -58,8 +58,8 @@ var (
 	ObjectKey4             = "rookObj4"
 	contentType            = "plain/text"
 	obcName                = "smoke-delete-bucket"
-	maxObject              = "2"
-	newMaxObject           = "3"
+	maxObjects             = "2"
+	newMaxObjects          = "3"
 	bucketStorageClassName = "rook-smoke-delete-bucket"
 	maxBucket              = 1
 	maxSize                = "100000"
@@ -241,10 +241,10 @@ func createCephObjectUser(
 	namespace, storeName, userID string,
 	checkPhase, checkQuotaAndCaps bool) {
 
-	maxObjectInt, err := strconv.Atoi(maxObject)
+	maxObjectsInt, err := strconv.Atoi(maxObjects)
 	assert.Nil(s.T(), err)
 	logger.Infof("creating CephObjectStore user %q for store %q in namespace %q", userID, storeName, namespace)
-	cosuErr := helper.ObjectUserClient.Create(userID, userdisplayname, storeName, userCap, maxSize, maxBucket, maxObjectInt)
+	cosuErr := helper.ObjectUserClient.Create(userID, userdisplayname, storeName, userCap, maxSize, maxBucket, maxObjectsInt)
 	assert.Nil(s.T(), cosuErr)
 	logger.Infof("Waiting 5 seconds for the object user %q to be created", userID)
 	time.Sleep(5 * time.Second)
@@ -278,12 +278,12 @@ func checkCephObjectUser(
 	}
 	if checkQuotaAndCaps {
 		// following fields in CephObjectStoreUser CRD doesn't exist before Rook v1.7.3
-		maxObjectInt, err := strconv.Atoi(maxObject)
+		maxObjectsInt, err := strconv.Atoi(maxObjects)
 		assert.Nil(s.T(), err)
 		maxSizeInt, err := strconv.Atoi(maxSize)
 		assert.Nil(s.T(), err)
 		assert.Equal(s.T(), maxBucket, userInfo.MaxBuckets)
-		assert.Equal(s.T(), int64(maxObjectInt), *userInfo.UserQuota.MaxObjects)
+		assert.Equal(s.T(), int64(maxObjectsInt), *userInfo.UserQuota.MaxObjects)
 		assert.Equal(s.T(), int64(maxSizeInt), *userInfo.UserQuota.MaxSize)
 		assert.Equal(s.T(), userCap, userInfo.Caps[0].Perm)
 	}

--- a/tests/integration/ceph_bucket_notification_test.go
+++ b/tests/integration/ceph_bucket_notification_test.go
@@ -380,7 +380,8 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 			assert.Nil(t, err)
 		})
 		t.Run("delete ObjectBucketClaim: reverse-obc", func(t *testing.T) {
-			err = helper.BucketClient.DeleteObc(reverseOBCName, bucketStorageClassName, reverseBucketName, maxObject, true)
+			additionalConfig := map[string]string{"maxObjects": maxObjects}
+			err = helper.BucketClient.DeleteObc(reverseOBCName, bucketStorageClassName, reverseBucketName, additionalConfig, true)
 			assert.Nil(t, err)
 			logger.Info("Checking to see if the obc, secret, and cm have all been deleted")
 			for i = 0; i < 4 && !helper.BucketClient.CheckOBC(reverseOBCName, "deleted"); i++ {
@@ -405,7 +406,8 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 
 	t.Run("delete ObjectBucketClaim", func(t *testing.T) {
 		i := 0
-		dobcErr := helper.BucketClient.DeleteObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
+		additionalConfig := map[string]string{"maxObjects": maxObjects}
+		dobcErr := helper.BucketClient.DeleteObc(obcName, bucketStorageClassName, bucketname, additionalConfig, true)
 		assert.Nil(t, dobcErr)
 		logger.Info("Checking to see if the obc, secret, and cm have all been deleted")
 		for i = 0; i < 4 && !helper.BucketClient.CheckOBC(obcName, "deleted"); i++ {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -119,7 +119,8 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
-		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
+		additionalConfig := map[string]string{"maxObjects": maxObjects}
+		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, additionalConfig, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
 		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
 	}()
@@ -187,7 +188,8 @@ func (s *UpgradeSuite) TestUpgradeCephToReefDevel() {
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
-		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
+		additionalConfig := map[string]string{"maxObjects": maxObjects}
+		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, additionalConfig, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
 		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
 	}()
@@ -221,7 +223,8 @@ func (s *UpgradeSuite) TestUpgradeCephToSquidDevel() {
 		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
 		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
-		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
+		additionalConfig := map[string]string{"maxObjects": maxObjects}
+		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, additionalConfig, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
 		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
 	}()
@@ -279,7 +282,8 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 	logger.Info("Initializing object bucket claim before the upgrade")
 	cobErr := s.helper.BucketClient.CreateBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreName, "Delete")
 	require.Nil(s.T(), cobErr)
-	cobcErr := s.helper.BucketClient.CreateObc(obcName, installer.ObjectStoreName, bucketPrefix, maxObject, false)
+	additionalConfig := map[string]string{"maxObjects": maxObjects}
+	cobcErr := s.helper.BucketClient.CreateObc(obcName, installer.ObjectStoreName, bucketPrefix, additionalConfig, false)
 	require.Nil(s.T(), cobcErr)
 
 	created := utils.Retry(12, 2*time.Second, "OBC is created", func() bool {


### PR DESCRIPTION
The `maxObjects` param is replaced with `additionalConfig map[string]string` to facilitate testing other additionalConfig keys.

This work was started for use in another PR and ended up not being needed.  It cleans up a confusing use of  `maxObject` vs `maxObjects` as a variable name.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
