### PR TITLE
object: rm unnecessary user bucket quota setting in bucket.{Grant,Provision}()

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -156,13 +156,6 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 		return nil, errors.Wrap(err, "Provision: can't create ceph user")
 	}
 
-	// restrict creation of new buckets in rgw
-	restrictBucketCreation := 0
-	_, err = p.adminOpsClient.ModifyUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName, MaxBuckets: &restrictBucketCreation})
-	if err != nil {
-		return nil, err
-	}
-
 	// get the bucket's owner via the bucket metadata
 	stats, err := p.adminOpsClient.GetBucketInfo(p.clusterInfo.Context, admin.Bucket{Bucket: p.bucketName})
 	if err != nil {

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -124,13 +124,6 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		logger.Debugf("bucket %q already exists", p.bucketName)
 	}
 
-	singleBucketQuota := 1
-	_, err = p.adminOpsClient.ModifyUser(p.clusterInfo.Context, admin.User{ID: p.cephUserName, MaxBuckets: &singleBucketQuota})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set user %q bucket quota to %d", p.cephUserName, singleBucketQuota)
-	}
-	logger.Infof("set user %q bucket max to %d", p.cephUserName, singleBucketQuota)
-
 	err = p.setAdditionalSettings(options)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set additional settings for OBC %q in NS %q associated with CephObjectStore %q in NS %q", options.ObjectBucketClaim.Name, options.ObjectBucketClaim.Namespace, p.objectStoreName, p.clusterInfo.Namespace)


### PR DESCRIPTION
It appears the user quota is set after the bucket is created and then immediately unset by bucket.setAdditionalSettings(). The logic also partially duplicates bucket.setUserQuota(). A default limit of a single bucket could be achieved by assuming `maxBuckets` is `1`, if the value is no explicitly set. However, that would be a visible change in behavior as users for buckets which do not currently have a bucket quota set would acquire a bucket quota.

Testing to with 1.15.3 to investigate the current behavior. Using this OBC:

```
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: test3
provisioner: rook-ceph.ceph.rook.io/bucket
parameters:
  objectStoreName: lfa
  objectStoreNamespace: rook-ceph
reclaimPolicy: Retain
---
apiVersion: objectbucket.io/v1alpha1
kind: ObjectBucketClaim
metadata:
  name: test3
  namespace: rook-ceph
spec:
  bucketName: test3
  storageClassName: test3
```

Results in the operator logging the initial bucket quota being set:

```
2024-10-21 22:09:31.009505 I | op-bucket-prov: set user "obc-rook-ceph-test4-6523feb9-6938-46c3-8c86-9443deb4299c" bucket max to 1
```

The change to the bucket quota is not logged after that. However, when inspecting the generated rgw user, there is no bucket quota set:

```
bash-5.1$ radosgw-admin user info --uid=obc-rook-ceph-test4-6523feb9-6938-46c3-8c86-9443deb4299c
{
    "user_id": "obc-rook-ceph-test4-6523feb9-6938-46c3-8c86-9443deb4299c",
    "display_name": "obc-rook-ceph-test4-6523feb9-6938-46c3-8c86-9443deb4299c",
    "email": "",
    "suspended": 0,
    "max_buckets": 1,
    "subusers": [],
    "keys": [
        {
            "user": "obc-rook-ceph-test4-6523feb9-6938-46c3-8c86-9443deb4299c",
            "access_key": "M43S1EH3I05S6D45VPRQ",
            "secret_key": "SLOOXDCy3YqhnNeemS7ijOLIQhCZcVBI2NAAB9bJ"
        }
    ],
    "swift_keys": [],
    "caps": [],
    "op_mask": "read, write, delete",
    "default_placement": "",
    "default_storage_class": "",
    "placement_tags": [],
    "bucket_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "user_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "temp_url_keys": [],
    "type": "rgw",
    "mfa_ids": []
}
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
