### PR TITLE
ci: fix the codegen workflow

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -38,8 +38,20 @@ jobs:
         with:
           go-version: "1.22"
 
+      - name: post-process checkout - copy to github.com
+        run: |
+          # copy to the github.com path so codegen will work as expected
+          mkdir -p $(go env GOPATH)/src/github.com/rook/rook/
+          cp -R . $(go env GOPATH)/src/github.com/rook/rook/
+
       - name: run codegen
-        run: GOPATH=$(go env GOPATH) make codegen
+        run: |
+          cd $(go env GOPATH)/src/github.com/rook/rook
+          GOPATH=$(go env GOPATH) make codegen
 
       - name: validate codegen
-        run: tests/scripts/validate_modified_files.sh codegen
+        run: |
+          # run validation again, explicitly.
+          # it is also part of 'make codegen'
+          cd $(go env GOPATH)/src/github.com/rook/rook
+          tests/scripts/validate_modified_files.sh codegen


### PR DESCRIPTION
The codegen workflow recently sometimes failed to detect files modified by codegen. This has been analysed in a test PR #14723 

The result of the analysis is the insight that the codegen tooling did not work as expected because the git checkout was not located in the src/github.com directory under the GOPATH.

This change fixes the codegen workflow by post-processing the git checkout action by copying the git checkout directory to the expected location.




**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
