### PR TITLE
ci: remove incorrect comment from codegen workflow

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -51,7 +51,5 @@ jobs:
 
       - name: validate codegen
         run: |
-          # run validation again, explicitly.
-          # it is also part of 'make codegen'
           cd $(go env GOPATH)/src/github.com/rook/rook
           tests/scripts/validate_modified_files.sh codegen


### PR DESCRIPTION
PR #14883 fixed the codegen workflow but introduced a comment that is simply wrong.

This change rectifies this mistake by removing the comment.



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
