### PR TITLE
core: Cleanup blockpool with annotation

### DIFF
--- a/Documentation/Storage-Configuration/ceph-teardown.md
+++ b/Documentation/Storage-Configuration/ceph-teardown.md
@@ -205,3 +205,4 @@ This cleanup is supported only for the following custom resources:
 | --------                             | ------- |
 | CephFilesystemSubVolumeGroup         | CSI stored RADOS OMAP details for pvc/volumesnapshots, subvolume snapshots, subvolume clones, subvolumes |
 | CephBlockPoolRadosNamespace          | Images and snapshots in the RADOS namespace|
+| CephBlockPool                        | Images and snapshots in the BlockPool|

--- a/pkg/daemon/ceph/cleanup/radosnamespace.go
+++ b/pkg/daemon/ceph/cleanup/radosnamespace.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cleanup
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -26,46 +28,67 @@ import (
 func RadosNamespaceCleanup(context *clusterd.Context, clusterInfo *client.ClusterInfo, poolName, radosNamespace string) error {
 	logger.Infof("starting clean up of CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
 
+	err := cleanupImages(context, clusterInfo, poolName, radosNamespace)
+	if err != nil {
+		logger.Errorf("failed to clean up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+		return err
+	}
+
+	logger.Infof("successfully cleaned up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+	return nil
+}
+
+func cleanupImages(context *clusterd.Context, clusterInfo *client.ClusterInfo, poolName, radosNamespace string) error {
+	msg := fmt.Sprintf("cephblockpool %q", poolName)
+	if radosNamespace != "" {
+		msg = fmt.Sprintf("%s in rados namespace %q", msg, radosNamespace)
+	}
 	images, err := cephclient.ListImagesInRadosNamespace(context, clusterInfo, poolName, radosNamespace)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list images in cephblockpool %q in rados namespace %q", poolName, radosNamespace)
+		return errors.Wrapf(err, "failed to list images in %s", msg)
 	}
 
 	var retErr error
 	for _, image := range images {
 		snaps, err := cephclient.ListSnapshotsInRadosNamespace(context, clusterInfo, poolName, image.Name, radosNamespace)
 		if err != nil {
-			retErr = errors.Wrapf(err, "failed to list snapshots for the image %q in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			retErr = errors.Wrapf(err, "failed to list snapshots for the image %q in %s", image.Name, msg)
 			logger.Error(retErr)
 		}
 
 		for _, snap := range snaps {
 			err := cephclient.DeleteSnapshotInRadosNamespace(context, clusterInfo, poolName, image.Name, snap.Name, radosNamespace)
 			if err != nil {
-				retErr = errors.Wrapf(err, "failed to delete snapshot %q of the image %q in cephblockpool %q in rados namespace %q.", snap.Name, image.Name, poolName, radosNamespace)
+				retErr = errors.Wrapf(err, "failed to delete snapshot %q of the image %q in %s", snap.Name, image.Name, msg)
 				logger.Error(retErr)
 			} else {
-				logger.Infof("successfully deleted snapshot %q of image %q in cephblockpool %q in rados namespace %q", snap.Name, image.Name, poolName, radosNamespace)
+				logger.Infof("successfully deleted snapshot %q of image %q in %s", snap.Name, image.Name, msg)
 			}
 		}
 
 		err = cephclient.MoveImageToTrashInRadosNamespace(context, clusterInfo, poolName, image.Name, radosNamespace)
 		if err != nil {
-			retErr = errors.Wrapf(err, "failed to move image %q to trash in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			retErr = errors.Wrapf(err, "failed to move image %q to trash in %s", image.Name, msg)
 			logger.Error(retErr)
 		}
 		err = cephclient.DeleteImageFromTrashInRadosNamespace(context, clusterInfo, poolName, image.ID, radosNamespace)
 		if err != nil {
-			retErr = errors.Wrapf(err, "failed to add task to remove image %q from trash in cephblockpool %q in rados namespace %q.", image.Name, poolName, radosNamespace)
+			retErr = errors.Wrapf(err, "failed to add task to remove image %q from trash in %s", image.Name, msg)
 			logger.Error(retErr)
 		}
 	}
+	return retErr
+}
 
-	if retErr != nil {
-		logger.Errorf("failed to clean up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
-		return retErr
+func BlockPoolCleanup(context *clusterd.Context, clusterInfo *client.ClusterInfo, poolName string) error {
+	logger.Infof("starting clean up of CephBlockPool %q resource", poolName)
+
+	err := cleanupImages(context, clusterInfo, poolName, "")
+	if err != nil {
+		logger.Errorf("failed to clean up CephBlockPool %q resource", poolName)
+		return err
 	}
 
-	logger.Infof("successfully cleaned up CephBlockPoolRadosNamespace %q resources in cephblockpool %q", radosNamespace, poolName)
+	logger.Infof("successfully cleaned up CephBlockPool %q resource", poolName)
 	return nil
 }

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -85,7 +85,10 @@ func ListImagesInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterI
 // ListSnapshotsInRadosNamespace lists all the snapshots created for an image in a cephblockpool in a given rados namespace
 func ListSnapshotsInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, imageName, namespace string) ([]CephBlockImageSnapshot, error) {
 	snapshots := []CephBlockImageSnapshot{}
-	args := []string{"snap", "ls", getImageSpec(imageName, poolName), "--namespace", namespace}
+	args := []string{"snap", "ls", getImageSpec(imageName, poolName)}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
 	cmd := NewRBDCommand(context, clusterInfo, args)
 	cmd.JsonOutput = true
 	buf, err := cmd.Run()
@@ -101,7 +104,10 @@ func ListSnapshotsInRadosNamespace(context *clusterd.Context, clusterInfo *Clust
 
 // DeleteSnapshotInRadosNamespace deletes a image snapshot created in block pool in a given rados namespace
 func DeleteSnapshotInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, imageName, snapshot, namespace string) error {
-	args := []string{"snap", "rm", getImageSnapshotSpec(poolName, imageName, snapshot), "--namespace", namespace}
+	args := []string{"snap", "rm", getImageSnapshotSpec(poolName, imageName, snapshot)}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
 	cmd := NewRBDCommand(context, clusterInfo, args)
 	_, err := cmd.Run()
 	if err != nil {
@@ -112,7 +118,10 @@ func DeleteSnapshotInRadosNamespace(context *clusterd.Context, clusterInfo *Clus
 
 // MoveImageToTrashInRadosNamespace moves the cephblockpool image to trash in the rados namespace
 func MoveImageToTrashInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, imageName, namespace string) error {
-	args := []string{"trash", "mv", getImageSpec(imageName, poolName), "--namespace", namespace}
+	args := []string{"trash", "mv", getImageSpec(imageName, poolName)}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
 	cmd := NewRBDCommand(context, clusterInfo, args)
 	_, err := cmd.Run()
 	if err != nil {
@@ -268,8 +277,12 @@ func getImageSpec(name, poolName string) string {
 }
 
 func getImageSpecInRadosNamespace(poolName, namespace, imageID string) string {
+	if namespace == "" {
+		return fmt.Sprintf("%s/%s", poolName, imageID)
+	}
 	return fmt.Sprintf("%s/%s/%s", poolName, namespace, imageID)
 }
+
 func getImageSnapshotSpec(poolName, imageName, snapshot string) string {
 	return fmt.Sprintf("%s/%s@%s", poolName, imageName, snapshot)
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

This is similar to #14052 we did for radosnamespace and this is an extension to support cleanup at the blockpool level to cleanup the images and the snapshots in a pool. 

Motive:- I saw an issue where users are using scripts to cleanup the resources, I thought it's better to have the functionality in Rook itself.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


Note:-  I tried to keep the changes minimal as much as possible and reuse whatever we have for the rados namespace cleanup (with little modification)

If this is good, i would like to do one final round of testing before merging.