### PR TITLE
rbd: CephBlockPool enableRBDStats not clearing rbd_stats_pools

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
@@ -419,35 +420,50 @@ func deletePool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 	return nil
 }
 
-// remove removes any element from a list
-func remove(list []string, s string) []string {
-	for i, v := range list {
-		if v == s {
-			list = append(list[:i], list[i+1:]...)
+// generateStatsPoolList combines existingStatsPools and rookStatsPools, removes items in removePools,
+// removes duplicates, ensures no empty strings, and returns a comma-separated string in a deterministic order.
+func generateStatsPoolList(existingStatsPools []string, rookStatsPools []string, removePools []string) string {
+	poolList := []string{}
+
+	// Helper function to add a poolList if it's not in the removePools list and not already in poolList
+	addUniquePool := func(pool string) {
+		if pool == "" {
+			return
 		}
+		// Check if the pool should be removed or already exists in poolList
+		if contains(removePools, pool) || contains(poolList, pool) {
+			return
+		}
+		poolList = append(poolList, pool)
+	}
+	for _, pool := range existingStatsPools {
+		addUniquePool(pool)
+	}
+	for _, pool := range rookStatsPools {
+		addUniquePool(pool)
 	}
 
-	return list
+	sort.Strings(poolList) // Sort the list to ensure deterministic output
+
+	return strings.Join(poolList, ",")
 }
 
-// Remove duplicate entries from slice
-func removeDuplicates(slice []string) []string {
-	inResult := make(map[string]bool)
-	var result []string
-	for _, str := range slice {
-		if _, ok := inResult[str]; !ok {
-			inResult[str] = true
-			result = append(result, str)
+// Helper function to check if a slice contains a string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
 		}
 	}
-	return result
+	return false
 }
 
 func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient.ClusterInfo, deletedPool string) error {
 	logger.Debug("configuring RBD per-image IO statistics collection")
 	namespaceListOpt := client.InNamespace(clusterInfo.Namespace)
 	cephBlockPoolList := &cephv1.CephBlockPoolList{}
-	var enableStatsForCephBlockPools []string
+	var rookStatsPools []string
+	var removePools []string
 	err := clusterContext.Client.List(clusterInfo.Context, cephBlockPoolList, namespaceListOpt)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve list of CephBlockPool")
@@ -455,28 +471,29 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 	for _, cephBlockPool := range cephBlockPoolList.Items {
 		if cephBlockPool.GetDeletionTimestamp() == nil && cephBlockPool.Spec.EnableRBDStats {
 			// add to list of CephBlockPool with enableRBDStats set to true and not marked for deletion
-			enableStatsForCephBlockPools = append(enableStatsForCephBlockPools, cephBlockPool.ToNamedPoolSpec().Name)
+			rookStatsPools = append(rookStatsPools, cephBlockPool.ToNamedPoolSpec().Name)
+		} else {
+			removePools = append(removePools, cephBlockPool.ToNamedPoolSpec().Name)
 		}
 	}
-	enableStatsForCephBlockPools = remove(enableStatsForCephBlockPools, deletedPool)
+	if deletedPool != "" {
+		removePools = append(removePools, deletedPool)
+	}
 	monStore := config.GetMonStore(clusterContext, clusterInfo)
 	// Check for existing rbd stats pools
-	existingRBDStatsPools, e := monStore.Get("mgr", "mgr/prometheus/rbd_stats_pools")
+	existingStatsPools, e := monStore.Get("mgr", "mgr/prometheus/rbd_stats_pools")
 	if e != nil {
 		return errors.Wrapf(e, "failed to get rbd_stats_pools")
 	}
-
-	existingRBDStatsPoolsList := strings.Split(existingRBDStatsPools, ",")
-	enableStatsForPools := append(enableStatsForCephBlockPools, existingRBDStatsPoolsList...)
-	enableStatsForPools = removeDuplicates(enableStatsForPools)
-
+	existingStatsPoolsList := strings.Split(existingStatsPools, ",")
+	enableStatsForPools := generateStatsPoolList(existingStatsPoolsList, rookStatsPools, removePools)
+	logger.Infof("enableStatsForPools=%q ", enableStatsForPools)
 	logger.Debugf("RBD per-image IO statistics will be collected for pools: %v", enableStatsForPools)
-
 	if len(enableStatsForPools) == 0 {
 		err = monStore.Delete("mgr", "mgr/prometheus/rbd_stats_pools")
 	} else {
 		// appending existing rbd stats pools if any
-		err = monStore.Set("mgr", "mgr/prometheus/rbd_stats_pools", strings.Trim(strings.Join(enableStatsForPools, ","), ","))
+		err = monStore.Set("mgr", "mgr/prometheus/rbd_stats_pools", enableStatsForPools)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to enable rbd_stats_pools")


### PR DESCRIPTION
#12627
<!-- Thank you for contributing to Rook! -->

This PR fixes an issue where disabling enableRBDStats in CephBlockPool did not remove the pool from rbd_stats_pools, leading to unnecessary monitoring. The update ensures that when enableRBDStats is set to false, the pool is properly removed from rbd_stats_pools, optimizing resource tracking
<!-- STEPS TO FOLLOW:
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


Tested with private image `docker.io/oviner/rook:test6`
1.Start minikube wiht kvm2:
```
$ minikube start --disk-size=10g --extra-disks=1 --driver kvm2
```

2.Create resources and operator
```
operator.yaml:
      containers:
        - name: rook-ceph-operator
          image: docker.io/oviner/rook:test6
```
```
$ kubectl create -f crds.yaml -f common.yaml -f operator.yaml
$ kubectl get pods -n rook-ceph
NAME                                 READY   STATUS    RESTARTS   AGE
rook-ceph-operator-cf4f7dfd4-vzwbt   1/1     Running   0          89s
```

3.Create cluster-test:
```
$ cd deploy/examples/
$ kubectl create -f cluster-test.yaml 
```

4.Create tool pod and check ceph status:
```
$ cd deploy/examples/
kubectl create -f toolbox.yaml
kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
bash-5.1$ ceph health
HEALTH_OK
```

5.Create 3 pools with [enableRBDStats: true]
```
kubectl create -f pool-test.yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: pool1
  namespace: rook-ceph # namespace:cluster
spec:
  enableRBDStats: true
  failureDomain: osd
  replicated:
    size: 1
```
```
kubectl create -f pool-test.yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: pool2
  namespace: rook-ceph # namespace:cluster
spec:
  enableRBDStats: true
  failureDomain: osd
  replicated:
    size: 1
```
```
kubectl create -f pool-test.yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: pool3
  namespace: rook-ceph # namespace:cluster
spec:
  enableRBDStats: true
  failureDomain: osd
  replicated:
    size: 1
```

6.Check mgr/prometheus/rbd_stats_pools list
```
$ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
bash-5.1$  ceph config get mgr mgr/prometheus/rbd_stats_pools
pool1,pool2,pool3
```

7.Change enableRBDStats to false on pool2
```
$ kubectl edit CephBlockPool pool2 -n rook-ceph 
 enableRBDStats: false
```

8.Check mgr/prometheus/rbd_stats_pools list
```
bash-5.1$  ceph config get mgr mgr/prometheus/rbd_stats_pools
pool1,pool3
```

9. Check operator logs:
```
$ kubectl logs rook-ceph-operator-7584779949-zx5x4 -n rook-ceph | grep enableStatsForCephBlockPools_2 -C 20
2024-10-23 18:00:05.145304 I | op-config: setting "mgr"="mgr/prometheus/rbd_stats_pools"="pool1,pool2,pool3" option to the mon configuration database
2024-10-23 18:00:05.336742 I | op-config: successfully set "mgr"="mgr/prometheus/rbd_stats_pools"="pool1,pool2,pool3" option to the mon configuration database
2024-10-23 18:01:09.272769 I | ceph-spec: CR has changed for "pool2". diff=  v1.NamedBlockPoolSpec{
        Name: "",
        PoolSpec: v1.PoolSpec{
                ... // 6 identical fields
                ErasureCoded:   {},
                Parameters:     nil,
-               EnableRBDStats: true,
+               EnableRBDStats: false,
                Mirroring:      {},
                StatusCheck:    {},
                ... // 2 identical fields
        },
  }
2024-10-23 18:01:09.278319 I | ceph-spec: parsing mon endpoints: a=10.104.219.46:6789
2024-10-23 18:01:09.501218 I | ceph-block-pool-controller: creating pool "pool2" in namespace "rook-ceph"
2024-10-23 18:01:10.120560 I | cephclient: application "rbd" is already set on pool "pool2"
2024-10-23 18:01:10.120571 I | cephclient: reconciling replicated pool pool2 succeeded
2024-10-23 18:01:10.120574 I | ceph-block-pool-controller: initializing pool "pool2" for RBD use
2024-10-23 18:01:10.986704 I | ceph-block-pool-controller: successfully initialized pool "pool2" for RBD use
2024-10-23 18:01:10.986795 I | ceph-block-pool-controller: enableStatsForCephBlockPools_1=["pool1"] 
2024-10-23 18:01:10.986800 I | ceph-block-pool-controller: enableStatsForCephBlockPools_1=["pool1" "pool3"] 
2024-10-23 18:01:10.986802 I | ceph-block-pool-controller: enableStatsForCephBlockPools_2=["pool1" "pool3"] 
2024-10-23 18:01:11.166235 I | ceph-block-pool-controller: existingRBDStatsPools= "pool1,pool2,pool3"
2024-10-23 18:01:11.166248 I | ceph-block-pool-controller: poolNames="pool1,pool3" 
2024-10-23 18:01:11.166250 I | ceph-block-pool-controller: poolNames_2="pool1,pool3" 
2024-10-23 18:01:11.166252 I | op-config: setting "mgr"="mgr/prometheus/rbd_stats_pools"="pool1,pool3" option to the mon configuration database
2024-10-23 18:01:11.357383 I | op-config: successfully set "mgr"="mgr/prometheus/rbd_stats_pools"="pool1,pool3" option to the mon configuration database
```
