### PR TITLE
rgw: workaround for default placement removal

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -10965,7 +10965,9 @@ bool
 </em>
 </td>
 <td>
-<p>Sets given placement as default. Only one placement in the list can be marked as default.</p>
+<em>(Optional)</em>
+<p>Sets given placement as default. Only one placement in the list can be marked as default.
+Default is false.</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -12384,7 +12384,9 @@ spec:
                             minLength: 1
                             type: string
                           default:
-                            description: Sets given placement as default. Only one placement in the list can be marked as default.
+                            description: |-
+                              Sets given placement as default. Only one placement in the list can be marked as default.
+                              Default is false.
                             type: boolean
                           metadataPoolName:
                             description: The metadata pool used to store ObjectStore bucket index.
@@ -12423,7 +12425,6 @@ spec:
                             type: array
                         required:
                           - dataPoolName
-                          - default
                           - metadataPoolName
                           - name
                         type: object
@@ -13310,7 +13311,9 @@ spec:
                             minLength: 1
                             type: string
                           default:
-                            description: Sets given placement as default. Only one placement in the list can be marked as default.
+                            description: |-
+                              Sets given placement as default. Only one placement in the list can be marked as default.
+                              Default is false.
                             type: boolean
                           metadataPoolName:
                             description: The metadata pool used to store ObjectStore bucket index.
@@ -13349,7 +13352,6 @@ spec:
                             type: array
                         required:
                           - dataPoolName
-                          - default
                           - metadataPoolName
                           - name
                         type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -12375,7 +12375,9 @@ spec:
                             minLength: 1
                             type: string
                           default:
-                            description: Sets given placement as default. Only one placement in the list can be marked as default.
+                            description: |-
+                              Sets given placement as default. Only one placement in the list can be marked as default.
+                              Default is false.
                             type: boolean
                           metadataPoolName:
                             description: The metadata pool used to store ObjectStore bucket index.
@@ -12414,7 +12416,6 @@ spec:
                             type: array
                         required:
                           - dataPoolName
-                          - default
                           - metadataPoolName
                           - name
                         type: object
@@ -13298,7 +13299,9 @@ spec:
                             minLength: 1
                             type: string
                           default:
-                            description: Sets given placement as default. Only one placement in the list can be marked as default.
+                            description: |-
+                              Sets given placement as default. Only one placement in the list can be marked as default.
+                              Default is false.
                             type: boolean
                           metadataPoolName:
                             description: The metadata pool used to store ObjectStore bucket index.
@@ -13337,7 +13340,6 @@ spec:
                             type: array
                         required:
                           - dataPoolName
-                          - default
                           - metadataPoolName
                           - name
                         type: object

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1564,6 +1564,8 @@ type PoolPlacementSpec struct {
 	Name string `json:"name"`
 
 	// Sets given placement as default. Only one placement in the list can be marked as default.
+	// Default is false.
+	// +optional
 	Default bool `json:"default"`
 
 	// The metadata pool used to store ObjectStore bucket index.

--- a/pkg/operator/ceph/object/shared_pools.go
+++ b/pkg/operator/ceph/object/shared_pools.go
@@ -493,7 +493,7 @@ func updateZoneGroupJSON(objContext *Context, group map[string]interface{}) (map
 	args := []string{"zonegroup", "set", zoneArg, "--infile=" + configFilename, realmArg, zoneGroupArg}
 	updatedBytes, err := RunAdminCommandNoMultisite(objContext, false, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to set zone config")
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to set zone config %s", updatedBytes))
 	}
 	updated := map[string]interface{}{}
 	err = json.Unmarshal([]byte(updatedBytes), &updated)


### PR DESCRIPTION
During local tests of RGW pool placement feature i discovered 2 issues which are fixed in this PR:
1. `placement.default` flag was not marked as optional in `CephObjectStore` CRD
2. `radosgw-admin` CLI always recreates `default-placement` in zone and zonegroup json when it is updated with `--infile` option. I've created corresponding issue in ceph bugtracker https://tracker.ceph.com/issues/68775. Rook fixes this issue by manually deleting `default-placement` with a separate CLI command `radosgw-admin zone placement rm --rgw-zone=<name> --placement-id=default-placement` for both zone and zonegroup.