### PR TITLE
osd: Allow scheduling on unschedulable nodes

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -94,6 +94,8 @@ For more details on the mons and when to choose a number other than `3`, see the
         * For non-PVCs: `placement.all` and `placement.osd`
         * For PVCs: `placement.all` and inside the storageClassDeviceSets from the `placement` or `preparePlacement`
     * `flappingRestartIntervalHours`: Defines the time for which an OSD pod will sleep before restarting, if it stopped due to flapping. Flapping occurs where OSDs are marked `down` by Ceph more than 5 times in 600 seconds. The OSDs will stay down when flapping since they likely have a bad disk or other issue that needs investigation. If the issue with the OSD is fixed manually, the OSD pod can be manually restarted. The sleep is disabled if this interval is set to 0.
+    * `scheduleAlways`: Whether to always schedule OSD pods on nodes declared explicitly in the "nodes" section, even if they are
+        temporarily not schedulable. If set to true, consider adding placement tolerations for unschedulable nodes.
     * `fullRatio`: The ratio at which Ceph should block IO if the OSDs are too full. The default is 0.95.
     * `backfillFullRatio`: The ratio at which Ceph should stop backfilling data if the OSDs are too full. The default is 0.90.
     * `nearFullRatio`: The ratio at which Ceph should raise a health warning if the cluster is almost full. The default is 0.85.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -12821,6 +12821,18 @@ bool
 </tr>
 <tr>
 <td>
+<code>scheduleAlways</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>onlyApplyOSDPlacement</code><br/>
 <em>
 bool

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -3645,6 +3645,9 @@ spec:
                       type: array
                     onlyApplyOSDPlacement:
                       type: boolean
+                    scheduleAlways:
+                      description: Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+                      type: boolean
                     storageClassDeviceSets:
                       items:
                         description: StorageClassDeviceSet is a storage class device set

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -285,6 +285,9 @@ spec:
     #     config: # configuration can be specified at the node level which overrides the cluster level config
     #   - name: "172.17.4.301"
     #     deviceFilter: "^sd."
+    # Whether to always schedule OSD pods on nodes declared explicitly in the "nodes" section, even if they are
+    # temporarily not schedulable. If set to true, consider adding placement tolerations for unschedulable nodes.
+    scheduleAlways: false
     # when onlyApplyOSDPlacement is false, will merge both placement.All() and placement.osd
     onlyApplyOSDPlacement: false
     # Time for which an OSD pod will sleep before restarting, if it stopped due to flapping

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -3643,6 +3643,9 @@ spec:
                       type: array
                     onlyApplyOSDPlacement:
                       type: boolean
+                    scheduleAlways:
+                      description: Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+                      type: boolean
                     storageClassDeviceSets:
                       items:
                         description: StorageClassDeviceSet is a storage class device set

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3035,6 +3035,9 @@ type StorageScopeSpec struct {
 	// +optional
 	UseAllNodes bool `json:"useAllNodes,omitempty"`
 	// +optional
+	// Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+	ScheduleAlways bool `json:"scheduleAlways,omitempty"`
+	// +optional
 	OnlyApplyOSDPlacement bool `json:"onlyApplyOSDPlacement,omitempty"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable

--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -100,7 +100,7 @@ func (c *clientCluster) onK8sNode(ctx context.Context, object runtime.Object, op
 		return false
 	}
 
-	if !k8sutil.GetNodeSchedulable(*node) {
+	if !k8sutil.GetNodeSchedulable(*node, false) {
 		logger.Debugf("node watcher: skipping cluster update. added node %q is unschedulable", node.Labels[corev1.LabelHostname])
 		return false
 	}
@@ -123,7 +123,7 @@ func (c *clientCluster) onK8sNode(ctx context.Context, object runtime.Object, op
 
 	logger.Debugf("node %q is ready, checking if it can run OSDs", node.Name)
 	nodesCheckedForReconcile.Insert(node.Name)
-	err := k8sutil.ValidNode(*node, cephv1.GetOSDPlacement(cluster.Spec.Placement))
+	err := k8sutil.ValidNode(*node, cephv1.GetOSDPlacement(cluster.Spec.Placement), cluster.Spec.Storage.ScheduleAlways)
 	if err == nil {
 		nodeName := node.Name
 		hostname, ok := node.Labels[corev1.LabelHostname]


### PR DESCRIPTION
For nodes that are explicitly requested for deploying OSDs, they will be skipped temporarily if not
schedulable or not ready. A future reconcile is expected to schedule them. Allow the OSDs to be scheduled even on these nodes that are temporarily down, even if it blocks the reconcile from completing. 

If the nodes remain unschedulable too long, the reconcile could wait a long time to complete, but as long as it is a temporary condition with nodes unschedulable, the reconcile will continue as soon as the node(s) all come online. 

If this really is expected to be a temporary condition, let's consider even making this behavior the default. But for now it feels we need to make it experimental to confirm no adverse delays or side effects on the reconcile.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14714 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
