### PR TITLE
ci: Default to the latest stable squid instead of devel

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -98,7 +98,8 @@ func ReturnCephVersion() cephv1.CephVersionSpec {
 	case "squid-devel":
 		return SquidDevelVersion
 	default:
-		return SquidDevelVersion
+		// Default to the latest stable version
+		return SquidVersion
 	}
 }
 


### PR DESCRIPTION
The devel images have been fairly stable for Rook to test against, but on occasion there are regressions from Ceph development that affect the Rook CI. For stability during Rook development, use the latest stable version of ceph for PRs, master, and release tests. The daily CI will still use the devel images from Ceph.

If we merge this to unblock the CI currently, I'm also inclined to revert it after https://tracker.ceph.com/issues/68802 is resolved, so we can continue to catch Ceph issues early that will affect Rook.
@BlaineEXE @satoru-takeuchi @subhamkrai thoughts?

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
