### PR TITLE
build: validate codegen path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
   macos-build:
     runs-on: macos-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    defaults:
+      run:
+        working-directory: ./github.com/rook/rook
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          path: github.com/rook/rook
 
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -14,9 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# outputs absolute path for given relative path.
+function toAbsolutePath(){
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
+
 GROUP_VERSIONS="ceph.rook.io:v1"
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+output_base="$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+output_pkg="github.com/rook/rook/pkg/client"
+apis_pkg="github.com/rook/rook/pkg/apis"
+
+# check that output directory for generated packages already exists.
+if [ ! -d "$output_base/$apis_pkg" ]; then
+  echo "apis pkg $(toAbsolutePath $output_base/$apis_pkg) does not exist."
+  echo "please make sure that project located in 'github.com/rook/rook' directory"
+  exit 1
+fi
+
+echo "Generate code for packages: 
+  - $(toAbsolutePath $output_base/$output_pkg)
+  - $(toAbsolutePath $output_base/$apis_pkg)"
 
 # CODE GENERATION
 # we run deepcopy and client,lister,informer generations separately so we can use the flag "--plural-exceptions"
@@ -25,18 +46,18 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # run code deepcopy generation
 bash ${CODE_GENERATOR}/generate-groups.sh \
     deepcopy \
-    github.com/rook/rook/pkg/client \
-    github.com/rook/rook/pkg/apis \
+    $output_pkg \
+    $apis_pkg \
     "${GROUP_VERSIONS}" \
-    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.." \
+    --output-base $output_base \
     --go-header-file "${scriptdir}/boilerplate.go.txt"
 
 # run code client,lister,informer generation
 bash ${CODE_GENERATOR}/generate-groups.sh \
     client,lister,informer \
-    github.com/rook/rook/pkg/client \
-    github.com/rook/rook/pkg/apis \
+    $output_pkg \
+    $apis_pkg \
     "${GROUP_VERSIONS}" \
-    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.." \
+    --output-base $output_base \
     --go-header-file "${scriptdir}/boilerplate.go.txt" \
     --plural-exceptions "CephNFS:CephNFSes" \


### PR DESCRIPTION
I had a problem that `make codegen` was not updating deepcopy functions for CRDs. The problem was in structure of my local directories:
- i had `$HOME/github/rook`
- but correct path is `<any path>/github.com/rook/rook`

So in my case `make codegen` was creating files outside of git repo and it was hard for me to investigate a problem. This PR adds check that codegen target directory exists in repo and warns user about recommended repository structure.


Directory structure is enforced by https://github.com/rook/rook/blob/master/build/codegen/codegen.sh#L28-L31 script. 
The script is using old version `v0.20.0` of k8s codegen tool. And this version [provides no option to set different values for codegen directory and package name](https://github.com/kubernetes/code-generator/blob/v0.20.0/generate-groups.sh#L27-L38). So it is not possible to use relative paths. But it looks like, the latest codegen version [has a separate params for directory and package name](https://github.com/kubernetes/code-generator/blob/master/kube_codegen.sh#L396-L402).

Do you think it is a good idea to migrate to the newest version? I've found [an example](https://github.com/kubernetes/sample-controller/blob/master/hack/update-codegen.sh) and tried to migrate in a separate branch but it fails with go mod erros. Probably it is related with `go.mod` files in `pkg/apis`. 
I will try to do a separate PR with codegen version upgrade if i will be able to fix this error.

