### PR TITLE
Amend k8s and Ceph minimum versions in the 1.15 upgrade guides. Fixes #14998.

### DIFF
--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -26,6 +26,7 @@ until all the daemons have been updated.
 
 Rook v1.15 supports the following Ceph versions:
 
+* Ceph Squid v19.2.0 or newer
 * Ceph Reef v18.2.0 or newer
 * Ceph Quincy v17.2.0 or newer
 

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -51,6 +51,9 @@ those releases.
 
 ## Breaking changes in v1.15
 
+* The minimum supported version of Kubernetes is v1.26.
+    Upgrade to Kubernetes v1.26 or higher before upgrading Rook.
+
 * Rook has deprecated CSI network "holder" pods.
     If there are pods named `csi-*plugin-holder-*` in the Rook operator namespace, see the
     [detailed documentation](../CRDs/Cluster/network-providers.md#holder-pod-deprecation)


### PR DESCRIPTION
Amend k8s and Ceph minimum versions in the 1.15 upgrade guides. Fixes #14998.

On main they're already set correctly.