### PR TITLE
helm: set service account for toolbox pod

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -114,6 +114,7 @@ spec:
               mountPath: /etc/rook
             - name: ceph-admin-secret
               mountPath: /var/lib/rook-ceph-mon
+      serviceAccountName: rook-ceph-default
       volumes:
         - name: ceph-admin-secret
           secret:


### PR DESCRIPTION
Run the tools pod with the rook-ceph-default service account

Setting the service account for the pod prevents SCC violations on openshift

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
