### PR TITLE
external: fix detect job in radosnamespace controller

### DIFF
--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -57,8 +57,6 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
 
 var poolNamespace = reflect.TypeOf(cephv1.CephBlockPoolRadosNamespace{}).Name()
 
-var detectCephVersion = opcontroller.DetectCephVersion
-
 // Sets the type meta for the controller main object
 var controllerTypeMeta = metav1.TypeMeta{
 	Kind:       poolNamespace,
@@ -183,21 +181,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
 	}
 	r.clusterInfo.Context = r.opManagerContext
-	cephversion, err := detectCephVersion(
-		r.opManagerContext,
-		r.opConfig.Image,
-		cephBlockPoolRadosNamespace.Namespace,
-		controllerName,
-		k8sutil.NewOwnerInfo(cephBlockPoolRadosNamespace, r.scheme),
-		r.context.Clientset,
-		&cephCluster.Spec,
-	)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to detect ceph version")
-	}
-	if cephversion != nil {
-		r.clusterInfo.CephVersion = *cephversion
-	}
+
 	// DELETE: the CR was deleted
 	if !cephBlockPoolRadosNamespace.GetDeletionTimestamp().IsZero() {
 		logger.Debugf("delete cephBlockPoolRadosNamespace %q", namespacedName)
@@ -243,6 +227,19 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 		r.updateStatus(r.client, namespacedName, cephv1.ConditionReady)
 		return reconcile.Result{}, nil
 	}
+
+	// cephversion check is only required for enabling mirroring
+	if cephBlockPoolRadosNamespace.Spec.Mirroring != nil {
+		// Get CephCluster version
+		cephVersion, err := opcontroller.GetImageVersion(cephCluster)
+		if err != nil {
+			return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to fetch ceph version from cephcluster %q running in namespace %q", cephCluster.Name, cephCluster.Namespace)
+		}
+		if cephVersion != nil {
+			r.clusterInfo.CephVersion = *cephVersion
+		}
+	}
+
 	// Build the NamespacedName to fetch the CephBlockPool and make sure it exists, if not we cannot
 	// create the rados namespace
 	cephBlockPool := &cephv1.CephBlockPool{}


### PR DESCRIPTION
in external mode deployments, ceph image is not provided and the job keeps on failing to get the cup version
fix by checking  if Ceph image is available

Issue:
```
2024-11-19 11:48:29.363305 E | blockpool-rados-namespace-controller: failed to reconcile "openshift-storage/namespace1" failed to detect ceph version: failed to set up ceph version job: Rook image [registry.redhat.io/odf4/rook-ceph-rhel9-operator@sha256:4477808782076370cc98ce59eaafb239e80d6c14f6eb6efdaae67cc397741305] and run image [] must be specified
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
