### PR TITLE
external: create object storage without cephcluster

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -192,36 +192,6 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		updateStatus(r.opManagerContext, k8sutil.ObservedGenerationNotAvailable, r.client, request.NamespacedName, cephv1.ConditionProgressing, buildStatusInfo(cephObjectStore))
 	}
 
-	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
-	if !isReadyToReconcile {
-		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
-		// We skip the deleteStore() function since everything is gone already
-		//
-		// Also, only remove the finalizer if the CephCluster is gone
-		// If not, we should wait for it to be ready
-		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
-		if !cephObjectStore.GetDeletionTimestamp().IsZero() && !cephClusterExists {
-			// Remove finalizer
-			err := opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephObjectStore)
-			if err != nil {
-				return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to remove finalizer")
-			}
-
-			// Return and do not requeue. Successful deletion.
-			return reconcile.Result{}, *cephObjectStore, nil
-		}
-
-		return reconcileResponse, *cephObjectStore, nil
-	}
-	r.clusterSpec = &cephCluster.Spec
-
-	// Populate clusterInfo during each reconcile
-	r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, r.clusterSpec)
-	if err != nil {
-		return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to populate cluster info")
-	}
-
 	// DELETE: the CR was deleted
 	if !cephObjectStore.GetDeletionTimestamp().IsZero() {
 		updateStatus(r.opManagerContext, k8sutil.ObservedGenerationNotAvailable, r.client, request.NamespacedName, cephv1.ConditionDeleting, buildStatusInfo(cephObjectStore))
@@ -280,14 +250,37 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, *cephObjectStore, nil
 	}
 
-	if cephObjectStore.Spec.IsExternal() {
-		// Check the ceph version of the running monitors
-		desiredCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.MonType)
-		if err != nil {
-			return reconcile.Result{}, *cephObjectStore, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
+	if !cephObjectStore.Spec.IsExternal() {
+		// Make sure a CephCluster is present otherwise do nothing
+		cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.opManagerContext, r.client, request.NamespacedName, controllerName)
+		if !isReadyToReconcile {
+			// This handles the case where the Ceph Cluster is gone and we want to delete that CR
+			// We skip the deleteStore() function since everything is gone already
+			//
+			// Also, only remove the finalizer if the CephCluster is gone
+			// If not, we should wait for it to be ready
+			// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
+			if !cephObjectStore.GetDeletionTimestamp().IsZero() && !cephClusterExists {
+				// Remove finalizer
+				err := opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephObjectStore)
+				if err != nil {
+					return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to remove finalizer")
+				}
+
+				// Return and do not requeue. Successful deletion.
+				return reconcile.Result{}, *cephObjectStore, nil
+			}
+
+			return reconcileResponse, *cephObjectStore, nil
 		}
-		r.clusterInfo.CephVersion = desiredCephVersion
-	} else {
+		r.clusterSpec = &cephCluster.Spec
+
+		// Populate clusterInfo during each reconcile
+		r.clusterInfo, _, _, err = opcontroller.LoadClusterInfo(r.context, r.opManagerContext, request.NamespacedName.Namespace, r.clusterSpec)
+		if err != nil {
+			return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to populate cluster info")
+		}
+
 		// Detect desired CephCluster version
 		runningCephVersion, desiredCephVersion, err := currentAndDesiredCephVersion(
 			r.opManagerContext,
@@ -326,7 +319,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	}
 
 	// CREATE/UPDATE
-	_, err = r.reconcileCreateObjectStore(cephObjectStore, request.NamespacedName, cephCluster.Spec)
+	_, err = r.reconcileCreateObjectStore(cephObjectStore, request.NamespacedName)
 	if err != nil && kerrors.IsNotFound(err) {
 		logger.Info(opcontroller.OperatorNotInitializedMessage)
 		return opcontroller.WaitForRequeueIfOperatorNotInitialized, *cephObjectStore, nil
@@ -344,7 +337,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	return reconcile.Result{}, *cephObjectStore, nil
 }
 
-func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *cephv1.CephObjectStore, namespacedName types.NamespacedName, cluster cephv1.ClusterSpec) (reconcile.Result, error) {
+func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *cephv1.CephObjectStore, namespacedName types.NamespacedName) (reconcile.Result, error) {
 	ownerInfo := k8sutil.NewOwnerInfo(cephObjectStore, r.scheme)
 	cfg := clusterConfig{
 		context:     r.context,
@@ -374,8 +367,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 		// service can also be removed at that point.
 		service := cfg.generateService(cephObjectStore)
 		clientset := cfg.context.Clientset
-		clusterCtx := cfg.clusterInfo.Context
-		_, err = clientset.CoreV1().Services(service.Namespace).Get(clusterCtx, service.Name, metav1.GetOptions{})
+		_, err = clientset.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				// We do not need to create Services/Endpoints for new CephObjectStores.


### PR DESCRIPTION
in certains cases where only s3 object storage
is needed, we do not want to create the cephcluster resources like mons endpoints,etc,
S3 api works on rest api protocol through endpoint

Closes: https://github.com/rook/rook/issues/15012 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
