### PR TITLE
object: stop creating cosi user in objstore reconcile

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -24,7 +24,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
 	bktclient "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
@@ -246,11 +245,6 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		opsCtx, err := newMultisiteAdminOpsCtxFunc(objCtx, &cephObjectStore.Spec)
 		if err != nil {
 			return reconcile.Result{}, *cephObjectStore, errors.Wrapf(err, "failed to get admin ops API context")
-		}
-		err = r.deleteCOSIUser(opsCtx)
-		if err != nil {
-			// Allow the object store removal to proceed even if the user deletion fails
-			logger.Warningf("failed to delete COSI user. %v", err)
 		}
 		deps, err := cephObjectStoreDependents(r.context, r.clusterInfo, cephObjectStore, objCtx, opsCtx)
 		if err != nil {
@@ -483,8 +477,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 	}
 
-	// Create COSI user and secret
-	return r.reconcileCOSIUser(cephObjectStore)
+	return reconcile.Result{}, nil
 }
 
 func (r *ReconcileCephObjectStore) retrieveMultisiteZone(store *cephv1.CephObjectStore, zoneGroupName string, realmName string) (reconcile.Result, error) {
@@ -544,62 +537,4 @@ func (r *ReconcileCephObjectStore) getMultisiteResourceNames(cephObjectStore *ce
 	logger.Debugf("CephObjectRealm resource %s found", realm.Name)
 
 	return realm.Name, zonegroup.Name, zone.Name, zone, reconcile.Result{}, nil
-}
-
-func (r *ReconcileCephObjectStore) reconcileCOSIUser(cephObjectStore *cephv1.CephObjectStore) (reconcile.Result, error) {
-	// Create COSI user and secret
-	userConfig := generateCOSIUserConfig()
-	var user admin.User
-
-	// Create COSI user
-	objCtx, err := NewMultisiteContext(r.context, r.clusterInfo, cephObjectStore)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get object context")
-	}
-
-	adminOpsCtx, err := newMultisiteAdminOpsCtxFunc(objCtx, &cephObjectStore.Spec)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get admin ops API context")
-	}
-
-	user, err = adminOpsCtx.AdminOpsClient.GetUser(r.opManagerContext, *userConfig)
-	if err != nil {
-		if errors.Is(err, admin.ErrNoSuchUser) {
-			logger.Infof("creating COSI user %q", userConfig.ID)
-			user, err = adminOpsCtx.AdminOpsClient.CreateUser(r.opManagerContext, *userConfig)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to create COSI user %q", userConfig.ID)
-			}
-		} else {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to get COSI user %q", userConfig.ID)
-		}
-	}
-
-	// Create COSI user secret
-	return ReconcileCephUserSecret(r.opManagerContext, r.client, r.scheme, cephObjectStore, &user, objCtx.Endpoint, cephObjectStore.Namespace, cephObjectStore.Name, cephObjectStore.Spec.Gateway.SSLCertificateRef)
-}
-
-func generateCOSIUserConfig() *admin.User {
-	userConfig := admin.User{
-		ID:          cosiUserName,
-		DisplayName: cosiUserName,
-	}
-
-	userConfig.UserCaps = cosiUserCaps
-
-	return &userConfig
-}
-
-func (r *ReconcileCephObjectStore) deleteCOSIUser(adminOpsCtx *AdminOpsContext) error {
-	userConfig := generateCOSIUserConfig()
-	err := adminOpsCtx.AdminOpsClient.RemoveUser(r.opManagerContext, *userConfig)
-	if err != nil {
-		if errors.Is(err, admin.ErrNoSuchUser) {
-			logger.Debugf("COSI user %q not found", userConfig.ID)
-			return nil
-		} else {
-			return errors.Wrapf(err, "failed to delete COSI user %q", userConfig.ID)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Stop creating the 'cosi' user in the CephObjectStore reconcile. This step often fails for some amount of time during initial object store creation, causing frequent user concern. It has also been the source of some reported failures that would otherwise be non-breaking for certain users.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
