### PR TITLE
docs: update Ceph Block Pool CRD reference

### DIFF
--- a/design/ceph/ceph-nfs-ganesha.md
+++ b/design/ceph/ceph-nfs-ganesha.md
@@ -44,7 +44,7 @@ This allows the NFS-Ganesha server cluster to be scalable and highly available.
   ```
 
 - An existing RADOS pool (e.g., CephFS's data pool) or a pool created with a
-  [Ceph Pool CRD] to store NFS client recovery data.
+  [Ceph Block Pool CRD] to store NFS client recovery data.
 
 ### Ceph NFS-Ganesha CRD
 
@@ -340,13 +340,11 @@ EXPORT {
 [NFS-Ganesha]: https://github.com/nfs-ganesha/nfs-ganesha/wiki
 [CephFS]: http://docs.ceph.com/docs/master/cephfs/nfs/
 [RGW]: http://docs.ceph.com/docs/master/radosgw/nfs/
-[Rook toolbox]: (/Documentation/ceph-toolbox.md)
-[Ceph manager]: (http://docs.ceph.com/docs/master/mgr/)
-[OpenStack]: (https://www.openstack.org/software/)
-[Manila]: (https://wiki.openstack.org/wiki/Manila)
-[CephFS driver]: (https://github.com/openstack/manila/blob/master/doc/source/admin/cephfs_driver.rst)
-[k8s ConfigMaps]: (https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
-[k8s Service]: (https://kubernetes.io/docs/concepts/services-networking/service)
-[Ceph Pool CRD]: (https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md)
-[k8s Deployments]: (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
-[SSSD]: (https://sssd.io)
+[OpenStack]: https://www.openstack.org/software/
+[Manila]: https://wiki.openstack.org/wiki/Manila
+[CephFS driver]: https://github.com/openstack/manila/blob/master/doc/source/admin/cephfs_driver.rst
+[k8s ConfigMaps]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
+[k8s Service]: https://kubernetes.io/docs/concepts/services-networking/service
+[Ceph Block Pool CRD]: https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+[k8s Deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[SSSD]: https://sssd.io


### PR DESCRIPTION
# PR Summary
Commit 74431443e31eec775a8a89a4228edb78d6cff51e renamed `Documentation/ceph-pool-crd.md` to be `Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md`. This PR updates all references to reflect this change, removes unused links, and fixes extra parentheses in links that previously caused them not to render correctly.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
