### PR TITLE
Revert "object: create cosi user for each object store"

### DIFF
--- a/deploy/examples/cosi/cephcosidriver.yaml
+++ b/deploy/examples/cosi/cephcosidriver.yaml
@@ -5,3 +5,17 @@ metadata:
   namespace: rook-ceph
 spec:
   deploymentStrategy: "Auto"
+---
+# The Ceph-COSI driver needs a privileged user for each CephObjectStore
+# in order to provision buckets and users
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: cosi
+  namespace: rook-ceph # namespace:cluster
+spec:
+  store: my-store # name of the CephObjectStore
+  displayName: "user for cosi"
+  capabilities:
+    user: "*"
+    bucket: "*"

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -53,8 +53,6 @@ const (
 	SecretKeyName         = "secret-key"
 	svcDNSSuffix          = "svc"
 	rgwRadosPoolPgNum     = "8"
-	cosiUserName          = "cosi"
-	cosiUserCaps          = "buckets=*;users=*"
 	rgwApplication        = "rgw"
 )
 

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -17,23 +17,13 @@ limitations under the License.
 package object
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"syscall"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
-	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -235,54 +225,4 @@ func DeleteUser(c *Context, id string, opts ...string) (string, error) {
 	}
 
 	return result, errors.Wrapf(err, "failed to delete s3 user uid=%q", id)
-}
-
-func GenerateCephUserSecretName(store, username string) string {
-	return fmt.Sprintf("rook-ceph-object-user-%s-%s", store, username)
-}
-
-func generateCephUserSecret(userConfig *admin.User, endpoint, namespace, storeName, tlsSecretName string) *corev1.Secret {
-	secretName := GenerateCephUserSecretName(storeName, userConfig.ID)
-	// Store the keys in a secret
-	secrets := map[string]string{
-		"AccessKey": userConfig.Keys[0].AccessKey,
-		"SecretKey": userConfig.Keys[0].SecretKey,
-		"Endpoint":  endpoint,
-	}
-	if tlsSecretName != "" {
-		secrets["SSLCertSecretName"] = tlsSecretName
-	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app":               AppName,
-				"user":              userConfig.ID,
-				"rook_cluster":      namespace,
-				"rook_object_store": storeName,
-			},
-		},
-		StringData: secrets,
-		Type:       k8sutil.RookType,
-	}
-	return secret
-}
-
-func ReconcileCephUserSecret(ctx context.Context, k8sclient client.Client, scheme *runtime.Scheme, ownerRef metav1.Object, userConfig *admin.User, endpoint, namespace, storeName, tlsSecretName string) (reconcile.Result, error) {
-	// Generate Kubernetes Secret
-	secret := generateCephUserSecret(userConfig, endpoint, namespace, storeName, tlsSecretName)
-
-	// Set owner ref to the object store user object
-	err := controllerutil.SetControllerReference(ownerRef, secret, scheme)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference of ceph object user secret %q", secret.Name)
-	}
-
-	// Create Kubernetes Secret
-	err = opcontroller.CreateOrUpdateObject(ctx, k8sclient, secret)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to create or update ceph object user %q secret", secret.Name)
-	}
-	return reconcile.Result{}, nil
 }

--- a/tests/integration/ceph_cosi_test.go
+++ b/tests/integration/ceph_cosi_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/ceph/object"
 	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
@@ -56,7 +55,8 @@ func testCOSIDriver(s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sH
 		assert.NoError(t, k8sh.WaitForLabeledDeploymentsToBeReady("app=ceph-cosi-driver", operatorNamespace))
 	})
 
-	objectStoreUserSecretName := object.GenerateCephUserSecretName(objectStoreCOSI, cosiUser)
+	createCephObjectUser(s, helper, k8sh, namespace, objectStoreCOSI, cosiUser, true)
+	objectStoreUserSecretName := "rook-ceph-object-user" + "-" + objectStoreCOSI + "-" + cosiUser
 	t.Run("Creating BucketClass", func(t *testing.T) {
 		err := helper.COSIClient.CreateBucketClass(bucketClassName, objectStoreUserSecretName, deletionPolicy)
 		assert.NoError(t, err, "failed to create BucketClass")


### PR DESCRIPTION
This reverts commit a941b3c33f452fe7e4c1af34b5e61bc28ffb6cbe.

Stop creating the 'cosi' user in the CephObjectStore reconcile. This step often fails for some amount of time during initial object store creation, causing frequent user concern. It has also been the source of some reported failures that would otherwise be non-breaking for certain users.

Resolves #15084

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
