### PR TITLE
doc: fix broken link to osd-topology in ceph-stretch-cluster.md

### DIFF
--- a/design/ceph/ceph-stretch-cluster.md
+++ b/design/ceph/ceph-stretch-cluster.md
@@ -54,7 +54,7 @@ The topology of the K8s cluster is to be determined by the admin, outside the sc
 Rook will simply detect the topology labels that have been added to the nodes.
 
 If the desired failure domain is a "zone", the `topology.kubernetes.io/zone` label should
-be added to the nodes. Any of the [topology labels](https://rook.io/docs/rook/latest/ceph-cluster-crd.html#osd-topology)
+be added to the nodes. Any of the [topology labels](https://rook.github.io/docs/rook/latest-release/CRDs/Cluster/ceph-cluster-crd/#osd-topology)
 supported by OSDs can be used.
 
 In the minimum configuration, two nodes in each data zone would be labeled, while one


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
Update ceph-strectch-cluster.md to fix broken link to osd-topology.


**Checklist:**
- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
