### PR TITLE
file: Add support for named MDS metadata pool names

### DIFF
--- a/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md
@@ -111,8 +111,10 @@ Also see an example in the [`storageclass-ec.yaml`](https://github.com/rook/rook
 The pools allow all of the settings defined in the Pool CRD spec. For more details, see the [Pool CRD](../Block-Storage/ceph-block-pool-crd.md) settings. In the example above, there must be at least three hosts (size 3) and at least eight devices (6 data + 2 coding chunks) in the cluster.
 
 * `metadataPool`: The settings used to create the filesystem metadata pool. Must use replication.
+    * `name`: (optional) Override the default generated name of the metadata pool.
 * `dataPools`: The settings to create the filesystem data pools. Optionally (and we highly recommend), a pool name can be specified with the `name` field to override the default generated name; see more below. If multiple pools are specified, Rook will add the pools to the filesystem. Assigning users or files to a pool is left as an exercise for the reader with the [CephFS documentation](http://docs.ceph.com/docs/master/cephfs/file-layouts/). The data pools can use replication or erasure coding. If erasure coding pools are specified, the cluster must be running with bluestore enabled on the OSDs.
-    * `name`: (optional, and highly recommended) Override the default generated name of the pool. The final pool name will consist of the filesystem name and pool name, e.g., `<fsName>-<poolName>`. We highly recommend to specify `name` to prevent issues that can arise from modifying the spec in a way that causes Rook to lose the original pool ordering.
+    * `name`: (optional, and highly recommended) Override the default generated name of the pool. We highly recommend to specify `name` to prevent issues that can arise from modifying the spec in a way that causes Rook to lose the original pool ordering.
+* `preservePoolNames`: Preserve pool names as specified.
 * `preserveFilesystemOnDelete`: If it is set to 'true' the filesystem will remain when the
     CephFilesystem resource is deleted. This is a security measure to avoid loss of data if the
     CephFilesystem resource is deleted accidentally. The default value is 'false'. This option
@@ -120,6 +122,10 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 * (deprecated) `preservePoolsOnDelete`: This option is replaced by the above
     `preserveFilesystemOnDelete`. For backwards compatibility and upgradeability, if this is set to
     'true', Rook will treat `preserveFilesystemOnDelete` as being set to 'true'.
+
+### Generated Pool Names
+
+Both `metadataPool` and `dataPools` support defining names as required. The final pool name will consist of the filesystem name and pool name, e.g., `<fsName>-<poolName>` or `<fsName>-metadata` for `metadataPool`. For more granular configuration you may want to set `preservePoolNames` to `true` in `pools` to disable generation of names. In that case all pool names defined are used as given.
 
 ## Metadata Server Settings
 

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1127,8 +1127,8 @@ FilesystemSpec
 <td>
 <code>metadataPool</code><br/>
 <em>
-<a href="#ceph.rook.io/v1.PoolSpec">
-PoolSpec
+<a href="#ceph.rook.io/v1.NamedPoolSpec">
+NamedPoolSpec
 </a>
 </em>
 </td>
@@ -1147,6 +1147,18 @@ PoolSpec
 </td>
 <td>
 <p>The data pool settings, with optional predefined pool name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preservePoolNames</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Preserve pool names as specified</p>
 </td>
 </tr>
 <tr>
@@ -6582,8 +6594,8 @@ FilesystemSnapshotScheduleStatusRetention
 <td>
 <code>metadataPool</code><br/>
 <em>
-<a href="#ceph.rook.io/v1.PoolSpec">
-PoolSpec
+<a href="#ceph.rook.io/v1.NamedPoolSpec">
+NamedPoolSpec
 </a>
 </em>
 </td>
@@ -6602,6 +6614,18 @@ PoolSpec
 </td>
 <td>
 <p>The data pool settings, with optional predefined pool name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preservePoolNames</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Preserve pool names as specified</p>
 </td>
 </tr>
 <tr>
@@ -11076,7 +11100,7 @@ This list allows defining additional StorageClasses on top of default STANDARD s
 <h3 id="ceph.rook.io/v1.PoolSpec">PoolSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemSpec">FilesystemSpec</a>, <a href="#ceph.rook.io/v1.NamedBlockPoolSpec">NamedBlockPoolSpec</a>, <a href="#ceph.rook.io/v1.NamedPoolSpec">NamedPoolSpec</a>, <a href="#ceph.rook.io/v1.ObjectStoreSpec">ObjectStoreSpec</a>, <a href="#ceph.rook.io/v1.ObjectZoneSpec">ObjectZoneSpec</a>)
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.NamedBlockPoolSpec">NamedBlockPoolSpec</a>, <a href="#ceph.rook.io/v1.NamedPoolSpec">NamedPoolSpec</a>, <a href="#ceph.rook.io/v1.ObjectStoreSpec">ObjectStoreSpec</a>, <a href="#ceph.rook.io/v1.ObjectZoneSpec">ObjectZoneSpec</a>)
 </p>
 <div>
 <p>PoolSpec represents the spec of ceph pool</p>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -7204,6 +7204,9 @@ spec:
                             type: object
                           type: array
                       type: object
+                    name:
+                      description: Name of the pool
+                      type: string
                     parameters:
                       additionalProperties:
                         type: string
@@ -8235,6 +8238,9 @@ spec:
                   type: object
                 preserveFilesystemOnDelete:
                   description: Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.
+                  type: boolean
+                preservePoolNames:
+                  description: Preserve pool names as specified
                   type: boolean
                 preservePoolsOnDelete:
                   description: Preserve pools on filesystem deletion

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -7199,6 +7199,9 @@ spec:
                             type: object
                           type: array
                       type: object
+                    name:
+                      description: Name of the pool
+                      type: string
                     parameters:
                       additionalProperties:
                         type: string
@@ -8230,6 +8233,9 @@ spec:
                   type: object
                 preserveFilesystemOnDelete:
                   description: Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.
+                  type: boolean
+                preservePoolNames:
+                  description: Preserve pool names as specified
                   type: boolean
                 preservePoolsOnDelete:
                   description: Preserve pools on filesystem deletion

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1168,11 +1168,15 @@ type CephFilesystemList struct {
 type FilesystemSpec struct {
 	// The metadata pool settings
 	// +nullable
-	MetadataPool PoolSpec `json:"metadataPool"`
+	MetadataPool NamedPoolSpec `json:"metadataPool"`
 
 	// The data pool settings, with optional predefined pool name.
 	// +nullable
 	DataPools []NamedPoolSpec `json:"dataPools"`
+
+	// Preserve pool names as specified
+	// +optional
+	PreservePoolNames bool `json:"preservePoolNames,omitempty"`
 
 	// Preserve pools on filesystem deletion
 	// +optional

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools.go
@@ -52,7 +52,7 @@ func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*c
 	}
 	poolCount += len(cephFilesystemList.Items)
 	for _, cephFilesystem := range cephFilesystemList.Items {
-		poolSpecs = append(poolSpecs, cephFilesystem.Spec.MetadataPool)
+		poolSpecs = append(poolSpecs, cephFilesystem.Spec.MetadataPool.PoolSpec)
 		for _, pool := range cephFilesystem.Spec.DataPools {
 			poolSpecs = append(poolSpecs, pool.PoolSpec)
 		}

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -63,7 +63,7 @@ func TestValidateSpec(t *testing.T) {
 
 	// missing metadata pool
 	assert.NotNil(t, validateFilesystem(context, clusterInfo, clusterSpec, fs))
-	fs.Spec.MetadataPool = p
+	fs.Spec.MetadataPool.PoolSpec = p
 
 	// missing mds count
 	assert.NotNil(t, validateFilesystem(context, clusterInfo, clusterSpec, fs))
@@ -108,6 +108,26 @@ func TestGenerateDataPoolNames(t *testing.T) {
 	}
 
 	expectedNames := []string{"fake-data0", "fake-somename"}
+	names := generateDataPoolNames(fs, fsSpec)
+	assert.Equal(t, expectedNames, names)
+}
+
+func TestPreservePoolNames(t *testing.T) {
+	fs := &Filesystem{Name: "fake", Namespace: "fake"}
+	fsSpec := cephv1.FilesystemSpec{
+		DataPools: []cephv1.NamedPoolSpec{
+			{
+				PoolSpec: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
+			},
+			{
+				Name:     "somename",
+				PoolSpec: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
+			},
+		},
+		PreservePoolNames: true,
+	}
+
+	expectedNames := []string{"fake-data0", "somename"}
 	names := generateDataPoolNames(fs, fsSpec)
 	assert.Equal(t, expectedNames, names)
 }
@@ -325,7 +345,9 @@ func fsTest(fsName string) cephv1.CephFilesystem {
 	return cephv1.CephFilesystem{
 		ObjectMeta: metav1.ObjectMeta{Name: fsName, Namespace: "ns"},
 		Spec: cephv1.FilesystemSpec{
-			MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
+			MetadataPool: cephv1.NamedPoolSpec{
+				PoolSpec: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
+			},
 			DataPools: []cephv1.NamedPoolSpec{
 				{
 					PoolSpec: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},


### PR DESCRIPTION
This commit adds optional support to specify the MDS metadata pool name. It defaults to `<fsName>-metadata` as current implementation expects but allows customization if needed e.g. if exisiting naming conventions used `<fsName>_metadata`.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.