### PR TITLE
osd: fix device class label on osd pod

### DIFF
--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -94,5 +94,5 @@ func (d *DesiredDevice) UpdateDeviceClass(agent *OsdAgent, device *sys.LocalDisk
 		}
 	}
 
-	d.DeviceClass = sys.GetDiskDeviceClass(device)
+	d.DeviceClass = sys.GetDiskDeviceType(device)
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1158,17 +1158,15 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 		if !skipDeviceClass {
 			diskInfo, err := clusterd.PopulateDeviceInfo(blockPath, context.Executor)
-			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-			if crushDeviceClass != "" {
-				osd.DeviceClass = crushDeviceClass
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get device info for %q", blockPath)
 			}
+			deviceType := sys.GetDiskDeviceType(diskInfo)
+			osd.DeviceType = deviceType
+			logger.Infof("setting device type %q for device %q", osd.DeviceType, diskInfo.Name)
 
-			if osd.DeviceClass == "" {
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to get device info for %q", blockPath)
-				}
-				osd.DeviceClass = sys.GetDiskDeviceClass(diskInfo)
-			}
+			crushDeviceClass := sys.GetDiskDeviceClass(oposd.CrushDeviceClassVarName, deviceType)
+			osd.DeviceClass = crushDeviceClass
 			logger.Infof("setting device class %q for device %q", osd.DeviceClass, diskInfo.Name)
 		}
 

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1158,10 +1158,17 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 		if !skipDeviceClass {
 			diskInfo, err := clusterd.PopulateDeviceInfo(blockPath, context.Executor)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get device info for %q", blockPath)
+			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
+			if crushDeviceClass != "" {
+				osd.DeviceClass = crushDeviceClass
 			}
-			osd.DeviceClass = sys.GetDiskDeviceClass(diskInfo)
+
+			if osd.DeviceClass == "" {
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to get device info for %q", blockPath)
+				}
+				osd.DeviceClass = sys.GetDiskDeviceClass(diskInfo)
+			}
 			logger.Infof("setting device class %q for device %q", osd.DeviceClass, diskInfo.Name)
 		}
 

--- a/pkg/operator/ceph/cluster/osd/key_rotation.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation.go
@@ -271,7 +271,7 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 			return errors.Errorf("pvc name label %q for osd %q is empty",
 				OSDOverPVCLabelKey, osdDep.Name)
 		}
-		osdProps, err := c.getOSDPropsForPVC(pvcName, osd.DeviceClass)
+		osdProps, err := c.getOSDPropsForPVC(pvcName)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate config for osd %q", osdDep.Name)
 		}

--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -60,6 +60,9 @@ func (c *Cluster) getOSDLabels(osd OSDInfo, failureDomainValue string, portable 
 	labels[portableKey] = strconv.FormatBool(portable)
 	labels[deviceClass] = osd.DeviceClass
 	labels[osdStore] = osd.Store
+	if osd.DeviceType != "" {
+		labels[deviceType] = osd.DeviceType
+	}
 
 	for k, v := range getOSDTopologyLocationLabels(osd.Location) {
 		labels[k] = v

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -73,6 +73,7 @@ const (
 	bluestorePVCData               = "data"
 	deviceClass                    = "device-class"
 	osdStore                       = "osd-store"
+	deviceType                     = "device-type"
 )
 
 // Cluster keeps track of the OSDs
@@ -121,6 +122,7 @@ type OSDInfo struct {
 	ExportService    bool   `json:"exportService"`
 	NodeName         string `json:"nodeName"`
 	PVCName          string `json:"pvcName"`
+	DeviceType       string `json:"device-type"`
 }
 
 // OrchestrationStatus represents the status of an OSD orchestration

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -408,7 +408,7 @@ func deploymentOnNode(c *Cluster, osd *OSDInfo, nodeName string, config *provisi
 func deploymentOnPVC(c *Cluster, osd *OSDInfo, pvcName string, config *provisionConfig) (*appsv1.Deployment, error) {
 	osdLongName := fmt.Sprintf("OSD %d on PVC %q", osd.ID, pvcName)
 
-	osdProps, err := c.getOSDPropsForPVC(pvcName, osd.DeviceClass)
+	osdProps, err := c.getOSDPropsForPVC(pvcName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate config for %s", osdLongName)
 	}
@@ -468,7 +468,7 @@ func (c *Cluster) getOSDPropsForNode(nodeName, deviceClass string) (osdPropertie
 	return osdProps, nil
 }
 
-func (c *Cluster) getOSDPropsForPVC(pvcName, osdDeviceClass string) (osdProperties, error) {
+func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 	for _, deviceSet := range c.deviceSets {
 		// The data PVC template is required.
 		dataSource, dataOK := deviceSet.PVCSources[bluestorePVCData]
@@ -491,7 +491,7 @@ func (c *Cluster) getOSDPropsForPVC(pvcName, osdDeviceClass string) (osdProperti
 			}
 
 			if deviceSet.Resources.Limits == nil && deviceSet.Resources.Requests == nil {
-				deviceSet.Resources = cephv1.GetOSDResources(c.spec.Resources, osdDeviceClass)
+				deviceSet.Resources = cephv1.GetOSDResources(c.spec.Resources, deviceSet.CrushDeviceClass)
 			}
 
 			osdProps := osdProperties{

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -19,6 +19,7 @@ package sys
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	osexec "os/exec"
 	"strconv"
 	"strings"
@@ -279,7 +280,7 @@ func GetDiskUUID(device string, executor exec.Executor) (string, error) {
 	return parseUUID(device, output)
 }
 
-func GetDiskDeviceClass(disk *LocalDisk) string {
+func GetDiskDeviceType(disk *LocalDisk) string {
 	if disk.Rotational {
 		return "hdd"
 	}
@@ -287,6 +288,15 @@ func GetDiskDeviceClass(disk *LocalDisk) string {
 		return "nvme"
 	}
 	return "ssd"
+}
+
+func GetDiskDeviceClass(crushDeviceClassVarName, deviceType string) string {
+	crushDeviceClass := os.Getenv(crushDeviceClassVarName)
+	if crushDeviceClass != "" {
+		return crushDeviceClass
+	} else {
+		return deviceType
+	}
 }
 
 // CheckIfDeviceAvailable checks if a device is available for consumption. The caller

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -197,12 +197,21 @@ func TestListDevicesChildListDevicesChild(t *testing.T) {
 	assert.Equal(t, 3, len(child))
 }
 
-func TestGetDiskDeviceClass(t *testing.T) {
+func TestGetDiskDeviceType(t *testing.T) {
 	d := &LocalDisk{}
-	assert.Equal(t, "ssd", GetDiskDeviceClass(d))
+	assert.Equal(t, "ssd", GetDiskDeviceType(d))
 	d.Rotational = true
-	assert.Equal(t, "hdd", GetDiskDeviceClass(d))
+	assert.Equal(t, "hdd", GetDiskDeviceType(d))
 	d.Rotational = false
 	d.RealPath = "nvme"
-	assert.Equal(t, "nvme", GetDiskDeviceClass(d))
+	assert.Equal(t, "nvme", GetDiskDeviceType(d))
+}
+
+func TestGetDiskDeviceClass(t *testing.T) {
+	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "test")
+	assert.Equal(t, "test", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "hdd"))
+	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "test1")
+	assert.Equal(t, "test1", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "hdd"))
+	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "")
+	assert.Equal(t, "nvme", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "nvme"))
 }


### PR DESCRIPTION
commit1: 
we were adding the device class as the
disk rotational type, but device class
can be user-defined, so if the user has
added the device class, use that value

commit2:
currently device class and device type
labels were clubbed with each other
create a separate label, as these two labels
can be separate

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
