### PR TITLE
core: Fix Annotations.Merge to prevent side effects

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/annotations.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations.go
@@ -110,14 +110,20 @@ func (a Annotations) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 // original Annotations with the attributes of the supplied one. The supplied
 // Annotation attributes will override the original ones if defined.
 func (a Annotations) Merge(with map[string]string) Annotations {
-	ret := a
-	if ret == nil {
-		ret = map[string]string{}
+	// Create a new map of type Annotations to hold the merged results
+	ret := Annotations{}
+
+	// Copy the contents of the original map (a) into ret
+	for k, v := range a {
+		ret[k] = v
 	}
+
+	// Add entries from the 'with' map only if the key does not already exist
 	for k, v := range with {
-		if _, ok := ret[k]; !ok {
+		if _, exists := ret[k]; !exists {
 			ret[k] = v
 		}
 	}
+
 	return ret
 }

--- a/pkg/apis/ceph.rook.io/v1/annotations_test.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations_test.go
@@ -62,6 +62,7 @@ func TestCephAnnotationsMerge(t *testing.T) {
 		"mgr":            {"mgrkey": "mgrval"},
 		"cmdreporter":    {"myversions": "detect"},
 		"crashcollector": {"crash": "crashval"},
+		"osd":            {"osdkey": "osdval"},
 	}
 	a = GetMonAnnotations(testAnnotations)
 	assert.Equal(t, "allval1", a["allkey1"])
@@ -80,6 +81,10 @@ func TestCephAnnotationsMerge(t *testing.T) {
 	assert.Equal(t, "crashval", c["crash"])
 	assert.Equal(t, "allval1", c["allkey1"])
 	assert.Equal(t, "allval2", c["allkey2"])
+	d := GetOSDAnnotations(testAnnotations)
+	assert.Equal(t, "allval1", d["allkey1"])
+	assert.Equal(t, "allval2", d["allkey2"])
+	assert.Equal(t, "osdval", d["osdkey"])
 }
 
 func TestAnnotationsSpec(t *testing.T) {


### PR DESCRIPTION
Resolves: #15055

This commit updates the Annotations.Merge function to fix an issue where 
the original Annotations map was unintentionally modified. 
The new implementation creates a separate map to ensure 
the original map remains unchanged during the merge process.

Tested with private image  `docker.io/oviner/rook:odf_qe`:

1.Start minikube wiht kvm2:
```
$ minikube start --disk-size=10g --extra-disks=1 --driver kvm2
```
2.Create resources and operator
```
$ kubectl create -f crds.yaml -f common.yaml -f operator.yaml
$ kubectl get pods -n rook-ceph
NAME                                 READY   STATUS    RESTARTS   AGE
rook-ceph-operator-cf4f7dfd4-vzwbt   1/1     Running   0          89s
```
```
$ kubectl get pods rook-ceph-operator-68694f9655-nt928 -n rook-ceph  -o yaml | grep oviner -A 4
    image: docker.io/oviner/rook:odf_qe
    imagePullPolicy: IfNotPresent
    name: rook-ceph-operator
    resources: {}
    securityContext:
```

3.Create cluster-test:

```
$ cd deploy/examples/
$ kubectl create -f cluster-test.yaml 
```

4.Add annotations to Cephcluster CR:
```
$ kubectl get cephclusters.ceph.rook.io -n rook-ceph -o yaml | grep -i annot -A 5 -B 1
  spec:
    annotations:
      all:
        my-cluster: foo
      mgr:
        my-mgr: bar
    cephConfig:
```

5.Check annotion on osd,mg and mon:
```
$ oc get pods -n rook-ceph -o yaml | grep -i anno -B 1 -A 6
  metadata:
    annotations:
      my-cluster: foo
    creationTimestamp: "2024-12-02T13:18:57Z"
    generateName: rook-ceph-exporter-minikube-66d58d446d-
    labels:
      app: rook-ceph-exporter
      ceph-version: 19.2.0-0
--
  metadata:
    annotations:
      my-cluster: foo
      my-mgr: bar
    creationTimestamp: "2024-12-02T13:18:31Z"
    generateName: rook-ceph-mgr-a-7667f787b9-
    labels:
      app: rook-ceph-mgr
--
  metadata:
    annotations:
      my-cluster: foo
    creationTimestamp: "2024-12-02T13:18:04Z"
    generateName: rook-ceph-mon-a-746c9cc64f-
    labels:
      app: rook-ceph-mon
      app.kubernetes.io/component: cephclusters.ceph.rook.io
--
  metadata:
    annotations:
      my-cluster: foo
    creationTimestamp: "2024-12-02T13:18:57Z"
    generateName: rook-ceph-osd-0-769b64c7b4-
    labels:
      app: rook-ceph-osd
      app.kubernetes.io/component: cephclusters.ceph.rook.io
--
  metadata:
    annotations:
      my-cluster: foo
    creationTimestamp: "2024-12-02T13:18:55Z"
    generateName: rook-ceph-osd-prepare-minikube-
    labels:
      app: rook-ceph-osd-prepare
      batch.kubernetes.io/controller-uid: 108e8e54-0078-4604-9601-57f346fd3571
```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
