### PR TITLE
object: update the bucket controller watcher to watch objectstore

### DIFF
--- a/pkg/operator/ceph/object/bucket/predicate.go
+++ b/pkg/operator/ceph/object/bucket/predicate.go
@@ -17,12 +17,8 @@ limitations under the License.
 package bucket
 
 import (
-	"context"
-
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -30,22 +26,17 @@ import (
 const rookOBCWatchOperatorNamespace = "ROOK_OBC_WATCH_OPERATOR_NAMESPACE"
 
 // predicateController is the predicate function to trigger reconcile on operator configuration cm change
-func predicateController(ctx context.Context, c client.Client) predicate.Funcs {
+func predicateController() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			// if the operator configuration file is created we want to reconcile
 			if cm, ok := e.Object.(*v1.ConfigMap); ok {
 				// It's probably fine to use the Generation value here. The case where the operator was stopped and the
 				// ConfigMap was created is low since the cm is always present these days
-				return cm.Name == controller.OperatorSettingConfigMapName && cm.Generation == 1
+				if cm.Name == controller.OperatorSettingConfigMapName && cm.Generation == 1 {
+					controller.ReloadManager()
+				}
 			}
-
-			// If a Ceph Cluster is created we want to reconcile the bucket provisioner
-			if _, ok := e.Object.(*cephv1.CephCluster); ok {
-				// If there are more than one ceph cluster in the same namespace do not reconcile
-				return !controller.DuplicateCephClusters(ctx, c, e.Object, false)
-			}
-
 			return false
 		},
 
@@ -57,7 +48,7 @@ func predicateController(ctx context.Context, c client.Client) predicate.Funcs {
 							logger.Infof("%s changed. reconciling bucket controller", rookOBCWatchOperatorNamespace)
 
 							// We reload the manager so that the controller restarts and goes
-							// through the CreateFunc again. Then the CephCluster watcher will be triggered
+							// through the CreateFunc again. Then the objectstore watcher will be triggered
 							controller.ReloadManager()
 						}
 					}


### PR DESCRIPTION
bucket controller was watching cephcluster,
but more relevant is to watch the objectstore
for the controller to reconcile

refer: https://github.com/rook/rook/pull/15028
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
