### PR TITLE
ci: simplify the codegen workflow a bit

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -38,18 +38,8 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: post-process checkout - copy to github.com
-        run: |
-          # copy to the github.com path so codegen will work as expected
-          mkdir -p $(go env GOPATH)/src/github.com/rook/rook/
-          cp -R . $(go env GOPATH)/src/github.com/rook/rook/
-
       - name: run codegen
-        run: |
-          cd $(go env GOPATH)/src/github.com/rook/rook
-          GOPATH=$(go env GOPATH) make codegen
+        run: GOPATH=$(go env GOPATH) make codegen
 
       - name: validate codegen
-        run: |
-          cd $(go env GOPATH)/src/github.com/rook/rook
-          tests/scripts/validate_modified_files.sh codegen
+        run: tests/scripts/validate_modified_files.sh codegen


### PR DESCRIPTION
**Description of changes:** 

the codegen ci workflow was previously fixed by copying the checkout dir to the GOPATH. With the updated codegen tooling, this alignment is not a requirement any more.

This simplifies the codegen workflow again by reverting the earlier changes that added the copy mechanism.

This reverts commit 714f80a80a4de1e104123d720301e6e74799b758.
This reverts commit f32d3df99530e6721d693a9f43a59cc6a0848449.




**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
