### PR TITLE
ci : rework docs-related workflows and  Makefile targets  a bit to be more systematic and consistent

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -42,10 +42,10 @@ jobs:
             Documentation/**/*.md
             !Documentation/Helm-Charts
 
-      - name: Check helm-docs
-        run: make check.helm-docs
       - name: Check docs
-        run: make check.docs
+        run: |
+          make gen.docs
+          tests/scripts/validate_modified_files.sh docs
       - name: Install mkdocs and dependencies
         run: cd build/release/ && make deps.docs
 

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ gen-rbac: $(HELM) $(YQ) ## Generate RBAC from Helm charts
 
 gen.docs: docs
 docs: helm-docs
+gen.helm-docs: helm-docs
 helm-docs: $(HELM_DOCS) ## Use helm-docs to generate documentation from helm charts
 	$(HELM_DOCS) -c deploy/charts/rook-ceph \
 		-o ../../../Documentation/Helm-Charts/operator-chart.md \
@@ -203,17 +204,6 @@ helm-docs: $(HELM_DOCS) ## Use helm-docs to generate documentation from helm cha
 		-o ../../../Documentation/Helm-Charts/ceph-cluster-chart.md \
 		-t ../../../Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md \
 		-t ../../../Documentation/Helm-Charts/_templates.gotmpl
-
-check.helm-docs:
-	@$(MAKE) helm-docs
-	@git diff --exit-code || { \
-	echo "Please run 'make helm-docs' locally, commit the updated docs, and push the change. See https://rook.io/docs/rook/latest/Contributing/documentation/#making-docs" ; \
-	exit 2 ; \
-	};
-check.docs:
-	@$(MAKE) docs
-	@tests/scripts/validate_modified_files.sh docs
-
 
 docs-preview: ## Preview the documentation through mkdocs
 	mkdocs serve
@@ -229,7 +219,7 @@ generate: gen.codegen gen.crds gen.rbac gen.docs gen.crd-docs ## Update all gene
 
 
 .PHONY: all build.common
-.PHONY: build build.all install test check vet fmt codegen gen.codegen gen.rbac gen.crds gen.crd-docs gen.docs generate mod.check clean distclean prune
+.PHONY: build build.all install test check vet fmt codegen gen.codegen gen.rbac gen.crds gen.crd-docs gen.docs gen.helm-docs generate mod.check clean distclean prune
 
 # ====================================================================================
 # Help

--- a/tests/scripts/validate_modified_files.sh
+++ b/tests/scripts/validate_modified_files.sh
@@ -10,6 +10,7 @@ CRD_ERR="changes found by 'make crds'. please run 'make crds' locally and update
 BUILD_ERR="changes found by make build', please commit your go.sum or other changed files"
 HELM_ERR="changes found by 'make gen-rbac'. please run 'make gen-rbac' locally and update your PR"
 DOCS_ERR="changes found by 'make docs'. please run 'make docs' locally and update your PR"
+HELM_DOCS_ERR="changes found by 'make helm-docs'. please run 'make helm-docs' locally and update your PR"
 
 #############
 # FUNCTIONS #
@@ -33,6 +34,9 @@ case "$1" in
   docs)
     validate "$DOCS_ERR"
   ;;
+  helm-docs)
+    validate "$HELM_DOCS_ERR"
+  ;;
   codegen)
     validate "$CODEGEN_ERR"
   ;;
@@ -49,6 +53,6 @@ case "$1" in
     validate "$HELM_ERR"
   ;;
   *)
-    echo $"Usage: $0 {docs|codegen|modcheck|crd|build|gen-rbac}"
+    echo $"Usage: $0 {docs|helm-docs|codegen|modcheck|crd|build|gen-rbac}"
     exit 1
 esac


### PR DESCRIPTION
**Description of changes:**

This continues an effort started earlier to make some make targets more systematic (  see #14922). It introduces a new target `gen.helm-docs`as an alias for `helm-docs`. 
it also removes the targets  `check.docs` and `check.helm-docs`because they were using `git` which was agreed to be of little value for a make target. The functionality is moved back to the corresponding ci workflow.





**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
