### PR TITLE
ci: Use images from ceph-ci instead of daemon-base

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -356,5 +356,5 @@ jobs:
     if: github.repository == 'rook/rook'
     uses: ./.github/workflows/canary-integration-test.yml
     with:
-      ceph_images: '["quay.io/ceph/ceph:v18", "quay.io/ceph/daemon-base:latest-main-devel", "quay.io/ceph/daemon-base:latest-reef-devel", "quay.io/ceph/daemon-base:latest-squid-devel"]'
+      ceph_images: '["quay.io/ceph/ceph:v18", "quay.io/ceph-ci/ceph:main", "quay.io/ceph-ci/ceph:reef", "quay.io/ceph-ci/ceph:squid"]'
     secrets: inherit

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -46,10 +46,10 @@ const (
 	reefTestImage  = "quay.io/ceph/ceph:v18"
 	squidTestImage = "quay.io/ceph/ceph:v19"
 	// test with the current development versions
-	reefDevelTestImage  = "quay.io/ceph/daemon-base:latest-reef-devel"
-	squidDevelTestImage = "quay.io/ceph/daemon-base:latest-squid-devel"
+	reefDevelTestImage  = "quay.io/ceph-ci/ceph:reef"
+	squidDevelTestImage = "quay.io/ceph-ci/ceph:squid"
 	// test with the latest Ceph main image
-	mainTestImage      = "quay.io/ceph/daemon-base:latest-main-devel"
+	mainTestImage      = "quay.io/ceph-ci/ceph:main"
 	cephOperatorLabel  = "app=rook-ceph-operator"
 	defaultclusterName = "test-cluster"
 


### PR DESCRIPTION
Ceph has changed the image build process to only require a dockerfile and stop using the ceph-container repo. The daily images are pushed to the quay.io/ceph-ci/ceph repo, so the Rook CI will now start using those images.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15097

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
