### PR TITLE
ci: Use correct ceph-ci repo

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -356,5 +356,5 @@ jobs:
     if: github.repository == 'rook/rook'
     uses: ./.github/workflows/canary-integration-test.yml
     with:
-      ceph_images: '["quay.io/ceph/ceph:v18", "quay.io/ceph/ceph:v19", "quay.io/ceph-ci/ceph:main", "quay.io/ceph-ci/ceph:reef", "quay.io/ceph-ci/ceph:squid"]'
+      ceph_images: '["quay.io/ceph/ceph:v18", "quay.io/ceph/ceph:v19", "quay.ceph.io/ceph-ci/ceph:main", "quay.ceph.io/ceph-ci/ceph:reef", "quay.ceph.io/ceph-ci/ceph:squid"]'
     secrets: inherit

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -46,10 +46,10 @@ const (
 	reefTestImage  = "quay.io/ceph/ceph:v18"
 	squidTestImage = "quay.io/ceph/ceph:v19"
 	// test with the current development versions
-	reefDevelTestImage  = "quay.io/ceph-ci/ceph:reef"
-	squidDevelTestImage = "quay.io/ceph-ci/ceph:squid"
+	reefDevelTestImage  = "quay.ceph.io/ceph-ci/ceph:reef"
+	squidDevelTestImage = "quay.ceph.io/ceph-ci/ceph:squid"
 	// test with the latest Ceph main image
-	mainTestImage      = "quay.io/ceph-ci/ceph:main"
+	mainTestImage      = "quay.ceph.io/ceph-ci/ceph:main"
 	cephOperatorLabel  = "app=rook-ceph-operator"
 	defaultclusterName = "test-cluster"
 


### PR DESCRIPTION
Typo from #15139, the `ceph-ci` repo is in `quay.ceph.io`, instead of `quay.io`. Only the daily CI uses those image, so the PR CI didn't catch this typo.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
