### PR TITLE
docs: Fix misleading example for urlPrefix

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -123,7 +123,7 @@ spec:
   protocols:
     swift:
       accountInUrl: true
-      urlPrefix: /swift
+      urlPrefix: swift
   [...]
 ```
 

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-swift.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-swift.md
@@ -76,7 +76,7 @@ spec:
   protocols:
     swift:
       accountInUrl: true
-      urlPrefix: /swift
+      urlPrefix: swift
     # note that s3 is enabled by default if protocols.s3.enabled is not explicitly set to false
   preservePoolsOnDelete: true
   gateway:


### PR DESCRIPTION
The default value for protocols.swift.urlPrefix is "swift", which makes the Swift API available at http://host:port/swift/v1. However, in the documentation our example says "/swift", which resulted in the unexpected endpoint http://host:port//swift/v1.

Apparently, Ceph distinguishes between both values even though their docs[1] seem to suggest that using leading slashes is fine.

This commit fixes the examples in the documentation to use the default value "swift".

[1]
https://docs.ceph.com/en/reef/radosgw/config-ref/#confval-rgw_swift_url_prefix

Fixes #15065

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
