### PR TITLE
object: allow overriding rgw configs and flags

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7172,6 +7172,36 @@ Example: for an additional mount at subPath <code>ldap</code>, mounted from a se
 <code>bindpass.secret</code>, the file would reside at <code>/var/rgw/ldap/bindpass.secret</code>.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>rgwConfig</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.
+Values are modified at runtime without RGW restart.
+This feature is intended for advanced users. It allows breaking configurations to be easily
+applied. Use with caution.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rgwCommandFlags</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
+store. Values are modified at RGW startup, resulting in RGW pod restarts.
+This feature is intended for advanced users. It allows breaking configurations to be easily
+applied. Use with caution.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.HTTPEndpointSpec">HTTPEndpointSpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11869,6 +11869,26 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    rgwCommandFlags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
+                        store. Values are modified at RGW startup, resulting in RGW pod restarts.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
+                    rgwConfig:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
                     securePort:
                       description: The port the rgw service will be listening on (https)
                       format: int32

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11860,6 +11860,26 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    rgwCommandFlags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
+                        store. Values are modified at RGW startup, resulting in RGW pod restarts.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
+                    rgwConfig:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
                     securePort:
                       description: The port the rgw service will be listening on (https)
                       format: int32

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1734,6 +1734,22 @@ type GatewaySpec struct {
 	// Example: for an additional mount at subPath `ldap`, mounted from a secret that has key
 	// `bindpass.secret`, the file would reside at `/var/rgw/ldap/bindpass.secret`.
 	AdditionalVolumeMounts AdditionalVolumeMounts `json:"additionalVolumeMounts,omitempty"`
+
+	// RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.
+	// Values are modified at runtime without RGW restart.
+	// This feature is intended for advanced users. It allows breaking configurations to be easily
+	// applied. Use with caution.
+	// +nullable
+	// +optional
+	RgwConfig map[string]string `json:"rgwConfig,omitempty"`
+
+	// RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
+	// store. Values are modified at RGW startup, resulting in RGW pod restarts.
+	// This feature is intended for advanced users. It allows breaking configurations to be easily
+	// applied. Use with caution.
+	// +nullable
+	// +optional
+	RgwCommandFlags map[string]string `json:"rgwCommandFlags,omitempty"`
 }
 
 // EndpointAddress is a tuple that describes a single IP address or host name. This is a subset of

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2731,6 +2731,20 @@ func (in *GatewaySpec) DeepCopyInto(out *GatewaySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RgwConfig != nil {
+		in, out := &in.RgwConfig, &out.RgwConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.RgwCommandFlags != nil {
+		in, out := &in.RgwCommandFlags, &out.RgwCommandFlags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -88,34 +88,6 @@ func TestStartRGW(t *testing.T) {
 
 		validateStart(ctx, t, c, clientset)
 	})
-
-	t.Run("Multisite sync traffic disabled", func(t *testing.T) {
-		store.ObjectMeta.Name = "client-rgw-sync-disabled"
-		store.Spec.Gateway.DisableMultisiteSyncTraffic = true
-
-		// Purge store of configurations applied to gateways
-		appliedRgwConfigurations = make(map[string]string)
-
-		err := c.startRGWPods(store.Name, store.Name, store.Name, nil)
-		assert.Nil(t, err)
-
-		assert.Contains(t, appliedRgwConfigurations, "rgw_run_sync_thread")
-		assert.Equal(t, appliedRgwConfigurations["rgw_run_sync_thread"], "false")
-	})
-
-	t.Run("Multisite sync traffic enabled", func(t *testing.T) {
-		store.ObjectMeta.Name = "client-rgw-sync-enabled"
-		store.Spec.Gateway.DisableMultisiteSyncTraffic = false
-
-		// Purge store of configurations applied to gateways
-		appliedRgwConfigurations = make(map[string]string)
-
-		err := c.startRGWPods(store.Name, store.Name, store.Name, nil)
-		assert.Nil(t, err)
-
-		assert.Contains(t, appliedRgwConfigurations, "rgw_run_sync_thread")
-		assert.Equal(t, appliedRgwConfigurations["rgw_run_sync_thread"], "true")
-	})
 }
 
 func validateStart(ctx context.Context, t *testing.T, c *clusterConfig, clientset *fclient.Clientset) {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -437,6 +437,12 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 	if hostingOptions != "" {
 		container.Args = append(container.Args, hostingOptions)
 	}
+
+	// user configs are very last arguments so that they override what Rook might be setting before
+	for flag, val := range c.store.Spec.Gateway.RgwCommandFlags {
+		container.Args = append(container.Args, cephconfig.NewFlag(flag, val))
+	}
+
 	return container, nil
 }
 


### PR DESCRIPTION
Implement #15119

Allow users to override RGW configurations by specifying Ceph config options in the CephObjectStore. For configurations that require RGW to be restarted when the config is applied, allow configs to be specified as CLI arguments to the RGW as well.

This is an advanced option and is documented as such. Users should be careful to understand the values they are setting, as there is no validation to prevent the object store from breaking when these configs are used.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
