### PR TITLE
doc: add object advanced config and vol mount example

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -407,6 +407,36 @@ spec:
 
 Once RGW debug logging is no longer needed, the values can simply be removed from the spec.
 
+### Example - usage with `additionalVolumeMounts`
+
+This sample configuration below demonstrates how advanced configuration can be used alongside
+`additionalVolumeMounts`. This hypothetical scenario shows how a Kubernetes secret containing an
+LDAP secret might be mounted to the RGW pod and how RGW would be configured to reference the mounted
+secret file.
+
+```yaml
+  # ...
+  gateway:
+    # ...
+    rgwConfig:
+      rgw_ldap_secret: /var/rgw/ldap/bindpass.secret
+    additionalVolumeMounts:
+      - subPath: ldap
+        volumeSource:
+          secret:
+            secretName: rgw-ldap
+            defaultMode: 0600
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: rgw-ldap
+    namespace: rook-ceph
+type: Opaque
+data:
+    "bindpass.secret": aGVsbG8ud29ybGQK # hello.world
+```
+
 ## Deleting a CephObjectStore
 
 During deletion of a CephObjectStore resource, Rook protects against accidental or premature


### PR DESCRIPTION
Add a sample to the CephObjectStore Advanced configuration section which shows how the new `rgwConfig` option can be used with the `additionalVolumeMounts` setting.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
