### PR TITLE
ceph: Update s5cmd to resolve vulnerabilities

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -407,8 +407,8 @@ jobs:
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools-operator-image -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           s5cmd_version="$(kubectl -n rook-ceph exec ${toolbox} -- /usr/local/bin/s5cmd version)"
-          echo ${s5cmd_version} | grep -q "^v2.2.1"  || {
-             echo " Error: the version of s5cmd version in the  toolbox is not the expected v2.2.1 but ${s5cmd_version}"
+          echo ${s5cmd_version} | grep -q "^v2.3.0"  || {
+             echo " Error: the version of s5cmd version in the  toolbox is not the expected v2.3.0 but ${s5cmd_version}"
              exit 1
           }
 

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -41,7 +41,7 @@ endif
 S5CMD_ARCH = Linux-64bit
 
 # s5cmd's version
-S5CMD_VERSION = 2.2.1
+S5CMD_VERSION = 2.3.0
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
 YQv3 := $(TOOLS_HOST_DIR)/yq-$(YQv3_VERSION)


### PR DESCRIPTION
The docker.io/rook/ceph image contains vulnerabilities in the s5cmd binary. A new version of s5cmd was released on 16th December which resolves these issues by being build with a newer version of golang.



<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
