### PR TITLE
test: ignore rgw cli flag order in unit test

### DIFF
--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -982,10 +982,12 @@ func TestRgwCommandFlags(t *testing.T) {
 		}
 		rgwContainer, err := c.makeDaemonContainer(rgwConfig)
 		assert.NoError(t, err)
+		// ordering of additional args amongst themselves doesn't matter (and is random b/c of
+		// underlying map data type), but it is still important that the additional args are always
+		// after the args Rook normally applies
 		l := len(rgwContainer.Args)
-		assert.Equal(t, "--rgw-option=val spaced", rgwContainer.Args[l-3])
-		assert.Equal(t, "--rgw-option=val-dashed", rgwContainer.Args[l-2])
-		assert.Equal(t, "--rgw-option=val_underscored", rgwContainer.Args[l-1])
+		addedArgs := rgwContainer.Args[l-3:]
+		assert.ElementsMatch(t, []string{"--rgw-option=val spaced", "--rgw-option=val-dashed", "--rgw-option=val_underscored"}, addedArgs)
 	})
 }
 


### PR DESCRIPTION
In the unit test that ensures `rgwCommandFlags` works properly, ignore the ordering of the flags. Golang maps are used underneath, which results in random flag ordering. This is fine as long as the `rgwCommandFlags` are still guaranteed to be appended to the args Rook normally applies.

Fixes #15180

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
