### PR TITLE
object: add opsLogSidecar to gateway subsection from zone

### DIFF
--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -105,9 +105,6 @@ spec:
     #       secret:
     #         secretName: rgw-ldap
     #         defaultMode: 0600
-  #zone:
-  #name: zone-a
-  # service endpoint healthcheck
     # opsLogSidecar:
     #   resources:
     #     limits:
@@ -115,6 +112,9 @@ spec:
     #   requests:
     #     cpu: "100m"
     #     memory: "60Mi"
+  # zone:
+  #   name: zone-a
+  # service endpoint healthcheck
   healthCheck:
     # Configure the pod probes for the rgw daemon
     startupProbe:


### PR DESCRIPTION
Correct yaml config for opsLogSidecar field from zone.opsLogSidecar to gateway.opsLogSidecar 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
