### PR TITLE
osd: use bluestore if store type is empty

### DIFF
--- a/pkg/operator/ceph/cluster/osd/migrate.go
+++ b/pkg/operator/ceph/cluster/osd/migrate.go
@@ -105,14 +105,15 @@ func (m *migrationConfig) migrateForEncryption(c *Cluster, osdDeployments *appsv
 
 // migrateForOSDStore gets all the OSDs that require migration due to change in the cephCluster OSD storeType setting
 func (m *migrationConfig) migrateForOSDStore(c *Cluster, osdDeployments *appsv1.DeploymentList) error {
+	desiredOSDStore := c.spec.Storage.GetOSDStore()
 	for i := range osdDeployments.Items {
 		if osdStore, ok := osdDeployments.Items[i].Labels[osdStore]; ok {
-			if osdStore != string(c.spec.Storage.Store.Type) {
+			if osdStore != desiredOSDStore {
 				osdInfo, err := c.getOSDInfo(&osdDeployments.Items[i])
 				if err != nil {
 					return errors.Wrapf(err, "failed to details about the OSD %q", osdDeployments.Items[i].Name)
 				}
-				logger.Infof("migration is required for OSD.%d to update storeType from %q to %q", osdInfo.ID, osdStore, c.spec.Storage.Store.Type)
+				logger.Infof("migration is required for OSD.%d to update storeType from %q to %q", osdInfo.ID, osdStore, desiredOSDStore)
 				if _, exists := m.osds[osdInfo.ID]; !exists {
 					m.osds[osdInfo.ID] = &osdInfo
 				}


### PR DESCRIPTION
If store type is empty in the cephCluster spec, use bluestore

OSD migration based on store type is done by comparing the OSD deployment label and store type provided in the spec. Store in the spec can be empty, which means its of bluestore type. 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
