### PR TITLE
csi: Set correct driver name with csi operator

### DIFF
--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -77,7 +77,7 @@ func (r *ReconcileCSI) createOrUpdateDriverResources(cluster cephv1.CephCluster,
 }
 
 func (r *ReconcileCSI) createOrUpdateRBDDriverResource(cluster cephv1.CephCluster, clusterInfo *cephclient.ClusterInfo) error {
-	resourceName := fmt.Sprintf("%s.rbd.csi.ceph.com", r.opConfig.OperatorNamespace)
+	resourceName := fmt.Sprintf("%s.rbd.csi.ceph.com", cluster.Namespace)
 	spec, err := r.generateDriverSpec(cluster.Name)
 	if err != nil {
 		return err
@@ -116,14 +116,14 @@ func (r *ReconcileCSI) createOrUpdateRBDDriverResource(cluster cephv1.CephCluste
 
 	err = r.createOrUpdateDriverResource(clusterInfo, rbdDriver)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create or update RDB driver resource %q", rbdDriver.Name)
+		return errors.Wrapf(err, "failed to create or update RBD driver resource %q", rbdDriver.Name)
 	}
 
 	return nil
 }
 
 func (r *ReconcileCSI) createOrUpdateCephFSDriverResource(cluster cephv1.CephCluster, clusterInfo *cephclient.ClusterInfo) error {
-	resourceName := fmt.Sprintf("%s.cephfs.csi.ceph.com", r.opConfig.OperatorNamespace)
+	resourceName := fmt.Sprintf("%s.cephfs.csi.ceph.com", cluster.Namespace)
 	spec, err := r.generateDriverSpec(cluster.Name)
 	if err != nil {
 		return err
@@ -175,7 +175,7 @@ func (r *ReconcileCSI) createOrUpdateCephFSDriverResource(cluster cephv1.CephClu
 }
 
 func (r *ReconcileCSI) createOrUpdateNFSDriverResource(cluster cephv1.CephCluster, clusterInfo *cephclient.ClusterInfo) error {
-	resourceName := fmt.Sprintf("%s.nfs.csi.ceph.com", r.opConfig.OperatorNamespace)
+	resourceName := fmt.Sprintf("%s.nfs.csi.ceph.com", cluster.Namespace)
 	spec, err := r.generateDriverSpec(cluster.Name)
 	if err != nil {
 		return err

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -131,7 +131,7 @@ func (o *Operator) runCRDManager() {
 
 	// The operator config manager is also watching for changes here so if the operator config map
 	// content changes for ROOK_CURRENT_NAMESPACE_ONLY we must reload the operator CRD manager
-	o.namespaceToWatch(opManagerContext)
+	o.namespaceToWatch()
 
 	// Pass the parent context to the cluster controller so that the monitoring go routines can
 	// consume it to terminate gracefully
@@ -148,11 +148,11 @@ func (o *Operator) runCRDManager() {
 	}()
 }
 
-func (o *Operator) namespaceToWatch(context context.Context) {
+func (o *Operator) namespaceToWatch() {
 	currentNamespaceOnly, _ := k8sutil.GetOperatorSetting(opManagerContext, o.context.Clientset, opcontroller.OperatorSettingConfigMapName, "ROOK_CURRENT_NAMESPACE_ONLY", "true")
 	if currentNamespaceOnly == "true" {
 		o.config.NamespaceToWatch = o.config.OperatorNamespace
-		logger.Infof("watching the current namespace %q for a Ceph CRs", o.config.OperatorNamespace)
+		logger.Infof("watching the current namespace %q for Ceph CRs", o.config.OperatorNamespace)
 	} else {
 		o.config.NamespaceToWatch = v1.NamespaceAll
 		logger.Infof("watching all namespaces for Ceph CRs")


### PR DESCRIPTION
When the cluster is in a different namespace from the rook operator, the csi provider name was setting the incorrect namespace prefix. Now the prefix will be the same as the ceph cluster namespace.

A second commit is also for small cleanup of an obsolete parameter for controller runtime init.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
