### PR TITLE
core: add tolerations to crashcollector pruner cronJob pod

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -190,8 +190,8 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		}
 
 		// If the node has Ceph pods we create the daemons
+		tolerations := uniqueTolerations.ToList()
 		if hasCephPods {
-			tolerations := uniqueTolerations.ToList()
 			err := r.createOrUpdateNodeDaemons(*node, tolerations, cephCluster, cephVersion)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "node reconcile failed")
@@ -219,7 +219,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 
-		if err := r.reconcileCrashPruner(namespace, cephCluster); err != nil {
+		if err := r.reconcileCrashPruner(namespace, cephCluster, tolerations); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
#15228
This PR addresses an issue where the CrashCollector Pruner CronJob pods were stuck in a 
Pending state due to missing tolerations in their PodTemplateSpec.
These tolerations were not being propagated from the cephClusterSpec.placement.all field.
Added tolerations to the PodTemplateSpec of the CrashCollector Pruner CronJob.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
