### PR TITLE
build: Auto merge backports without blocking on multisite test

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -224,7 +224,6 @@ pull_request_rules:
       - "check-success=canary-tests / encryption-pvc-kms-vault-k8s-auth (quay.io/ceph/ceph:v19)"
       - "check-success=canary-tests / lvm-pvc (quay.io/ceph/ceph:v19)"
       - "check-success=canary-tests / multi-cluster-mirroring (quay.io/ceph/ceph:v19)"
-      - "check-success=canary-tests / rgw-multisite-testing (quay.io/ceph/ceph:v19)"
       - "check-success=canary-tests / encryption-pvc-kms-ibm-kp (quay.io/ceph/ceph:v19)"
       - "check-success=canary-tests / multus-public-and-cluster (quay.io/ceph/ceph:v19)"
       - "check-success=TestCephSmokeSuite (v1.27.16)"


### PR DESCRIPTION
The rgw-multisite-testing job is consistently failing and blocking the backport of PRs that are passing all other CI. Until issue #15177 is fixed let's disable this check.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
