### PR TITLE
osd: Enable node specific ceph conf overrides

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -88,6 +88,7 @@ type Cluster struct {
 	deviceSets     []deviceSet
 	migrateOSD     *OSDInfo
 	deprecatedOSDs map[string][]int
+	nodeConfigmaps map[string]struct{}
 }
 
 // New creates an instance of the OSD manager
@@ -204,6 +205,9 @@ func (c *Cluster) Start() error {
 	errs := newProvisionErrors()
 
 	if err := c.validateOSDSettings(); err != nil {
+		return err
+	}
+	if err := c.initializeNodeConfigmaps(); err != nil {
 		return err
 	}
 	logger.Infof("start running osds in namespace %q", namespace)
@@ -1044,4 +1048,25 @@ func getOSDLocationFromArgs(args []string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func (c *Cluster) initializeNodeConfigmaps() error {
+	// Find existing configmaps matching the label
+	label := "node.config.rook.io/osd"
+	options := metav1.ListOptions{LabelSelector: label}
+	configmaps, err := c.context.Clientset.CoreV1().ConfigMaps(c.clusterInfo.Namespace).List(c.clusterInfo.Context, options)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list configmaps in namespace %q with label %q", c.clusterInfo.Namespace, label)
+	}
+
+	c.nodeConfigmaps = map[string]struct{}{}
+	prefix := k8sutil.ConfigOverrideName + "-"
+	for _, configmap := range configmaps.Items {
+		if strings.HasPrefix(configmap.Name, prefix) {
+			nodeName := strings.TrimPrefix(configmap.Name, prefix)
+			logger.Infof("found node %q configmap, will mount it for alternate ceph conf overrides for osds on this node", nodeName)
+			c.nodeConfigmaps[nodeName] = struct{}{}
+		}
+	}
+	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -104,6 +104,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	// ceph-volume is currently set up to use /etc/ceph/ceph.conf; this means no user config
 	// overrides will apply to ceph-volume, but this is unnecessary anyway
 	volumes := append(controller.PodVolumes(provisionConfig.DataPathMap, c.spec.DataDirHostPath, c.spec.DataDirHostPath, true), copyBinariesVolume)
+	volumes = c.updateCephConfigVolume(volumes, osdProps.crushHostname)
 
 	// create a volume on /dev so the pod can access devices on the host
 	devVolume := v1.Volume{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}}

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -325,6 +325,24 @@ func deploymentName(osdID int) string {
 	return fmt.Sprintf(osdAppNameFmt, osdID)
 }
 
+func (c *Cluster) updateCephConfigVolume(volumes []v1.Volume, nodeName string) []v1.Volume {
+	if _, ok := c.nodeConfigmaps[nodeName]; !ok {
+		logger.Debugf("no configmap to override for node %q", nodeName)
+		return volumes
+	}
+
+	updatedVolumes := []v1.Volume{}
+	for _, volume := range volumes {
+		if volume.Name == k8sutil.ConfigOverrideName {
+			logger.Debugf("found configmap volume to override for node %q", nodeName)
+			name := fmt.Sprintf("%s-%s", k8sutil.ConfigOverrideName, nodeName)
+			volume.VolumeSource.Projected.Sources[0].ConfigMap.LocalObjectReference.Name = name
+		}
+		updatedVolumes = append(updatedVolumes, volume)
+	}
+	return updatedVolumes
+}
+
 func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provisionConfig *provisionConfig) (*apps.Deployment, error) {
 	deploymentName := deploymentName(osd.ID)
 	replicaCount := int32(1)
@@ -336,6 +354,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 		dataDirHostPath = ""
 	}
 	volumes := controller.PodVolumes(provisionConfig.DataPathMap, dataDirHostPath, c.spec.DataDirHostPath, false)
+	volumes = c.updateCephConfigVolume(volumes, osdProps.crushHostname)
+
 	failureDomainValue := osdProps.crushHostname
 	doConfigInit := true     // initialize ceph.conf in init container?
 	doBinaryCopyInit := true // copy rook binary in an init container?


### PR DESCRIPTION
Some ceph.conf settings need to be unique per node depending on the hardware. The ceph.conf overrides can now be customized per-node by creating a node-specific configmap that will be loaded for all OSDs and OSD prepare jobs on that node, instead of the default ceph.conf that is loaded from the rook-config-override configmap.

The node-specific configmaps must have the label:
`node.config.rook.io/osd`

And the configmap must follow the naming convention:
`rook-config-override-<hostname>`

An example configmap:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: rook-config-override-minikube
  namespace: rook-ceph
  labels:
    node.config.rook.io/osd: ""
data:
  config: |
    [global]
    foo = bar
```

TODO:
- [ ] Unit tests
- [ ] Documentation

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15200

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
