### PR TITLE
mgr: make exclude perf counters as an optional

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -8943,6 +8943,19 @@ CephExporterSpec
 <p>Ceph exporter configuration</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>excludePerfCounters</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExcludePerfCounters determines whether export ceph daemon perf
+counters as prometheus metrics</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.MultiClusterServiceSpec">MultiClusterServiceSpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2509,6 +2509,11 @@ spec:
                         Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
                         types must exist or the creation will fail. Default is false.
                       type: boolean
+                    excludePerfCounters:
+                      description: |-
+                        ExcludePerfCounters determines whether export ceph daemon perf
+                        counters as prometheus metrics
+                      type: boolean
                     exporter:
                       description: Ceph exporter configuration
                       properties:

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -82,6 +82,8 @@ spec:
   monitoring:
     # requires Prometheus to be pre-installed
     enabled: false
+    # whether export ceph daemon perf counters as mgr prometheus metrics
+    excludePerfCounters: true
     # Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled.
     # If true, the prometheus mgr module and Ceph exporter are both disabled. Default is false.
     metricsDisabled: false

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2507,6 +2507,11 @@ spec:
                         Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus
                         types must exist or the creation will fail. Default is false.
                       type: boolean
+                    excludePerfCounters:
+                      description: |-
+                        ExcludePerfCounters determines whether export ceph daemon perf
+                        counters as prometheus metrics
+                      type: boolean
                     exporter:
                       description: Ceph exporter configuration
                       properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -410,6 +410,11 @@ type MonitoringSpec struct {
 	// Ceph exporter configuration
 	// +optional
 	Exporter *CephExporterSpec `json:"exporter,omitempty"`
+
+	// ExcludePerfCounters determines whether export ceph daemon perf
+	// counters as prometheus metrics
+	// +optional
+	ExcludePerfCounters *bool `json:"excludePerfCounters,omitempty"`
 }
 
 type CephExporterSpec struct {

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -3400,6 +3400,11 @@ func (in *MonitoringSpec) DeepCopyInto(out *MonitoringSpec) {
 		*out = new(CephExporterSpec)
 		**out = **in
 	}
+	if in.ExcludePerfCounters != nil {
+		in, out := &in.ExcludePerfCounters, &out.ExcludePerfCounters
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
mgr prometheus introduce exclude_perf_counters since ceph reef, it set true by default. We could make it an optional to provide user modify it, and we respect the default configuration of ceph as true.

refer: https://github.com/ceph/ceph/pull/49248

Signed-off-by: Yite Gu <guyite@bytedance.com>
<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
