### PR TITLE
Ci: refactor  a shellcheck make target out of the github ci  workflow 

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -24,13 +24,10 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
-      with:
-        severity: warning
-        check_together: 'yes'
-        disable_matcher: false
-        additional_files: build/reset build/sed-in-place
-        ignore: olm
-        format: gcc
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: make shellcheck

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ yamllint:
 pylint:
 	pylint $(shell find $(ROOT_DIR)  -name '*.py') -E
 
+.PHONY: shellcheck
+shellcheck:
+	shellcheck --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
+
 gen.codegen: codegen
 codegen: ${CODE_GENERATOR} ## Run code generators.
 	@build/codegen/codegen.sh


### PR DESCRIPTION
**description of changes:**

In continuation of PR #15256 , this refactors a new make target `shellcheck`out of the corresponding github ci workflow for convenient local execution in developer environments. 

NOTE: This is currently based on #15256  and will need to be rebased (trivially), should that PR merge.




**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
