### PR TITLE
build: remove broken make target lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,6 @@ check test: ## Runs unit tests.
 test-integration: ## Runs integration tests.
 	@$(MAKE) go.test.integration
 
-lint: ## Check syntax and styling of go sources.
-	@$(MAKE) go.init
-	@$(MAKE) go.lint
-
 vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -64,7 +64,6 @@ endif
 GOPATH := $(shell go env GOPATH)
 
 # setup tools used during the build
-GOLINT := $(TOOLS_HOST_DIR)/golint
 GOJUNIT := $(TOOLS_DIR)/go-junit-report
 
 GO := go
@@ -144,11 +143,6 @@ go.test.integration: $(GOJUNIT)
 	CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GOHOST) test -v -timeout 7200s $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_INTEGRATION_TEST_PACKAGES) $(TEST_FILTER_PARAM) 2>&1 | tee $(GO_TEST_OUTPUT)/integration-tests.log
 	@cat $(GO_TEST_OUTPUT)/integration-tests.log | $(GOJUNIT) -set-exit-code > $(GO_TEST_OUTPUT)/integration-tests.xml
 
-.PHONY: go.lint
-go.lint: $(GOLINT)
-	@echo === go lint
-	@$(GOLINT) -set_exit_status=true $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES)
-
 .PHONY: go.vet
 go.vet:
 	@echo === go vet
@@ -184,12 +178,6 @@ go.mod.clean:
 	@echo === cleaning modules cache
 	@sudo rm -fr $(WORK_DIR)/cross_pkg
 	@$(GOHOST) clean -modcache
-
-$(GOLINT):
-	@echo === installing golint
-	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get github.com/golang/lint/golint
-	@rm -fr $(TOOLS_HOST_DIR)/tmp
 
 $(GOFMT):
 	@echo === installing gofmt$(GOFMT_VERSION)


### PR DESCRIPTION

The `lint` make target is not used anywhere in the codebase and is particular not run in the CI.
Ir was recently discovered that `make lint`does not even work at all (issue #15317).
It was subsequently suggested to remove the broken and unused target altogether: https://github.com/rook/rook/issues/15317#issuecomment-2611120587

This change settles that issue by removing the  lint target and the preparatory golint installation target.



***Description of changes:**


**Issue resolved by this Pull Request:**
Resolves #15317 


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
