### PR TITLE
Build: add make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,12 @@ fmt: ## Check formatting of go sources.
 yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
 
+.PHONY: lint
+lint: yamllint pylint shellcheck vet ## Run various linters
+
 .PHONY: pylint
 pylint:
-	pylint $(shell find $(ROOT_DIR)  -name '*.py') -E
+	pylint $(shell find $(ROOT_DIR) -name '*.py') -E
 
 .PHONY: shellcheck
 shellcheck:


### PR DESCRIPTION
**description of changes:**

this re-adds a `lint` make target after the broken one has been removed with #15319 .
The new lint target executes various linting checks.
This PR depends on #15313  as it uses the `shellcheck`target added by that PR.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
