### PR TITLE
osd: fix duplicate tolerations in key rotation pods

### DIFF
--- a/pkg/operator/ceph/cluster/osd/key_rotation.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation.go
@@ -196,6 +196,7 @@ func (c *Cluster) getKeyRotationPodTemplateSpec(osdProps osdProperties, osd OSDI
 	podTemplateSpec.Spec.HostIPC = true
 
 	k8sutil.RemoveDuplicateEnvVars(&podTemplateSpec.Spec)
+	k8sutil.RemoveDuplicateTolerations(&podTemplateSpec.Spec)
 	return &podTemplateSpec, nil
 }
 

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -383,6 +383,20 @@ func RemoveDuplicateEnvVars(pod *v1.PodSpec) {
 	}
 }
 
+func RemoveDuplicateTolerations(podSpec *v1.PodSpec) {
+	tolerationsMap := make(map[v1.Toleration]struct{})
+	var uniqueTolerations []v1.Toleration
+
+	for _, toleration := range podSpec.Tolerations {
+		if _, exists := tolerationsMap[toleration]; !exists {
+			tolerationsMap[toleration] = struct{}{}
+			uniqueTolerations = append(uniqueTolerations, toleration)
+		}
+	}
+
+	podSpec.Tolerations = uniqueTolerations
+}
+
 func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
 	foundVars := map[string]string{}
 	vars := []v1.EnvVar{}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
This pr addresses the issue of duplicate tolerations being added to the `rook-ceph-osd-key-rotation-x` pods. 
A new utility function, `removeDuplicateTolerations`, has been added and integrated into the `getKeyRotationPodTemplateSpec` method. 
This ensures that all tolerations in the podspec are deduplicated before returning the template, preventing prometheus alerts for `prometheusduplicatetimestamps`


<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
