### PR TITLE
external: allow cephfs, or rgw only deployments

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -553,12 +553,6 @@ class RadosJSON:
                 contents = f.read()
                 return contents.rstrip()
 
-    def _check_conflicting_options(self):
-        if not self._arg_parser.upgrade and not self._arg_parser.rbd_data_pool_name:
-            raise ExecutionFailureException(
-                "Either '--upgrade' or '--rbd-data-pool-name <pool_name>' should be specified"
-            )
-
     def _invalid_endpoint(self, endpoint_str):
         # extract the port by getting the last split on `:` delimiter
         try:
@@ -651,7 +645,6 @@ class RadosJSON:
         self._arg_parser = self.gen_arg_parser(args_to_parse=arg_list)
         if self._arg_parser.config_file:
             self.config = self.parse_config_file(self._arg_parser.config_file)
-        self._check_conflicting_options()
         self.run_as_user = self._arg_parser.run_as_user
         self.output_file = self._arg_parser.output
         self.ceph_conf = self._arg_parser.ceph_conf


### PR DESCRIPTION
currently, there was a restriction to always create rbd pool with this change only cephfs or rgw volumes created

closes: https://github.com/rook/rook/issues/15039

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
