### PR TITLE
osd: Enable osd ok-to-stop checks on single node where there are at least three OSDs

### DIFF
--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -20,6 +20,8 @@ spec:
   mon:
     count: 1
     allowMultiplePerNode: true
+  # test environments can skip ok-to-stop checks during upgrades
+  skipUpgradeChecks: true
   mgr:
     count: 1
     allowMultiplePerNode: true

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -344,21 +344,6 @@ func OSDUpdateShouldCheckOkToStop(context *clusterd.Context, clusterInfo *Cluste
 		return false
 	}
 
-	// aio means all in one
-	aio, err := allOSDsSameHost(context, clusterInfo)
-	if err != nil {
-		if errors.Is(err, errNoHostInCRUSH) {
-			logger.Warning("the CRUSH map has no 'host' entries so not performing ok-to-stop checks")
-			return false
-		}
-		logger.Warningf("failed to determine if all osds are running on the same host. will check if OSDs are ok-to-stop. if all OSDs are running on one host %s. %v", userIntervention, err)
-		return true
-	}
-	if aio {
-		logger.Warningf("all OSDs are running on the same host. not performing upgrade check. running in best-effort")
-		return false
-	}
-
 	return true
 }
 

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -323,7 +323,7 @@ func TestOSDUpdateShouldCheckOkToStop(t *testing.T) {
 	t.Run("1 node with 3 OSDs", func(t *testing.T) {
 		lsOutput = fake.OsdLsOutput(3)
 		treeOutput = fake.OsdTreeOutput(1, 3)
-		assert.False(t, OSDUpdateShouldCheckOkToStop(context, clusterInfo))
+		assert.True(t, OSDUpdateShouldCheckOkToStop(context, clusterInfo))
 	})
 
 	t.Run("2 nodes with 1 OSD each", func(t *testing.T) {
@@ -349,6 +349,6 @@ func TestOSDUpdateShouldCheckOkToStop(t *testing.T) {
 	t.Run("0 nodes with down OSDs", func(t *testing.T) {
 		lsOutput = fake.OsdLsOutput(3)
 		treeOutput = fake.OsdTreeOutput(0, 1)
-		assert.False(t, OSDUpdateShouldCheckOkToStop(context, clusterInfo))
+		assert.True(t, OSDUpdateShouldCheckOkToStop(context, clusterInfo))
 	})
 }


### PR DESCRIPTION
If there are at least three OSDs on a single node, we should treat it as a potential production cluster and perform the ok-to-stop checks during reconcile. Otherwise, it may cause instability during upgrades on single-node clusters.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15367

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
