### PR TITLE
object: rm ReconcileObjectStoreUser.userConfig field

### DIFF
--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -498,30 +498,27 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 		objContext: &cephobject.AdminOpsContext{
 			AdminOpsClient: adminClient,
 		},
-		userConfig:       &userConfig,
 		opManagerContext: context.TODO(),
 	}
 	maxsize, err := resource.ParseQuantity(maxsizestr)
 	assert.NoError(t, err)
 
 	t.Run("user with empty name", func(t *testing.T) {
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.Error(t, err)
 	})
 
 	t.Run("user without any Quotas or Capabilities", func(t *testing.T) {
 		objectUser.Name = name
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 
 	t.Run("setting MaxBuckets for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxBuckets: &maxbucket}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 
@@ -534,8 +531,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 			Info:   "read, write",
 		}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 
@@ -544,36 +540,31 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 		objectUser.Spec.Capabilities = nil
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxObjects: &maxobject}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("setting MaxSize for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxSize: &maxsize}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("resetting MaxSize and MaxObjects for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = nil
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("setting both MaxSize and MaxObjects for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxObjects: &maxobject, MaxSize: &maxsize}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("resetting MaxSize and MaxObjects again for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = nil
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 
@@ -586,8 +577,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 		}
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxBuckets: &maxbucket, MaxObjects: &maxobject, MaxSize: &maxsize}
 		userConfig = generateUserConfig(objectUser)
-		r.userConfig = &userConfig
-		err = r.createOrUpdateCephUser(objectUser)
+		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This field held state for a single reconciliation request, which should not have been retrained / reused across multiple, possibly concurrent, reconciliations.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
