### PR TITLE
object: disallow unsafe OBC fields by default

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -157,6 +157,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `logLevel` | Global log level for the operator. Options: `ERROR`, `WARNING`, `INFO`, `DEBUG` | `"INFO"` |
 | `monitoring.enabled` | Enable monitoring. Requires Prometheus to be pre-installed. Enabling will also create RBAC rules to allow Operator to create ServiceMonitors | `false` |
 | `nodeSelector` | Kubernetes [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) to add to the Deployment. | `{}` |
+| `obcAllowAdditionalConfigFields` | Many OBC additional config fields may be risky for administrators to allow users control over. The safe and default-allowed fields are 'maxObjects' and 'maxSize'. Other fields should be considered risky. To allow all additional configs, use this value:   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner" | "maxObjects,maxSize" |
 | `obcProvisionerNamePrefix` | Specify the prefix for the OBC provisioner in place of the cluster namespace | `ceph cluster namespace` |
 | `priorityClassName` | Set the priority class for the rook operator deployment if desired | `nil` |
 | `pspEnable` | If true, create & use PSP resources | `false` |

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
@@ -91,11 +91,25 @@ If both `bucketName` and `generateBucketName` are blank or omitted then the stor
 
     * `maxObjects`: The maximum number of objects in the bucket as a quota on the user account automatically created for the bucket.
     * `maxSize`: The maximum size of the bucket as a quota on the user account automatically created for the bucket. Please note minimum recommended value is 4K.
-    * `bucketMaxObjects`: The maximum number of objects in the bucket as an individual bucket quota. This is useful when the bucket is shared among multiple users.
-    * `bucketMaxSize`: The maximum size of the bucket as an individual bucket quota.
-    * `bucketPolicy`: A raw JSON format string that defines an AWS S3 format the bucket policy. If set, the policy string will override any existing policy set on the bucket and any default bucket policy that the bucket provisioner potentially would have automatically generated.
-    * `bucketLifecycle`: A raw JSON format string that defines an AWS S3 format bucket lifecycle configuration. Note that the rules must be sorted by `ID` in order to be idempotent.
-    * `bucketOwner`: The name of a pre-existing ceph rgw user account that will own the bucket. A `CephObjectStoreUser` resource may be used to create an ceph rgw user account. If the bucket already exists and is owned by a different user, the bucket will be re-linked to the specified user.
+    * `bucketMaxObjects`: (disabled by default) The maximum number of objects in the bucket as an individual bucket quota. This is useful when the bucket is shared among multiple users.
+    * `bucketMaxSize`: (disabled by default) The maximum size of the bucket as an individual bucket quota.
+    * `bucketPolicy`: (disabled by default) A raw JSON format string that defines an AWS S3 format the bucket policy. If set, the policy string will override any existing policy set on the bucket and any default bucket policy that the bucket provisioner potentially would have automatically generated.
+    * `bucketLifecycle`: (disabled by default) A raw JSON format string that defines an AWS S3 format bucket lifecycle configuration. Note that the rules must be sorted by `ID` in order to be idempotent.
+    * `bucketOwner`: (disabled by default)  The name of a pre-existing ceph rgw user account that will own the bucket. A `CephObjectStoreUser` resource may be used to create an ceph rgw user account. If the bucket already exists and is owned by a different user, the bucket will be re-linked to the specified user.
+
+Several OBC `additionalConfig` fields are disabled by default. Default-disabled additional config
+fields may be risky for administrators to allow users control over, and they should be enabled only
+with caution.
+
+The default allowed fields are `maxObjects` and `maxSize`. These are designed to fit into the OBC
+framework's original design goals. Other fields can be allowed but exert control outside of OBC's
+original design goals and should be considered risky. At best, users may be able to break their own
+OBCs in unexpected ways. At worst, users may brick the whole S3 object store for all users
+(`bucketPolicy` in particular). Administrators should take care to enable features only when they
+are personally willing to take on the risks.
+
+OBC `additionalConfig` fields can be enabled and disabled using the the `rook-ceph-operator-config`
+configmap value `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`.
 
 ### OBC Custom Resource after Bucket Provisioning
 

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
 {{- if .Values.obcProvisionerNamePrefix }}
   ROOK_OBC_PROVISIONER_NAME_PREFIX: {{ .Values.obcProvisionerNamePrefix | quote }}
 {{- end }}
+{{- if .Values.obcAllowAdditionalConfigFields }}
+  ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: {{ .Values.obcAllowAdditionalConfigFields | quote }}
+{{- end }}
   ROOK_CEPH_ALLOW_LOOP_DEVICES: {{ .Values.allowLoopDevices | quote }}
   ROOK_ENABLE_DISCOVERY_DAEMON: {{ .Values.enableDiscoveryDaemon | quote }}
 {{- if .Values.discoverDaemonUdev }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -624,7 +624,7 @@ discover:
   #       memory: 128Mi
 
 # -- Custom label to identify node hostname. If not set `kubernetes.io/hostname` will be used
-customHostnameLabel: 
+customHostnameLabel:
 
 # -- Runs Ceph Pods as privileged to be able to write to `hostPaths` in OpenShift with SELinux restrictions.
 hostpathRequiresPrivileged: false
@@ -651,6 +651,13 @@ enableOBCWatchOperatorNamespace: true
 # -- Specify the prefix for the OBC provisioner in place of the cluster namespace
 # @default -- `ceph cluster namespace`
 obcProvisionerNamePrefix:
+
+# -- Many OBC additional config fields may be risky for administrators to allow users control over.
+# The safe and default-allowed fields are 'maxObjects' and 'maxSize'.
+# Other fields should be considered risky. To allow all additional configs, use this value:
+#   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
+# @default -- "maxObjects,maxSize"
+obcAllowAdditionalConfigFields: "maxObjects,maxSize"
 
 monitoring:
   # -- Enable monitoring. Requires Prometheus to be pre-installed.

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -541,6 +541,12 @@ data:
   # Custom prefix value for the OBC provisioner instead of ceph cluster namespace, do not set on existing cluster
   # ROOK_OBC_PROVISIONER_NAME_PREFIX: "custom-prefix"
 
+  # Many OBC additional config fields may be risky for administrators to allow users control over.
+  # The safe and default-allowed fields are 'maxObjects' and 'maxSize'.
+  # Other fields should be considered risky. To allow all additional configs, use this value:
+  #   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
+  # ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs
+
   # Whether to start the discovery daemon to watch for raw storage devices on nodes in the cluster.
   # This daemon does not need to run if you are only going to create your OSDs based on StorageClassDeviceSets with PVCs.
   ROOK_ENABLE_DISCOVERY_DAEMON: "false"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -491,6 +491,12 @@ data:
   # Custom prefix value for the OBC provisioner instead of ceph cluster namespace, do not set on existing cluster
   # ROOK_OBC_PROVISIONER_NAME_PREFIX: "custom-prefix"
 
+  # Many OBC additional config fields may be risky for administrators to allow users control over.
+  # The safe and default-allowed fields are 'maxObjects' and 'maxSize'.
+  # Other fields should be considered risky. To allow all additional configs, use this value:
+  #   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
+  # ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs
+
   # Whether to start the discovery daemon to watch for raw storage devices on nodes in the cluster.
   # This daemon does not need to run if you are only going to create your OSDs based on StorageClassDeviceSets with PVCs.
   ROOK_ENABLE_DISCOVERY_DAEMON: "false"

--- a/pkg/operator/ceph/controller.go
+++ b/pkg/operator/ceph/controller.go
@@ -134,6 +134,7 @@ func (r *ReconcileConfig) reconcile(request reconcile.Request) (reconcile.Result
 	opcontroller.SetAllowLoopDevices(r.config.Parameters)
 	opcontroller.SetEnforceHostNetwork(r.config.Parameters)
 	opcontroller.SetRevisionHistoryLimit(r.config.Parameters)
+	opcontroller.SetObcAllowAdditionalConfigFields(r.config.Parameters)
 
 	logger.Infof("%s done reconciling", controllerName)
 	return reconcile.Result{}, nil

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -53,6 +54,9 @@ const (
 	OperatorSettingConfigMapName   string = "rook-ceph-operator-config"
 	enforceHostNetworkSettingName  string = "ROOK_ENFORCE_HOST_NETWORK"
 	enforceHostNetworkDefaultValue string = "false"
+
+	obcAllowAdditionalConfigFieldsSettingName  string = "ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS"
+	obcAllowAdditionalConfigFieldsDefaultValue string = "maxObjects,maxSize"
 
 	revisionHistoryLimitSettingName string = "ROOK_REVISION_HISTORY_LIMIT"
 
@@ -90,6 +94,9 @@ var (
 	// loopDevicesAllowed indicates whether loop devices are allowed to be used
 	loopDevicesAllowed          = false
 	revisionHistoryLimit *int32 = nil
+
+	// allowed OBC additional config fields
+	obcAllowAdditionalConfigFields = strings.Split(obcAllowAdditionalConfigFieldsDefaultValue, ",")
 )
 
 func DiscoveryDaemonEnabled(data map[string]string) bool {
@@ -157,6 +164,15 @@ func SetRevisionHistoryLimit(data map[string]string) {
 
 func RevisionHistoryLimit() *int32 {
 	return revisionHistoryLimit
+}
+
+func SetObcAllowAdditionalConfigFields(data map[string]string) {
+	strval := k8sutil.GetValue(data, obcAllowAdditionalConfigFieldsSettingName, obcAllowAdditionalConfigFieldsDefaultValue)
+	obcAllowAdditionalConfigFields = strings.Split(strval, ",")
+}
+
+func ObcAdditionalConfigKeyIsAllowed(configField string) bool {
+	return slices.Contains(obcAllowAdditionalConfigFields, configField)
 }
 
 // canIgnoreHealthErrStatusInReconcile determines whether a status of HEALTH_ERR in the CephCluster can be ignored safely.

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	cephObject "github.com/rook/rook/pkg/operator/ceph/object"
 	storagev1 "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -93,6 +94,9 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	spec := additionalConfigSpec{}
 
 	if _, ok := config["maxObjects"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("maxObjects") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "maxObjects")
+		}
 		spec.maxObjects, err = quanityToInt64(config["maxObjects"])
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse maxObjects quota")
@@ -100,6 +104,9 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	}
 
 	if _, ok := config["maxSize"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("maxSize") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "maxSize")
+		}
 		spec.maxSize, err = quanityToInt64(config["maxSize"])
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse maxSize quota")
@@ -107,6 +114,9 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	}
 
 	if _, ok := config["bucketMaxObjects"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketMaxObjects") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "bucketMaxObjects")
+		}
 		spec.bucketMaxObjects, err = quanityToInt64(config["bucketMaxObjects"])
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse bucketMaxObjects quota")
@@ -114,6 +124,9 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	}
 
 	if _, ok := config["bucketMaxSize"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketMaxSize") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "bucketMaxSize")
+		}
 		spec.bucketMaxSize, err = quanityToInt64(config["bucketMaxSize"])
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse bucketMaxSize quota")
@@ -121,16 +134,25 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	}
 
 	if _, ok := config["bucketPolicy"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketPolicy") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "bucketPolicy")
+		}
 		policy := config["bucketPolicy"]
 		spec.bucketPolicy = &policy
 	}
 
 	if _, ok := config["bucketLifecycle"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketLifecycle") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "bucketLifecycle")
+		}
 		lifecycle := config["bucketLifecycle"]
 		spec.bucketLifecycle = &lifecycle
 	}
 
 	if _, ok := config["bucketOwner"]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketOwner") {
+			return nil, errors.Errorf("OBC config %q is not allowed", "bucketOwner")
+		}
 		bucketOwner := config["bucketOwner"]
 		spec.bucketOwner = &bucketOwner
 	}

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -86,6 +86,9 @@ func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
 	manifest = strings.ReplaceAll(manifest, `ROOK_ENABLE_DISCOVERY_DAEMON: "false"`, fmt.Sprintf(`ROOK_ENABLE_DISCOVERY_DAEMON: "%t"`, s.EnableDiscovery))
 	manifest = strings.ReplaceAll(manifest, `CSI_ENABLE_VOLUME_REPLICATION: "false"`, fmt.Sprintf(`CSI_ENABLE_VOLUME_REPLICATION: "%t"`, s.EnableVolumeReplication))
 	manifest = strings.ReplaceAll(manifest, `ROOK_CSI_ENABLE_NFS: "false"`, fmt.Sprintf(`ROOK_CSI_ENABLE_NFS: "%t"`, s.TestNFSCSI))
+	manifest = strings.ReplaceAll(manifest,
+		`# ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs`,
+		`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"`)
 	return manifest
 }
 


### PR DESCRIPTION
Implement an allow list mechanism that disables potentially unsafe OBC fields by default. OBC fields beyond `maxObjects` and `maxSize` don't neatly fit into the OBC framework as it was originally envisioned and implemented.

Some of the newly added configs could allow users to cause confusion for themselves. Others might allow users to hijack others buckets. Some might allow bricking the entire S3 store.

Out of an abundance of safety, allow-list the known-safe options by default, and require administrators to enable potentially troublesome options via the new operator-level config
`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
