### PR TITLE
helm: add support for ingress path type

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -21,7 +21,7 @@ spec:
                 name: rook-ceph-rgw-{{ .name }}
                 port:
                   number: {{ .spec.gateway.securePort | default .spec.gateway.port }}
-            pathType: Prefix
+            pathType: {{ .ingress.host.pathType | default "Prefix" }}
 {{- else }}
               serviceName: rook-ceph-rgw-{{ .name }}
               servicePort: {{ .spec.gateway.securePort | default .spec.gateway.port }}

--- a/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
                   {{- else }}
                   name: http-dashboard
                   {{- end }}
-            pathType: Prefix
+            pathType: {{ .Values.ingress.dashboard.host.pathType | default "Prefix" }}
 {{- else }}
               serviceName: rook-ceph-mgr-dashboard
               {{- if .Values.cephClusterSpec.dashboard.ssl }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -431,6 +431,7 @@ ingress:
     # host:
     #   name: dashboard.example.com
     #   path: "/ceph-dashboard(/|$)(.*)"
+    #   pathType: Prefix
     # tls:
     # - hosts:
     #     - dashboard.example.com
@@ -634,6 +635,7 @@ cephObjectStores:
       # host:
       #   name: objectstore.example.com
       #   path: /
+      #   pathType: Prefix
       # tls:
       # - hosts:
       #     - objectstore.example.com


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

This PR just introduces `ingress.dashboard.host.pathType` in the Helm values, with the default value `Prefix`.

Interestingly, the default path given as `/ceph-dashboard(/|$)(.*)` does not work properly in nginx ingress.
> invalid paths: path /ceph-dashboard(/|$)(.*) cannot be used with pathType Prefix

This can be solved by setting the path type to `ImplementationSpecific`.

There is no side effect.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
