### PR TITLE
nfs: workaround broken nfs-ganesha config parser

### DIFF
--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -113,7 +113,7 @@ EXPORT_DEFAULTS {
 
 NFSv4 {
 	Delegations = false;
-	RecoveryBackend = 'rados_cluster';
+	RecoveryBackend = "rados_cluster";
 	Minor_Versions = 1, 2;
 }
 
@@ -128,7 +128,7 @@ RADOS_KV {
 RADOS_URLS {
 	ceph_conf = "` + cephclient.DefaultConfigFilePath() + `";
 	userid = ` + userID + `;
-	watch_url = '` + url + `';
+	watch_url = "` + url + `";
 }
 
 RGW {


### PR DESCRIPTION
NFS-Ganesha introduced a breaking change in its config parser that no longer accepts single quotes around values. This seems to be working for most Ceph release images, but this was seen in at least one dev build of Ceph.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
