### PR TITLE
helm: Fix hardcoded namespace in cephECBlockPool StorageClass

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephecblockpool.yaml
@@ -47,11 +47,11 @@ parameters:
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $root.Release.Namespace }} # namespace:cluster
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $root.Release.Namespace }} # namespace:cluster
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $root.Release.Namespace }} # namespace:cluster
   # Specify the filesystem type of the volume. If not specified, csi-provisioner
   # will set default as `ext4`.
   csi.storage.k8s.io/fstype: ext4


### PR DESCRIPTION
I have realised that there is hardcocded `rook-ceph` namespace in cephECBlockPool StorageClass template, so this chart is not working if cluster has been created in namespace different than `rook-ceph`. This change replaces hardcoded namespace with templated one.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
