### PR TITLE
helm: Fix deploy notes documentation link to CRDs

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/NOTES.txt
+++ b/deploy/charts/rook-ceph-cluster/templates/NOTES.txt
@@ -1,7 +1,7 @@
 The Ceph Cluster has been installed. Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get cephcluster
 
-Visit https://rook.io/docs/rook/latest/CRDs/ceph-cluster-crd/ for more information about the Ceph CRD.
+Visit https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/ for more information about the Ceph CRD.
 
 Important Notes:
 - You can only deploy a single cluster per namespace


### PR DESCRIPTION
corrects the link in the `rook-ceph-cluster` Helm chart notes to the correct CRD documentation

Signed-off-by: jcookin <56096898+jcookin@users.noreply.github.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
