### PR TITLE
CI: extract    'markdownlint' and 'golangci-lint' make targets from the ci workflows

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -207,6 +207,11 @@ All pull requests must pass all continuous integration (CI) tests before they ca
 automatically run against every pull request. The results of these tests along with code review feedback determine whether
 your request will be merged.
 
+For developers who would like to locally test their changes
+as much as possible before pushing
+(a behavior that is not required but highly encouraged),
+the unit tests and various linters can easily be run locally.
+
 ## Unit Tests
 
 From the root of your local Rook repo execute the following to run all of the unit tests:
@@ -242,6 +247,21 @@ Common cases that may need tests:
 * an input is not specified, for each input
 * an input is specified incorrectly, for each input
 * a resource the code relies on doesn't exist, for each dependency
+
+## Linting
+
+Run `make lint` to run all linters. This will require the following CLI tools to be installed on the system:
+
+* [yamllint](https://www.yamllint.com/)
+* [shellcheck](https://www.shellcheck.net/)
+* [pylint](https://www.pylint.org/)
+* [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
+
+Many of those tools are available via `brew` for MacOS or as Linux distribution packages.
+Otherwise refer to the respective project websites for installation instructions.
+
+!!! tip
+    Run `make help` to see a list of all possible make targets
 
 ## Integration Tests
 

--- a/Makefile
+++ b/Makefile
@@ -167,10 +167,10 @@ yamllint:
 
 .PHONY: golangci-lint
 golangci-lint:
-	@golangci-lint run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 
 .PHONY: lint
-lint: yamllint pylint shellcheck vet markdownlint ## Run various linters
+lint: yamllint pylint shellcheck vet markdownlint golangci-lint ## Run various linters
 
 .PHONY: pylint
 pylint:

--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,20 @@ fmt: ## Check formatting of go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.fmt
 
+.PHONY: markdownlint
+markdownlint: ## Check formatting of documentation sources
+	markdownlint-cli2 "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
+
 .PHONY: yamllint
 yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
 
+.PHONY: golangci-lint
+golangci-lint:
+	@golangci-lint run
+
 .PHONY: lint
-lint: yamllint pylint shellcheck vet ## Run various linters
+lint: yamllint pylint shellcheck vet markdownlint ## Run various linters
 
 .PHONY: pylint
 pylint:


### PR DESCRIPTION
**Description of changes:**

This PR extracts a `markdownlint` make target out of the docs-check github ci workflow

This is done so that developers can conveniently check syntactic correctness of the documentation  sources locally using  `make markdownlint`

Note that this is not a refactoring, i. e. the docs-check workflow is not changed and keeps using the markdownlint action.

Instead of being self-contained, he newly added `markdownlint` make target relies
on `markdownlint-cli2` being locally available in the `PATH`

This PR additionally extracts a `golangci-lint` make target from the corresponding CI workflow.

Finally, this PR extends the develoment guide to documents how to locally run linters



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
