### PR TITLE
object: allow overriding rgw config value from secret

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -390,6 +390,10 @@ spec:
       debug_rgw: "10" # int
       # debug-rgw: "20" # equivalent config keys can have dashes or underscores
       rgw_s3_auth_use_ldap: "true" # bool
+    rgwConfigFromSecret:
+      rgw_keystone_barbican_password: # name of rgw option with secret value
+        name: "barbican-secret" # name of K8s secret 
+        key: "password" # key of secret value in K8s secret.Data map[string]string
     rgwCommandFlags:
       rgw_dmclock_auth_res: "100.0" # float
       rgw_d4n_l1_datacache_persistent_path: /var/log/rook/rgwd4ncache # string
@@ -397,12 +401,13 @@ spec:
 ```
 
 * `rgwConfig` - These configurations are applied and modified at runtime, without RGW restart.
+* `rgwConfigFromSecret` - same as `rgwConfig` but config value is referenced from k8s secret.
 * `rgwCommandFlags` - These configurations are applied as CLI arguments and result in RGW daemons
     restarting when updates are applied. Restarts are desired behavior for some RGW configs.
 
 !!! note
-    Once an `rgwConfig` is set, it will not be removed from Ceph's central config store when removed
-    from the `rgwConfig` spec. Be sure to specifically set values back to their defaults once done.
+    Once an `rgwConfig` or `rgwConfigFromSecret` is set, it will not be removed from Ceph's central config store when removed
+    from the `rgwConfig` or `rgwConfigFromSecret` spec. Be sure to specifically set values back to their defaults once done.
     With this in mind, `rgwCommandFlags` may be a better choice for temporary config values like
     debug levels.
 
@@ -453,6 +458,34 @@ metadata:
 type: Opaque
 data:
     "bindpass.secret": aGVsbG8ud29ybGQK # hello.world
+```
+
+### Example - usage with `rgwConfigFromSecret`
+
+The sample configuration below demonstrates how to securely handle secret configuration parameters when setting up RGW for [Barbican integration](https://docs.ceph.com/en/reef/radosgw/config-ref/#barbican-settings).
+
+```yaml
+  # ...
+  gateway:
+    # ...
+    rgwConfig:
+      rgw_barbican_url: "http://barbican.example.com:9311"
+      rgw_keystone_barbican_domain: "domain"
+      rgw_keystone_barbican_project: "project" 
+      rgw_keystone_barbican_user: "user"
+    rgwConfigFromSecret:
+      rgw_keystone_barbican_password:
+        name: "barbican-secret"
+        key: "password"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: barbican-secret
+    namespace: rook-ceph
+type: Opaque
+data:
+    "password": aGVsbG8ud29ybGQK # hello.world
 ```
 
 ## Deleting a CephObjectStore

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -462,7 +462,7 @@ data:
 
 ### Example - usage with `rgwConfigFromSecret`
 
-The sample configuration below demonstrates how to securely handle secret configuration parameters when setting up RGW for [Barbican integration](https://docs.ceph.com/en/reef/radosgw/config-ref/#barbican-settings).
+The sample configuration below demonstrates how to securely handle secret configuration parameters when setting up RGW for [Barbican integration](https://docs.ceph.com/en/latest/radosgw/config-ref/#barbican-settings).
 
 ```yaml
   # ...
@@ -481,11 +481,11 @@ The sample configuration below demonstrates how to securely handle secret config
 apiVersion: v1
 kind: Secret
 metadata:
-    name: barbican-secret
-    namespace: rook-ceph
+  name: barbican-secret
+  namespace: rook-ceph
 type: Opaque
 data:
-    "password": aGVsbG8ud29ybGQK # hello.world
+  "password": aGVsbG8ud29ybGQK # hello.world
 ```
 
 ## Deleting a CephObjectStore

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7203,6 +7203,23 @@ applied. Use with caution.</p>
 </tr>
 <tr>
 <td>
+<code>rgwConfigFromSecret</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core">
+map[string]k8s.io/api/core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RgwConfigFromSecret works exactly like RgwConfig but takes config value from Secret Key reference.
+Values are modified at runtime without RGW restart.
+This feature is intended for advanced users. It allows breaking configurations to be easily
+applied. Use with caution.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>rgwCommandFlags</code><br/>
 <em>
 map[string]string

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11953,6 +11953,36 @@ spec:
                         applied. Use with caution.
                       nullable: true
                       type: object
+                    rgwConfigFromSecret:
+                      additionalProperties:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      description: |-
+                        RgwConfigFromSecret works exactly like RgwConfig but takes config value from Secret Key reference.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
                     securePort:
                       description: The port the rgw service will be listening on (https)
                       format: int32

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11944,6 +11944,36 @@ spec:
                         applied. Use with caution.
                       nullable: true
                       type: object
+                    rgwConfigFromSecret:
+                      additionalProperties:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      description: |-
+                        RgwConfigFromSecret works exactly like RgwConfig but takes config value from Secret Key reference.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
                     securePort:
                       description: The port the rgw service will be listening on (https)
                       format: int32

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1748,6 +1748,14 @@ type GatewaySpec struct {
 	// +optional
 	RgwConfig map[string]string `json:"rgwConfig,omitempty"`
 
+	// RgwConfigFromSecret works exactly like RgwConfig but takes config value from Secret Key reference.
+	// Values are modified at runtime without RGW restart.
+	// This feature is intended for advanced users. It allows breaking configurations to be easily
+	// applied. Use with caution.
+	// +nullable
+	// +optional
+	RgwConfigFromSecret map[string]v1.SecretKeySelector `json:"rgwConfigFromSecret,omitempty"`
+
 	// RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
 	// store. Values are modified at RGW startup, resulting in RGW pod restarts.
 	// This feature is intended for advanced users. It allows breaking configurations to be easily

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2743,6 +2743,13 @@ func (in *GatewaySpec) DeepCopyInto(out *GatewaySpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.RgwConfigFromSecret != nil {
+		in, out := &in.RgwConfigFromSecret, &out.RgwConfigFromSecret
+		*out = make(map[string]corev1.SecretKeySelector, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
+	}
 	if in.RgwCommandFlags != nil {
 		in, out := &in.RgwCommandFlags, &out.RgwCommandFlags
 		*out = make(map[string]string, len(*in))

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -27,6 +27,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -215,10 +216,37 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 	for flag, val := range c.store.Spec.Gateway.RgwConfig {
 		if currVal, ok := configOptions[flag]; ok {
 			// RGW might break with some user-specified config overrides; log clearly to help triage
-			logger.Infof("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfig %q",
+			logger.Infof("overriding object store %q RGW config option %q with user-specified rgwConfig",
+				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag)
+			logger.Debugf("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfig %q",
 				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, currVal, val)
 		}
 		configOptions[flag] = val
+	}
+
+	for flag, val := range c.store.Spec.Gateway.RgwConfigFromSecret {
+		if val.Key == "" || val.Name == "" {
+			logger.Warningf("invalid object store %q rgwConfigFromSecret value %q=%+v", fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, val)
+			continue
+		}
+		secret, err := c.context.Clientset.CoreV1().Secrets(c.clusterInfo.Namespace).Get(c.clusterInfo.Context, val.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to lookup secret for object store %q rgwConfigFromSecret %q=%+v", fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, val)
+		}
+		secretVal, ok := secret.Data[val.Key]
+		if !ok {
+			return nil, fmt.Errorf("unable to lookup secret for object store %q rgwConfigFromSecret %q: key %q not found in secret %q",
+				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, val.Key, val.Name)
+		}
+
+		if currVal, ok := configOptions[flag]; ok {
+			// RGW might break with some user-specified config overrides; log clearly to help triage
+			logger.Infof("overriding object store %q RGW config option %q with user-specified rgwConfigFromSecret",
+				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag)
+			logger.Debugf("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfigFromSecret %q",
+				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, currVal, secretVal)
+		}
+		configOptions[flag] = string(secretVal)
 	}
 
 	return configOptions, nil

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -218,7 +218,7 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 			// RGW might break with some user-specified config overrides; log clearly to help triage
 			logger.Infof("overriding object store %q RGW config option %q with user-specified rgwConfig",
 				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag)
-			logger.Debugf("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfig %q",
+			logger.Tracef("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfig %q",
 				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, currVal, val)
 		}
 		configOptions[flag] = val
@@ -226,8 +226,7 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 
 	for flag, val := range c.store.Spec.Gateway.RgwConfigFromSecret {
 		if val.Key == "" || val.Name == "" {
-			logger.Warningf("invalid object store %q rgwConfigFromSecret value %q=%+v", fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, val)
-			continue
+			return nil, fmt.Errorf("invalid object store %q rgwConfigFromSecret value %q=%+v", fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, val)
 		}
 		secret, err := c.context.Clientset.CoreV1().Secrets(c.clusterInfo.Namespace).Get(c.clusterInfo.Context, val.Name, metav1.GetOptions{})
 		if err != nil {
@@ -243,7 +242,7 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 			// RGW might break with some user-specified config overrides; log clearly to help triage
 			logger.Infof("overriding object store %q RGW config option %q with user-specified rgwConfigFromSecret",
 				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag)
-			logger.Debugf("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfigFromSecret %q",
+			logger.Tracef("overriding object store %q RGW config option %q (current value %q) with user-specified rgwConfigFromSecret %q",
 				fmt.Sprintf("%s/%s", c.store.Namespace, c.store.Name), flag, currVal, secretVal)
 		}
 		configOptions[flag] = string(secretVal)


### PR DESCRIPTION
Implements #15422
Extends existing ObjectStore configuration options with rgwConfigFromSecret allowing to refer config value from kubernetes secret.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
