### PR TITLE
doc: add obc allow list to pending release notes

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,5 +2,14 @@
 
 ## Breaking Changes
 
+Object:
+
+- Some ObjectBucketClaim options were added in Rook v1.16 that allowed more control over buckets.
+    These controls allow users to self-serve their own S3 policies, which many administrators might
+    consider a risk, depending on their environment. Rook has taken steps to ensure potentially risky
+    configurations are disabled by default to ensure the safest off-the-shelf configurations.
+    Administrators who wish to allow users to use the full range of OBC configurations must use the
+    new `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` to enable users to set potentially risky options.
+    See https://github.com/rook/rook/pull/15376 for more information.
 
 ## Features


### PR DESCRIPTION
Add a note about the upcoming potentially-breaking change to OBCs to the v1.17 release notes. This covers usage of
`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` for OBC fields that some admins might not want exposed to users.

Follow-up from https://github.com/rook/rook/pull/15376#issuecomment-2669522301

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
