### PR TITLE
helm: quote object store ingress hostname

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.dashboard.host.name }}
+    - host: {{ .Values.ingress.dashboard.host.name | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.dashboard.host.path | default "/" }}


### PR DESCRIPTION
If you are deploying a Ceph Object Storage Gateway and want to make use of subdomain-style routing instead of path routing, then the hostname must start with a wildcard. Unfortunately, when this happens, you end up with something like `host: *.blah` which is then parsed like a YAML pointer. Quoting the hostname fixes the issue.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
