### PR TITLE
mgr: Wait for builtin mgr pool to exist before enabling stretch

### DIFF
--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -46,7 +46,11 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 	var cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
 		"MDS_ALL_DOWN": {
 			Severity: "HEALTH_ERR",
-			Message:  "MDS_ALL_DOWN",
+			Message:  "mds all down error",
+		},
+		"MGR_MODULE_ERROR": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
 		},
 		"TEST_OTHER": {
 			Severity: "HEALTH_WARN",
@@ -58,6 +62,22 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 		},
 	})
 	assert.True(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MGR_MODULE_ERROR": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
+		},
+	})
+	assert.True(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MGR_MODULE_ERROR_FALSE": {
+			Severity: "HEALTH_ERR",
+			Message:  "mgr module error",
+		},
+	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
 
 	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
 		"MDS_ALL_DOWN": {
@@ -77,6 +97,10 @@ func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
 			Message:  "TEST_UNIGNORABLE",
 		},
 	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	// The empty status should return false
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{})
 	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
 }
 

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -254,6 +254,7 @@ func TestCephFilesystemController(t *testing.T) {
 			recorder:         record.NewFakeRecorder(5),
 			scheme:           s,
 			context:          c,
+			fsContexts:       make(map[string]*fsHealth),
 			opManagerContext: context.TODO(),
 		}
 		res, err := r.Reconcile(ctx, req)


### PR DESCRIPTION
There is a race condition in ceph v19 at startup of a stretch cluster where if the .mgr pool is created by the mgr pod after stretch mode is entered, the devicehealth mgr module will crash and cause a ceph HEALTH_ERR. The error then causes rook reconcile of all CRs to be skipped because Rook is assuming admin intervention is needed to continue. The fix is to wait until the .mgr pool is created by the mgr pod before entering stretch mode.

After the [ceph fix](https://github.com/ceph/ceph/pull/61371) is merged, we can consider reverting this workaround. 

At the same time, we suppress mgr module health errors during reconcile.  Some ceph health errors should not block the reconcile of the cluster. Mgr modules do not have cause to block the reconcile, as the cluster can usually work even if a module is failing.
   
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
