### PR TITLE
docs: unsupported kubectl exec params

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -24,7 +24,7 @@ ceph osd utilization
 ```
 
 ```console
-kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') bash
+kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') -- bash
 ```
 
 ## Add an OSD

--- a/Documentation/Troubleshooting/ceph-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-common-issues.md
@@ -99,7 +99,7 @@ After you verify the basic health of the running pods, next you will want to run
 The [rook-ceph-tools pod](ceph-toolbox.md) provides a simple environment to run Ceph tools. Once the pod is up and running, connect to the pod to execute Ceph commands to evaluate that current state of the cluster.
 
 ```console
-kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[*].metadata.name}') bash
+kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[*].metadata.name}') -- bash
 ```
 
 #### Ceph Commands

--- a/Documentation/Troubleshooting/direct-tools.md
+++ b/Documentation/Troubleshooting/direct-tools.md
@@ -19,7 +19,7 @@ After the pod is started, connect to it like this:
 
 ```console
 kubectl -n rook-ceph get pod -l app=rook-direct-mount
-$ kubectl -n rook-ceph exec -it <pod> bash
+$ kubectl -n rook-ceph exec -it <pod> -- bash
 ```
 
 ## Block Storage Tools


### PR DESCRIPTION
Unsupported `kubectl exec <pod> <command>`. Switched to `<pod> -- <command>`

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
