### PR TITLE
rgw: ensure listening on pod ip instead of 0.0.0.0

### DIFF
--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -69,17 +69,17 @@ func (c *clusterConfig) portString() string {
 		if !c.store.Spec.IsHostNetwork(c.clusterSpec) {
 			port = rgwPortInternalPort
 		}
-		portString = fmt.Sprintf("port=%s", strconv.Itoa(int(port)))
+		portString = fmt.Sprintf("endpoint=$(POD_IP):%s", strconv.Itoa(int(port)))
 	}
 	if c.store.Spec.IsTLSEnabled() {
 		certPath := path.Join(certDir, certFilename)
 		// This is the beast backend
 		// Config is: http://docs.ceph.com/docs/master/radosgw/frontends/#id3
 		if port != 0 {
-			portString = fmt.Sprintf("%s ssl_port=%d ssl_certificate=%s",
+			portString = fmt.Sprintf("%s ssl_endpoint=$(POD_IP):%d ssl_certificate=%s",
 				portString, c.store.Spec.Gateway.SecurePort, certPath)
 		} else {
-			portString = fmt.Sprintf("ssl_port=%d ssl_certificate=%s",
+			portString = fmt.Sprintf("ssl_endpoint=$(POD_IP):%d ssl_certificate=%s",
 				c.store.Spec.Gateway.SecurePort, certPath)
 		}
 		secretType, _ := c.rgwTLSSecretType(c.store.Spec.Gateway.SSLCertificateRef)

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -62,14 +62,14 @@ func TestPortString(t *testing.T) {
 	cfg.clusterSpec.Network.HostNetwork = true
 	cfg.store.Spec.Gateway.Port = 80
 	result = cfg.portString()
-	assert.Equal(t, "port=80", result)
+	assert.Equal(t, "endpoint=$(POD_IP):80", result)
 
 	// Secure port on beast
 	cfg = newConfig(t)
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
 	result = cfg.portString()
-	assert.Equal(t, "ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+	assert.Equal(t, "ssl_endpoint=$(POD_IP):443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
 	// Both ports on beast
 	cfg = newConfig(t)
@@ -79,7 +79,7 @@ func TestPortString(t *testing.T) {
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
 	result = cfg.portString()
-	assert.Equal(t, "port=80 ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+	assert.Equal(t, "endpoint=$(POD_IP):80 ssl_endpoint=$(POD_IP):443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
 	// Secure port requires the cert on beast
 	cfg = newConfig(t)
@@ -91,7 +91,7 @@ func TestPortString(t *testing.T) {
 	cfg = newConfig(t)
 	cfg.store.Spec.Gateway.Port = 80
 	result = cfg.portString()
-	assert.Equal(t, "port=8080", result)
+	assert.Equal(t, "endpoint=$(POD_IP):8080", result)
 }
 
 func TestGenerateCephXUser(t *testing.T) {

--- a/pkg/operator/ceph/object/rgw-probe.sh
+++ b/pkg/operator/ceph/object/rgw-probe.sh
@@ -4,6 +4,7 @@ PROBE_TYPE="{{ .ProbeType }}"
 PROBE_PORT="{{ .Port }}"
 PROBE_PROTOCOL="{{ .Protocol }}"
 PROBE_PATH="{{ .Path }}"
+PROBE_HOST="{{ .Host }}"
 
 # standard bash codes start at 126 and progress upward. pick error codes from 125 downward for
 # script as to allow curl to output new error codes and still return a distinctive number.
@@ -14,7 +15,7 @@ PROBE_ERR_CODE=124
 STARTUP_TYPE='startup'
 READINESS_TYPE='readiness'
 
-RGW_URL="$PROBE_PROTOCOL://0.0.0.0:$PROBE_PORT$PROBE_PATH"
+RGW_URL="$PROBE_PROTOCOL://$PROBE_HOST:$PROBE_PORT$PROBE_PATH"
 
 function check() {
   local URL="$1"


### PR DESCRIPTION
Ensures RGW listens only on the host IP, reducing unnecessary network exposure.

The change updates RGW command-line flags and sets the pod’s IP as an environment variable.

Adresses https://github.com/rook/rook/issues/15240

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
