### PR TITLE
mon: manage endpoints containing set of mon ip addresses

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,3 +15,4 @@ Object:
 ## Features
 
 - Support external mons for local Rook cluster (see [#14733](https://github.com/rook/rook/issues/14733)).
+- Manage EndpointSlice resources containing monitor IPs to support DNS-based resolution for Ceph clients (see [#14986](https://github.com/rook/rook/issues/14986)).

--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -99,6 +99,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - "discovery.k8s.io"
   resources:
   # Rook creates events for its custom resources
   - events
@@ -108,6 +109,7 @@ rules:
   # Rook creates endpoints for mgr and object store access
   - endpoints
   - services
+  - endpointslices
   verbs:
   - get
   - list

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -294,6 +294,7 @@ rules:
       - watch
   - apiGroups:
       - ""
+      - "discovery.k8s.io"
     resources:
       # Rook creates events for its custom resources
       - events
@@ -303,6 +304,7 @@ rules:
       # Rook creates endpoints for mgr and object store access
       - endpoints
       - services
+      - endpointslices
     verbs:
       - get
       - list

--- a/deploy/examples/headless-mon-service.yaml
+++ b/deploy/examples/headless-mon-service.yaml
@@ -1,0 +1,9 @@
+# Create a headless service which will effectively referenced by the EndpointSlice resources
+# of the same name which is created automatically by Rook
+apiVersion: v1
+kind: Service
+metadata:
+  name: rook-ceph-active-mons
+  namespace: rook-ceph # namespace:cluster
+spec:
+  clusterIP: None # headless service

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -231,7 +231,7 @@ func TestTrackMonsOutOfQuorum(t *testing.T) {
 	assert.NoError(t, err)
 
 	// initialize the configmap
-	err = c.persistExpectedMonDaemons()
+	err = c.persistExpectedMonDaemonsInConfigMap()
 	assert.NoError(t, err)
 
 	// Track mon.a as out of quorum

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -44,9 +44,9 @@ func (c *Cluster) createService(mon *monConfig) (*v1.Service, error) {
 
 	// If the mon port was not msgr2, add the msgr1 port
 	if mon.Port != DefaultMsgr2Port {
-		addServicePort(svcDef, "tcp-msgr1", mon.Port)
+		addServicePort(svcDef, DefaultMsgr1PortName, mon.Port)
 	}
-	addServicePort(svcDef, "tcp-msgr2", DefaultMsgr2Port)
+	addServicePort(svcDef, DefaultMsgr2PortName, DefaultMsgr2Port)
 
 	// Set the ClusterIP if the service does not exist and we expect a certain cluster IP
 	// For example, in disaster recovery the service might have been deleted accidentally, but we have the

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -313,7 +313,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 		SecurityContext: controller.PodSecurityContext(),
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "tcp-msgr2",
+				Name:          DefaultMsgr2PortName,
 				ContainerPort: DefaultMsgr2Port,
 				Protocol:      corev1.ProtocolTCP,
 			},
@@ -350,7 +350,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 	} else {
 		// Add messenger 1 port
 		container.Ports = append(container.Ports, corev1.ContainerPort{
-			Name:          "tcp-msgr1",
+			Name:          DefaultMsgr1PortName,
 			ContainerPort: monConfig.Port,
 			Protocol:      corev1.ProtocolTCP,
 		})


### PR DESCRIPTION
The change creates and manages an Endpoints resource with the current Ceph monitor (mon) IPs, allowing clients to resolve mon IPs via DNS without relying on the rook-ceph-mon-endpoints ConfigMap.

Resolves: https://github.com/rook/rook/issues/14986

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
