### PR TITLE
core: run gofumpt on all files

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -40,7 +40,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: -E gosec -E gofmt --timeout=10m
+          args: -E gosec -E gofmt -E gofumpt --timeout=10m
 
           # actions/setup-go already handles caching
           skip-cache: true

--- a/cmd/rook/ceph/config.go
+++ b/cmd/rook/ceph/config.go
@@ -82,7 +82,7 @@ mon_host = ` + monHost + `
 keyring = ` + keyring + `
 `
 
-	var fileMode os.FileMode = 0444 // read-only
+	var fileMode os.FileMode = 0o444 // read-only
 	err := os.WriteFile(cephclient.DefaultConfigFilePath(), []byte(cfg), fileMode)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to write config file"))

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -44,18 +44,22 @@ var osdCmd = &cobra.Command{
 	Use:   "osd",
 	Short: "Provisions and runs the osd daemon",
 }
+
 var osdConfigCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Updates ceph.conf for the osd",
 }
+
 var provisionCmd = &cobra.Command{
 	Use:   "provision",
 	Short: "Generates osd config and prepares an osd for runtime",
 }
+
 var osdStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts the osd daemon", // OSDs that were provisioned by ceph-volume
 }
+
 var osdRemoveCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Removes a set of OSDs from the cluster",
@@ -199,7 +203,6 @@ func writeOSDConfig(cmd *cobra.Command, args []string) error {
 
 // Provision a device or directory for an OSD
 func prepareOSD(cmd *cobra.Command, args []string) error {
-
 	if err := verifyConfigFlags(provisionCmd); err != nil {
 		return err
 	}

--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -200,7 +200,7 @@ func TestReadSecretFile(t *testing.T) {
 
 	// Write a test keyring
 	testSecret := "testkeyring"
-	err = os.WriteFile(path.Name(), []byte(testSecret), 0600)
+	err = os.WriteFile(path.Name(), []byte(testSecret), 0o600)
 	assert.NoError(t, err)
 
 	// Read the secret from the file

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -97,7 +97,7 @@ func init() {
 		zap.Encoder(logfmtEncoder))
 	log.SetLogger(logger)
 	// To disable controller runtime logging, instead set the null logger:
-	//log.SetLogger(logr.New(log.NullLogSink{}))
+	// log.SetLogger(logr.New(log.NullLogSink{}))
 }
 
 // SetLogLevel set log level based on provided log option.
@@ -107,7 +107,6 @@ func SetLogLevel() {
 
 // LogStartupInfo log the version number, arguments, and all final flag values (environment variable overrides have already been taken into account)
 func LogStartupInfo(cmdFlags *pflag.FlagSet) {
-
 	flagValues := flags.GetFlagsAndValues(cmdFlags, "secret|keyring")
 	logger.Infof("starting Rook %s with arguments '%s'", version.Version, strings.Join(os.Args, " "))
 	logger.Infof("flag values: %s", strings.Join(flagValues, ", "))
@@ -187,7 +186,7 @@ func TerminateOnError(err error, msg string) {
 // TerminateFatal terminates the process with an exit code of 1
 // and writes the given reason to stderr and the termination log file.
 func TerminateFatal(reason error) {
-	file, err := os.OpenFile(terminationLog, os.O_APPEND|os.O_WRONLY, 0600)
+	file, err := os.OpenFile(terminationLog, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("failed to write message to termination log: %v", err))
 	} else {

--- a/cmd/rook/secret.go
+++ b/cmd/rook/secret.go
@@ -115,7 +115,7 @@ func getSecret(cmd *cobra.Command, args []string) {
 	}
 
 	// Write down the secret to a file
-	err = os.WriteFile(secretPath, []byte(s), 0400)
+	err = os.WriteFile(secretPath, []byte(s), 0o400)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to write secret %q file to %q", secretName, secretPath))
 	}

--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -277,6 +277,7 @@ func (t *timeoutMinutes) Set(v string) error {
 	*t = timeoutMinutes(time.Duration(i) * time.Minute)
 	return nil
 }
+
 func (t timeoutMinutes) Type() string {
 	return "timeoutMinutes"
 }
@@ -295,6 +296,7 @@ func (t *timeoutSeconds) Set(v string) error {
 	*t = timeoutSeconds(time.Duration(i) * time.Second)
 	return nil
 }
+
 func (t timeoutSeconds) Type() string {
 	return "timeoutSeconds"
 }

--- a/pkg/apis/ceph.rook.io/v1/labels_test.go
+++ b/pkg/apis/ceph.rook.io/v1/labels_test.go
@@ -105,6 +105,7 @@ mon:
 	}
 	assert.Equal(t, expected, Labels)
 }
+
 func TestLabelsApply(t *testing.T) {
 	tcs := []struct {
 		name     string
@@ -262,26 +263,36 @@ func TestToValidDNSLabel(t *testing.T) {
 		{"single : symbol", ":", ""},
 		{"single . symbol", ".", ""},
 		{"bunch of symbols", "`~!@#$%^&*()_+-={}[]\\|;':\",.<>/?", ""},
-		{"alphabet with symbols",
-			"a~b!c@d#e$f^g&h*i(j)k_l-m+n+o[p]q{r}s|t:u;v'w<x,y>z", "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z"},
+		{
+			"alphabet with symbols",
+			"a~b!c@d#e$f^g&h*i(j)k_l-m+n+o[p]q{r}s|t:u;v'w<x,y>z", "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z",
+		},
 		{"multiple symbols between letters", "a//b//c", "a-b-c"},
 		{"symbol before", "/a/b/c", "a-b-c"},
 		{"symbol after", "a/b/c/", "a-b-c"},
 		{"symbols before and after", "/a/b/c/", "a-b-c"},
 		{"multiple symbols before after between", "//a//b//c//", "a-b-c"},
 		{"mix of all tests except length", "//1a//B-c/d_f/../00-thing.ini/", "d1a-b-c-d-f-00-thing-ini"},
-		{"too long input -> middle trim",
+		{
+			"too long input -> middle trim",
 			"qwertyuiopqwertyuiopqwertyuiopaaqwertyuiopqwertyuiopqwertyuiopaa",
-			"qwertyuiopqwertyuiopqwertyuiop--wertyuiopqwertyuiopqwertyuiopaa"},
-		{"too long input but symbols allow for no middle trim",
+			"qwertyuiopqwertyuiopqwertyuiop--wertyuiopqwertyuiopqwertyuiopaa",
+		},
+		{
+			"too long input but symbols allow for no middle trim",
 			"/qwertyuiopqwerty/uiopqwertyuiop//qwertyuiopqwerty/uiopqwertyuiop/",
-			"qwertyuiopqwerty-uiopqwertyuiop-qwertyuiopqwerty-uiopqwertyuiop"},
-		{"max allowed length but starts with number -> middle trim",
+			"qwertyuiopqwerty-uiopqwertyuiop-qwertyuiopqwerty-uiopqwertyuiop",
+		},
+		{
+			"max allowed length but starts with number -> middle trim",
 			"123qwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiop",
-			"d123qwertyuiopqwertyuiopqwerty--pqwertyuiopqwertyuiopqwertyuiop"},
-		{"max allowed length ok",
+			"d123qwertyuiopqwertyuiopqwerty--pqwertyuiopqwertyuiopqwertyuiop",
+		},
+		{
+			"max allowed length ok",
 			"qwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiop123",
-			"qwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiop123"},
+			"qwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiopqwertyuiop123",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -127,7 +127,6 @@ func TestNetworkCephIsHost(t *testing.T) {
 	assert.False(t, net.IsHost())
 	SetEnforceHostNetwork(true)
 	assert.True(t, net.IsHost())
-
 }
 
 func TestNetworkSpec(t *testing.T) {
@@ -175,7 +174,6 @@ func TestAddressRangesSpec_IsEmpty(t *testing.T) {
 	for _, spec := range nonEmptyTests {
 		assert.False(t, spec.IsEmpty())
 	}
-
 }
 
 func TestAddressRangesSpec_Validate(t *testing.T) {

--- a/pkg/apis/ceph.rook.io/v1/nfs_test.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs_test.go
@@ -45,12 +45,15 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 		{"security = nil", nil, isOkay},
 		{"security empty", &NFSSecuritySpec{}, isOkay},
 		{"security.sssd empty", withSSSD(&SSSDSpec{}), isFailing},
-		{"security.sssd.sidecar empty",
+		{
+			"security.sssd.sidecar empty",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{},
 			}),
-			isFailing},
-		{"security.sssd.sidecar fully specified",
+			isFailing,
+		},
+		{
+			"security.sssd.sidecar fully specified",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -59,8 +62,10 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isOkay},
-		{"security.sssd.sidecar missing image",
+			isOkay,
+		},
+		{
+			"security.sssd.sidecar missing image",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "",
@@ -69,16 +74,20 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isFailing},
-		{"security.sssd.sidecar.sssdConfigFile empty",
+			isFailing,
+		},
+		{
+			"security.sssd.sidecar.sssdConfigFile empty",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image:          "myimage",
 					SSSDConfigFile: SSSDSidecarConfigFile{},
 				},
 			}),
-			isOkay},
-		{"security.sssd.sidecar.sssdConfigFile.volumeSource empty",
+			isOkay,
+		},
+		{
+			"security.sssd.sidecar.sssdConfigFile.volumeSource empty",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -87,16 +96,20 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isFailing},
-		{"security.sssd.sidecar.additionalFiles empty",
+			isFailing,
+		},
+		{
+			"security.sssd.sidecar.additionalFiles empty",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image:           "myimage",
 					AdditionalFiles: AdditionalVolumeMounts{},
 				},
 			}),
-			isOkay},
-		{"security.sssd.sidecar.additionalFiles multiple valid",
+			isOkay,
+		},
+		{
+			"security.sssd.sidecar.additionalFiles multiple valid",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -107,8 +120,10 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isOkay},
-		{"security.sssd.sidecar.additionalFiles one empty subDir",
+			isOkay,
+		},
+		{
+			"security.sssd.sidecar.additionalFiles one empty subDir",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -119,8 +134,10 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isFailing},
-		{"security.sssd.sidecar.additionalFiles duplicate subDirs",
+			isFailing,
+		},
+		{
+			"security.sssd.sidecar.additionalFiles duplicate subDirs",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -131,8 +148,10 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isFailing},
-		{"security.sssd.sidecar.additionalFiles one vol source empty",
+			isFailing,
+		},
+		{
+			"security.sssd.sidecar.additionalFiles one vol source empty",
 			withSSSD(&SSSDSpec{
 				Sidecar: &SSSDSidecar{
 					Image: "myimage",
@@ -143,7 +162,8 @@ func TestNFSSecuritySpec_Validate(t *testing.T) {
 					},
 				},
 			}),
-			isFailing},
+			isFailing,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/ceph.rook.io/v1/object_test.go
+++ b/pkg/apis/ceph.rook.io/v1/object_test.go
@@ -128,6 +128,7 @@ func TestValidateObjectStoreSpec(t *testing.T) {
 		assert.ErrorContains(t, err, `"*.invalid.dns.name"`)
 	})
 }
+
 func TestIsTLSEnabled(t *testing.T) {
 	objStore := &CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/ceph.rook.io/v1/placement.go
+++ b/pkg/apis/ceph.rook.io/v1/placement.go
@@ -73,8 +73,7 @@ func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity) *v1.NodeAffi
 	// take the placement affinity node selectors without the need to merge
 	if len(p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		// take the placement from the first option since the second isn't specified
-		result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
-			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		return result
 	}
 

--- a/pkg/apis/ceph.rook.io/v1/security.go
+++ b/pkg/apis/ceph.rook.io/v1/security.go
@@ -24,9 +24,7 @@ import (
 	"github.com/libopenstorage/secrets/vault"
 )
 
-var (
-	VaultTLSConnectionDetails = []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey}
-)
+var VaultTLSConnectionDetails = []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey}
 
 // IsEnabled return whether a KMS is configured
 func (kms *KeyManagementServiceSpec) IsEnabled() bool {

--- a/pkg/apis/ceph.rook.io/v1/storage_test.go
+++ b/pkg/apis/ceph.rook.io/v1/storage_test.go
@@ -156,7 +156,8 @@ func TestUseAllDevices(t *testing.T) {
 
 	storageSpec = StorageScopeSpec{
 		Selection: Selection{
-			UseAllDevices: newBool(true)}, // UseAllDevices is set to true on the storage spec
+			UseAllDevices: newBool(true),
+		}, // UseAllDevices is set to true on the storage spec
 	}
 	assert.True(t, storageSpec.AnyUseAllDevices())
 
@@ -271,7 +272,8 @@ func TestStorageScopeSpec_NodeWithNameExists(t *testing.T) {
 	spec.Nodes = []Node{
 		{Name: "node0-hostname"},
 		{Name: "node1"},
-		{Name: "node2"}}
+		{Name: "node2"},
+	}
 	assert.True(t, spec.NodeWithNameExists("node0-hostname"))
 	assert.False(t, spec.NodeWithNameExists("node0"))
 	assert.True(t, spec.NodeWithNameExists("node1"))

--- a/pkg/apis/ceph.rook.io/v1/volume_test.go
+++ b/pkg/apis/ceph.rook.io/v1/volume_test.go
@@ -105,6 +105,6 @@ func setSomeData(v reflect.Value) {
 	case reflect.Bool:
 		v.SetBool(true)
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
-		v.SetInt(0755)
+		v.SetInt(0o755)
 	}
 }

--- a/pkg/daemon/ceph/cleanup/disk.go
+++ b/pkg/daemon/ceph/cleanup/disk.go
@@ -35,9 +35,7 @@ const (
 	shredBS      = "10M" // Shred's block size
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "cleanup")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cleanup")
 
 // DiskSanitizer is simple struct to old the context to execute the commands
 type DiskSanitizer struct {
@@ -170,7 +168,8 @@ func (s *DiskSanitizer) buildShredArgs(disk string) []string {
 		"--force",
 		"--verbose",
 		fmt.Sprintf("--iterations=%s", strconv.Itoa(int(s.sanitizeDisksSpec.Iteration))),
-		disk}...)
+		disk,
+	}...)
 
 	return shredArgs
 }

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -81,8 +81,10 @@ func FinalizeCephCommandArgs(command string, clusterInfo *ClusterInfo, args []st
 
 	// If the command should be run inside the toolbox pod, include the kubectl args to call the toolbox
 	if RunAllCephCommandsInToolboxPod != "" {
-		toolArgs := []string{"exec", "-i", RunAllCephCommandsInToolboxPod, "-n", clusterInfo.Namespace,
-			"--", "timeout", timeout, command}
+		toolArgs := []string{
+			"exec", "-i", RunAllCephCommandsInToolboxPod, "-n", clusterInfo.Namespace,
+			"--", "timeout", timeout, command,
+		}
 		return Kubectl, append(toolArgs, args...)
 	}
 

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -129,7 +129,6 @@ func TestNewRBDCommand(t *testing.T) {
 		output, err := cmd.Run()
 		assert.NoError(t, err)
 		assert.Equal(t, "success", string(output))
-
 	})
 	t.Run("rbd command with multus", func(t *testing.T) {
 		clusterInfo := AdminTestClusterInfo("rook")
@@ -158,7 +157,6 @@ func TestNewRBDCommand(t *testing.T) {
 		// This is not the best but it shows we go through the right codepath
 		assert.EqualError(t, err, "context canceled")
 	})
-
 }
 
 func TestNewGaneshaRadosGraceCommand(t *testing.T) {

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -108,9 +108,8 @@ func GenerateConnectionConfigWithSettings(context *clusterd.Context, clusterInfo
 
 // generateConfigFile generates and writes a config file to disk.
 func generateConfigFile(context *clusterd.Context, clusterInfo *ClusterInfo, pathRoot, keyringPath string, globalConfig *CephConfig, clientSettings map[string]string) (string, error) {
-
 	// create the config directory
-	if err := os.MkdirAll(pathRoot, 0744); err != nil {
+	if err := os.MkdirAll(pathRoot, 0o744); err != nil {
 		return "", errors.Wrapf(err, "failed to create config directory at %q", pathRoot)
 	}
 
@@ -177,7 +176,6 @@ func getQualifiedUser(user string) string {
 
 // CreateDefaultCephConfig creates a default ceph config file.
 func CreateDefaultCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) (*CephConfig, error) {
-
 	cephVersionEnv := os.Getenv("ROOK_CEPH_VERSION")
 	if cephVersionEnv != "" {
 		v, err := cephver.ExtractCephVersion(cephVersionEnv)
@@ -204,7 +202,6 @@ func CreateDefaultCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo
 
 // create a config file with global settings configured, and return an ini file
 func createGlobalConfigFileSection(context *clusterd.Context, clusterInfo *ClusterInfo, userConfig *CephConfig) (*ini.File, error) {
-
 	var ceph *CephConfig
 
 	if userConfig != nil {
@@ -290,7 +287,7 @@ func WriteCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) error 
 	if err != nil {
 		return errors.Wrap(err, "failed to copy connection config to /etc/ceph. failed to read the connection config")
 	}
-	err = os.WriteFile(DefaultConfigFilePath(), src, 0600)
+	err = os.WriteFile(DefaultConfigFilePath(), src, 0o600)
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy connection config to /etc/ceph. failed to write %q", DefaultConfigFilePath())
 	}

--- a/pkg/daemon/ceph/client/crash_test.go
+++ b/pkg/daemon/ceph/client/crash_test.go
@@ -25,8 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	fakecrash = `[
+var fakecrash = `[
     		{
 				"crash_id": "2020-11-09_13:58:08.230130Z_ca918f58-c078-444d-a91a-bd972c14c155",
 				"timestamp": "2020-11-09 13:58:08.230130Z",
@@ -34,7 +33,6 @@ var (
 				"entity_name": "osd.0"
 		    }
 	    ]`
-)
 
 func TestCephCrash(t *testing.T) {
 	executor := &exectest.MockExecutor{}

--- a/pkg/daemon/ceph/client/crush_rule.go
+++ b/pkg/daemon/ceph/client/crush_rule.go
@@ -57,9 +57,7 @@ rule %s {
 `
 )
 
-var (
-	stepEmit = &stepSpec{Operation: "emit"}
-)
+var stepEmit = &stepSpec{Operation: "emit"}
 
 func buildTwoStepPlainCrushRule(crushMap CrushMap, ruleName string, pool cephv1.PoolSpec) string {
 	var crushRuleInsert string

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -185,7 +185,6 @@ func AddDataPoolToFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo
 
 // SetNumMDSRanks sets the number of mds ranks (max_mds) for a Ceph filesystem.
 func SetNumMDSRanks(context *clusterd.Context, clusterInfo *ClusterInfo, fsName string, activeMDSCount int32) error {
-
 	// Always tell Ceph to set the new max_mds value
 	args := []string{"fs", "set", fsName, "max_mds", strconv.Itoa(int(activeMDSCount))}
 	if _, err := NewCephCommand(context, clusterInfo, args).Run(); err != nil {
@@ -372,7 +371,6 @@ func WaitForNoStandbys(context *clusterd.Context, clusterInfo *ClusterInfo, fsNa
 		}
 		return !filesystemHasStandby(mdsDump, fsName), nil
 	})
-
 	if err != nil {
 		return errors.Wrap(err, "timeout waiting for no standbys")
 	}

--- a/pkg/daemon/ceph/client/filesystem_mirror_test.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror_test.go
@@ -115,7 +115,6 @@ func TestCreateFSMirrorBootstrapPeer(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = base64.StdEncoding.DecodeString(string(token))
 	assert.NoError(t, err)
-
 }
 
 func TestRemoveFilesystemMirrorPeer(t *testing.T) {

--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -48,7 +48,8 @@ func TestFilesystemListMarshal(t *testing.T) {
 			MetadataPool:   "myfs1-metadata",
 			MetadataPoolID: 2,
 			DataPools:      []string{"myfs1-data"},
-			DataPoolIDs:    []int{1}},
+			DataPoolIDs:    []int{1},
+		},
 	}
 
 	assert.Equal(t, expectedFilesystems, filesystems)

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -18,11 +18,9 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"syscall"
-
-	"strconv"
-
 	"regexp"
+	"strconv"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -65,10 +63,10 @@ func ListImagesInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterI
 		return nil, errors.Wrapf(err, "failed to list images for pool %s", poolName)
 	}
 
-	//The regex expression captures the json result at the end buf
-	//When logLevel is DEBUG buf contains log statements of librados (see tests for examples)
-	//It can happen that the end of the "real" output doesn't not contain a new line
-	//that's why looking for the end isn't an option here (anymore?)
+	// The regex expression captures the json result at the end buf
+	// When logLevel is DEBUG buf contains log statements of librados (see tests for examples)
+	// It can happen that the end of the "real" output doesn't not contain a new line
+	// that's why looking for the end isn't an option here (anymore?)
 	res := regexp.MustCompile(`(?m)^\[(.*)\]`).FindStringSubmatch(string(buf))
 	if len(res) == 0 {
 		return []CephBlockImage{}, nil

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -17,10 +17,9 @@ package client
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
-
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -187,7 +186,6 @@ func TestListImageLogLevelInfo(t *testing.T) {
 				return `[]`, nil
 			} else {
 				return `[{"image":"image1","size":1048576,"format":2},{"image":"image2","size":2048576,"format":2},{"image":"image3","size":3048576,"format":2}]`, nil
-
 			}
 		}
 		return "", errors.Errorf("unexpected ceph command %q", args)

--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -88,10 +88,10 @@ func CreateKeyring(context *clusterd.Context, clusterInfo *ClusterInfo, username
 // TODO: Write keyring only to the default ceph config location since we are in a container
 func writeKeyring(keyring, keyringPath string) error {
 	// save the keyring to the given path
-	if err := os.MkdirAll(filepath.Dir(keyringPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(keyringPath), 0o700); err != nil {
 		return errors.Wrapf(err, "failed to create keyring directory for %s", keyringPath)
 	}
-	if err := os.WriteFile(keyringPath, []byte(keyring), 0600); err != nil {
+	if err := os.WriteFile(keyringPath, []byte(keyring), 0o600); err != nil {
 		return errors.Wrapf(err, "failed to write monitor keyring to %s", keyringPath)
 	}
 	return nil

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -25,9 +25,7 @@ import (
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 )
 
-var (
-	moduleEnableWaitTime = 5 * time.Second
-)
+var moduleEnableWaitTime = 5 * time.Second
 
 const (
 	readBalancerMode      = "read"

--- a/pkg/daemon/ceph/client/mgr_test.go
+++ b/pkg/daemon/ceph/client/mgr_test.go
@@ -49,7 +49,6 @@ func TestEnableModuleRetries(t *testing.T) {
 
 		moduleEnableRetries = moduleEnableRetries + 1
 		return "", errors.Errorf("unexpected ceph command %q", args)
-
 	}
 
 	clusterInfo := AdminTestClusterInfo("mycluster")

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -69,7 +69,7 @@ func ImportRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 	}
 
 	// Write token into a file
-	err = os.WriteFile(tokenFilePath.Name(), token, 0400)
+	err = os.WriteFile(tokenFilePath.Name(), token, 0o400)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write token to file %q", tokenFilePath.Name())
 	}

--- a/pkg/daemon/ceph/client/mirror_health.go
+++ b/pkg/daemon/ceph/client/mirror_health.go
@@ -28,9 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	defaultHealthCheckInterval = 1 * time.Minute
-)
+var defaultHealthCheckInterval = 1 * time.Minute
 
 type mirrorChecker struct {
 	context        *clusterd.Context
@@ -195,7 +193,8 @@ func updateRadosNamespaceStatusMirroring(c *mirrorChecker, mirrorStatus *cephv1.
 func toCustomResourceStatus(currentStatus *cephv1.MirroringStatusSpec, mirroringStatus *cephv1.MirroringStatusSummarySpec,
 	currentInfo *cephv1.MirroringInfoSpec, mirroringInfo *cephv1.MirroringInfo,
 	currentSnapSchedStatus *cephv1.SnapshotScheduleStatusSpec, snapSchedStatus []cephv1.SnapshotSchedulesSpec,
-	details string) (*cephv1.MirroringStatusSpec, *cephv1.MirroringInfoSpec, *cephv1.SnapshotScheduleStatusSpec) {
+	details string,
+) (*cephv1.MirroringStatusSpec, *cephv1.MirroringInfoSpec, *cephv1.SnapshotScheduleStatusSpec) {
 	mirroringStatusSpec := &cephv1.MirroringStatusSpec{}
 	mirroringInfoSpec := &cephv1.MirroringInfoSpec{}
 	snapshotScheduleStatusSpec := &cephv1.SnapshotScheduleStatusSpec{}

--- a/pkg/daemon/ceph/client/mirror_test.go
+++ b/pkg/daemon/ceph/client/mirror_test.go
@@ -58,6 +58,7 @@ func TestCreateRBDMirrorBootstrapPeer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bootstrapPeerToken, string(token))
 }
+
 func TestEnablePoolMirroring(t *testing.T) {
 	pool := cephv1.NamedPoolSpec{
 		Name: "pool-test",

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -149,19 +149,18 @@ type SafeToDestroyStatus struct {
 // OsdTree represents the CRUSH hierarchy
 type OsdTree struct {
 	Nodes []struct {
-		ID          int    `json:"id"`
-		Name        string `json:"name"`
-		Type        string `json:"type"`
-		TypeID      int    `json:"type_id"`
-		Children    []int  `json:"children,omitempty"`
-		PoolWeights struct {
-		} `json:"pool_weights,omitempty"`
-		CrushWeight     float64 `json:"crush_weight,omitempty"`
-		Depth           int     `json:"depth,omitempty"`
-		Exists          int     `json:"exists,omitempty"`
-		Status          string  `json:"status,omitempty"`
-		Reweight        float64 `json:"reweight,omitempty"`
-		PrimaryAffinity float64 `json:"primary_affinity,omitempty"`
+		ID              int      `json:"id"`
+		Name            string   `json:"name"`
+		Type            string   `json:"type"`
+		TypeID          int      `json:"type_id"`
+		Children        []int    `json:"children,omitempty"`
+		PoolWeights     struct{} `json:"pool_weights,omitempty"`
+		CrushWeight     float64  `json:"crush_weight,omitempty"`
+		Depth           int      `json:"depth,omitempty"`
+		Exists          int      `json:"exists,omitempty"`
+		Status          string   `json:"status,omitempty"`
+		Reweight        float64  `json:"reweight,omitempty"`
+		PrimaryAffinity float64  `json:"primary_affinity,omitempty"`
 	} `json:"nodes"`
 	Stray []struct {
 		ID              int     `json:"id"`

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -86,7 +86,6 @@ func TestHostTree(t *testing.T) {
 	tree, err = HostTree(&clusterd.Context{Executor: executor}, AdminTestClusterInfo("mycluster"))
 	assert.Error(t, err)
 	assert.Equal(t, 0, len(tree.Nodes))
-
 }
 
 func TestOsdListNum(t *testing.T) {

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -463,7 +463,6 @@ func createReplicatedPoolForApp(context *clusterd.Context, clusterInfo *ClusterI
 }
 
 func updatePoolCrushRule(context *clusterd.Context, clusterInfo *ClusterInfo, clusterSpec *cephv1.ClusterSpec, pool cephv1.NamedPoolSpec) error {
-
 	if !pool.EnableCrushUpdates {
 		logger.Debugf("Skipping crush rule update for pool %q: EnableCrushUpdates is disabled", pool.Name)
 		return nil
@@ -631,7 +630,6 @@ func createHybridCrushRule(context *clusterd.Context, clusterInfo *ClusterInfo, 
 }
 
 func updateCrushMap(context *clusterd.Context, clusterInfo *ClusterInfo, ruleset string) error {
-
 	// Fetch the compiled crush map
 	compiledCRUSHMapFilePath, err := GetCompiledCrushMap(context, clusterInfo)
 	if err != nil {
@@ -658,7 +656,7 @@ func updateCrushMap(context *clusterd.Context, clusterInfo *ClusterInfo, ruleset
 	}()
 
 	// Append plain rule to the decompiled crush map
-	f, err := os.OpenFile(filepath.Clean(decompiledCRUSHMapFilePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0400)
+	f, err := os.OpenFile(filepath.Clean(decompiledCRUSHMapFilePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o400)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open decompiled crush map %q", decompiledCRUSHMapFilePath)
 	}

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -147,7 +147,6 @@ func TestSetPoolApplication(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, setAppName)
 	})
-
 }
 
 func TestCreateReplicaPoolWithFailureDomain(t *testing.T) {

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -43,9 +43,7 @@ const (
 	defaultPgHealthyRegex    = `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`
 )
 
-var (
-	defaultPgHealthyRegexCompiled = regexp.MustCompile(defaultPgHealthyRegex)
-)
+var defaultPgHealthyRegexCompiled = regexp.MustCompile(defaultPgHealthyRegex)
 
 type CephStatus struct {
 	Health        HealthStatus `json:"health"`

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -28,10 +28,9 @@ const (
 	CephStatusResponseRaw = `{"fsid":"613975f3-3025-4802-9de1-a2280b950e75","health":{"checks":{"OSD_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 osds down"}},"OSD_HOST_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 host (1 osds) down"}},"PG_AVAILABILITY":{"severity":"HEALTH_WARN","summary":{"message":"Reduced data availability: 101 pgs stale"}},"POOL_APP_NOT_ENABLED":{"severity":"HEALTH_WARN","summary":{"message":"application not enabled on 1 pool(s)"}}},"status":"HEALTH_WARN","overall_status":"HEALTH_WARN"},"election_epoch":12,"quorum":[0,1,2],"quorum_names":["rook-ceph-mon0","rook-ceph-mon2","rook-ceph-mon1"],"monmap":{"epoch":3,"fsid":"613975f3-3025-4802-9de1-a2280b950e75","modified":"2017-08-11 20:13:02.075679","created":"2017-08-11 20:12:35.314510","features":{"persistent":["kraken","luminous"],"optional":[]},"mons":[{"rank":0,"name":"rook-ceph-mon0","addr":"10.3.0.45:6789/0","public_addr":"10.3.0.45:6789/0"},{"rank":1,"name":"rook-ceph-mon2","addr":"10.3.0.249:6789/0","public_addr":"10.3.0.249:6789/0"},{"rank":2,"name":"rook-ceph-mon1","addr":"10.3.0.252:6789/0","public_addr":"10.3.0.252:6789/0"}]},"osdmap":{"epoch":17,"num_osds":2,"num_up_osds":1,"num_in_osds":2,"full":false,"nearfull":true,"num_remapped_pgs":0},"pgmap":{"pgs_by_state":[{"state_name":"stale+active+clean","count":101},{"state_name":"active+clean","count":99}],"num_pgs":200,"num_pools":2,"num_objects":243,"data_bytes":976793635,"bytes_used":13611479040,"bytes_avail":19825307648,"bytes_total":33436786688},"fsmap":{"epoch":1,"by_rank":[]},"mgrmap":{"epoch":3,"active_gid":14111,"active_name":"rook-ceph-mgr0","active_addr":"10.2.73.6:6800/9","available":true,"standbys":[],"modules":["restful","status"],"available_modules":["dashboard","prometheus","restful","status","zabbix"]},"servicemap":{"epoch":1,"modified":"0.000000","services":{}}}`
 )
 
-var (
-	// this JSON was generated from `ceph status -f json`, using Ceph Nautilus 14.2.1
-	// It was chopped to only show what the tests are looking for
-	statusFakeRaw = []byte(`{
+// this JSON was generated from `ceph status -f json`, using Ceph Nautilus 14.2.1
+// It was chopped to only show what the tests are looking for
+var statusFakeRaw = []byte(`{
 		"fsmap": {
 		  "epoch": 13,
 		  "id": 1,
@@ -50,7 +49,6 @@ var (
 		  "up:standby": 1
 		}
 	  }`)
-)
 
 func TestStatusMarshal(t *testing.T) {
 	var status CephStatus

--- a/pkg/daemon/ceph/client/subvolumegroup_test.go
+++ b/pkg/daemon/ceph/client/subvolumegroup_test.go
@@ -26,49 +26,49 @@ import (
 func TestValidatePinningValues(t *testing.T) {
 	// set Distributed correctly
 	var testDistributedData cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testDistributedValue = 1
+	testDistributedValue := 1
 	testDistributedData.Distributed = &testDistributedValue
 	err := validatePinningValues(testDistributedData)
 	assert.NoError(t, err)
 
 	// set Distributed wrongly
 	var testDistributedData1 cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testDistributedValue1 = 5
+	testDistributedValue1 := 5
 	testDistributedData1.Distributed = &testDistributedValue1
 	err = validatePinningValues(testDistributedData1)
 	assert.Error(t, err)
 
 	// set Random correctly
 	var testRandomData cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testRandomdValue = 1.0
+	testRandomdValue := 1.0
 	testRandomData.Random = &testRandomdValue
 	err = validatePinningValues(testRandomData)
 	assert.NoError(t, err)
 
 	// set Random wrongly
 	var testRandomData1 cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testRandomdValue1 = 5.0
+	testRandomdValue1 := 5.0
 	testRandomData1.Random = &testRandomdValue1
 	err = validatePinningValues(testRandomData1)
 	assert.Error(t, err)
 
 	// set export correctly
 	var testExportData cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testExportValue = 1
+	testExportValue := 1
 	testExportData.Distributed = &testExportValue
 	err = validatePinningValues(testExportData)
 	assert.NoError(t, err)
 
 	// set export wrongly
 	var testExportData1 cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testExportValue1 = 500
+	testExportValue1 := 500
 	testExportData1.Distributed = &testExportValue1
 	err = validatePinningValues(testExportData1)
 	assert.Error(t, err)
 
 	// more than one set at a time, error
 	var testData cephv1.CephFilesystemSubVolumeGroupSpecPinning
-	var testValue = 1
+	testValue := 1
 	testData.Distributed = &testValue
 	testData.Export = &testValue
 	err = validatePinningValues(testData)

--- a/pkg/daemon/ceph/client/test/info.go
+++ b/pkg/daemon/ceph/client/test/info.go
@@ -27,13 +27,13 @@ import (
 )
 
 func CreateConfigDir(configDir string) error {
-	if err := os.MkdirAll(configDir, 0700); err != nil {
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
 		return errors.Wrap(err, "error while creating directory")
 	}
-	if err := os.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0600); err != nil {
+	if err := os.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0o600); err != nil {
 		return errors.Wrap(err, "admin writefile error")
 	}
-	if err := os.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0600); err != nil {
+	if err := os.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0o600); err != nil {
 		return errors.Wrap(err, "mon writefile error")
 	}
 	return nil

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -44,8 +44,8 @@ type OsdAgent struct {
 // NewAgent is the instantiation of the OSD agent
 func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice string, forceFormat bool,
 	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore,
-	replaceOSD *oposd.OSDInfo, pvcBacked bool) *OsdAgent {
-
+	replaceOSD *oposd.OSDInfo, pvcBacked bool,
+) *OsdAgent {
 	return &OsdAgent{
 		devices:        devices,
 		metadataDevice: metadataDevice,

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -44,16 +44,13 @@ const (
 	bluestoreSignature    = "bluestore block device"
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephosd")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephosd")
 
 // StartOSD starts an OSD on a device that was provisioned by ceph-volume
 func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string, pvcBackedOSD, lvBackedPV bool, cephArgs []string) error {
-
 	// ensure the config mount point exists
 	configDir := fmt.Sprintf("/var/lib/ceph/osd/ceph-%s", osdID)
-	err := os.Mkdir(configDir, 0750)
+	err := os.Mkdir(configDir, 0o750)
 	if err != nil {
 		logger.Errorf("failed to create config dir %q. %v", configDir, err)
 	}
@@ -119,7 +116,6 @@ func handleTerminate(context *clusterd.Context, lvPath, volumeGroupName string) 
 }
 
 func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
-
 	pid, err := context.Executor.ExecuteCommandWithOutput("fuser", "-a", lvPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to retrieve process ID for %q", lvPath)

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -349,7 +349,6 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 				} else if args[0] == "lvm" && args[1] == "list" {
 					return `{}`, nil
 				}
-
 			} else if command == "stdbuf" {
 				if args[4] == "raw" && args[5] == "list" {
 					return cephVolumeRAWTestResult, nil

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -40,9 +40,7 @@ const (
 	removeEncryptedDeviceCmdTimeOut = 30 * time.Second
 )
 
-var (
-	luksLabelCephFSID = regexp.MustCompile("ceph_fsid=(.*)")
-)
+var luksLabelCephFSID = regexp.MustCompile("ceph_fsid=(.*)")
 
 func CloseEncryptedDevice(context *clusterd.Context, dmName string) error {
 	args := []string{"--verbose", "luksClose", dmName}
@@ -326,5 +324,4 @@ func isCephEncryptedBlock(context *clusterd.Context, currentClusterFSID string, 
 	}
 
 	return true
-
 }

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -27,8 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	luksDump = `LUKS header information
+var luksDump = `LUKS header information
 Version:        2
 Epoch:          13
 Metadata area:  12288 bytes
@@ -67,7 +66,6 @@ Digests:
                     ef 90 8d 81 46 37 78 b4 82 37 3b 84 e8 e7 d8 1b
         Digest:     6d 86 96 05 99 4f a9 48 87 54
                     5c ef 4b 99 3b 9d fa 0b 8f 8a`
-)
 
 func TestCloseEncryptedDevice(t *testing.T) {
 	executor := &exectest.MockExecutor{}

--- a/pkg/daemon/ceph/osd/init.go
+++ b/pkg/daemon/ceph/osd/init.go
@@ -18,7 +18,6 @@ package osd
 
 import (
 	"fmt"
-
 	"path"
 
 	"github.com/rook/rook/pkg/clusterd"

--- a/pkg/daemon/ceph/osd/kms/azure.go
+++ b/pkg/daemon/ceph/osd/kms/azure.go
@@ -88,7 +88,7 @@ func azureKVCert(ctx context.Context, context *clusterd.Context, namespace strin
 		return nil, removeCertFiles, errors.Wrapf(err, "failed to generate temp file for k8s secret %q content", clientCertSecretName)
 	}
 
-	err = os.WriteFile(file.Name(), secret.Data["CLIENT_CERT"], 0400)
+	err = os.WriteFile(file.Name(), secret.Data["CLIENT_CERT"], 0o400)
 	if err != nil {
 		return nil, removeCertFiles, errors.Wrapf(err, "failed to write k8s secret %q content to a file", clientCertSecretName)
 	}

--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -28,9 +28,11 @@ import (
 
 func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 	t.Run("vault - no tls", func(t *testing.T) {
-		spec := cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
-			TokenSecretName:   "vault-token",
-			ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200"}}},
+		spec := cephv1.ClusterSpec{
+			Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
+				TokenSecretName:   "vault-token",
+				ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200"},
+			}},
 		}
 		envVars := ConfigToEnvVar(spec)
 		areEnvVarsSorted := sort.SliceIsSorted(envVars, func(i, j int) bool {
@@ -44,9 +46,11 @@ func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 		assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_BACKEND_PATH", Value: "secret/"})
 	})
 	t.Run("vault tls", func(t *testing.T) {
-		spec := cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
-			TokenSecretName:   "vault-token",
-			ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200", "VAULT_CACERT": "vault-ca-cert-secret"}}},
+		spec := cephv1.ClusterSpec{
+			Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
+				TokenSecretName:   "vault-token",
+				ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200", "VAULT_CACERT": "vault-ca-cert-secret"},
+			}},
 		}
 		envVars := ConfigToEnvVar(spec)
 		areEnvVarsSorted := sort.SliceIsSorted(envVars, func(i, j int) bool {
@@ -60,9 +64,11 @@ func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 		assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Key: "token"}}})
 	})
 	t.Run("ibm kp", func(t *testing.T) {
-		spec := cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
-			TokenSecretName:   "ibm-kp-token",
-			ConnectionDetails: map[string]string{"KMS_PROVIDER": TypeIBM, "IBM_KP_SERVICE_INSTANCE_ID": "1"}}},
+		spec := cephv1.ClusterSpec{
+			Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
+				TokenSecretName:   "ibm-kp-token",
+				ConnectionDetails: map[string]string{"KMS_PROVIDER": TypeIBM, "IBM_KP_SERVICE_INSTANCE_ID": "1"},
+			}},
 		}
 		envVars := ConfigToEnvVar(spec)
 		areEnvVarsSorted := sort.SliceIsSorted(envVars, func(i, j int) bool {

--- a/pkg/daemon/ceph/osd/kms/kms_test.go
+++ b/pkg/daemon/ceph/osd/kms/kms_test.go
@@ -55,8 +55,9 @@ func TestValidateConnectionDetails(t *testing.T) {
 			Name:      "kmip-token",
 			Namespace: ns,
 		},
-		Data: map[string][]byte{"CLIENT_CERT": []byte("bar"),
-			"CLIENT_KEY": []byte("bar"),
+		Data: map[string][]byte{
+			"CLIENT_CERT": []byte("bar"),
+			"CLIENT_KEY":  []byte("bar"),
 		},
 	}
 	tlsSecret := &v1.Secret{
@@ -176,7 +177,6 @@ func TestValidateConnectionDetails(t *testing.T) {
 		assert.Error(t, err, "")
 		assert.EqualError(t, err, "failed to validate kms configuration (missing token in spec)")
 		ibmKMSSpec.TokenSecretName = "ibm-token"
-
 	})
 
 	t.Run("ibm kp - token present but no key for service key", func(t *testing.T) {

--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -41,9 +41,7 @@ const (
 	VaultTransitSecretEngineKey = "transit"
 )
 
-var (
-	vaultMandatoryConnectionDetails = []string{api.EnvVaultAddress}
-)
+var vaultMandatoryConnectionDetails = []string{api.EnvVaultAddress}
 
 // Used for unit tests mocking too as well as production code
 var (
@@ -147,7 +145,7 @@ func configTLS(ctx context.Context, clusterdContext *clusterd.Context, namespace
 			}
 
 			// Write into a file
-			err = os.WriteFile(file.Name(), secret.Data[tlsSecretKeyToCheck(tlsOption)], 0400)
+			err = os.WriteFile(file.Name(), secret.Data[tlsSecretKeyToCheck(tlsOption)], 0o400)
 			if err != nil {
 				return nil, removeCertFiles, errors.Wrapf(err, "failed to write k8s secret %q content to a file", tlsSecretName)
 			}

--- a/pkg/daemon/ceph/osd/kms/volumes.go
+++ b/pkg/daemon/ceph/osd/kms/volumes.go
@@ -50,7 +50,7 @@ func VaultSecretVolumeAndMount(kmsVaultConfigFiles map[string]string, tokenSecre
 	// File mode, anybody can read, this is a must-have since the container runs as "rook" and the
 	// secret is mounted as root. There is no non-ugly way to change this behavior and it's
 	// probably as less safe as doing this mode.
-	mode := int32(0444)
+	mode := int32(0o444)
 
 	// Vault TLS Secrets
 	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
@@ -101,6 +101,7 @@ func VaultVolumeAndMountWithCustomName(kmsVaultConfigFiles map[string]string, to
 
 	return v, m
 }
+
 func tlsSecretPath(tlsOption string) string {
 	switch tlsOption {
 	case api.EnvVaultCACert:
@@ -116,7 +117,7 @@ func tlsSecretPath(tlsOption string) string {
 }
 
 func KMIPVolumeAndMount(tokenSecretName string) (v1.Volume, v1.VolumeMount) {
-	mode := int32(0444)
+	mode := int32(0o444)
 	v := v1.Volume{
 		Name: TypeKMIP,
 		VolumeSource: v1.VolumeSource{

--- a/pkg/daemon/ceph/osd/kms/volumes_test.go
+++ b/pkg/daemon/ceph/osd/kms/volumes_test.go
@@ -48,7 +48,7 @@ func Test_tlsSecretPath(t *testing.T) {
 }
 
 func TestVaultSecretVolumeAndMount(t *testing.T) {
-	m := int32(0444)
+	m := int32(0o444)
 	type args struct {
 		config          map[string]string
 		tokenSecretName string
@@ -59,8 +59,10 @@ func TestVaultSecretVolumeAndMount(t *testing.T) {
 		want []v1.VolumeProjection
 	}{
 		{"empty", args{config: map[string]string{"foo": "bar"}, tokenSecretName: ""}, []v1.VolumeProjection{}},
-		{"single ca", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: ""}, []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}}},
+		{
+			"single ca", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: ""}, []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
+			},
 		},
 		{"ca and client cert", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret", "VAULT_CLIENT_CERT": "vault-client-cert"}, tokenSecretName: ""}, []v1.VolumeProjection{
 			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
@@ -71,8 +73,10 @@ func TestVaultSecretVolumeAndMount(t *testing.T) {
 			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-client-cert"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.crt", Mode: &m}}, Optional: nil}},
 			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-client-key"}, Items: []v1.KeyToPath{{Key: "key", Path: "vault.key", Mode: &m}}, Optional: nil}},
 		}},
-		{"token file", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}}, []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}}},
+		{
+			"token file", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}}, []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}},
+			},
 		},
 		{"token and ca", args{tokenSecretName: "vault-token", config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}}, []v1.VolumeProjection{
 			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
@@ -100,7 +104,7 @@ func TestVaultSecretVolumeAndMount(t *testing.T) {
 }
 
 func TestVaultVolumeAndMountWithCustomName(t *testing.T) {
-	m := int32(0444)
+	m := int32(0o444)
 	type args struct {
 		config          map[string]string
 		tokenSecretName string
@@ -114,27 +118,39 @@ func TestVaultVolumeAndMountWithCustomName(t *testing.T) {
 	}{
 		{"empty without custom name", args{config: map[string]string{}, tokenSecretName: "", customName: ""}, v1.Volume{}, v1.VolumeMount{}},
 		{"no kms related configs without custom name", args{config: map[string]string{"foo": "bar"}, tokenSecretName: "", customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir}},
-		{"only cert passed without custom name", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: "", customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
+		{
+			"only cert passed without custom name", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: "", customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
 		},
-		{"only token passed without custom name", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}, customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
+		{
+			"only token passed without custom name", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}, customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
 		},
-		{"both token and cert passed without custom name", args{tokenSecretName: "vault-token", config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
+		{
+			"both token and cert passed without custom name", args{tokenSecretName: "vault-token", config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, customName: ""}, v1.Volume{Name: secrets.TypeVault, VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault, ReadOnly: true, MountPath: EtcVaultDir},
 		},
 		{"empty with custom name", args{config: map[string]string{}, tokenSecretName: "", customName: "custom"}, v1.Volume{}, v1.VolumeMount{}},
 		{"no kms related configs with custom name", args{config: map[string]string{"foo": "bar"}, tokenSecretName: "", customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")}},
-		{"only cert passed with custom name", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: "", customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
+		{
+			"only cert passed with custom name", args{config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, tokenSecretName: "", customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
 		},
-		{"only token passed with custom name", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}, customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
+		{
+			"only token passed with custom name", args{tokenSecretName: "vault-token", config: map[string]string{"foo": "bar"}, customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
 		},
-		{"both token and cert passed with custom name", args{tokenSecretName: "vault-token", config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
-			{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}}}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
+		{
+			"both token and cert passed with custom name", args{tokenSecretName: "vault-token", config: map[string]string{"VAULT_CACERT": "vault-ca-secret"}, customName: "custom"}, v1.Volume{Name: secrets.TypeVault + "custom", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-ca-secret"}, Items: []v1.KeyToPath{{Key: "cert", Path: "vault.ca", Mode: &m}}, Optional: nil}},
+				{Secret: &v1.SecretProjection{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Items: []v1.KeyToPath{{Key: "token", Path: "vault.token", Mode: &m}}, Optional: nil}},
+			}}}}, v1.VolumeMount{Name: secrets.TypeVault + "custom", ReadOnly: true, MountPath: path.Join(EtcVaultDir, "custom")},
 		},
 	}
 	for _, tt := range tests {
@@ -146,13 +162,12 @@ func TestVaultVolumeAndMountWithCustomName(t *testing.T) {
 			if !reflect.DeepEqual(gotVolMount, tt.wantVolMount) {
 				t.Errorf("VaultVolumeAndMountWithCustomName() = %v, want %v", gotVolMount, tt.wantVolMount)
 			}
-
 		})
 	}
 }
 
 func TestKMIPVolumeAndMount(t *testing.T) {
-	mode := int32(0444)
+	mode := int32(0o444)
 	tokenSecretName := "kmip-credentials"
 	type args struct {
 		tokenSecretName string
@@ -174,7 +189,6 @@ func TestKMIPVolumeAndMount(t *testing.T) {
 					Projected: &v1.ProjectedVolumeSource{
 						Sources: []v1.VolumeProjection{
 							{
-
 								Secret: &v1.SecretProjection{
 									LocalObjectReference: v1.LocalObjectReference{
 										Name: tokenSecretName,

--- a/pkg/daemon/ceph/osd/nsenter.go
+++ b/pkg/daemon/ceph/osd/nsenter.go
@@ -33,9 +33,7 @@ const (
 	rootFSPath = "/rootfs"
 )
 
-var (
-	binPathsToCheck = []string{"/usr/sbin", "/sbin/", "/run/current-system/sw/bin", "/run/current-system/sw/sbin"}
-)
+var binPathsToCheck = []string{"/usr/sbin", "/sbin/", "/run/current-system/sw/bin", "/run/current-system/sw/sbin"}
 
 // NSEnter is an nsenter object
 type NSEnter struct {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -229,7 +229,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 	// Create a specific log directory so that each prepare command will have its own log
 	// Only do this if nothing is present so that we don't override existing logs
 	cvLogDir = path.Join(cephLogDir, a.nodeName)
-	err := os.MkdirAll(cvLogDir, 0750)
+	err := os.MkdirAll(cvLogDir, 0o750)
 	if err != nil {
 		logger.Errorf("failed to create ceph-volume log directory %q, continue with default %q. %v", cvLogDir, cephLogDir, err)
 		baseArgs = []string{"-oL", cephVolumeCmd, "raw", "prepare", storeFlag}
@@ -258,7 +258,8 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 		// This will make the devices.Entries larger than usual
 		if _, ok := devices.Entries["metadata"]; ok {
 			metadataDev = true
-			metadataArg = append(metadataArg, []string{"--block.db",
+			metadataArg = append(metadataArg, []string{
+				"--block.db",
 				devices.Entries["metadata"].Config.Name,
 			}...)
 
@@ -267,7 +268,8 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 
 		if _, ok := devices.Entries["wal"]; ok {
 			walDev = true
-			walArg = append(walArg, []string{"--block.wal",
+			walArg = append(walArg, []string{
+				"--block.wal",
 				devices.Entries["wal"].Config.Name,
 			}...)
 
@@ -375,7 +377,6 @@ func getEncryptedBlockPath(op, blockType string) string {
 
 // UpdateLVMConfig updates the lvm.conf file
 func UpdateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
-
 	input, err := os.ReadFile(lvmConfPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read lvm config file %q", lvmConfPath)
@@ -405,7 +406,7 @@ func UpdateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
 		}
 	}
 
-	if err = os.WriteFile(lvmConfPath, output, 0600); err != nil {
+	if err = os.WriteFile(lvmConfPath, output, 0o600); err != nil {
 		return errors.Wrapf(err, "failed to update lvm config file %q", lvmConfPath)
 	}
 
@@ -585,7 +586,7 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *DeviceOsdMapping) error {
 	storeFlag := a.storeConfig.GetStoreFlag()
 	logPath := "/tmp/ceph-log"
-	if err := os.MkdirAll(logPath, 0700); err != nil {
+	if err := os.MkdirAll(logPath, 0o700); err != nil {
 		return errors.Wrapf(err, "failed to create dir %q", logPath)
 	}
 
@@ -1238,7 +1239,7 @@ func callCephVolume(context *clusterd.Context, args ...string) (string, error) {
 	// failure log later without also printing out past failures
 	// TODO: does this mess up expectations from the ceph log collector daemon?
 	logPath := "/tmp/ceph-log"
-	if err := os.MkdirAll(logPath, 0700); err != nil {
+	if err := os.MkdirAll(logPath, 0o700); err != nil {
 		return "", errors.Wrapf(err, "failed to create dir %q", logPath)
 	}
 	baseArgs := []string{"-oL", cephVolumeCmd, "--log-path", logPath}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1291,7 +1291,8 @@ func TestInitializeBlock(t *testing.T) {
 			nodeName:    "node1",
 			storeConfig: config.StoreConfig{StoreType: "bluestore"},
 		}
-		context := &clusterd.Context{Executor: executor,
+		context := &clusterd.Context{
+			Executor: executor,
 			Devices: []*sys.LocalDisk{
 				{
 					Name:     "sda",
@@ -1351,7 +1352,8 @@ func TestInitializeBlock(t *testing.T) {
 			nodeName:    "node1",
 			storeConfig: config.StoreConfig{StoreType: "bluestore"},
 		}
-		context := &clusterd.Context{Executor: executor,
+		context := &clusterd.Context{
+			Executor: executor,
 			Devices: []*sys.LocalDisk{
 				{
 					Name:     "sda",
@@ -1433,7 +1435,8 @@ func TestInitializeBlock(t *testing.T) {
 			nodeName:    "node1",
 			storeConfig: config.StoreConfig{StoreType: "bluestore"},
 		}
-		context := &clusterd.Context{Executor: executor,
+		context := &clusterd.Context{
+			Executor: executor,
 			Devices: []*sys.LocalDisk{
 				{
 					Name:     "sda",
@@ -1477,7 +1480,8 @@ func TestInitializeBlock(t *testing.T) {
 			nodeName:    "node1",
 			storeConfig: config.StoreConfig{StoreType: "bluestore"},
 		}
-		context := &clusterd.Context{Executor: executor,
+		context := &clusterd.Context{
+			Executor: executor,
 			Devices: []*sys.LocalDisk{
 				{
 					Name:     "sda",
@@ -1964,7 +1968,6 @@ func TestInitializeBlockWithMD(t *testing.T) {
 		err := a.initializeDevicesLVMMode(context, devices)
 		assert.NoError(t, err, "failed LV as metadataDevice test")
 	}
-
 }
 
 func TestAllowRawMode(t *testing.T) {
@@ -2114,5 +2117,4 @@ func TestLVMModeAllowed(t *testing.T) {
 	// encrypted part
 	storeConfig.EncryptedDevice = true
 	assert.False(t, lvmModeAllowed(device, storeConfig))
-
 }

--- a/pkg/daemon/multus/config.go
+++ b/pkg/daemon/multus/config.go
@@ -30,10 +30,8 @@ import (
 	metavalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
-var (
-	//go:embed config.yaml
-	ConfigYaml string
-)
+//go:embed config.yaml
+var ConfigYaml string
 
 var (
 	DefaultValidationNamespace = "rook-ceph"

--- a/pkg/daemon/multus/templates.go
+++ b/pkg/daemon/multus/templates.go
@@ -102,9 +102,11 @@ const (
 
 type daemonsetAppType string
 
-const imagePullDaemonSetAppType = "image pull"
-const hostCheckerDaemonsetAppType = "host checker"
-const clientDaemonSetAppType = "client"
+const (
+	imagePullDaemonSetAppType   = "image pull"
+	hostCheckerDaemonsetAppType = "host checker"
+	clientDaemonSetAppType      = "client"
+)
 
 func (vt *ValidationTest) generateWebServerTemplateConfig(placement PlacementConfig) webServerTemplateConfig {
 	return webServerTemplateConfig{

--- a/pkg/daemon/util/cmdreporter.go
+++ b/pkg/daemon/util/cmdreporter.go
@@ -49,9 +49,7 @@ const (
 	CmdReporterConfigMapRetcodeKey = "retcode"
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "job-reporter-cmd")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "job-reporter-cmd")
 
 // CmdReporter is a process intended to be run in simple Kubernetes jobs. The CmdReporter runs a
 // command in a job and stores the results in a ConfigMap which can be read by the operator.

--- a/pkg/daemon/util/cmdreporter_test.go
+++ b/pkg/daemon/util/cmdreporter_test.go
@@ -44,15 +44,20 @@ func TestCommandMarshallingUnmarshalling(t *testing.T) {
 	}{
 		{name: "one command only", args: args{cmd: []string{"one"}, args: []string{}}},
 		{name: "no command or args", args: args{
-			cmd: []string{}, args: []string{}}},
+			cmd: []string{}, args: []string{},
+		}},
 		{name: "no command w/ args", args: args{
-			cmd: []string{}, args: []string{"arg1", "arg2"}}},
+			cmd: []string{}, args: []string{"arg1", "arg2"},
+		}},
 		{name: "one command w/ args", args: args{
-			cmd: []string{"one"}, args: []string{"arg1", "arg2"}}},
+			cmd: []string{"one"}, args: []string{"arg1", "arg2"},
+		}},
 		{name: "multi command only", args: args{
-			cmd: []string{"one", "two", "three"}, args: []string{}}},
+			cmd: []string{"one", "two", "three"}, args: []string{},
+		}},
 		{name: "multi command and arg", args: args{
-			cmd: []string{"one", "two", "three"}, args: []string{"arg1", "arg2", "--", "arg3"}}},
+			cmd: []string{"one", "two", "three"}, args: []string{"arg1", "arg2", "--", "arg3"},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -71,7 +71,8 @@ func TestValidateClient(t *testing.T) {
 }
 
 func TestGenerateClient(t *testing.T) {
-	p := &cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Name: "client1", Namespace: "myns"},
+	p := &cephv1.CephClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client1", Namespace: "myns"},
 		Spec: cephv1.ClientSpec{
 			Caps: map[string]string{
 				"osd": "allow *",
@@ -90,7 +91,8 @@ func TestGenerateClient(t *testing.T) {
 	assert.True(t, strings.Contains(strings.Join(caps, " "), "mds allow rwx"))
 
 	// Fail if caps are empty
-	p2 := &cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Name: "client2", Namespace: "myns"},
+	p2 := &cephv1.CephClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client2", Namespace: "myns"},
 		Spec: cephv1.ClientSpec{
 			Caps: map[string]string{
 				"osd": "",

--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -39,10 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	// defaultStatusCheckInterval is the interval to check the status of the ceph cluster
-	defaultStatusCheckInterval = 60 * time.Second
-)
+// defaultStatusCheckInterval is the interval to check the status of the ceph cluster
+var defaultStatusCheckInterval = 60 * time.Second
 
 // cephStatusChecker aggregates the mon/cluster info needed to check the health of the monitors
 type cephStatusChecker struct {
@@ -342,7 +340,6 @@ func (c *cephStatusChecker) getRookPodsOnNode(node string) ([]v1.Pod, error) {
 				break
 			}
 		}
-
 	}
 	return podsOnNode, nil
 }

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	clusterCleanUpPolicyRetryInterval = 5 //seconds
+	clusterCleanUpPolicyRetryInterval = 5 // seconds
 	// CleanupAppName is the cluster clean up job name
 	CleanupAppName = "rook-ceph-cleanup"
 )

--- a/pkg/operator/ceph/cluster/cluster_external_test.go
+++ b/pkg/operator/ceph/cluster/cluster_external_test.go
@@ -42,5 +42,4 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err, err)
 	assert.Equal(t, uint16(9283), c.Spec.Monitoring.ExternalMgrPrometheusPort)
-
 }

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -302,9 +302,9 @@ func TestTelemetry(t *testing.T) {
 			telemetry.ExternalModeEnabledKey:     "false",
 			telemetry.K8sNodeCount:               "3",
 			telemetry.CephFSNodeCount:            "0",
-			telemetry.RBDNodeCount:               "1", //should be 1
+			telemetry.RBDNodeCount:               "1", // should be 1
 			telemetry.NFSNodeCount:               "0",
-			telemetry.CephNodeCount:              "1", //should be 1
+			telemetry.CephNodeCount:              "1", // should be 1
 		}
 		c.reportTelemetry()
 	})
@@ -335,6 +335,7 @@ func TestTelemetry(t *testing.T) {
 		c.reportTelemetry()
 	})
 }
+
 func TestClusterFullSettings(t *testing.T) {
 	actualFullRatio := 0.95
 	actualBackfillFullRatio := 0.90

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -494,20 +494,18 @@ func (c *ClusterController) checkPVPresentInCluster(drivers []string, clusterID 
 			continue
 		}
 		if p.Spec.CSI.VolumeAttributes["clusterID"] == clusterID {
-			//check PV is created by drivers deployed by rook
+			// check PV is created by drivers deployed by rook
 			for _, d := range drivers {
 				if d == p.Spec.CSI.Driver {
 					return true, nil
 				}
 			}
-
 		}
 	}
 	return false, nil
 }
 
 func (r *ReconcileCephCluster) removeFinalizers(client client.Client, clusterName types.NamespacedName) error {
-
 	// Remove finalizer for rook-ceph-mon secret
 	name := types.NamespacedName{Name: mon.AppName, Namespace: clusterName.Namespace}
 	err := r.removeFinalizer(client, name, &corev1.Secret{}, mon.DisasterProtectionFinalizerName)

--- a/pkg/operator/ceph/cluster/dependents.go
+++ b/pkg/operator/ceph/cluster/dependents.go
@@ -30,26 +30,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	// must use plural kinds
-	cephClusterDependentListKinds []string = []string{
-		"CephBlockPoolList",
-		"CephRBDMirrorList",
-		"CephFilesystemList",
-		"CephFilesystemMirrorList",
-		"CephObjectStoreList",
-		"CephObjectStoreUserList",
-		"CephObjectZoneList",
-		"CephObjectZoneGroupList",
-		"CephObjectRealmList",
-		"CephNFSList",
-		"CephClientList",
-		"CephBucketTopic",
-		"CephBucketNotification",
-		"CephFilesystemSubVolumeGroup",
-		"CephBlockPoolRadosNamespace",
-	}
-)
+// must use plural kinds
+var cephClusterDependentListKinds []string = []string{
+	"CephBlockPoolList",
+	"CephRBDMirrorList",
+	"CephFilesystemList",
+	"CephFilesystemMirrorList",
+	"CephObjectStoreList",
+	"CephObjectStoreUserList",
+	"CephObjectZoneList",
+	"CephObjectZoneGroupList",
+	"CephObjectRealmList",
+	"CephNFSList",
+	"CephClientList",
+	"CephBucketTopic",
+	"CephBucketNotification",
+	"CephFilesystemSubVolumeGroup",
+	"CephBlockPoolRadosNamespace",
+}
 
 // CephClusterDependents returns a DependentList of dependents of a CephCluster in the namespace.
 func CephClusterDependents(c *clusterd.Context, namespace string) (*dependents.DependentList, error) {

--- a/pkg/operator/ceph/cluster/dependents_test.go
+++ b/pkg/operator/ceph/cluster/dependents_test.go
@@ -232,9 +232,11 @@ func TestCephClusterDependents(t *testing.T) {
 		deps, err := CephClusterDependents(c, ns)
 		assert.NoError(t, err)
 		assert.False(t, deps.Empty())
-		assert.ElementsMatch(t, []string{"CephBlockPool", "CephRBDMirror", "CephFilesystem",
+		assert.ElementsMatch(t, []string{
+			"CephBlockPool", "CephRBDMirror", "CephFilesystem",
 			"CephFilesystemMirror", "CephObjectStore", "CephObjectStoreUser", "CephObjectZone",
-			"CephObjectZoneGroup", "CephObjectRealm", "CephNFS", "CephClient", "CephBucketTopic", "CephBucketNotification"}, deps.PluralKinds())
+			"CephObjectZoneGroup", "CephObjectRealm", "CephNFS", "CephClient", "CephBucketTopic", "CephBucketNotification",
+		}, deps.PluralKinds())
 		assert.ElementsMatch(t, []string{"pool-1"}, deps.OfKind("CephBlockPool"))
 		assert.ElementsMatch(t, []string{"rbdmirror-1", "rbdmirror-2"}, deps.OfKind("CephRBDMirror"))
 		assert.ElementsMatch(t, []string{"filesystem-1"}, deps.OfKind("CephFilesystem"))

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -108,7 +108,6 @@ func (c *Cluster) configureDashboardModules() error {
 // Delete the manager per-daemon configuration. Returns true
 // if all the configuration entries have been delete successfully.
 func (c *Cluster) deleteManagerDaemonConfiguration() bool {
-
 	mgrKeysToDelete := []string{
 		"mgr/dashboard/url_prefix",
 		"mgr/dashboard/ssl",
@@ -141,7 +140,6 @@ func (c *Cluster) deleteManagerDaemonConfiguration() bool {
 }
 
 func (c *Cluster) configureDashboardModuleSettings() (bool, error) {
-
 	monStore := config.GetMonStore(c.context, c.clusterInfo)
 
 	// url prefix
@@ -227,7 +225,6 @@ func (c *Cluster) initializeSecureDashboard() (bool, error) {
 }
 
 func (c *Cluster) createSelfSignedCert() (bool, error) {
-
 	// Check if the cert already exists
 	args := []string{"config-key", "get", "mgr/dashboard/crt"}
 	output, err := client.NewCephCommand(c.context, c.clusterInfo, args).RunWithTimeout(exec.CephCommandsTimeout)

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -118,7 +118,8 @@ func TestStartSecureDashboard(t *testing.T) {
 		OwnerInfo:   ownerInfo,
 		Context:     ctx,
 	}
-	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: clientset, Executor: executor},
+	c := &Cluster{
+		clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: clientset, Executor: executor},
 		spec: cephv1.ClusterSpec{
 			Dashboard:   cephv1.DashboardSpec{Port: 443, Enabled: true, SSL: true},
 			CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v15"},

--- a/pkg/operator/ceph/cluster/mgr/drain_test.go
+++ b/pkg/operator/ceph/cluster/mgr/drain_test.go
@@ -112,5 +112,4 @@ func TestDeleteMgrPDB(t *testing.T) {
 	// mgr PDB deleted
 	err = c.context.Client.Get(context.TODO(), fakeNamespaceName, existingPDBV1)
 	assert.Error(t, err)
-
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -80,8 +80,10 @@ func New(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, spec ce
 	}
 }
 
-var waitForDeploymentToStart = k8sutil.WaitForDeploymentToStart
-var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
+var (
+	waitForDeploymentToStart = k8sutil.WaitForDeploymentToStart
+	updateDeploymentAndWait  = mon.UpdateCephDeploymentAndWait
+)
 
 // for backward compatibility, default to 1 mgr
 func (c *Cluster) getReplicas() int {

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -293,7 +293,8 @@ func TestUpdateServiceSelectors(t *testing.T) {
 				Selector: map[string]string{
 					"app":                    "rook-ceph-mgr",
 					controller.DaemonIDLabel: "a",
-				}},
+				},
+			},
 		}
 		svc2 := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: "svc2"},
@@ -301,7 +302,8 @@ func TestUpdateServiceSelectors(t *testing.T) {
 				Selector: map[string]string{
 					"app":                    "rook-ceph-mgr",
 					controller.DaemonIDLabel: "a",
-				}},
+				},
+			},
 		}
 		_, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Create(clusterInfo.Context, &svc1, metav1.CreateOptions{})
 		assert.NoError(t, err)
@@ -346,7 +348,7 @@ func TestConfigureModules(t *testing.T) {
 					lastModuleConfigured = args[3]
 				}
 			}
-			return "", nil //return "{\"key\":\"mysecurekey\"}", nil
+			return "", nil // return "{\"key\":\"mysecurekey\"}", nil
 		},
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "config" && args[1] == "set" && args[2] == "global" {
@@ -407,12 +409,14 @@ func TestApplyMonitoringLabels(t *testing.T) {
 	}
 	c := &Cluster{spec: clusterSpec}
 	sm := &monitoringv1.ServiceMonitor{Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{}}}}
+		Endpoints: []monitoringv1.Endpoint{{}},
+	}}
 
 	// Service Monitor RelabelConfigs updated when 'rook.io/managedBy' monitoring label is found
 	monitoringLabels := cephv1.LabelsSpec{
 		cephv1.KeyMonitoring: map[string]string{
-			"rook.io/managedBy": "storagecluster"},
+			"rook.io/managedBy": "storagecluster",
+		},
 	}
 	c.spec.Labels = monitoringLabels
 	applyMonitoringLabels(c, sm)
@@ -423,7 +427,8 @@ func TestApplyMonitoringLabels(t *testing.T) {
 	// Service Monitor RelabelConfigs not updated when the required monitoring label is not found
 	monitoringLabels = cephv1.LabelsSpec{
 		cephv1.KeyMonitoring: map[string]string{
-			"wrongLabelKey": "storagecluster"},
+			"wrongLabelKey": "storagecluster",
+		},
 	}
 	c.spec.Labels = monitoringLabels
 	sm.Spec.Endpoints[0].RelabelConfigs = nil
@@ -457,7 +462,7 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 					lastModuleConfigured = args[3]
 				}
 			}
-			return "", nil //return "{\"key\":\"mysecurekey\"}", nil
+			return "", nil // return "{\"key\":\"mysecurekey\"}", nil
 		},
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "config" && args[1] == "set" && args[2] == "mgr" {
@@ -532,5 +537,4 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 	assert.Equal(t, 1, modulesDisabled)
 	assert.Equal(t, "30002", configSettings["mgr/prometheus/server_port"])
 	assert.Equal(t, "60", configSettings["mgr/prometheus/scrape_interval"])
-
 }

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -29,9 +29,7 @@ const (
 	rookModuleName = "rook"
 )
 
-var (
-	orchestratorInitWaitTime = 5 * time.Second
-)
+var orchestratorInitWaitTime = 5 * time.Second
 
 // Ceph docs about the orchestrator modules: http://docs.ceph.com/docs/master/mgr/orchestrator_cli/
 func (c *Cluster) configureOrchestratorModules() error {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -81,12 +81,14 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 				Name: "rook-config",
 				VolumeSource: v1.VolumeSource{
 					EmptyDir: &v1.EmptyDirVolumeSource{},
-				}},
+				},
+			},
 			v1.Volume{
 				Name: "default-config-dir",
 				VolumeSource: v1.VolumeSource{
 					EmptyDir: &v1.EmptyDirVolumeSource{},
-				}},
+				},
+			},
 			mon.CephSecretVolume())
 
 		// Stretch the mgrs across hosts by default, or across a bigger failure domain for when zones are required like in case of stretched cluster
@@ -163,7 +165,6 @@ func (c *Cluster) makeChownInitContainer(mgrConfig *mgrConfig) v1.Container {
 }
 
 func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
-
 	container := v1.Container{
 		Name: "mgr",
 		Command: []string{
@@ -282,7 +283,6 @@ func (c *Cluster) makeCmdProxySidecarContainer(mgrConfig *mgrConfig) v1.Containe
 
 // MakeMetricsService generates the Kubernetes service object for the monitoring service
 func (c *Cluster) MakeMetricsService(name, servicePortMetricName string) (*v1.Service, error) {
-
 	labels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
 	selectorLabels := c.buildSelectorLabels(labels)
 
@@ -317,7 +317,6 @@ func (c *Cluster) MakeMetricsService(name, servicePortMetricName string) (*v1.Se
 }
 
 func (c *Cluster) makeDashboardService(name string) (*v1.Service, error) {
-
 	labels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
 	selectorLabels := c.buildSelectorLabels(labels)
 

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -40,16 +40,17 @@ func TestPodSpec(t *testing.T) {
 		Dashboard:          cephv1.DashboardSpec{Port: 1234},
 		PriorityClassNames: map[cephv1.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",
-		Resources: cephv1.ResourceSpec{string(cephv1.KeyMgr): v1.ResourceRequirements{
-			Limits: v1.ResourceList{
-				v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
-				v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
+		Resources: cephv1.ResourceSpec{
+			string(cephv1.KeyMgr): v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+					v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+					v1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
+				},
 			},
-			Requests: v1.ResourceList{
-				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
-				v1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
-			},
-		},
 		},
 	}
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "rook/rook:myversion")

--- a/pkg/operator/ceph/cluster/mon/drain.go
+++ b/pkg/operator/ceph/cluster/mon/drain.go
@@ -32,7 +32,7 @@ const (
 
 func (c *Cluster) reconcileMonPDB() error {
 	if !c.spec.DisruptionManagement.ManagePodBudgets {
-		//TODO: Delete mon PDB
+		// TODO: Delete mon PDB
 		return nil
 	}
 
@@ -58,7 +58,8 @@ func (c *Cluster) createOrUpdateMonPDB(maxUnavailable int32) (controllerutil.Ope
 		MatchLabels: map[string]string{k8sutil.AppAttr: AppName},
 	}
 	pdb := &policyv1.PodDisruptionBudget{
-		ObjectMeta: objectMeta}
+		ObjectMeta: objectMeta,
+	}
 
 	mutateFunc := func() error {
 		pdb.Spec = policyv1.PodDisruptionBudgetSpec{

--- a/pkg/operator/ceph/cluster/mon/drain_test.go
+++ b/pkg/operator/ceph/cluster/mon/drain_test.go
@@ -145,7 +145,6 @@ func TestAllowMonDrain(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, int(existingPDBV1.Spec.MaxUnavailable.IntValue()))
 	})
-
 }
 
 func TestBlockMonDrain(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/endpoint_test.go
+++ b/pkg/operator/ceph/cluster/mon/endpoint_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestMonFlattening(t *testing.T) {
-
 	// single endpoint
 	mons := map[string]*cephclient.MonInfo{
 		"foo": {Name: "foo", Endpoint: "1.2.3.4:5000"},

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -218,7 +218,8 @@ func TestTrackMonsOutOfQuorum(t *testing.T) {
 		mapping:   &opcontroller.Mapping{},
 		context:   &clusterd.Context{Clientset: clientset, ConfigDir: tempDir},
 		ownerInfo: ownerInfo,
-		Namespace: "ns"}
+		Namespace: "ns",
+	}
 	c.ClusterInfo = &cephclient.ClusterInfo{InternalMonitors: map[string]*cephclient.MonInfo{
 		"a": {Name: "a", Endpoint: endpoint},
 		"b": {Name: "b", Endpoint: endpoint},
@@ -444,7 +445,8 @@ func TestAddRemoveMons(t *testing.T) {
 		"rook-ceph-mon-b",                    // b updated when c created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", // b and c updated when d created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", // etc.
-		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e"},
+		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e",
+	},
 		testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
@@ -762,7 +764,8 @@ func TestExternalMons_notInSpec_InQuorum(t *testing.T) {
 		"rook-ceph-mon-b",                    // b updated when c created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", // b and c updated when d created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", // etc.
-		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e"},
+		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e",
+	},
 		testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
@@ -852,7 +855,6 @@ func TestExternalMons_notInSpec_InQuorum(t *testing.T) {
 		assert.Equal(t, c.ClusterInfo.InternalMonitors[id].Endpoint, mon.Endpoint)
 		assert.Equal(t, c.ClusterInfo.InternalMonitors[id].OutOfQuorum, mon.OutOfQuorum)
 	}
-
 }
 
 func TestExternalMons_inSpec_notInQuorum(t *testing.T) {
@@ -893,7 +895,8 @@ func TestExternalMons_inSpec_notInQuorum(t *testing.T) {
 		"rook-ceph-mon-b",                    // b updated when c created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", // b and c updated when d created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", // etc.
-		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e"},
+		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e",
+	},
 		testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
@@ -975,7 +978,6 @@ func TestExternalMons_inSpec_notInQuorum(t *testing.T) {
 		assert.Equal(t, c.ClusterInfo.InternalMonitors[id].Endpoint, mon.Endpoint)
 		assert.Equal(t, c.ClusterInfo.InternalMonitors[id].OutOfQuorum, mon.OutOfQuorum)
 	}
-
 }
 
 func TestExternalMons_inSpec_inQuorum(t *testing.T) {
@@ -1016,7 +1018,8 @@ func TestExternalMons_inSpec_inQuorum(t *testing.T) {
 		"rook-ceph-mon-b",                    // b updated when c created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", // b and c updated when d created
 		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", // etc.
-		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e"},
+		"rook-ceph-mon-b", "rook-ceph-mon-c", "rook-ceph-mon-d", "rook-ceph-mon-e",
+	},
 		testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -980,7 +980,6 @@ func (c *Cluster) assignMons(mons []*monConfig) error {
 }
 
 func (c *Cluster) monVolumeClaimTemplate(mon *monConfig) *v1.PersistentVolumeClaim {
-
 	if c.spec.ZonesRequired() {
 		// If a stretch cluster, a zone can override the template from the default.
 
@@ -1316,7 +1315,6 @@ func (c *Cluster) commitMaxMonIDRequireIncrementing(desiredMaxMonID int, require
 var updateDeploymentAndWait = UpdateCephDeploymentAndWait
 
 func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
-
 	// Expand mon PVC if storage request for mon has increased in cephcluster crd
 	if c.monVolumeClaimTemplate(m) != nil {
 		desiredPvc, err := c.makeDeploymentPVC(m, false)

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -559,6 +559,7 @@ func TestFindAvailableZoneMon(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "", availableZone)
 }
+
 func TestFindAvailableZoneForStretchedMon(t *testing.T) {
 	c := &Cluster{spec: cephv1.ClusterSpec{
 		Mon: cephv1.MonSpec{
@@ -654,16 +655,24 @@ func TestMonVolumeClaimTemplate(t *testing.T) {
 	}{
 		{"no template", fields{cephv1.ClusterSpec{}}, args{&monConfig{Zone: "z1"}}, nil},
 		{"default template", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{VolumeClaimTemplate: defaultTemplate}}}, args{&monConfig{Zone: "z1"}}, defaultTemplate.ToPVC()},
-		{"default template with 3 zones", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
-			VolumeClaimTemplate: defaultTemplate,
-			Zones:               []cephv1.MonZoneSpec{{Name: "z1"}, {Name: "z2"}, {Name: "z3"}}}}},
+		{
+			"default template with 3 zones",
+			fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
+				VolumeClaimTemplate: defaultTemplate,
+				Zones:               []cephv1.MonZoneSpec{{Name: "z1"}, {Name: "z2"}, {Name: "z3"}},
+			}}},
 			args{&monConfig{Zone: "z1"}},
-			defaultTemplate.ToPVC()},
-		{"overridden template", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
-			VolumeClaimTemplate: defaultTemplate,
-			Zones:               []cephv1.MonZoneSpec{{Name: "z1", VolumeClaimTemplate: zoneTemplate}, {Name: "z2"}, {Name: "z3"}}}}},
+			defaultTemplate.ToPVC(),
+		},
+		{
+			"overridden template",
+			fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
+				VolumeClaimTemplate: defaultTemplate,
+				Zones:               []cephv1.MonZoneSpec{{Name: "z1", VolumeClaimTemplate: zoneTemplate}, {Name: "z2"}, {Name: "z3"}},
+			}}},
 			args{&monConfig{Zone: "z1"}},
-			zoneTemplate.ToPVC()},
+			zoneTemplate.ToPVC(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -705,7 +714,8 @@ func TestRemoveExtraMonDeployments(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "rook-ceph-mon-b",
 			Labels: map[string]string{"ceph_daemon_id": "b"},
-		}})
+		},
+	})
 	removed = c.checkForExtraMonResources(mons, deployments)
 	assert.Equal(t, "b", removed)
 
@@ -727,12 +737,14 @@ func TestRemoveExtraMonDeployments(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "rook-ceph-mon-c",
 			Labels: map[string]string{"ceph_daemon_id": "c"},
-		}})
+		},
+	})
 	deployments = append(deployments, apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "rook-ceph-mon-d",
 			Labels: map[string]string{"ceph_daemon_id": "d"},
-		}})
+		},
+	})
 	c.spec.Mon.Count = 3
 	removed = c.checkForExtraMonResources(mons, deployments)
 	assert.Equal(t, "", removed)
@@ -757,16 +769,24 @@ func TestStretchMonVolumeClaimTemplate(t *testing.T) {
 	}{
 		{"no template", fields{cephv1.ClusterSpec{}}, args{&monConfig{Zone: "z1"}}, nil},
 		{"default template", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{VolumeClaimTemplate: defaultTemplate}}}, args{&monConfig{Zone: "z1"}}, defaultTemplate.ToPVC()},
-		{"default template with 3 zones", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
-			VolumeClaimTemplate: defaultTemplate,
-			StretchCluster:      &cephv1.StretchClusterSpec{Zones: []cephv1.MonZoneSpec{{Name: "z1"}, {Name: "z2"}, {Name: "z3"}}}}}},
+		{
+			"default template with 3 zones",
+			fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
+				VolumeClaimTemplate: defaultTemplate,
+				StretchCluster:      &cephv1.StretchClusterSpec{Zones: []cephv1.MonZoneSpec{{Name: "z1"}, {Name: "z2"}, {Name: "z3"}}},
+			}}},
 			args{&monConfig{Zone: "z1"}},
-			defaultTemplate.ToPVC()},
-		{"overridden template", fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
-			VolumeClaimTemplate: defaultTemplate,
-			StretchCluster:      &cephv1.StretchClusterSpec{Zones: []cephv1.MonZoneSpec{{Name: "z1", VolumeClaimTemplate: zoneTemplate}, {Name: "z2"}, {Name: "z3"}}}}}},
+			defaultTemplate.ToPVC(),
+		},
+		{
+			"overridden template",
+			fields{cephv1.ClusterSpec{Mon: cephv1.MonSpec{
+				VolumeClaimTemplate: defaultTemplate,
+				StretchCluster:      &cephv1.StretchClusterSpec{Zones: []cephv1.MonZoneSpec{{Name: "z1", VolumeClaimTemplate: zoneTemplate}, {Name: "z2"}, {Name: "z3"}}},
+			}}},
 			args{&monConfig{Zone: "z1"}},
-			zoneTemplate.ToPVC()},
+			zoneTemplate.ToPVC(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -831,7 +851,6 @@ func TestArbiterPlacement(t *testing.T) {
 }
 
 func TestCheckIfArbiterReady(t *testing.T) {
-
 	c := &Cluster{
 		Namespace: "ns",
 		spec: cephv1.ClusterSpec{
@@ -844,7 +863,8 @@ func TestCheckIfArbiterReady(t *testing.T) {
 					},
 				},
 			},
-		}}
+		},
+	}
 	crushZoneCount := 0
 	balanced := true
 	executor := &exectest.MockExecutor{
@@ -867,7 +887,6 @@ func TestCheckIfArbiterReady(t *testing.T) {
 						 ,{"id": -%d,"name": "zone%d~ssd","type_id": 1,"type_name": "zone","weight": 2056}`, i+5, i, weight, i+6, i)
 				}
 				return fmt.Sprintf(`{"buckets": [%s]}`, crushBuckets), nil
-
 			}
 			return "", fmt.Errorf("unrecognized output file command: %s %v", command, args)
 		},
@@ -919,7 +938,8 @@ func TestSkipReconcile(t *testing.T) {
 				k8sutil.AppAttr: AppName,
 				config.MonType:  "a",
 			},
-		}}
+		},
+	}
 
 	deployment, err := c.context.Clientset.AppsV1().Deployments(c.ClusterInfo.Namespace).Create(c.ClusterInfo.Context, monDeployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
@@ -948,7 +968,8 @@ func TestHasMonPathChanged(t *testing.T) {
 			Labels: map[string]string{
 				"pvc_name": "test-pvc",
 			},
-		}}
+		},
+	}
 
 	pvcTemplate := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -41,21 +41,22 @@ func TestNodeAffinity(t *testing.T) {
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Placement = map[cephv1.KeyType]cephv1.Placement{}
-	c.spec.Placement[cephv1.KeyMon] = cephv1.Placement{NodeAffinity: &v1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-			NodeSelectorTerms: []v1.NodeSelectorTerm{
-				{
-					MatchExpressions: []v1.NodeSelectorRequirement{
-						{
-							Key:      "label",
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{"bar", "baz"},
+	c.spec.Placement[cephv1.KeyMon] = cephv1.Placement{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "label",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"bar", "baz"},
+							},
 						},
 					},
 				},
 			},
 		},
-	},
 	}
 
 	// label nodes so they appear as not schedulable / invalid
@@ -162,7 +163,6 @@ func TestPodMemory(t *testing.T) {
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookImage, cephver.Squid, c.spec)
 	assert.NoError(t, err)
-
 }
 
 func TestHostNetwork(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -76,7 +76,6 @@ func (c *Cluster) getFailureDomainName() string {
 }
 
 func GetFailureDomainLabel(spec cephv1.ClusterSpec) string {
-
 	if spec.IsStretchCluster() && spec.Mon.StretchCluster.FailureDomainLabel != "" {
 		return spec.Mon.StretchCluster.FailureDomainLabel
 	}
@@ -381,7 +380,6 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 
 // UpdateCephDeploymentAndWait verifies a deployment can be stopped or continued
 func UpdateCephDeploymentAndWait(context *clusterd.Context, clusterInfo *client.ClusterInfo, deployment *apps.Deployment, daemonType, daemonName string, skipUpgradeChecks, continueUpgradeAfterChecksEvenIfNotHealthy bool) error {
-
 	callback := func(action string) error {
 		// At this point, we are in an upgrade
 		if skipUpgradeChecks {

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -27,9 +27,7 @@ import (
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 )
 
-var (
-	monitorDaemonList = []string{"mon", "osd", "status"}
-)
+var monitorDaemonList = []string{"mon", "osd", "status"}
 
 func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInfo *cephclient.ClusterInfo) {
 	var isEnabled bool

--- a/pkg/operator/ceph/cluster/nodedaemon/crash.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/crash.go
@@ -63,7 +63,6 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 	volumes = append(volumes, keyring.Volume().CrashCollector())
 
 	mutateFunc := func() error {
-
 		// labels for the pod, the deployment, and the deploymentSelector
 		deploymentLabels := map[string]string{
 			k8sutil.LabelHostname(): nodeHostnameLabel,

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -50,9 +50,7 @@ const (
 	exporterKeyName                  = "rook-ceph-exporter-keyring"
 )
 
-var (
-	MinVersionForCephExporter = cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
-)
+var MinVersionForCephExporter = cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
 
 // createOrUpdateCephExporter is a wrapper around controllerutil.CreateOrUpdate
 func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations []corev1.Toleration, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) (controllerutil.OperationResult, error) {
@@ -88,7 +86,6 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 		keyring.Volume().Exporter())
 
 	mutateFunc := func() error {
-
 		// labels for the pod, the deployment, and the deploymentSelector
 		deploymentLabels := map[string]string{
 			k8sutil.LabelHostname(): nodeHostnameLabel,

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -201,12 +201,14 @@ func TestApplyCephExporterLabels(t *testing.T) {
 	cephCluster.Spec.PriorityClassNames = cephv1.PriorityClassNamesSpec{}
 
 	sm := &monitoringv1.ServiceMonitor{Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{}}}}
+		Endpoints: []monitoringv1.Endpoint{{}},
+	}}
 
 	// Service Monitor RelabelConfigs updated when 'rook.io/managedBy' monitoring label is found
 	monitoringLabels := cephv1.LabelsSpec{
 		cephv1.KeyCephExporter: map[string]string{
-			"rook.io/managedBy": "storagecluster"},
+			"rook.io/managedBy": "storagecluster",
+		},
 	}
 	cephCluster.Spec.Labels = monitoringLabels
 	applyCephExporterLabels(cephCluster, sm)
@@ -217,7 +219,8 @@ func TestApplyCephExporterLabels(t *testing.T) {
 	// Service Monitor RelabelConfigs not updated when the required monitoring label is not found
 	monitoringLabels = cephv1.LabelsSpec{
 		cephv1.KeyCephExporter: map[string]string{
-			"wrongLabelKey": "storagecluster"},
+			"wrongLabelKey": "storagecluster",
+		},
 	}
 	cephCluster.Spec.Labels = monitoringLabels
 	sm.Spec.Endpoints[0].RelabelConfigs = nil

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -82,7 +82,6 @@ func createCrashCollectorKeyring(s *keyring.SecretStore) (string, error) {
 }
 
 func createOrUpdateCrashCollectorSecret(clusterInfo *client.ClusterInfo, crashCollectorSecretKey string, k *keyring.SecretStore) error {
-
 	keyring := fmt.Sprintf(crashKeyringTemplate, crashCollectorSecretKey)
 
 	crashCollectorSecret := map[string][]byte{
@@ -148,7 +147,6 @@ func createExporterKeyring(s *keyring.SecretStore) (string, error) {
 }
 
 func createOrUpdateExporterSecret(clusterInfo *client.ClusterInfo, exporterSecretKey string, k *keyring.SecretStore) error {
-
 	keyring := fmt.Sprintf(exporterKeyringTemplate, exporterSecretKey)
 
 	exporterSecret := map[string][]byte{

--- a/pkg/operator/ceph/cluster/nodedaemon/pruner.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/pruner.go
@@ -68,6 +68,7 @@ func (r *ReconcileNode) reconcileCrashPruner(namespace string, cephCluster cephv
 	}
 	return nil
 }
+
 func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, tolerations []corev1.Toleration) (controllerutil.OperationResult, error) {
 	objectMeta := metav1.ObjectMeta{
 		Name:      prunerName,

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -269,7 +269,6 @@ func (r *ReconcileNode) createOrUpdateNodeDaemons(node corev1.Node, tolerations 
 					logger.Debug("service monitor for ceph exporter was enabled successfully")
 				}
 			}
-
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/create_test.go
+++ b/pkg/operator/ceph/cluster/osd/create_test.go
@@ -56,7 +56,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 	clusterInfo.SetName("mycluster")
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 
-	var oldCreateDaemonOnNodeFunc = createDaemonOnNodeFunc
+	oldCreateDaemonOnNodeFunc := createDaemonOnNodeFunc
 	defer func() {
 		createDaemonOnNodeFunc = oldCreateDaemonOnNodeFunc
 	}()
@@ -70,7 +70,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		return nil
 	}
 
-	var oldCreateDaemonOnPVCFunc = createDaemonOnPVCFunc
+	oldCreateDaemonOnPVCFunc := createDaemonOnPVCFunc
 	defer func() {
 		createDaemonOnPVCFunc = oldCreateDaemonOnPVCFunc
 	}()

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -84,7 +84,7 @@ func testPrepareDeviceSets(t *testing.T, setTemplateName bool) {
 	assert.Equal(t, fmt.Sprintf("mydata-%s-0", expectedName), pvcs.Items[0].GenerateName)
 	assert.Equal(t, cluster.clusterInfo.Namespace, pvcs.Items[0].Namespace)
 
-	//Verify that the PVC has correct Image Version Label
+	// Verify that the PVC has correct Image Version Label
 	cephImageVersion := createValidImageVersionLabel(cluster.spec.CephVersion.Image)
 	for _, item := range pvcs.Items {
 		val, exist := item.Labels[CephImageLabelKey]

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -54,9 +54,7 @@ const (
 	tcmallocMaxTotalThreadCacheBytesEnv = "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 )
 
-var (
-	cephEnvConfigFile = "/etc/sysconfig/ceph"
-)
+var cephEnvConfigFile = "/etc/sysconfig/ceph"
 
 func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string, prepare bool) []v1.EnvVar {
 	envVars := []v1.EnvVar{
@@ -187,6 +185,7 @@ func crushInitialWeightEnvVar(crushInitialWeight string) v1.EnvVar {
 func encryptedDeviceEnvVar(encryptedDevice bool) v1.EnvVar {
 	return v1.EnvVar{Name: EncryptedDeviceEnvVarName, Value: strconv.FormatBool(encryptedDevice)}
 }
+
 func pvcNameEnvVar(pvcName string) v1.EnvVar {
 	return v1.EnvVar{Name: PVCNameEnvVarName, Value: pvcName}
 }
@@ -217,11 +216,17 @@ func cephVolumeEnvVar() []v1.EnvVar {
 
 func osdActivateEnvVar() []v1.EnvVar {
 	monEnvVars := []v1.EnvVar{
-		{Name: "ROOK_CEPH_MON_HOST",
+		{
+			Name: "ROOK_CEPH_MON_HOST",
 			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
-					Name: "rook-ceph-config"},
-					Key: "mon_host"}}},
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "rook-ceph-config",
+					},
+					Key: "mon_host",
+				},
+			},
+		},
 		{Name: "CEPH_ARGS", Value: "-m $(ROOK_CEPH_MON_HOST)"},
 	}
 

--- a/pkg/operator/ceph/cluster/osd/envs_test.go
+++ b/pkg/operator/ceph/cluster/osd/envs_test.go
@@ -23,8 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	sysconfig = []byte(`# /etc/sysconfig/ceph
+var sysconfig = []byte(`# /etc/sysconfig/ceph
 #
 # Environment file for ceph daemon systemd unit files.
 #
@@ -42,7 +41,6 @@ TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
 # currently active on the node.
 #
 CEPH_AUTO_RESTART_ON_UPGRADE=no`)
-)
 
 func TestCephVolumeEnvVar(t *testing.T) {
 	cvEnv := cephVolumeEnvVar()
@@ -86,7 +84,7 @@ func TestGetTcmallocMaxTotalThreadCacheBytes(t *testing.T) {
 	assert.Equal(t, "67108864", v.Value)
 
 	// Read the file now
-	err = os.WriteFile(file.Name(), sysconfig, 0400)
+	err = os.WriteFile(file.Name(), sysconfig, 0o400)
 	assert.NoError(t, err)
 	v = getTcmallocMaxTotalThreadCacheBytes("")
 	assert.Equal(t, "134217728", v.Value)

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -35,9 +35,7 @@ const (
 	graceTime = 60 * time.Minute
 )
 
-var (
-	defaultHealthCheckInterval = 60 * time.Second
-)
+var defaultHealthCheckInterval = 60 * time.Second
 
 // OSDHealthMonitor defines OSD process monitoring
 type OSDHealthMonitor struct {
@@ -68,7 +66,6 @@ func NewOSDHealthMonitor(context *clusterd.Context, clusterInfo *client.ClusterI
 
 // Start runs monitoring logic for osds status at set intervals
 func (m *OSDHealthMonitor) Start(monitoringRoutines map[string]*opcontroller.ClusterHealth, daemon string) {
-
 	for {
 		// We must perform this check otherwise the case will check an index that does not exist anymore and
 		// we will get an invalid pointer error and the go routine will panic

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -39,7 +39,7 @@ func TestOSDHealthCheck(t *testing.T) {
 	clientset := testexec.New(t, 2)
 	clusterInfo := client.AdminTestClusterInfo("fake")
 
-	var execCount = 0
+	execCount := 0
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -49,10 +49,8 @@ import (
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var (
-	// global to allow creating helper functions that are not inline with test functions
-	testIDGenerator osdIDGenerator
-)
+// global to allow creating helper functions that are not inline with test functions
+var testIDGenerator osdIDGenerator
 
 // TODO: look into: failed to calculate diff between current deployment and newly generated one.
 //   Failed to generate strategic merge patch: map: map[] does not contain declared merge key: uid

--- a/pkg/operator/ceph/cluster/osd/migrate_test.go
+++ b/pkg/operator/ceph/cluster/osd/migrate_test.go
@@ -106,7 +106,6 @@ func TestMigrateForEncryption(t *testing.T) {
 		assert.Equal(t, 1, len(mc.osds))
 		assert.Equal(t, 1, mc.osds[1].ID)
 	})
-
 }
 
 func TestMigrationForOSDStore(t *testing.T) {
@@ -187,6 +186,7 @@ func createMigrationConfigmap(osdID, ns string, clientset *fake.Clientset) error
 	_, err := clientset.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 	return err
 }
+
 func TestIsLastOSDMigrationComplete(t *testing.T) {
 	namespace := "rook-ceph"
 	clientset := fake.NewSimpleClientset()

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -136,7 +136,7 @@ type OrchestrationStatus struct {
 }
 
 type osdProperties struct {
-	//crushHostname refers to the hostname or PVC name when the OSD is provisioned on Nodes or PVC block device, respectively.
+	// crushHostname refers to the hostname or PVC name when the OSD is provisioned on Nodes or PVC block device, respectively.
 	crushHostname       string
 	devices             []cephv1.Device
 	pvc                 corev1.PersistentVolumeClaimVolumeSource

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -69,10 +69,14 @@ const (
 
 func TestOSDProperties(t *testing.T) {
 	osdProps := []osdProperties{
-		{pvc: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "claim"},
-			metadataPVC: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "claim"}},
-		{pvc: corev1.PersistentVolumeClaimVolumeSource{ClaimName: ""},
-			metadataPVC: corev1.PersistentVolumeClaimVolumeSource{ClaimName: ""}},
+		{
+			pvc:         corev1.PersistentVolumeClaimVolumeSource{ClaimName: "claim"},
+			metadataPVC: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "claim"},
+		},
+		{
+			pvc:         corev1.PersistentVolumeClaimVolumeSource{ClaimName: ""},
+			metadataPVC: corev1.PersistentVolumeClaimVolumeSource{ClaimName: ""},
+		},
 	}
 	expected := [][2]bool{
 		{true, true},
@@ -275,7 +279,8 @@ func TestAddRemoveNode(t *testing.T) {
 	// simulate the OSD pod having been created
 	osdPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:   "osdPod",
-		Labels: map[string]string{k8sutil.AppAttr: AppName}}}
+		Labels: map[string]string{k8sutil.AppAttr: AppName},
+	}}
 	_, err = c.context.Clientset.CoreV1().Pods(c.clusterInfo.Namespace).Create(ctx, osdPod, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -660,21 +665,22 @@ func TestGetPreparePlacement(t *testing.T) {
 	assert.Nil(t, result.NodeAffinity)
 
 	// the osd daemon placement is specified
-	prop.placement = cephv1.Placement{NodeAffinity: &corev1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-			NodeSelectorTerms: []corev1.NodeSelectorTerm{
-				{
-					MatchExpressions: []corev1.NodeSelectorRequirement{
-						{
-							Key:      "label1",
-							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{"bar", "baz"},
+	prop.placement = cephv1.Placement{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "label1",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"bar", "baz"},
+							},
 						},
 					},
 				},
 			},
 		},
-	},
 	}
 
 	result = prop.getPreparePlacement()
@@ -682,21 +688,22 @@ func TestGetPreparePlacement(t *testing.T) {
 	assert.Equal(t, "label1", result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key)
 
 	// The prepare placement is specified and takes precedence over the osd placement
-	prop.preparePlacement = &cephv1.Placement{NodeAffinity: &corev1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-			NodeSelectorTerms: []corev1.NodeSelectorTerm{
-				{
-					MatchExpressions: []corev1.NodeSelectorRequirement{
-						{
-							Key:      "label2",
-							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{"foo", "bar"},
+	prop.preparePlacement = &cephv1.Placement{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "label2",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"foo", "bar"},
+							},
 						},
 					},
 				},
 			},
 		},
-	},
 	}
 	result = prop.getPreparePlacement()
 	assert.Equal(t, 1, len(result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms))
@@ -868,7 +875,6 @@ func TestUpdateCephStorageStatus(t *testing.T) {
 		assert.Equal(t, "ssd", cephCluster.Status.CephStorage.DeviceClasses[0].Name)
 		assert.Equal(t, 1, cephCluster.Status.CephStorage.OSD.StoreType["bluestore"])
 		assert.Equal(t, 0, cephCluster.Status.CephStorage.OSD.StoreType["bluestore-rdr"])
-
 	})
 
 	t.Run("verify bluestoreRDR OSD count in storage status", func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -416,11 +416,17 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 		{Name: "ROOK_OSD_RESTART_INTERVAL", Value: strconv.Itoa(c.spec.Storage.FlappingRestartIntervalHours)},
 		{Name: "ROOK_OSD_UUID", Value: osd.UUID},
 		{Name: "ROOK_OSD_ID", Value: osdID},
-		{Name: "ROOK_CEPH_MON_HOST",
+		{
+			Name: "ROOK_CEPH_MON_HOST",
 			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
-					Name: "rook-ceph-config"},
-					Key: "mon_host"}}},
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "rook-ceph-config",
+					},
+					Key: "mon_host",
+				},
+			},
+		},
 		{Name: "CEPH_ARGS", Value: "-m $(ROOK_CEPH_MON_HOST)"},
 		blockPathEnvVariable(osd.BlockPath),
 		cvModeEnvVariable(osd.CVMode),

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -661,14 +661,15 @@ func TestOsdPrepareResources(t *testing.T) {
 	clusterInfo.SetName("test")
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	spec := cephv1.ClusterSpec{
-		Resources: map[string]corev1.ResourceRequirements{"prepareosd": {
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU: *resource.NewQuantity(2000.0, resource.BinarySI),
+		Resources: map[string]corev1.ResourceRequirements{
+			"prepareosd": {
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(2000.0, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
+				},
 			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
-			},
-		},
 		},
 	}
 	c := New(context, clusterInfo, spec, "rook/rook:myversion")
@@ -839,38 +840,40 @@ func TestOSDPlacement(t *testing.T) {
 			ClaimName: "pvc1",
 		},
 	}
-	osdProps.placement = cephv1.Placement{NodeAffinity: &corev1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-			NodeSelectorTerms: []corev1.NodeSelectorTerm{
-				{
-					MatchExpressions: []corev1.NodeSelectorRequirement{
-						{
-							Key:      "role",
-							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{"storage-node3"},
+	osdProps.placement = cephv1.Placement{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "role",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"storage-node3"},
+							},
 						},
 					},
 				},
 			},
 		},
-	},
 	}
 
-	osdProps.preparePlacement = &cephv1.Placement{NodeAffinity: &corev1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-			NodeSelectorTerms: []corev1.NodeSelectorTerm{
-				{
-					MatchExpressions: []corev1.NodeSelectorRequirement{
-						{
-							Key:      "role",
-							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{"storage-node3"},
+	osdProps.preparePlacement = &cephv1.Placement{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "role",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"storage-node3"},
+							},
 						},
 					},
 				},
 			},
 		},
-	},
 	}
 
 	c := New(context, clusterInfo, spec, "rook/rook:myversion")

--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -71,8 +71,10 @@ func rookTopologyLabelsOrdered() []string {
 
 func allKubernetesTopologyLabelsOrdered() []string {
 	return append(
-		append([]string{corev1.LabelTopologyRegion,
-			corev1.LabelTopologyZone},
+		append([]string{
+			corev1.LabelTopologyRegion,
+			corev1.LabelTopologyZone,
+		},
 			rookTopologyLabelsOrdered()...),
 		k8sutil.LabelHostname(), //  host is the lowest level in the crush map hierarchy
 	)

--- a/pkg/operator/ceph/cluster/osd/topology/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology_test.go
@@ -50,7 +50,8 @@ func TestCleanTopologyLabels(t *testing.T) {
 		"topology.rook.io/datacenter": "d.datacenter",
 		"topology.rook.io/room":       "test",
 		"topology.rook.io/chassis":    "test",
-		"topology.rook.io/pod":        "test"}
+		"topology.rook.io/pod":        "test",
+	}
 	topology, affinity := ExtractOSDTopologyFromLabels(nodeLabels)
 	assert.Equal(t, 6, len(topology))
 	assert.Equal(t, "r-region", topology["region"])
@@ -152,5 +153,4 @@ func TestGetDefaultTopologyLabels(t *testing.T) {
 		"topology.rook.io/room," +
 		"topology.rook.io/datacenter"
 	assert.Equal(t, expectedLabels, GetDefaultTopologyLabels())
-
 }

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -134,18 +134,17 @@ func Test_updateExistingOSDs(t *testing.T) {
 		return true
 	}
 
-	updateMultipleDeploymentsAndWaitFunc =
-		func(
-			ctx context.Context,
-			clientset kubernetes.Interface,
-			deployments []*appsv1.Deployment,
-			listFunc func() (*appsv1.DeploymentList, error),
-		) k8sutil.Failures {
-			for _, d := range deployments {
-				deploymentsUpdated = append(deploymentsUpdated, d.Name)
-			}
-			return updateInjectFailures
+	updateMultipleDeploymentsAndWaitFunc = func(
+		ctx context.Context,
+		clientset kubernetes.Interface,
+		deployments []*appsv1.Deployment,
+		listFunc func() (*appsv1.DeploymentList, error),
+	) k8sutil.Failures {
+		for _, d := range deployments {
+			deploymentsUpdated = append(deploymentsUpdated, d.Name)
 		}
+		return updateInjectFailures
+	}
 
 	executor = &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
@@ -381,7 +380,6 @@ func Test_updateExistingOSDs(t *testing.T) {
 		assert.Zero(t, errs.len())
 		assert.ElementsMatch(t, deploymentsUpdated, []string{})
 		assert.Equal(t, 1, updateQueue.Len()) // the OSD should remain
-
 	})
 
 	t.Run("PGs clean to upgrade OSD", func(t *testing.T) {
@@ -401,7 +399,6 @@ func Test_updateExistingOSDs(t *testing.T) {
 		assert.Zero(t, errs.len())
 		assert.ElementsMatch(t, deploymentsUpdated, []string{deploymentName(0)})
 		assert.Equal(t, 0, updateQueue.Len()) // should be done with updates
-
 	})
 
 	t.Run("continueUpgradesAfterChecksEvenIfUnhealthy = true", func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/volumes.go
+++ b/pkg/operator/ceph/cluster/osd/volumes.go
@@ -192,7 +192,7 @@ func getUdevVolume() (v1.Volume, v1.VolumeMount) {
 
 func (c *Cluster) getEncryptionVolume(osdProps osdProperties) (v1.Volume, v1.VolumeMount) {
 	// Generate volume
-	var m int32 = 0400
+	var m int32 = 0o400
 	volume := v1.Volume{
 		Name: osdEncryptionVolName,
 		VolumeSource: v1.VolumeSource{

--- a/pkg/operator/ceph/cluster/osd/volumes_test.go
+++ b/pkg/operator/ceph/cluster/osd/volumes_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGetEncryptionVolume(t *testing.T) {
-	var m int32 = 0400
+	var m int32 = 0o400
 	c := &Cluster{}
 
 	// No KMS

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -252,7 +252,6 @@ func (r *ReconcileCephRBDMirror) reconcile(request reconcile.Request) (reconcile
 	// Return and do not requeue
 	logger.Debug("done reconciling ceph rbd mirror")
 	return reconcile.Result{}, *cephRBDMirror, nil
-
 }
 
 func (r *ReconcileCephRBDMirror) reconcileCreateCephRBDMirror(cephRBDMirror *cephv1.CephRBDMirror) (reconcile.Result, error) {

--- a/pkg/operator/ceph/cluster/rbd/controller_test.go
+++ b/pkg/operator/ceph/cluster/rbd/controller_test.go
@@ -202,7 +202,6 @@ func TestCephRBDMirrorController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
-
 	})
 
 	t.Run("success - peers are configured", func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
-
 	// 1st test
 	fakeImageVersion := cephver.Reef
 	fakeRunningVersions := []byte(`
@@ -98,8 +97,10 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.True(t, m)
 
 	// 5 test - spec version and running cluster versions are identical --> we upgrade
-	fakeImageVersion = cephver.CephVersion{Major: 19, Minor: 2, Extra: 0,
-		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc"}
+	fakeImageVersion = cephver.CephVersion{
+		Major: 19, Minor: 2, Extra: 0,
+		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc",
+	}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {
@@ -115,8 +116,10 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.False(t, m)
 
 	// 6 test - spec version and running cluster have different commit ID
-	fakeImageVersion = cephver.CephVersion{Major: 19, Minor: 2, Extra: 0, Build: 139,
-		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc"}
+	fakeImageVersion = cephver.CephVersion{
+		Major: 19, Minor: 2, Extra: 0, Build: 139,
+		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc",
+	}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {
@@ -132,8 +135,10 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.True(t, m)
 
 	// 7 test - spec version and running cluster have same commit ID
-	fakeImageVersion = cephver.CephVersion{Major: 19, Minor: 2, Extra: 0,
-		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc"}
+	fakeImageVersion = cephver.CephVersion{
+		Major: 19, Minor: 2, Extra: 0,
+		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc",
+	}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {

--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -189,7 +189,6 @@ func (c *clientCluster) handleNodeFailure(ctx context.Context, cluster *cephv1.C
 			logger.Infof("Found taint: Key=%v, Value=%v on node %s\n", taint.Key, taint.Value, node.Name)
 			break
 		}
-
 	}
 
 	if nodeHasOutOfServiceTaint {
@@ -395,8 +394,8 @@ func pvSupportsMultiNodeAccess(accessModes []corev1.PersistentVolumeAccessMode) 
 
 func (c *clientCluster) fenceRbdImage(
 	ctx context.Context, node *corev1.Node, cluster *cephv1.CephCluster,
-	clusterInfo *cephclient.ClusterInfo, rbdPV corev1.PersistentVolume) error {
-
+	clusterInfo *cephclient.ClusterInfo, rbdPV corev1.PersistentVolume,
+) error {
 	logger.Debugf("rbd PV NAME %v", rbdPV.Spec.CSI.VolumeAttributes)
 	args := []string{"status", fmt.Sprintf("%s/%s", rbdPV.Spec.CSI.VolumeAttributes["pool"], rbdPV.Spec.CSI.VolumeAttributes["imageName"])}
 	cmd := cephclient.NewRBDCommand(c.context, clusterInfo, args)
@@ -425,8 +424,8 @@ func (c *clientCluster) fenceRbdImage(
 
 func (c *clientCluster) fenceCephFSSubvolume(
 	ctx context.Context, node *corev1.Node, cluster *cephv1.CephCluster,
-	clusterInfo *cephclient.ClusterInfo, cephFSPV corev1.PersistentVolume) error {
-
+	clusterInfo *cephclient.ClusterInfo, cephFSPV corev1.PersistentVolume,
+) error {
 	logger.Infof("fencing cephfs subvolume %q on node %q", cephFSPV.Name, node.Name)
 
 	status, err := cephclient.StatusWithUser(c.context, clusterInfo)

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -444,7 +444,6 @@ func TestHandleNodeFailure(t *testing.T) {
 
 	err = c.client.Get(ctx, types.NamespacedName{Name: fenceResourceName(node.Name, cephfsDriver, clusterns), Namespace: cephCluster.Namespace}, networkFenceCephFs)
 	assert.Error(t, err, kerrors.IsNotFound(err))
-
 }
 
 func TestGetCephVolumesInUse(t *testing.T) {

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -34,8 +34,8 @@ import (
 
 func TestGenerateKey(t *testing.T) {
 	clientset := testop.New(t, 1)
-	var generateKey = ""
-	var failGenerateKey = false
+	generateKey := ""
+	failGenerateKey := false
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if failGenerateKey {

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -257,7 +257,7 @@ func (m *MonStore) setAll(who string, settings map[string]string) ([]string, err
 		return []string{}, errors.Wrapf(err, "failed to create assimilateConf temp dir for  %s.", who)
 	}
 
-	err = os.WriteFile(assimilateConfPath.Name(), []byte(""), 0600)
+	err = os.WriteFile(assimilateConfPath.Name(), []byte(""), 0o600)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to write config file"))
 	}

--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -42,14 +42,13 @@ func TestMonStore_Set(t *testing.T) {
 	// us to cause it to return an error when it detects a keyword.
 	execedCmd := ""
 	execInjectErr := false
-	executor.MockExecuteCommandWithTimeout =
-		func(timeout time.Duration, command string, args ...string) (string, error) {
-			execedCmd = command + " " + strings.Join(args, " ")
-			if execInjectErr {
-				return "output from cmd with error", errors.New("mocked error")
-			}
-			return "", nil
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		execedCmd = command + " " + strings.Join(args, " ")
+		if execInjectErr {
+			return "output from cmd with error", errors.New("mocked error")
 		}
+		return "", nil
+	}
 
 	monStore := GetMonStore(ctx, client.AdminTestClusterInfo("mycluster"))
 
@@ -87,14 +86,13 @@ func TestMonStore_Delete(t *testing.T) {
 	// us to cause it to return an error when it detects a keyword.
 	execedCmd := ""
 	execInjectErr := false
-	executor.MockExecuteCommandWithTimeout =
-		func(timeout time.Duration, command string, args ...string) (string, error) {
-			execedCmd = command + " " + strings.Join(args, " ")
-			if execInjectErr {
-				return "output from cmd with error", errors.New("mocked error")
-			}
-			return "", nil
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		execedCmd = command + " " + strings.Join(args, " ")
+		if execInjectErr {
+			return "output from cmd with error", errors.New("mocked error")
 		}
+		return "", nil
+	}
 
 	monStore := GetMonStore(ctx, client.AdminTestClusterInfo("mycluster"))
 
@@ -126,14 +124,13 @@ func TestMonStore_GetDaemon(t *testing.T) {
 		"\"rgw_enable_usage_log\":{\"value\":\"true\",\"section\":\"client.rgw.test.a\",\"mask\":{}," +
 		"\"can_update_at_runtime\":true}}"
 	execInjectErr := false
-	executor.MockExecuteCommandWithTimeout =
-		func(timeout time.Duration, command string, args ...string) (string, error) {
-			execedCmd = command + " " + strings.Join(args, " ")
-			if execInjectErr {
-				return "output from cmd with error", errors.New("mocked error")
-			}
-			return execReturn, nil
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		execedCmd = command + " " + strings.Join(args, " ")
+		if execInjectErr {
+			return "output from cmd with error", errors.New("mocked error")
 		}
+		return execReturn, nil
+	}
 
 	monStore := GetMonStore(ctx, client.AdminTestClusterInfo("mycluster"))
 
@@ -172,11 +169,10 @@ func TestMonStore_DeleteDaemon(t *testing.T) {
 		"\"can_update_at_runtime\":true}," +
 		"\"rgw_enable_usage_log\":{\"value\":\"true\",\"section\":\"client.rgw.test.a\",\"mask\":{}," +
 		"\"can_update_at_runtime\":true}}"
-	executor.MockExecuteCommandWithTimeout =
-		func(timeout time.Duration, command string, args ...string) (string, error) {
-			execedCmd = command + " " + strings.Join(args, " ")
-			return execReturn, nil
-		}
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		execedCmd = command + " " + strings.Join(args, " ")
+		return execReturn, nil
+	}
 
 	monStore := GetMonStore(ctx, client.AdminTestClusterInfo("mycluster"))
 
@@ -197,11 +193,10 @@ func TestMonStore_SetAll(t *testing.T) {
 	// create a mock command runner which creates a simple string of the command it ran, and allow
 	// us to cause it to return an error when it detects a keyword.
 	appliedSettings := false
-	executor.MockExecuteCommandWithTimeout =
-		func(timeout time.Duration, command string, args ...string) (string, error) {
-			appliedSettings = true
-			return "", nil
-		}
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		appliedSettings = true
+		return "", nil
+	}
 
 	monStore := GetMonStore(ctx, client.AdminTestClusterInfo("mycluster"))
 

--- a/pkg/operator/ceph/config/probes_test.go
+++ b/pkg/operator/ceph/config/probes_test.go
@@ -96,8 +96,10 @@ func integrationLivenessProbeCheck(t *testing.T, keyType cephv1.KeyType, livenes
 			FailureThreshold:    555,
 		}
 
-		l := &cephv1.ProbeSpec{Disabled: false,
-			Probe: userProbe}
+		l := &cephv1.ProbeSpec{
+			Disabled: false,
+			Probe:    userProbe,
+		}
 		livenessProbes[keyType] = l
 
 		container := v1.Container{StartupProbe: defaultProbe}
@@ -179,8 +181,10 @@ func integrationStartupProbeCheck(t *testing.T, keyType cephv1.KeyType, startupP
 			FailureThreshold:    555,
 		}
 
-		l := &cephv1.ProbeSpec{Disabled: false,
-			Probe: userProbe}
+		l := &cephv1.ProbeSpec{
+			Disabled: false,
+			Probe:    userProbe,
+		}
 		startupProbes[keyType] = l
 
 		container := v1.Container{StartupProbe: defaultProbe}

--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -71,7 +71,6 @@ func (s *Store) CreateOrUpdate(clusterInfo *cephclient.ClusterInfo) error {
 
 // update "mon_host" and "mon_initial_members" in the stored config
 func (s *Store) createOrUpdateMonHostSecrets(clusterInfo *cephclient.ClusterInfo) error {
-
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// and "mon hosts" global config field
 	members, hosts := cephclient.PopulateMonHostMembers(clusterInfo)
@@ -119,16 +118,28 @@ func (s *Store) createOrUpdateMonHostSecrets(clusterInfo *cephclient.ClusterInfo
 // "mon_host" and "mon_initial_members" information.
 func StoredMonHostEnvVars() []v1.EnvVar {
 	return []v1.EnvVar{
-		{Name: "ROOK_CEPH_MON_HOST",
+		{
+			Name: "ROOK_CEPH_MON_HOST",
 			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
-					Name: StoreName},
-					Key: monHostKey}}},
-		{Name: "ROOK_CEPH_MON_INITIAL_MEMBERS",
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: StoreName,
+					},
+					Key: monHostKey,
+				},
+			},
+		},
+		{
+			Name: "ROOK_CEPH_MON_INITIAL_MEMBERS",
 			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
-					Name: StoreName},
-					Key: monInitialMembersKey}}},
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: StoreName,
+					},
+					Key: monInitialMembersKey,
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -197,7 +197,7 @@ func createNamedClusterInfo(context *clusterd.Context, namespace string) (*cephc
 	}
 
 	dir := path.Join(context.ConfigDir, namespace)
-	if err = os.MkdirAll(dir, 0744); err != nil {
+	if err = os.MkdirAll(dir, 0o744); err != nil {
 		return nil, errors.Wrapf(err, "failed to create dir %s", dir)
 	}
 
@@ -212,7 +212,8 @@ func createNamedClusterInfo(context *clusterd.Context, namespace string) (*cephc
 		"--cap", "mon", "'allow *'",
 		"--cap", "osd", "'allow *'",
 		"--cap", "mgr", "'allow *'",
-		"--cap", "mds", "'allow'"}
+		"--cap", "mds", "'allow'",
+	}
 	adminSecret, err := genSecret(context.Executor, dir, cephclient.AdminUsername, args)
 	if err != nil {
 		return nil, err
@@ -228,6 +229,7 @@ func createNamedClusterInfo(context *clusterd.Context, namespace string) (*cephc
 		},
 	}, nil
 }
+
 func genSecret(executor exec.Executor, configDir, name string, args []string) (string, error) {
 	path := path.Join(configDir, fmt.Sprintf("%s.keyring", name))
 	path = strings.Replace(path, "..", ".", 1)

--- a/pkg/operator/ceph/controller/cluster_info_test.go
+++ b/pkg/operator/ceph/controller/cluster_info_test.go
@@ -37,7 +37,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
 	configDir := "ns"
-	err := os.MkdirAll(configDir, 0755)
+	err := os.MkdirAll(configDir, 0o755)
 	assert.NoError(t, err)
 	defer os.RemoveAll(configDir)
 	adminSecret := "AQDkLIBd9vLGJxAAnXsIKPrwvUXAmY+D1g0X1Q==" //nolint:gosec // This is just a var name, not a real secret
@@ -46,7 +46,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 			logger.Infof("COMMAND: %s %v", command, args)
 			if command == "ceph-authtool" && args[0] == "--create-keyring" {
 				filename := args[1]
-				assert.NoError(t, os.WriteFile(filename, []byte(fmt.Sprintf("key = %s", adminSecret)), 0600))
+				assert.NoError(t, os.WriteFile(filename, []byte(fmt.Sprintf("key = %s", adminSecret)), 0o600))
 			}
 			return "", nil
 		},
@@ -57,7 +57,8 @@ func TestCreateClusterSecrets(t *testing.T) {
 	}
 	cephClusterSpec := &cephv1.ClusterSpec{
 		Network: cephv1.NetworkSpec{
-			Provider: cephv1.NetworkProviderMultus},
+			Provider: cephv1.NetworkProviderMultus,
+		},
 	}
 	namespace := "ns"
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()

--- a/pkg/operator/ceph/controller/conditions.go
+++ b/pkg/operator/ceph/controller/conditions.go
@@ -44,8 +44,8 @@ func UpdateCondition(ctx context.Context, c *clusterd.Context, namespaceName typ
 
 // UpdateClusterCondition function will export each condition into the cluster custom resource
 func UpdateClusterCondition(c *clusterd.Context, cluster *cephv1.CephCluster, namespaceName types.NamespacedName, observedGeneration int64, conditionType cephv1.ConditionType, status v1.ConditionStatus,
-	reason cephv1.ConditionReason, message string, preserveAllConditions bool) {
-
+	reason cephv1.ConditionReason, message string, preserveAllConditions bool,
+) {
 	// Keep the conditions that already existed if they are in the list of long-term conditions,
 	// otherwise discard the temporary conditions
 	var currentCondition *cephv1.Condition

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -158,7 +158,6 @@ func SetRevisionHistoryLimit() {
 	}
 	limit = int32(numval)
 	revisionHistoryLimit = &limit
-
 }
 
 func RevisionHistoryLimit() *int32 {
@@ -177,7 +176,7 @@ func ObcAdditionalConfigKeyIsAllowed(configField string) bool {
 // canIgnoreHealthErrStatusInReconcile determines whether a status of HEALTH_ERR in the CephCluster can be ignored safely.
 func canIgnoreHealthErrStatusInReconcile(cephCluster cephv1.CephCluster, controllerName string) bool {
 	// Get a list of all the keys causing the HEALTH_ERR status.
-	var healthErrKeys = make([]string, 0)
+	healthErrKeys := make([]string, 0)
 	for key, health := range cephCluster.Status.CephStatus.Details {
 		if health.Severity == "HEALTH_ERR" {
 			healthErrKeys = append(healthErrKeys, key)
@@ -239,7 +238,7 @@ func IsReadyToReconcile(ctx context.Context, c client.Client, namespacedName typ
 
 	// read the CR status of the cluster
 	if cephCluster.Status.CephStatus != nil {
-		var operatorDeploymentOk = cephCluster.Status.CephStatus.Health == "HEALTH_OK" || cephCluster.Status.CephStatus.Health == "HEALTH_WARN"
+		operatorDeploymentOk := cephCluster.Status.CephStatus.Health == "HEALTH_OK" || cephCluster.Status.CephStatus.Health == "HEALTH_WARN"
 
 		if operatorDeploymentOk || canIgnoreHealthErrStatusInReconcile(cephCluster, controllerName) {
 			logger.Debugf("%q: ceph status is %q, operator is ready to run ceph command, reconciling", controllerName, cephCluster.Status.CephStatus.Health)

--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -43,7 +43,7 @@ func CreateTestClusterFromStatusDetails(details map[string]cephv1.CephHealthMess
 }
 
 func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
-	var cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+	cluster := CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
 		"MDS_ALL_DOWN": {
 			Severity: "HEALTH_ERR",
 			Message:  "mds all down error",
@@ -196,6 +196,7 @@ func TestSetRevisionHistoryLimit(t *testing.T) {
 		assert.Equal(t, int32(10), *RevisionHistoryLimit())
 	})
 }
+
 func TestIsReadyToReconcile(t *testing.T) {
 	scheme := scheme.Scheme
 	scheme.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
@@ -252,7 +253,8 @@ func TestIsReadyToReconcile(t *testing.T) {
 				CleanupPolicy: cephv1.CleanupPolicySpec{
 					Confirmation: cephv1.DeleteDataDirOnHostsConfirmation,
 				},
-			}}
+			},
+		}
 		objects := []runtime.Object{cephCluster}
 		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 		c, ready, clusterExists, _ := IsReadyToReconcile(ctx.TODO(), client, clusterName, controllerName)
@@ -273,7 +275,8 @@ func TestIsReadyToReconcile(t *testing.T) {
 				CleanupPolicy: cephv1.CleanupPolicySpec{
 					Confirmation: cephv1.DeleteDataDirOnHostsConfirmation,
 				},
-			}}
+			},
+		}
 		objects := []runtime.Object{cephCluster}
 		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 		c, ready, clusterExists, _ := IsReadyToReconcile(ctx.TODO(), client, clusterName, controllerName)
@@ -290,26 +293,38 @@ func TestObcAllowAdditionalConfigFields(t *testing.T) {
 		shouldAllow      []string
 		shouldDisallow   []string
 	}{
-		{"not set", "<notset>",
+		{
+			"not set", "<notset>",
 			[]string{"maxObjects", "maxSize"}, // default allowlist is unlikely to need changing EVER
-			[]string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"}},
-		{"set to empty", "",
+			[]string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"},
+		},
+		{
+			"set to empty", "",
 			[]string{}, // admin can allow no quota options if desired
-			[]string{"maxObjects", "maxSize", "bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"}},
-		{"set to default", "maxObjects,maxSize",
+			[]string{"maxObjects", "maxSize", "bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"},
+		},
+		{
+			"set to default", "maxObjects,maxSize",
 			[]string{"maxObjects", "maxSize"},
-			[]string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"}},
-		{"all quota fields", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize",
+			[]string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"},
+		},
+		{
+			"all quota fields", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize",
 			[]string{"maxObjects", "maxSize", "bucketMaxObjects", "bucketMaxSize"},
-			[]string{"bucketPolicy", "bucketLifecycle", "bucketOwner", "random"}},
-		{"all fields", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner",
+			[]string{"bucketPolicy", "bucketLifecycle", "bucketOwner", "random"},
+		},
+		{
+			"all fields", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner",
 			[]string{"maxObjects", "maxSize", "bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner"},
-			[]string{"random"}},
+			[]string{"random"},
+		},
 		// this mechanism doesn't do any field checking - that isn't it's job - it merely handles
 		// allow-listing essentially arbitrary config keys
-		{"all fields including unknown", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner,random",
+		{
+			"all fields including unknown", "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner,random",
 			[]string{"maxObjects", "maxSize", "bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "random"},
-			[]string{"otherRandom"}},
+			[]string{"otherRandom"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/ceph/controller/handler.go
+++ b/pkg/operator/ceph/controller/handler.go
@@ -62,6 +62,5 @@ func ObjectToCRMapper(ctx context.Context, c client.Client, ro runtime.Object, s
 			})
 		}
 		return results
-
 	}), nil
 }

--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -344,7 +344,11 @@ func networkStatusVolumeAndMount() (corev1.Volume, corev1.VolumeMount) {
 					Path: "network-status",
 					FieldRef: &corev1.ObjectFieldSelector{
 						FieldPath: `metadata.annotations['` + nadv1.NetworkStatusAnnot + `']`,
-					}}}}}}
+					},
+				}},
+			},
+		},
+	}
 	mnt := corev1.VolumeMount{
 		Name:      "network-status",
 		MountPath: "/var/lib/rook/multus",

--- a/pkg/operator/ceph/controller/predicate_test.go
+++ b/pkg/operator/ceph/controller/predicate_test.go
@@ -39,7 +39,6 @@ var (
 )
 
 func TestObjectChanged(t *testing.T) {
-
 	oldObject := &cephv1.CephBlockPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -149,7 +149,7 @@ func configOverrideConfigMapVolumeAndMount() (v1.Volume, v1.VolumeMount) {
 	// If we don't set 0444 to the ceph.conf configuration file during its respawn (with exec) the ceph-mgr
 	// won't be able to read the ceph.conf and the container will die, the "restart" count will increase in k8s
 	// This will mislead users thinking something won't wrong but that a false positive
-	mode := int32(0444)
+	mode := int32(0o444)
 	projectionConfigMap := &v1.ConfigMapProjection{Items: []v1.KeyToPath{{Key: k8sutil.ConfigOverrideVal, Path: file, Mode: &mode}}}
 	projectionConfigMap.Name = name
 	configMapProjection := v1.VolumeProjection{
@@ -181,7 +181,8 @@ func ConfGeneratedInPodVolumeAndMount() (v1.Volume, v1.VolumeMount) {
 	name := "ceph-conf-emptydir"
 	dir := config.EtcCephDir
 	v := v1.Volume{Name: name, VolumeSource: v1.VolumeSource{
-		EmptyDir: &v1.EmptyDirVolumeSource{}}}
+		EmptyDir: &v1.EmptyDirVolumeSource{},
+	}}
 	// configmap's "config" to "/etc/ceph/ceph.conf"
 	m := v1.VolumeMount{
 		Name:      name,
@@ -193,7 +194,6 @@ func ConfGeneratedInPodVolumeAndMount() (v1.Volume, v1.VolumeMount) {
 // PodVolumes fills in the volumes parameter with the common list of Kubernetes volumes for use in Ceph pods.
 // This function is only used for OSDs.
 func PodVolumes(dataPaths *config.DataPathMap, dataDirHostPath string, exporterHostPath string, confGeneratedInPod bool) []v1.Volume {
-
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if dataDirHostPath != "" {
 		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: dataDirHostPath}}
@@ -238,7 +238,6 @@ func CephVolumeMounts(dataPaths *config.DataPathMap, confGeneratedInPod bool) []
 // This function is only used by OSDs.
 func RookVolumeMounts(dataPaths *config.DataPathMap, confGeneratedInPod bool) []v1.VolumeMount {
 	return CephVolumeMounts(dataPaths, confGeneratedInPod)
-
 }
 
 // DaemonVolumesBase returns the common / static set of volumes.
@@ -371,7 +370,7 @@ func DaemonFlags(cluster *client.ClusterInfo, spec *cephv1.ClusterSpec, daemonID
 		config.NewFlag("id", daemonID),
 		// Ceph daemons in Rook will run as 'ceph' instead of 'root'
 		// If we run on a version of Ceph does not these flags it will simply ignore them
-		//run ceph daemon process under the 'ceph' user
+		// run ceph daemon process under the 'ceph' user
 		config.NewFlag("setuser", "ceph"),
 		// run ceph daemon process under the 'ceph' group
 		config.NewFlag("setgroup", "ceph"),

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -62,19 +62,23 @@ func TestMountsMatchVolumes(t *testing.T) {
 
 	volsMountsTestDef := test.VolumesAndMountsTestDefinition{
 		VolumesSpec: &test.VolumesSpec{
-			Moniker: "PodVolumes(\"/dev/sdc\")", Volumes: PodVolumes(dataPathMap, "/dev/sdc", clusterSpec.DataDirHostPath, false)},
+			Moniker: "PodVolumes(\"/dev/sdc\")", Volumes: PodVolumes(dataPathMap, "/dev/sdc", clusterSpec.DataDirHostPath, false),
+		},
 		MountsSpecItems: []*test.MountsSpec{
 			{Moniker: "CephVolumeMounts(true)", Mounts: CephVolumeMounts(dataPathMap, false)},
-			{Moniker: "RookVolumeMounts(true)", Mounts: RookVolumeMounts(dataPathMap, false)}},
+			{Moniker: "RookVolumeMounts(true)", Mounts: RookVolumeMounts(dataPathMap, false)},
+		},
 	}
 	volsMountsTestDef.TestMountsMatchVolumes(t)
 
 	volsMountsTestDef = test.VolumesAndMountsTestDefinition{
 		VolumesSpec: &test.VolumesSpec{
-			Moniker: "PodVolumes(\"/dev/sdc\")", Volumes: PodVolumes(dataPathMap, "/dev/sdc", clusterSpec.DataDirHostPath, true)},
+			Moniker: "PodVolumes(\"/dev/sdc\")", Volumes: PodVolumes(dataPathMap, "/dev/sdc", clusterSpec.DataDirHostPath, true),
+		},
 		MountsSpecItems: []*test.MountsSpec{
 			{Moniker: "CephVolumeMounts(false)", Mounts: CephVolumeMounts(dataPathMap, true)},
-			{Moniker: "RookVolumeMounts(false)", Mounts: RookVolumeMounts(dataPathMap, true)}},
+			{Moniker: "RookVolumeMounts(false)", Mounts: RookVolumeMounts(dataPathMap, true)},
+		},
 	}
 	volsMountsTestDef.TestMountsMatchVolumes(t)
 }
@@ -86,7 +90,7 @@ func TestCheckPodMemory(t *testing.T) {
 
 	// A value for the memory used in the tests
 	// nolint:gosec // G115 no overflow expected in the test
-	var memory_value = int64(PodMinimumMemory * 8 * uint64(math.Pow10(6)))
+	memory_value := int64(PodMinimumMemory * 8 * uint64(math.Pow10(6)))
 
 	// Case 1: No memory limits, no memory requested
 	test_resource := v1.ResourceRequirements{}
@@ -156,7 +160,8 @@ func TestBuildSocketPath(t *testing.T) {
 func TestGenerateLivenessProbeExecDaemon(t *testing.T) {
 	daemonID := "0"
 	probe := GenerateLivenessProbeExecDaemon(config.OsdType, daemonID)
-	expectedCommand := []string{"env",
+	expectedCommand := []string{
+		"env",
 		"-i",
 		"sh",
 		"-c",
@@ -192,10 +197,12 @@ func TestDaemonFlags(t *testing.T) {
 				},
 			},
 			daemonID: "daemon-id",
-			expected: []string{"--fsid=id", "--keyring=/etc/ceph/keyring-store/keyring", "--default-log-to-stderr=true", "--default-err-to-stderr=true",
+			expected: []string{
+				"--fsid=id", "--keyring=/etc/ceph/keyring-store/keyring", "--default-log-to-stderr=true", "--default-err-to-stderr=true",
 				"--default-mon-cluster-log-to-stderr=true", "--default-log-stderr-prefix=debug ", "--default-log-to-file=false", "--default-mon-cluster-log-to-file=false",
 				"--mon-host=$(ROOK_CEPH_MON_HOST)", "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)", "--id=daemon-id", "--setuser=ceph", "--setgroup=ceph",
-				"--ms-bind-ipv4=false", "--ms-bind-ipv6=true"},
+				"--ms-bind-ipv4=false", "--ms-bind-ipv6=true",
+			},
 		},
 		{
 			label: "case 2: IPv6 disabled",
@@ -204,9 +211,11 @@ func TestDaemonFlags(t *testing.T) {
 			},
 			clusterSpec: &cephv1.ClusterSpec{},
 			daemonID:    "daemon-id",
-			expected: []string{"--fsid=id", "--keyring=/etc/ceph/keyring-store/keyring", "--default-log-to-stderr=true", "--default-err-to-stderr=true",
+			expected: []string{
+				"--fsid=id", "--keyring=/etc/ceph/keyring-store/keyring", "--default-log-to-stderr=true", "--default-err-to-stderr=true",
 				"--default-mon-cluster-log-to-stderr=true", "--default-log-stderr-prefix=debug ", "--default-log-to-file=false", "--default-mon-cluster-log-to-file=false",
-				"--mon-host=$(ROOK_CEPH_MON_HOST)", "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)", "--id=daemon-id", "--setuser=ceph", "--setgroup=ceph"},
+				"--mon-host=$(ROOK_CEPH_MON_HOST)", "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)", "--id=daemon-id", "--setuser=ceph", "--setgroup=ceph",
+			},
 		},
 	}
 

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -56,17 +56,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
-var (
-	resourcesSchemeFuncs = []func(*runtime.Scheme) error{
-		clientgoscheme.AddToScheme,
-		cephv1.AddToScheme,
-	}
-)
+var resourcesSchemeFuncs = []func(*runtime.Scheme) error{
+	clientgoscheme.AddToScheme,
+	cephv1.AddToScheme,
+}
 
-var (
-	// EnableMachineDisruptionBudget checks whether machine disruption budget is enabled
-	EnableMachineDisruptionBudget bool
-)
+// EnableMachineDisruptionBudget checks whether machine disruption budget is enabled
+var EnableMachineDisruptionBudget bool
 
 // AddToManagerFuncsMaintenance is a list of functions to add all Controllers to the Manager (entrypoint for controller)
 var AddToManagerFuncsMaintenance = []func(manager.Manager, *controllerconfig.Context) error{

--- a/pkg/operator/ceph/csi/ceph_connection.go
+++ b/pkg/operator/ceph/csi/ceph_connection.go
@@ -32,7 +32,6 @@ import (
 )
 
 func CreateUpdateCephConnection(c client.Client, clusterInfo *cephclient.ClusterInfo, clusterSpec cephv1.ClusterSpec) error {
-
 	logger.Infof("Configuring ceph connection CR %q in namespace %q", clusterInfo.NamespacedName().Name, clusterInfo.NamespacedName().Namespace)
 	csiCephConnection := &csiopv1a1.CephConnection{}
 

--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -215,7 +215,6 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 		assert.Equal(t, "my-group", cc[2].CephFS.SubvolumeGroup)
 		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.KernelMountOptions, cc[2].CephFS.KernelMountOptions)
 		assert.Equal(t, csiClusterConfigEntryMountOptions.CephFS.FuseMountOptions, cc[2].CephFS.FuseMountOptions)
-
 	})
 
 	t.Run("add a 4th mon to the 3rd cluster and subvolumegroup is preserved", func(t *testing.T) {

--- a/pkg/operator/ceph/csi/config.go
+++ b/pkg/operator/ceph/csi/config.go
@@ -36,7 +36,6 @@ import (
 )
 
 func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Client, clusterInfo *cephclient.ClusterInfo, cephBlockPoolRadosNamespaceName, clusterID, clusterName string) error {
-
 	logger.Info("creating ceph-csi clientProfile CR for rados namespace")
 
 	csiOpClientProfile := &csiopv1a1.ClientProfile{}
@@ -74,7 +73,6 @@ func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Clien
 }
 
 func CreateUpdateClientProfileSubVolumeGroup(ctx context.Context, c client.Client, clusterInfo *cephclient.ClusterInfo, cephFilesystemSubVolumeGroupName, clusterID, clusterName string) error {
-
 	logger.Info("Creating ceph-csi clientProfile CR for subvolume group")
 
 	csiOpClientProfile := generateProfileSubVolumeGroupSpec(clusterInfo, cephFilesystemSubVolumeGroupName, clusterID, clusterName)

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -31,9 +31,7 @@ import (
 )
 
 func (r *ReconcileCSI) validateAndConfigureDrivers(ownerInfo *k8sutil.OwnerInfo) error {
-	var (
-		err error
-	)
+	var err error
 
 	if err = r.setParams(); err != nil {
 		return errors.Wrapf(err, "failed to configure CSI parameters")

--- a/pkg/operator/ceph/csi/csidriver.go
+++ b/pkg/operator/ceph/csi/csidriver.go
@@ -37,7 +37,8 @@ func (d v1CsiDriver) createCSIDriverInfo(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	name, fsGroupPolicy string,
-	attachRequired, seLinuxMountRequired bool) error {
+	attachRequired, seLinuxMountRequired bool,
+) error {
 	mountInfo := false
 	// Create CSIDriver object
 	csiDriver := &v1k8scsi.CSIDriver{

--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -129,7 +129,6 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 }
 
 func (r *ReconcileCSI) createImageSetConfigmap() (string, error) {
-
 	data := map[string]string{
 		"provisioner": CSIParam.ProvisionerImage,
 		"attacher":    CSIParam.AttacherImage,

--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -38,7 +38,6 @@ import (
 )
 
 func (r *ReconcileCSI) createOrUpdateDriverResources(cluster cephv1.CephCluster, clusterInfo *cephclient.ClusterInfo) error {
-
 	if EnableRBD {
 		logger.Info("Creating RBD driver resources")
 		err := r.transferCSIDriverOwner(r.opManagerContext, RBDDriverName)
@@ -381,7 +380,6 @@ func createDriverNodePluginResouces(key string) csiopv1a1.NodePluginResourcesSpe
 
 // transferCSIDriverOwner update CSIDriver and returns the error if any
 func (r *ReconcileCSI) transferCSIDriverOwner(ctx context.Context, name string) error {
-
 	logger.Info("adding annotation to CSIDriver resource for csi-operator to own it")
 	csiDriver, err := r.context.Clientset.StorageV1().CSIDrivers().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/ceph/csi/peermap/config.go
+++ b/pkg/operator/ceph/csi/peermap/config.go
@@ -210,7 +210,8 @@ func getClusterPoolIDMap(clusterContext *clusterd.Context, clusterInfo *cephclie
 		defer os.Remove(configFile.Name())
 
 		// Build command
-		args := []string{"osd", "pool", "get", pool.Name, "all",
+		args := []string{
+			"osd", "pool", "get", pool.Name, "all",
 			fmt.Sprintf("--cluster=%s", decodedTokenToGo.Namespace),
 			fmt.Sprintf("--conf=%s", configFile.Name()),
 			fmt.Sprintf("--fsid=%s", decodedTokenToGo.ClusterFSID),

--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -241,7 +241,7 @@ var fakeMultiPeerCephBlockPool = cephv1.CephBlockPool{
 func saveMockDataInTempFile(data, filePattern string) error {
 	matches, _ := filepath.Glob(fmt.Sprintf("%s/%s*", os.TempDir(), filePattern))
 	for _, m := range matches {
-		file, err := os.OpenFile(m, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		file, err := os.OpenFile(m, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return fmt.Errorf("failed to open file %q. %v", m, err)
 		}
@@ -265,7 +265,6 @@ var mockExecutor = &exectest.MockExecutor{
 			} else if args[3] == "mirrorPool2" {
 				return `{"pool_id": 2}`, nil
 			}
-
 		}
 		return "", nil
 	},
@@ -331,7 +330,7 @@ func TestSinglePeerMappings(t *testing.T) {
 	_, err := fakeContext.Clientset.CoreV1().Secrets(ns).Create(context.TODO(), &peer1Secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	//expected: &[{ClusterIDMapping:{peer1:rook-ceph-primary}. RBDPoolIDMapping:[{2:1}]}]
+	// expected: &[{ClusterIDMapping:{peer1:rook-ceph-primary}. RBDPoolIDMapping:[{2:1}]}]
 	actualMappings, err := getClusterPoolIDMap(
 		fakeContext,
 		clusterInfo,
@@ -451,9 +450,9 @@ func TestCreateOrUpdateConfig(t *testing.T) {
 
 	err = CreateOrUpdateConfig(context.TODO(), fakeContext, actualMappings)
 	assert.NoError(t, err)
-	//validateConfig(t, fakeContext, actualMappings)
+	// validateConfig(t, fakeContext, actualMappings)
 
-	//Update existing mapping config
+	// Update existing mapping config
 	mappings := *actualMappings
 	mappings = append(mappings, PeerIDMapping{
 		ClusterIDMapping: map[string]string{"peer2": ns},

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -321,8 +321,8 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 }
 
 func (r *ReconcileClusterDisruption) handleActiveDrains(allFailureDomains []string, drainingFailureDomain,
-	failureDomainType, namespace string) error {
-
+	failureDomainType, namespace string,
+) error {
 	for _, failureDomainName := range allFailureDomains {
 		// create blocking PDB for failure domains not currently draining
 		if failureDomainName != drainingFailureDomain {

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -108,7 +108,6 @@ func getFakeClusterInfo() *client.ClusterInfo {
 	sharedClusterMap := &ClusterMap{}
 	sharedClusterMap.UpdateClusterMap(namespace, cephCluster)
 	return sharedClusterMap.GetClusterInfo(namespace)
-
 }
 
 func TestGetOSDFailureDomains(t *testing.T) {
@@ -124,8 +123,10 @@ func TestGetOSDFailureDomains(t *testing.T) {
 	}{
 		{
 			name: "case 1: all osds are running",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 1)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 1),
+			},
 			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{},
@@ -134,8 +135,10 @@ func TestGetOSDFailureDomains(t *testing.T) {
 		},
 		{
 			name: "case 2: osd in zone-1 is pending and node is unschedulable",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 1)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 1),
+			},
 			nodes:                          []corev1.Node{*getNodeObject("node-1", true), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1"},
@@ -144,8 +147,10 @@ func TestGetOSDFailureDomains(t *testing.T) {
 		},
 		{
 			name: "case 3: osd in zone-1 and zone-2 are pending and node is unschedulable",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 0),
-				fakeOSDDeployment(3, 1)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 0),
+				fakeOSDDeployment(3, 1),
+			},
 			nodes:                          []corev1.Node{*getNodeObject("node-1", true), *getNodeObject("node-2", true), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1", "zone-2"},
@@ -154,8 +159,10 @@ func TestGetOSDFailureDomains(t *testing.T) {
 		},
 		{
 			name: "case 4: osd in zone-1 is pending but osd node is schedulable",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 1)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 0), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 1),
+			},
 			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", false)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-1"},
@@ -164,8 +171,10 @@ func TestGetOSDFailureDomains(t *testing.T) {
 		},
 		{
 			name: "case 5: osd in zone-3 is pending and the osd node is not schedulable",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 0)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 0),
+			},
 			nodes:                          []corev1.Node{*getNodeObject("node-1", false), *getNodeObject("node-2", false), *getNodeObject("node-3", true)},
 			expectedAllFailureDomains:      []string{"zone-1", "zone-2", "zone-3"},
 			expectedOsdDownFailureDomains:  []string{"zone-3"},
@@ -222,8 +231,10 @@ func TestGetOSDFailureDomainsError(t *testing.T) {
 	}{
 		{
 			name: "case 1: one or more OSD deployment is missing crush location label",
-			osds: []appsv1.Deployment{fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
-				fakeOSDDeployment(3, 1)},
+			osds: []appsv1.Deployment{
+				fakeOSDDeployment(1, 1), fakeOSDDeployment(2, 1),
+				fakeOSDDeployment(3, 1),
+			},
 			expectedAllFailureDomains:      nil,
 			expectedDrainingFailureDomains: nil,
 			expectedOsdDownFailureDomains:  nil,
@@ -472,5 +483,4 @@ func TestSetPDBConfig(t *testing.T) {
 			assert.Equal(t, tc.expecteNoOutSetting, tc.pdbConfig.Data[setNoOut])
 		})
 	}
-
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools.go
@@ -73,7 +73,6 @@ func (r *ReconcileClusterDisruption) processPools(request reconcile.Request) (*c
 	minFailureDomain := getMinimumFailureDomain(poolSpecs)
 
 	return cephObjectStoreList, cephFilesystemList, minFailureDomain, poolCount, nil
-
 }
 
 func getMinimumFailureDomain(poolList []cephv1.PoolSpec) string {
@@ -81,7 +80,7 @@ func getMinimumFailureDomain(poolList []cephv1.PoolSpec) string {
 		return cephv1.DefaultFailureDomain
 	}
 
-	//start with max as the min
+	// start with max as the min
 	minfailureDomainIndex := len(topology.CRUSHMapLevelsOrdered) - 1
 	matched := false
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools_test.go
@@ -48,5 +48,4 @@ func TestGetMinimumFailureDomain(t *testing.T) {
 	}
 
 	assert.Equal(t, "host", getMinimumFailureDomain(poolList))
-
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -187,7 +187,6 @@ func (c *ClusterMap) UpdateClusterMap(namespace string, cluster *cephv1.CephClus
 		c.clusterMap = make(map[string]*cephv1.CephCluster)
 	}
 	c.clusterMap[namespace] = cluster
-
 }
 
 // GetClusterInfo looks up the context for the current ceph cluster.

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestClusterMap(t *testing.T) {
-
 	sharedClusterMap := &ClusterMap{}
 
 	clusterInfo := sharedClusterMap.GetClusterInfo("rook-ceph-0")

--- a/pkg/operator/ceph/disruption/controllerconfig/toleration_test.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/toleration_test.go
@@ -84,7 +84,7 @@ func TestTolerationSet(t *testing.T) {
 			Effect:   corev1.TaintEffectNoExecute,
 		},
 	}
-	//identical to uniqueTolerationsManualA
+	// identical to uniqueTolerationsManualA
 	uniqueTolerationsManualB := []corev1.Toleration{
 		// key1
 		//   exists
@@ -149,7 +149,7 @@ func TestTolerationSet(t *testing.T) {
 	for i := range uniqueTolerationsManualA {
 		tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManualA[i])
 
-		//append the previous one again if it's within range, else append the last one
+		// append the previous one again if it's within range, else append the last one
 		if i > 0 {
 			tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManualB[i-1])
 		} else {

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -343,7 +343,6 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 
 	// Enable mirroring if needed
 	if cephFilesystem.Spec.Mirroring != nil {
-
 		// Disable mirroring on that filesystem if needed
 		if !cephFilesystem.Spec.Mirroring.Enabled {
 			err = cephclient.DisableFilesystemSnapshotMirror(r.context, r.clusterInfo, cephFilesystem.Name)

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -242,7 +242,6 @@ func (f *Filesystem) updateFilesystem(context *clusterd.Context, clusterInfo *ce
 
 // doFilesystemCreate starts the Ceph file daemons and creates the filesystem in Ceph.
 func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, clusterSpec *cephv1.ClusterSpec, spec cephv1.FilesystemSpec) error {
-
 	_, err := cephclient.GetFilesystem(context, clusterInfo, f.Name)
 	if err == nil {
 		logger.Infof("filesystem %q already exists", f.Name)

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -381,7 +381,8 @@ func TestCreateFilesystem(t *testing.T) {
 	context := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,
-		Clientset: clientset}
+		Clientset: clientset,
+	}
 	fs := fsTest(fsName)
 	clusterInfo := &cephclient.ClusterInfo{FSID: "myfsid", CephVersion: version.Squid, Context: ctx}
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
@@ -407,7 +408,8 @@ func TestCreateFilesystem(t *testing.T) {
 		context = &clusterd.Context{
 			Executor:  executor,
 			ConfigDir: configDir,
-			Clientset: clientset}
+			Clientset: clientset,
+		}
 		// add not named pool, with default naming
 		fs.Spec.DataPools = append(fs.Spec.DataPools, cephv1.NamedPoolSpec{
 			PoolSpec: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
@@ -447,7 +449,8 @@ func TestUpgradeFilesystem(t *testing.T) {
 	context := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,
-		Clientset: clientset}
+		Clientset: clientset,
+	}
 	fs := fsTest(fsName)
 	clusterInfo := &cephclient.ClusterInfo{FSID: "myfsid", CephVersion: version.Squid, Context: ctx}
 
@@ -598,7 +601,8 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 	context := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,
-		Clientset: clientset}
+		Clientset: clientset,
+	}
 	fs := cephv1.CephFilesystem{
 		ObjectMeta: metav1.ObjectMeta{Name: "myfs", Namespace: "ns"},
 		Spec: cephv1.FilesystemSpec{

--- a/pkg/operator/ceph/file/mds/livenessprobe.go
+++ b/pkg/operator/ceph/file/mds/livenessprobe.go
@@ -28,10 +28,8 @@ const (
 	mdsSuccessThreshold int32 = 1
 )
 
-var (
-	//go:embed livenessprobe.sh
-	mdsLivenessProbeCmdScript string
-)
+//go:embed livenessprobe.sh
+var mdsLivenessProbeCmdScript string
 
 type mdsLivenessProbeConfig struct {
 	MdsId          string

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -100,7 +100,7 @@ func (c *Cluster) Start() error {
 
 	// If attempt was made to prepare daemons for upgrade, make sure that an attempt is made to
 	// bring fs state back to desired when this method returns with any error or success.
-	var fsPreparedForUpgrade = false
+	fsPreparedForUpgrade := false
 
 	// upgrading MDS cluster needs to set max_mds to 1 and stop all stand-by MDSes first
 	isUpgrade, err := c.isCephUpgrade()
@@ -230,7 +230,6 @@ func (c *Cluster) startDeployment(ctx context.Context, daemonLetterID string) (s
 
 // isCephUpgrade determine if mds version inferior than image
 func (c *Cluster) isCephUpgrade() (bool, error) {
-
 	allVersions, err := cephclient.GetAllCephDaemonVersions(c.context, c.clusterInfo)
 	if err != nil {
 		return false, err
@@ -250,7 +249,6 @@ func (c *Cluster) isCephUpgrade() (bool, error) {
 }
 
 func (c *Cluster) upgradeMDS() error {
-
 	logger.Infof("upgrading MDS cluster for filesystem %q", c.fs.Name)
 
 	// 1. set allow_standby_replay to false

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -43,7 +43,6 @@ const (
 )
 
 func (c *Cluster) makeDeployment(mdsConfig *mdsConfig, fsNamespacedname types.NamespacedName) (*apps.Deployment, error) {
-
 	mdsContainer := c.makeMdsDaemonContainer(mdsConfig, fsNamespacedname.Name)
 	mdsContainer = cephconfig.ConfigureStartupProbe(mdsContainer, c.fs.Spec.MetadataServer.StartupProbe)
 	mdsContainer = cephconfig.ConfigureLivenessProbe(mdsContainer, c.fs.Spec.MetadataServer.LivenessProbe)

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -228,7 +228,6 @@ func (r *ReconcileFilesystemMirror) reconcile(request reconcile.Request) (reconc
 	// Return and do not requeue
 	logger.Debug("done reconciling ceph filesystem mirror")
 	return reconcile.Result{}, *filesystemMirror, nil
-
 }
 
 func (r *ReconcileFilesystemMirror) reconcileFilesystemMirror(filesystemMirror *cephv1.CephFilesystemMirror) (reconcile.Result, error) {

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -78,7 +78,8 @@ func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, f
 			Name:        daemonConfig.ResourceName,
 			Namespace:   fsMirror.Namespace,
 			Annotations: fsMirror.Spec.Annotations,
-			Labels:      controller.CephDaemonAppLabels(AppName, fsMirror.Namespace, config.FilesystemMirrorType, userID, fsMirror.Name, "cephfilesystemmirrors.ceph.rook.io", true)},
+			Labels:      controller.CephDaemonAppLabels(AppName, fsMirror.Namespace, config.FilesystemMirrorType, userID, fsMirror.Name, "cephfilesystemmirrors.ceph.rook.io", true),
+		},
 		Spec: apps.DeploymentSpec{
 			RevisionHistoryLimit: controller.RevisionHistoryLimit(),
 			Selector: &metav1.LabelSelector{

--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -345,7 +345,8 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) createOrUpdateSubVolumeGroup(cep
 
 // Delete the ceph filesystem subvolume group
 func (r *ReconcileCephFilesystemSubVolumeGroup) deleteSubVolumeGroup(cephFilesystemSubVolumeGroup *cephv1.CephFilesystemSubVolumeGroup,
-	cephCluster *cephv1.CephCluster) error {
+	cephCluster *cephv1.CephCluster,
+) error {
 	namespacedName := fmt.Sprintf("%s/%s", cephFilesystemSubVolumeGroup.Namespace, cephFilesystemSubVolumeGroup.Name)
 	logger.Infof("deleting ceph filesystem subvolume group object %q", namespacedName)
 	if err := cephclient.DeleteCephFSSubVolumeGroup(r.context, r.clusterInfo, cephFilesystemSubVolumeGroup.Spec.FilesystemName, getSubvolumeGroupName(cephFilesystemSubVolumeGroup)); err != nil {

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -366,5 +366,4 @@ func Test_formatPinning(t *testing.T) {
 	pinning.Random = &randomValue
 	pinningStatus = formatPinning(*pinning)
 	assert.Equal(t, "random=0.31", pinningStatus)
-
 }

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -290,7 +290,7 @@ func atomicPrependToConfigObject(
 	logger.Debugf("rados object %s will have config block prepended: %s", objInfoString, configBlock)
 
 	newConfig := fmt.Sprintf("%s%s", configBlock, string(rawObj))
-	if err := os.WriteFile(tempFile.Name(), []byte(newConfig), fs.FileMode(0644)); err != nil {
+	if err := os.WriteFile(tempFile.Name(), []byte(newConfig), fs.FileMode(0o644)); err != nil {
 		return errors.Wrapf(err, "failed to write new config content for object %s to temp file", objInfoString)
 	}
 
@@ -365,7 +365,7 @@ func atomicRemoveFromConfigObject(context *clusterd.Context, clusterInfo *cephcl
 	logger.Debugf("rados object %s will have config block removed: %s", objInfoString, configBlock)
 
 	newConfig := strings.ReplaceAll(string(rawObj), configBlock, "")
-	if err := os.WriteFile(tempFile.Name(), []byte(newConfig), fs.FileMode(0644)); err != nil {
+	if err := os.WriteFile(tempFile.Name(), []byte(newConfig), fs.FileMode(0o644)); err != nil {
 		return errors.Wrapf(err, "failed to write new config content for object %s to temp file", objInfoString)
 	}
 

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -294,7 +294,6 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 	// Return and do not requeue
 	logger.Debug("done reconciling ceph nfs")
 	return reconcile.Result{}, *cephNFS, nil
-
 }
 
 func (r *ReconcileCephNFS) reconcileCreateCephNFS(cephNFS *cephv1.CephNFS) (reconcile.Result, error) {

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -186,7 +186,6 @@ func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, actio
 }
 
 func (r *ReconcileCephNFS) generateConfigMap(n *cephv1.CephNFS, name string) *v1.ConfigMap {
-
 	data := map[string]string{
 		"config": getGaneshaConfig(n, r.clusterInfo.CephVersion, name),
 	}
@@ -275,6 +274,7 @@ func (r *ReconcileCephNFS) removeServersFromDatabase(n *cephv1.CephNFS, newActiv
 
 	return nil
 }
+
 func instanceName(n *cephv1.CephNFS, name string) string {
 	return fmt.Sprintf("%s-%s-%s", AppName, n.Name, name)
 }

--- a/pkg/operator/ceph/nfs/spec_test.go
+++ b/pkg/operator/ceph/nfs/spec_test.go
@@ -46,22 +46,23 @@ func newDeploymentSpecTest(t *testing.T) (*ReconcileCephNFS, daemonConfig) {
 	}
 
 	s := scheme.Scheme
-	object := []runtime.Object{&cephv1.CephNFS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		TypeMeta: controllerTypeMeta,
-		Spec: cephv1.NFSGaneshaSpec{
-			RADOS: cephv1.GaneshaRADOSSpec{
-				Pool:      "foo",
+	object := []runtime.Object{
+		&cephv1.CephNFS{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
 				Namespace: namespace,
 			},
-			Server: cephv1.GaneshaServerSpec{
-				Active: 1,
+			TypeMeta: controllerTypeMeta,
+			Spec: cephv1.NFSGaneshaSpec{
+				RADOS: cephv1.GaneshaRADOSSpec{
+					Pool:      "foo",
+					Namespace: namespace,
+				},
+				Server: cephv1.GaneshaServerSpec{
+					Active: 1,
+				},
 			},
 		},
-	},
 	}
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 

--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -239,7 +239,8 @@ func TestCommitConfigChanges(t *testing.T) {
 	}{
 		// a bit more background: creating a realm creates the first period epoch. When Rook creates
 		// zonegroup and zone, it results in many changes to the period.
-		{"real-world first reconcile (many changes, should commit period)",
+		{
+			"real-world first reconcile (many changes, should commit period)",
 			commandReturns{
 				periodGetOutput:    firstPeriodGet,
 				periodUpdateOutput: firstPeriodUpdate,
@@ -251,7 +252,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			expectNoErr,
 		},
 		// note: this also tests that we support the output changing in the future to increment "epoch"
-		{"real-world second reconcile (no changes, should not commit period)",
+		{
+			"real-world second reconcile (no changes, should not commit period)",
 			commandReturns{
 				periodGetOutput:    secondPeriodGet,
 				periodUpdateOutput: secondPeriodUpdateWithoutChanges,
@@ -262,7 +264,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectNoErr,
 		},
-		{"second reconcile with changes",
+		{
+			"second reconcile with changes",
 			commandReturns{
 				periodGetOutput:    secondPeriodGet,
 				periodUpdateOutput: secondPeriodUpdateWithChanges,
@@ -273,7 +276,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectNoErr,
 		},
-		{"invalid get json",
+		{
+			"invalid get json",
 			commandReturns{
 				periodGetOutput:    `{"ids": [}`, // json obj with incomplete array that won't parse
 				periodUpdateOutput: firstPeriodUpdate,
@@ -284,7 +288,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectErr,
 		},
-		{"invalid update json",
+		{
+			"invalid update json",
 			commandReturns{
 				periodGetOutput:    firstPeriodGet,
 				periodUpdateOutput: `{"ids": [}`,
@@ -295,7 +300,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectErr,
 		},
-		{"fail period get",
+		{
+			"fail period get",
 			commandReturns{
 				periodGetOutput:    "", // error
 				periodUpdateOutput: firstPeriodUpdate,
@@ -306,7 +312,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectErr,
 		},
-		{"fail period update",
+		{
+			"fail period update",
 			commandReturns{
 				periodGetOutput:    firstPeriodGet,
 				periodUpdateOutput: "", // error
@@ -317,7 +324,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectErr,
 		},
-		{"fail period commit",
+		{
+			"fail period commit",
 			commandReturns{
 				periodGetOutput:    firstPeriodGet,
 				periodUpdateOutput: firstPeriodUpdate,
@@ -329,7 +337,8 @@ func TestCommitConfigChanges(t *testing.T) {
 			},
 			expectErr,
 		},
-		{"configs are removed",
+		{
+			"configs are removed",
 			commandReturns{
 				periodGetOutput:    secondPeriodUpdateWithChanges,
 				periodUpdateOutput: secondPeriodUpdateWithoutChanges,

--- a/pkg/operator/ceph/object/bucket.go
+++ b/pkg/operator/ceph/object/bucket.go
@@ -81,7 +81,6 @@ func GetBucketStats(c *Context, bucketName string) (*ObjectBucketStats, bool, er
 		"bucket",
 		"stats",
 		"--bucket", bucketName)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 2") {
 			return nil, true, errors.New("not found")

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -435,7 +435,6 @@ func (p *Provisioner) initializeCreateOrGrant(bucket *bucket) error {
 }
 
 func (p *Provisioner) initializeDeleteOrRevoke(ob *bktv1alpha1.ObjectBucket) error {
-
 	sc, err := p.getStorageClassWithBackoff(ob.Spec.StorageClassName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get storage class for OB %q", ob.Name)
@@ -477,7 +476,6 @@ func (p *Provisioner) initializeDeleteOrRevoke(ob *bktv1alpha1.ObjectBucket) err
 
 // Return the OB struct with minimal fields filled in.
 func (p *Provisioner) composeObjectBucket(bucket *bucket) *bktv1alpha1.ObjectBucket {
-
 	conn := &bktv1alpha1.Connection{
 		Endpoint: &bktv1alpha1.Endpoint{
 			// if there are multiple endpoints on the object store, the OBC will get the endpoint

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -90,7 +90,8 @@ func TestPopulateDomainAndPort(t *testing.T) {
 			Namespace: namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
-			Kind: "CephObjectStore"},
+			Kind: "CephObjectStore",
+		},
 		Spec: cephv1.ObjectStoreSpec{
 			Gateway: cephv1.GatewaySpec{
 				Port: int32(80),

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -57,9 +57,7 @@ caps osd = "allow rwx"
 	rgwVaultDirName                 = "/etc/vault/rgw/"
 )
 
-var (
-	rgwFrontendName = "beast"
-)
+var rgwFrontendName = "beast"
 
 func (c *clusterConfig) portString() string {
 	var portString string
@@ -112,14 +110,15 @@ func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {
 }
 
 func mapKeystoneSecretToConfig(cfg map[string]string, secret *v1.Secret) (map[string]string, error) {
-
-	requiredKeys := []string{"OS_PROJECT_DOMAIN_NAME",
+	requiredKeys := []string{
+		"OS_PROJECT_DOMAIN_NAME",
 		"OS_USER_DOMAIN_NAME",
 		"OS_PROJECT_DOMAIN_NAME",
 		"OS_USER_DOMAIN_NAME",
 		"OS_PROJECT_NAME",
 		"OS_USERNAME",
-		"OS_PASSWORD"}
+		"OS_PASSWORD",
+	}
 
 	data := make(map[string]string)
 	for key, value := range secret.Data {
@@ -154,7 +153,6 @@ func mapKeystoneSecretToConfig(cfg map[string]string, secret *v1.Secret) (map[st
 }
 
 func (c *clusterConfig) setFlagsMonConfigStore(rgwConfig *rgwConfig) error {
-
 	monStore := cephconfig.GetMonStore(c.context, c.clusterInfo)
 	who := generateCephXUser(rgwConfig.ResourceName)
 
@@ -252,7 +250,6 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 }
 
 func configureKeystoneAuthentication(rgwConfig *rgwConfig, configOptions map[string]string) (map[string]string, error) {
-
 	keystone := rgwConfig.Auth.Keystone
 	if keystone == nil {
 		logger.Debug("Authentication with keystone is disabled")
@@ -275,7 +272,6 @@ func configureKeystoneAuthentication(rgwConfig *rgwConfig, configOptions map[str
 			lc != "s3" {
 
 			return nil, errors.New(fmt.Sprintf("ImplicitTenantSetting can only be 'swift', 's3', 'true' or 'false', not %q", string(keystone.ImplicitTenants)))
-
 		}
 
 		configOptions["rgw_keystone_implicit_tenants"] = lc

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -45,7 +45,8 @@ func newConfig(t *testing.T) *clusterConfig {
 		store: &cephv1.CephObjectStore{
 			Spec: cephv1.ObjectStoreSpec{
 				Gateway: cephv1.GatewaySpec{},
-			}},
+			},
+		},
 		clusterInfo: clusterInfo,
 		clusterSpec: clusterSpec,
 		context:     &clusterd.Context{Clientset: test.New(t, 3)},
@@ -156,7 +157,8 @@ func Test_clusterConfig_generateMonConfigOptions(t *testing.T) {
 			Gateway: cephv1.GatewaySpec{
 				DisableMultisiteSyncTraffic: true,
 				RgwConfig:                   map[string]string{"one": "add", "rgw_enable_usage_log": "false"},
-				RgwCommandFlags:             map[string]string{"two": "add", "rgw_zone": "bob"}},
+				RgwCommandFlags:             map[string]string{"two": "add", "rgw_zone": "bob"},
+			},
 		}, overlayOnDefaultConfigs("rgw_run_sync_thread", "false", "one", "add", "rgw_enable_usage_log", "false"), false},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -236,7 +236,8 @@ func mapSecretToCR(k8sClient client.Client) func(context.Context, client.Object)
 					NamespacedName: types.NamespacedName{
 						Name:      objStore.Name,
 						Namespace: objStore.Namespace,
-					}})
+					},
+				})
 			}
 		}
 		return requests

--- a/pkg/operator/ceph/object/cosi/spec.go
+++ b/pkg/operator/ceph/object/cosi/spec.go
@@ -120,7 +120,8 @@ func createCOSIDriverContainer(cephCOSIDriver *cephv1.CephCOSIDriver) corev1.Con
 			"--driver-prefix=" + CephCOSIDriverPrefix,
 		},
 		Env: []corev1.EnvVar{
-			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: cosiSocketVolumeName, MountPath: cosiSocketMountPath},
 		},
@@ -140,7 +141,8 @@ func createCOSISideCarContainer(cephCOSIDriver *cephv1.CephCOSIDriver) corev1.Co
 			"--v=5",
 		},
 		Env: []corev1.EnvVar{
-			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: cosiSocketVolumeName, MountPath: cosiSocketMountPath},
 		},

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -63,7 +63,9 @@ func (c *clusterConfig) mimeTypesVolume() v1.Volume {
 		VolumeSource: v1.VolumeSource{
 			ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{
 				Name: c.mimeTypesConfigMapName(),
-			}}}}
+			}},
+		},
+	}
 }
 
 func (c *clusterConfig) mimeTypesVolumeMount() v1.VolumeMount {

--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -53,10 +53,12 @@ const (
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", packageName)
 
-var waitForRequeueIfTopicNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
-var waitForRequeueIfNotificationNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
-var waitForRequeueIfObjectBucketNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
-var waitForRequeueIfNotificationNotDeleted = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+var (
+	waitForRequeueIfTopicNotReady          = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+	waitForRequeueIfNotificationNotReady   = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+	waitForRequeueIfObjectBucketNotReady   = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+	waitForRequeueIfNotificationNotDeleted = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+)
 
 // ReconcileNotifications reconciles a CephbucketNotification
 type ReconcileNotifications struct {

--- a/pkg/operator/ceph/object/notification/controller_test.go
+++ b/pkg/operator/ceph/object/notification/controller_test.go
@@ -78,8 +78,8 @@ func resetValues() {
 	getWasInvoked = false
 	createdNotifications = nil
 	deletedNotifications = nil
-
 }
+
 func mockCleanup() {
 	resetValues()
 	createNotificationFunc = createNotification
@@ -146,8 +146,10 @@ func mockSetup(t *testing.T) {
 			return []string{testNotificationName}, nil
 		}
 		if bucket.Name == multipleDeleteBucketName || bucket.Name == multipleBothBucketName {
-			return []string{multipleDeleteBucketName + testNotificationName + "-1",
-				multipleDeleteBucketName + testNotificationName + "-2"}, nil
+			return []string{
+				multipleDeleteBucketName + testNotificationName + "-1",
+				multipleDeleteBucketName + testNotificationName + "-2",
+			}, nil
 		}
 		return nil, nil
 	}

--- a/pkg/operator/ceph/object/notification/obc_label_controller_test.go
+++ b/pkg/operator/ceph/object/notification/obc_label_controller_test.go
@@ -68,7 +68,8 @@ func createOBResources(name, provisioner string) (*bktv1alpha1.ObjectBucketClaim
 					},
 				},
 				ClaimRef: &corev1.ObjectReference{
-					Name: name},
+					Name: name,
+				},
 			},
 			Status: bktv1alpha1.ObjectBucketStatus{
 				Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
@@ -92,7 +93,7 @@ func createBucketNotification(name string) *cephv1.CephBucketNotification {
 }
 
 func setNotificationLabels(labelList []string) map[string]string {
-	var label = make(map[string]string)
+	label := make(map[string]string)
 	for _, value := range labelList {
 		label[notificationLabelPrefix+value] = value
 	}

--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -76,7 +76,6 @@ func newS3Agent(p provisioner) (*object.S3Agent, error) {
 	adminOpsCtx, err := object.NewMultisiteAdminOpsContext(objContext, &objStore.Spec)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get admin Ops context for CephObjectStore %q", p.objectStoreName)
-
 	}
 	accessKey, secretKey, err := getUserCredentials(adminOpsCtx, p.opManagerContext, p.owner)
 	if err != nil {

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -556,7 +556,6 @@ func TestGetObjectBucketProvisioner(t *testing.T) {
 		_, err := GetObjectBucketProvisioner(testNamespace)
 		assert.Error(t, err)
 	})
-
 }
 
 func TestCheckDashboardUser(t *testing.T) {
@@ -846,7 +845,8 @@ func Test_createMultisite(t *testing.T) {
 		expectCommands expectCommands
 		wantErr        bool
 	}{
-		{"create realm, zonegroup, and zone; commit config",
+		{
+			"create realm, zonegroup, and zone; commit config",
 			commandReturns{
 				// nothing exists, and all should succeed
 			},
@@ -859,8 +859,10 @@ func Test_createMultisite(t *testing.T) {
 				createZone:          true,
 				commitConfigChanges: true,
 			},
-			expectNoErr},
-		{"fail creating realm",
+			expectNoErr,
+		},
+		{
+			"fail creating realm",
 			commandReturns{
 				failCreateRealm: true,
 			},
@@ -869,8 +871,10 @@ func Test_createMultisite(t *testing.T) {
 				createRealm: true,
 				// when we fail to create realm, we should not continue
 			},
-			expectErr},
-		{"fail creating zonegroup",
+			expectErr,
+		},
+		{
+			"fail creating zonegroup",
 			commandReturns{
 				failCreateZoneGroup: true,
 			},
@@ -881,8 +885,10 @@ func Test_createMultisite(t *testing.T) {
 				createZoneGroup: true,
 				// when we fail to create zonegroup, we should not continue
 			},
-			expectErr},
-		{"fail creating zone",
+			expectErr,
+		},
+		{
+			"fail creating zone",
 			commandReturns{
 				failCreateZone: true,
 			},
@@ -895,8 +901,10 @@ func Test_createMultisite(t *testing.T) {
 				createZone:      true,
 				// when we fail to create zone, we should not continue
 			},
-			expectErr},
-		{"fail commit config",
+			expectErr,
+		},
+		{
+			"fail commit config",
 			commandReturns{
 				failCommitConfigChanges: true,
 			},
@@ -909,8 +917,10 @@ func Test_createMultisite(t *testing.T) {
 				createZone:          true,
 				commitConfigChanges: true,
 			},
-			expectErr},
-		{"realm exists; create zonegroup and zone; commit config",
+			expectErr,
+		},
+		{
+			"realm exists; create zonegroup and zone; commit config",
 			commandReturns{
 				realmExists: true,
 			},
@@ -923,8 +933,10 @@ func Test_createMultisite(t *testing.T) {
 				createZone:          true,
 				commitConfigChanges: true,
 			},
-			expectNoErr},
-		{"realm and zonegroup exist; create zone; commit config",
+			expectNoErr,
+		},
+		{
+			"realm and zonegroup exist; create zone; commit config",
 			commandReturns{
 				realmExists:     true,
 				zoneGroupExists: true,
@@ -938,8 +950,10 @@ func Test_createMultisite(t *testing.T) {
 				createZone:          true,
 				commitConfigChanges: true,
 			},
-			expectNoErr},
-		{"realm, zonegroup, and zone exist; commit config",
+			expectNoErr,
+		},
+		{
+			"realm, zonegroup, and zone exist; commit config",
 			commandReturns{
 				realmExists:     true,
 				zoneGroupExists: true,
@@ -954,7 +968,8 @@ func Test_createMultisite(t *testing.T) {
 				createZone:          false,
 				commitConfigChanges: true,
 			},
-			expectNoErr},
+			expectNoErr,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -984,19 +999,20 @@ func Test_createMultisite(t *testing.T) {
 }
 
 func getExecutor() []exec.Executor {
-	executor := []exec.Executor{&exectest.MockExecutor{
-		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
-			if args[0] == "realm" {
-				return `{
+	executor := []exec.Executor{
+		&exectest.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if args[0] == "realm" {
+					return `{
 	"id": "237e6250-5f7d-4b85-9359-8cb2b1848507",
 	"name": "realm-a",
 	"current_period": "df665ecb-1762-47a9-9c66-f938d251c02a",
 	"epoch": 2
 }`, nil
-			}
-			return "", nil
+				}
+				return "", nil
+			},
 		},
-	},
 		&exectest.MockExecutor{
 			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "realm" {
@@ -1221,11 +1237,13 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
-		{"all the fields are empty",
+		{
+			"all the fields are empty",
 			args{zones: []zoneType{}, zoneEndpointList: []string{}, zoneName: ""},
 			false, true,
 		},
-		{"zoneName is empty",
+		{
+			"zoneName is empty",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint"},
@@ -1233,7 +1251,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			false, true,
 		},
-		{"new endpoint list is same existing containing single zone",
+		{
+			"new endpoint list is same existing containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-1"},
@@ -1241,7 +1260,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			false, false,
 		},
-		{"new endpoint list to existing list is empty containing single zone",
+		{
+			"new endpoint list to existing list is empty containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-1"},
@@ -1249,7 +1269,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"deleting endpoints from existing list containing single zone",
+		{
+			"deleting endpoints from existing list containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
 				zoneEndpointList: []string{},
@@ -1257,14 +1278,17 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"zone not listed in zonegroup containing single zone",
-			args{zones: []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
+		{
+			"zone not listed in zonegroup containing single zone",
+			args{
+				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-2"},
 				zoneName:         "zone-2",
 			},
 			false, false,
 		},
-		{"new endpoint list is different from existing list containing single zone",
+		{
+			"new endpoint list is different from existing list containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-2"},
@@ -1272,7 +1296,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list  has multiple entries is different from existing listed containing single zone",
+		{
+			"new endpoint list  has multiple entries is different from existing listed containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"},
@@ -1280,7 +1305,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list removed one endpoint from existing list containing single zone",
+		{
+			"new endpoint list removed one endpoint from existing list containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-1"},
@@ -1288,7 +1314,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list is different from existing listed containing single zone",
+		{
+			"new endpoint list is different from existing listed containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-3"},
@@ -1296,7 +1323,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list is different from existing list but contains one similar endpoint containing single zone",
+		{
+			"new endpoint list is different from existing list but contains one similar endpoint containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-2", "http://rgw-endpoint-3"},
@@ -1304,7 +1332,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list contains multiple different endpoints from existing list containing single zone",
+		{
+			"new endpoint list contains multiple different endpoints from existing list containing single zone",
 			args{
 				zones:            []zoneType{{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-1", "http://rgw-endpoint-2"}}},
 				zoneEndpointList: []string{"http://rgw-endpoint-3", "http://rgw-endpoint-4"},
@@ -1312,7 +1341,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"deleting endpoint list containing multiple zone",
+		{
+			"deleting endpoint list containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-12"}},
@@ -1323,7 +1353,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"adding new endpoint list to empty containing multiple zone",
+		{
+			"adding new endpoint list to empty containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11"}},
@@ -1334,7 +1365,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"zone not listed containing multiple zone",
+		{
+			"zone not listed containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-22"}},
@@ -1345,7 +1377,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			false, false,
 		},
-		{"new endpoint list have one new entry than existing list containing multiple zone",
+		{
+			"new endpoint list have one new entry than existing list containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1356,7 +1389,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list same as existing list containing multiple zone",
+		{
+			"new endpoint list same as existing list containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1367,7 +1401,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			false, false,
 		},
-		{"new endpoint list is different from existing list containing multiple zone",
+		{
+			"new endpoint list is different from existing list containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1378,7 +1413,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"new endpoint list have duplicate entries, containing multiple zone",
+		{
+			"new endpoint list have duplicate entries, containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1389,7 +1425,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"existing endpoint list have duplicate entries, containing multiple zone",
+		{
+			"existing endpoint list have duplicate entries, containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1400,7 +1437,8 @@ func TestUpdateZoneEndpointList(t *testing.T) {
 			},
 			true, false,
 		},
-		{"both list have duplicate entries, containing multiple zone",
+		{
+			"both list have duplicate entries, containing multiple zone",
 			args{
 				zones: []zoneType{
 					{Name: "zone-1", Endpoints: []string{"http://rgw-endpoint-11", "http://rgw-endpoint-12"}},
@@ -1436,55 +1474,68 @@ func TestListsAreEqual(t *testing.T) {
 		args args
 		want bool
 	}{
-		{"lists are empty",
+		{
+			"lists are empty",
 			args{listA: []string{}, listB: []string{}},
 			true,
 		},
-		{"first list is empty",
+		{
+			"first list is empty",
 			args{listA: []string{"a"}, listB: []string{}},
 			false,
 		},
-		{"second list is empty",
+		{
+			"second list is empty",
 			args{listA: []string{}, listB: []string{"a"}},
 			false,
 		},
-		{"lists are equal with single entry",
+		{
+			"lists are equal with single entry",
 			args{listA: []string{"a"}, listB: []string{"a"}},
 			true,
 		},
-		{"lists are equal with multiple entries",
+		{
+			"lists are equal with multiple entries",
 			args{listA: []string{"a", "b"}, listB: []string{"a", "b"}},
 			true,
 		},
-		{"lists have different entries with same length",
+		{
+			"lists have different entries with same length",
 			args{listA: []string{"a", "b"}, listB: []string{"c", "d"}},
 			false,
 		},
-		{"lists have similar entries with different length",
+		{
+			"lists have similar entries with different length",
 			args{listA: []string{"a", "b"}, listB: []string{"a"}},
 			false,
 		},
-		{"lists have some similar entries with same length",
+		{
+			"lists have some similar entries with same length",
 			args{listA: []string{"a", "b"}, listB: []string{"c", "a"}},
 			false,
 		},
-		{"lists have similar entries with same length but order different",
+		{
+			"lists have similar entries with same length but order different",
 			args{listA: []string{"a", "b"}, listB: []string{"b", "a"}},
 			true,
 		},
-		{"lists have similar entries but contains duplicate",
+		{
+			"lists have similar entries but contains duplicate",
 			args{listA: []string{"a", "b", "b"}, listB: []string{"b", "a", "b"}},
 			true,
 		},
-		{"lists have similar entries but contains duplicate in first",
+		{
+			"lists have similar entries but contains duplicate in first",
 			args{listA: []string{"a", "b", "b"}, listB: []string{"a", "b"}},
 			false,
 		},
-		{"lists have all similar entries but length is different",
+		{
+			"lists have all similar entries but length is different",
 			args{listA: []string{"b", "b", "b"}, listB: []string{"b", "b"}},
 			false,
 		},
-		{"lists have different entries but contains duplicate in first",
+		{
+			"lists have different entries but contains duplicate in first",
 			args{listA: []string{"a", "b", "b"}, listB: []string{"c", "d"}},
 			false,
 		},

--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -162,7 +162,6 @@ func NewBucketPolicy(ps ...PolicyStatement) *BucketPolicy {
 
 // PutBucketPolicy applies the policy to the bucket
 func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBucketPolicyOutput, error) {
-
 	confirmRemoveSelfBucketAccess := false
 	serializedPolicy, _ := json.Marshal(policy)
 	consumablePolicy := string(serializedPolicy)
@@ -252,9 +251,11 @@ func (ps *PolicyStatement) WithSID(sid string) *PolicyStatement {
 	return ps
 }
 
-const awsPrinciple = "AWS"
-const arnPrefixPrinciple = "arn:aws:iam:::user/%s"
-const arnPrefixResource = "arn:aws:s3:::%s"
+const (
+	awsPrinciple       = "AWS"
+	arnPrefixPrinciple = "arn:aws:iam:::user/%s"
+	arnPrefixResource  = "arn:aws:s3:::%s"
+)
 
 // ForPrincipals adds users to the PolicyStatement
 func (ps *PolicyStatement) ForPrincipals(users ...string) *PolicyStatement {

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -226,7 +226,6 @@ func (r *ReconcileObjectRealm) pullCephRealm(realm *cephv1.CephObjectRealm) (rec
 
 	objContext := object.NewContext(r.context, r.clusterInfo, realm.Name)
 	output, err := object.RunAdminCommandNoMultisite(objContext, false, "realm", "pull", realmArg, urlArg, accessKeyArg, secretKeyArg)
-
 	if err != nil {
 		return waitForRequeueIfRealmNotReady, errors.Wrapf(err, "realm pull failed for reason: %v", output)
 	}
@@ -240,7 +239,6 @@ func (r *ReconcileObjectRealm) createCephRealm(realm *cephv1.CephObjectRealm) (r
 	objContext := object.NewContext(r.context, r.clusterInfo, realm.Namespace)
 
 	_, err := object.RunAdminCommandNoMultisite(objContext, true, "realm", "get", realmArg)
-
 	if err != nil {
 		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
 			logger.Debugf("ceph realm %q not found, running `radosgw-admin realm create`", realm.Name)

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -69,9 +69,7 @@ type rgwConfig struct {
 
 var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
-var (
-	insecureSkipVerify = "insecureSkipVerify"
-)
+var insecureSkipVerify = "insecureSkipVerify"
 
 func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName string, keystoneSecret *v1.Secret) error {
 	logger.Infof("creating object store %q in namespace %q", c.store.Name, c.store.Namespace)

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -211,14 +211,16 @@ func TestGenerateSecretName(t *testing.T) {
 	cl := fake.NewClientBuilder().Build()
 
 	// start a basic cluster
-	c := &clusterConfig{&clusterd.Context{},
+	c := &clusterConfig{
+		&clusterd.Context{},
 		&client.ClusterInfo{},
 		&cephv1.CephObjectStore{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "mycluster"}},
 		"v1.1.0",
 		&cephv1.ClusterSpec{},
 		&k8sutil.OwnerInfo{},
 		&config.DataPathMap{},
-		cl}
+		cl,
+	}
 	secret := c.generateSecretName("a")
 	assert.Equal(t, "rook-ceph-rgw-default-a-keyring", secret)
 }

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -136,7 +136,8 @@ func (s *S3Agent) DeleteBucket(name string) (bool, error) {
 
 // PutObjectInBucket function puts an object in a bucket using s3 client
 func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
-	contentType string) (bool, error) {
+	contentType string,
+) (bool, error) {
 	_, err := s.Client.PutObject(&s3.PutObjectInput{
 		Body:        strings.NewReader(body),
 		Bucket:      &bucketname,
@@ -157,7 +158,6 @@ func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, erro
 		Bucket: aws.String(bucketname),
 		Key:    aws.String(key),
 	})
-
 	if err != nil {
 		logger.Errorf("failed to retrieve object from bucket. %v", err)
 		return "ERROR_ OBJECT NOT FOUND", err

--- a/pkg/operator/ceph/object/shared_pools.go
+++ b/pkg/operator/ceph/object/shared_pools.go
@@ -76,7 +76,7 @@ func adjustZonePlacementPools(zone map[string]interface{}, spec cephv1.ObjectSha
 		return nil, fmt.Errorf("unable to get zone name: %w", err)
 	}
 
-	//deep copy source zone
+	// deep copy source zone
 	zone, err = deepCopyJson(zone)
 	if err != nil {
 		return nil, fmt.Errorf("unable to deep copy config for zone %s: %w", name, err)
@@ -138,11 +138,11 @@ func adjustZonePlacementPools(zone map[string]interface{}, spec cephv1.ObjectSha
 		}
 	}
 	if len(idxToRemove) != 0 {
-		//delete placements from slice
+		// delete placements from slice
 		updated := make([]interface{}, 0, len(placements)-len(idxToRemove))
 		for i := range placements {
 			if _, ok := idxToRemove[i]; ok {
-				//remove
+				// remove
 				continue
 			}
 			updated = append(updated, placements[i])
@@ -153,7 +153,7 @@ func adjustZonePlacementPools(zone map[string]interface{}, spec cephv1.ObjectSha
 	// add new placements from spec:
 	for placementID, p := range fromSpec {
 		if _, ok := inConfig[placementID]; ok {
-			//already in config
+			// already in config
 			continue
 		}
 		pObj, err := toObj(p)
@@ -281,7 +281,7 @@ func adjustZoneGroupPlacementTargets(group, zone map[string]interface{}, default
 		return nil, fmt.Errorf("unable to get zonegroup name: %w", err)
 	}
 
-	//deep copy source group
+	// deep copy source group
 	group, err = deepCopyJson(group)
 	if err != nil {
 		return nil, fmt.Errorf("unable to deep copy config for zonegroup %s: %w", name, err)
@@ -332,11 +332,11 @@ func adjustZoneGroupPlacementTargets(group, zone map[string]interface{}, default
 		}
 	}
 	if len(idxToRemove) != 0 {
-		//delete targets from slice
+		// delete targets from slice
 		updated := make([]interface{}, 0, len(currentTargets)-len(idxToRemove))
 		for i := range currentTargets {
 			if _, ok := idxToRemove[i]; ok {
-				//remove
+				// remove
 				continue
 			}
 			updated = append(updated, currentTargets[i])
@@ -347,7 +347,7 @@ func adjustZoneGroupPlacementTargets(group, zone map[string]interface{}, default
 	// add new targets:
 	for targetName, target := range desiredTargets {
 		if _, ok := applied[targetName]; ok {
-			//already in config
+			// already in config
 			continue
 		}
 		tObj, err := toObj(target)
@@ -476,7 +476,7 @@ func updateZoneJSON(objContext *Context, zone map[string]interface{}) (map[strin
 		return nil, err
 	}
 	configFilename := path.Join(objContext.Context.ConfigDir, objContext.Name+".zonecfg")
-	if err := os.WriteFile(configFilename, configBytes, 0600); err != nil {
+	if err := os.WriteFile(configFilename, configBytes, 0o600); err != nil {
 		return nil, errors.Wrap(err, "failed to write zone config file")
 	}
 	defer os.Remove(configFilename)
@@ -513,7 +513,7 @@ func updateZoneGroupJSON(objContext *Context, group map[string]interface{}) (map
 		return nil, err
 	}
 	configFilename := path.Join(objContext.Context.ConfigDir, objContext.Name+".zonegroupcfg")
-	if err := os.WriteFile(configFilename, configBytes, 0600); err != nil {
+	if err := os.WriteFile(configFilename, configBytes, 0o600); err != nil {
 		return nil, errors.Wrap(err, "failed to write zonegroup config file")
 	}
 	defer os.Remove(configFilename)

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -386,24 +386,36 @@ func TestDefaultProbes(t *testing.T) {
 	//   - HTTP vs HTTPS vs both
 	for _, typ := range []ProbeType{ReadinessProbeType, StartupProbeType} {
 		tests = append(tests, []test{
-			{typ, "internal HTTP",
+			{
+				typ, "internal HTTP",
 				storeSpec{Port: 80},
-				want{Port: 8080, Protocol: HTTPProtocol}},
-			{typ, "host net HTTP",
+				want{Port: 8080, Protocol: HTTPProtocol},
+			},
+			{
+				typ, "host net HTTP",
 				storeSpec{Port: 8088, HostNetwork: true},
-				want{Port: 8088, Protocol: HTTPProtocol}},
-			{typ, "internal HTTPS",
+				want{Port: 8088, Protocol: HTTPProtocol},
+			},
+			{
+				typ, "internal HTTPS",
 				storeSpec{SecurePort: 8443},
-				want{Port: 8443, Protocol: HTTPSProtocol}},
-			{typ, "host net HTTPS",
+				want{Port: 8443, Protocol: HTTPSProtocol},
+			},
+			{
+				typ, "host net HTTPS",
 				storeSpec{SecurePort: 10443, HostNetwork: true},
-				want{Port: 10443, Protocol: HTTPSProtocol}},
-			{typ, "internal HTTP+HTTPS",
+				want{Port: 10443, Protocol: HTTPSProtocol},
+			},
+			{
+				typ, "internal HTTP+HTTPS",
 				storeSpec{Port: 80, SecurePort: 443},
-				want{Port: 8080, Protocol: HTTPProtocol}}, // uses HTTP
-			{typ, "host net HTTP+HTTPS",
+				want{Port: 8080, Protocol: HTTPProtocol},
+			}, // uses HTTP
+			{
+				typ, "host net HTTP+HTTPS",
 				storeSpec{Port: 10080, SecurePort: 10443, HostNetwork: true},
-				want{Port: 10080, Protocol: HTTPProtocol}}, // uses HTTP
+				want{Port: 10080, Protocol: HTTPProtocol},
+			}, // uses HTTP
 		}...)
 	}
 
@@ -915,7 +927,7 @@ func TestAWSServerSideEncryption(t *testing.T) {
 }
 
 func TestRgwCommandFlags(t *testing.T) {
-	//ctx := context.TODO()
+	// ctx := context.TODO()
 	// Placeholder
 	context := &clusterd.Context{Clientset: test.New(t, 3)}
 
@@ -1238,7 +1250,6 @@ func TestGetHostnameFromEndpoint(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, res)
-
 		})
 	}
 }

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -214,7 +214,8 @@ func TestCephBucketTopicController(t *testing.T) {
 				Namespace: namespace,
 			},
 			TypeMeta: metav1.TypeMeta{
-				Kind: "CephObjectStore"},
+				Kind: "CephObjectStore",
+			},
 			Spec: cephv1.ObjectStoreSpec{
 				Gateway: cephv1.GatewaySpec{
 					Port: int32(80),

--- a/pkg/operator/ceph/object/topic/provisioner.go
+++ b/pkg/operator/ceph/object/topic/provisioner.go
@@ -195,7 +195,6 @@ func createTopic(p provisioner, topic *cephv1.CephBucketTopic) (*string, error) 
 		Name:       &topic.Name,
 		Attributes: createTopicAttributes(topic),
 	})
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision CephBucketTopic %q", nsName)
 	}
@@ -223,7 +222,6 @@ func deleteTopic(p provisioner, topic *cephv1.CephBucketTopic) error {
 	}
 
 	_, err = snsClient.DeleteTopic(&sns.DeleteTopicInput{TopicArn: topic.Status.ARN})
-
 	if err != nil {
 		if err.(awserr.Error).Code() != sns.ErrCodeNotFoundException {
 			return errors.Wrapf(err, "failed to delete CephBucketTopic %q", nsName)

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -192,7 +192,6 @@ func CreateOrRecreateUserIfExists(c *Context, user ObjectUser, force bool) (*Obj
 }
 
 func ListUserBuckets(c *Context, id string, opts ...string) (string, error) {
-
 	args := []string{"bucket", "list", "--uid", id}
 	if opts != nil {
 		args = append(args, opts...)

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -338,7 +338,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		logCreateOrUpdate = fmt.Sprintf("updated ceph object user %q", u.Name)
 	}
 
-	var quotaEnabled = false
+	quotaEnabled := false
 	var maxSize int64 = -1
 	var maxObjects int64 = -1
 	if u.Spec.Quotas != nil {

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -280,7 +280,8 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		rgwPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name:      "rook-ceph-rgw-my-store-a-5fd6fb4489-xv65v",
 			Namespace: namespace,
-			Labels:    map[string]string{k8sutil.AppAttr: appName, "rgw": "my-store"}}}
+			Labels:    map[string]string{k8sutil.AppAttr: appName, "rgw": "my-store"},
+		}}
 
 		// Get the updated object.
 		// Create RGW pod
@@ -356,7 +357,8 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		rgwPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name:      "rook-ceph-rgw-my-store-a-5fd6fb4489-xv65v",
 			Namespace: namespace,
-			Labels:    map[string]string{k8sutil.AppAttr: appName, "rgw": "my-store"}}}
+			Labels:    map[string]string{k8sutil.AppAttr: appName, "rgw": "my-store"},
+		}}
 
 		// Create a user in a different namespace, and where the cephcluster does exist
 		r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c, opManagerContext: ctx, recorder: record.NewFakeRecorder(5)}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -363,7 +363,6 @@ func TestCephBlockPoolController(t *testing.T) {
 					return "{}", nil
 				}
 				return "", nil
-
 			},
 		}
 		c.Executor = executor
@@ -718,7 +717,7 @@ func TestConfigureRBDStats(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "pool1,pool2", rbdStatsPools)
 
-	//Case 7: Duplicate entries should be removed from config
+	// Case 7: Duplicate entries should be removed from config
 	e = monStore.Set("mgr", "mgr/prometheus/rbd_stats_pools", "pool1,pool2,pool1")
 	assert.Nil(t, e)
 	err = configureRBDStats(context, clusterInfo, "")

--- a/pkg/operator/ceph/pool/dependents_test.go
+++ b/pkg/operator/ceph/pool/dependents_test.go
@@ -85,12 +85,12 @@ func Test_cephBlockPoolDependents(t *testing.T) {
 	t.Run("one namespace", func(t *testing.T) {
 		c = newClusterdCtx(&cephv1.CephBlockPoolRadosNamespace{ObjectMeta: meta("namespace1")})
 		_, err := c.RookClientset.CephV1().CephBlockPoolRadosNamespaces(clusterInfo.Namespace).Create(ctx, &cephv1.CephBlockPoolRadosNamespace{ObjectMeta: meta("namespace1"), Spec: cephv1.CephBlockPoolRadosNamespaceSpec{
-			BlockPoolName: "replicapool"}}, v1.CreateOptions{})
+			BlockPoolName: "replicapool",
+		}}, v1.CreateOptions{})
 		assert.NoError(t, err)
 		assert.NoError(t, err)
 		deps, err := cephBlockPoolDependents(c, clusterInfo, bp)
 		assert.NoError(t, err)
 		assert.False(t, deps.Empty())
 	})
-
 }

--- a/pkg/operator/ceph/pool/peers.go
+++ b/pkg/operator/ceph/pool/peers.go
@@ -27,8 +27,8 @@ import (
 )
 
 func (r *ReconcileCephBlockPool) reconcileAddBootstrapPeer(pool *cephv1.CephBlockPool,
-	namespacedName types.NamespacedName) (reconcile.Result, error) {
-
+	namespacedName types.NamespacedName,
+) (reconcile.Result, error) {
 	if pool.Spec.Mirroring.Peers == nil {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/operator/ceph/pool/status_test.go
+++ b/pkg/operator/ceph/pool/status_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestUpdateStatusInfo(t *testing.T) {
-
 	cephBlockPoolReplicated := &cephv1.CephBlockPool{
 		Spec: cephv1.NamedBlockPoolSpec{
 			Name: "test-pool-replicated",

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -45,7 +45,6 @@ func validatePool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo
 
 // ValidatePoolSpec validates the Ceph block pool spec CR
 func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, clusterSpec *cephv1.ClusterSpec, p *cephv1.PoolSpec) error {
-
 	if p.IsHybridStoragePool() {
 		err := validateDeviceClasses(context, clusterInfo, p)
 		if err != nil {
@@ -186,7 +185,6 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 
 // validateDeviceClasses validates the primary and secondary device classes in the HybridStorageSpec
 func validateDeviceClasses(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, p *cephv1.PoolSpec) error {
-
 	primaryDeviceClass := p.Replicated.HybridStorage.PrimaryDeviceClass
 	secondaryDeviceClass := p.Replicated.HybridStorage.SecondaryDeviceClass
 

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -84,8 +84,10 @@ func (d *Discover) Start(ctx context.Context, namespace, discoverImage, security
 func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, discoverImage, securityAccount string, useCephVolume bool) error {
 	discoveryInterval := k8sutil.GetOperatorSetting(discoverIntervalEnv, defaultDiscoverInterval)
 
-	discoveryParameters := []string{"discover",
-		"--discover-interval", discoveryInterval}
+	discoveryParameters := []string{
+		"discover",
+		"--discover-interval", discoveryInterval,
+	}
 	if useCephVolume {
 		discoveryParameters = append(discoveryParameters, "--use-ceph-volume")
 	}
@@ -252,7 +254,6 @@ func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, disco
 		logger.Infof("rook-discover daemonset started")
 	}
 	return nil
-
 }
 
 func getLabels() map[string]string {
@@ -425,7 +426,7 @@ func GetAvailableDevices(ctx context.Context, clusterdContext *clusterd.Context,
 		}
 	} else if len(filter) >= 0 {
 		for i := range nodeDevices {
-			//TODO support filter based on other keys
+			// TODO support filter based on other keys
 			matched, err := regexp.Match(filter, []byte(nodeDevices[i].Name))
 			if err == nil && matched {
 				d := cephv1.Device{

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -50,9 +50,7 @@ const (
 	CopyBinariesMountDir = "/rook/copied-binaries"
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "CmdReporter")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "CmdReporter")
 
 type CmdReporterInterface interface {
 	Job() *batch.Job

--- a/pkg/operator/k8sutil/configmap.go
+++ b/pkg/operator/k8sutil/configmap.go
@@ -86,7 +86,6 @@ func ApplyOperatorSettingsConfigmap(ctx context.Context, clientset kubernetes.In
 	namespacedName := types.NamespacedName{Namespace: os.Getenv(PodNamespaceEnvVar), Name: "rook-ceph-operator-config"}
 	logger.Debugf("loading operator settings configmap from %v", namespacedName)
 	opConfig, err := clientset.CoreV1().ConfigMaps(namespacedName.Namespace).Get(ctx, namespacedName.Name, metav1.GetOptions{})
-
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			loadedOperatorSettings = true

--- a/pkg/operator/k8sutil/deployment_test.go
+++ b/pkg/operator/k8sutil/deployment_test.go
@@ -100,7 +100,8 @@ func TestUpdateMultipleDeploymentsAndWait(t *testing.T) {
 	}
 	addProgressDeadlineExceeded := func(d *appsv1.Deployment) {
 		d.Status.Conditions = append(d.Status.Conditions, appsv1.DeploymentCondition{
-			Type: appsv1.DeploymentProgressing, Reason: "ProgressDeadlineExceeded"})
+			Type: appsv1.DeploymentProgressing, Reason: "ProgressDeadlineExceeded",
+		})
 	}
 
 	clientset = fake.NewSimpleClientset()
@@ -296,7 +297,8 @@ func TestWaitForDeploymentsToUpdate(t *testing.T) {
 	}
 	addProgressDeadlineExceeded := func(d *appsv1.Deployment) {
 		d.Status.Conditions = append(d.Status.Conditions, appsv1.DeploymentCondition{
-			Type: appsv1.DeploymentProgressing, Reason: "ProgressDeadlineExceeded"})
+			Type: appsv1.DeploymentProgressing, Reason: "ProgressDeadlineExceeded",
+		})
 	}
 
 	// inputs

--- a/pkg/operator/k8sutil/kvstore_test.go
+++ b/pkg/operator/k8sutil/kvstore_test.go
@@ -86,7 +86,6 @@ func TestSetValueStoreNotExist(t *testing.T) {
 	_, err = kv.GetValue(ctx, storeName, "key2")
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsNotFound(err))
-
 }
 
 func TestSetValueUpdate(t *testing.T) {

--- a/pkg/operator/k8sutil/name.go
+++ b/pkg/operator/k8sutil/name.go
@@ -66,5 +66,4 @@ func NameToIndex(name string) (int, error) {
 		factor /= maxPerChar
 	}
 	return result, nil
-
 }

--- a/pkg/operator/k8sutil/network_test.go
+++ b/pkg/operator/k8sutil/network_test.go
@@ -145,7 +145,8 @@ func TestParseLinuxIpAddrOutput(t *testing.T) {
 			ipAddrRawOutput: "",
 			want:            []LinuxIpAddrResult{},
 			wantErr:         true,
-		}, {
+		},
+		{
 			name:            "full output",
 			ipAddrRawOutput: ipAddrOutputMixedIPv4v6,
 			want: []LinuxIpAddrResult{

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -381,8 +381,7 @@ func GenerateNodeAffinity(nodeAffinity string) (*v1.NodeAffinity, error) {
 					Operator: v1.NodeSelectorOpIn,
 					Values:   nodeLabelValues,
 				}
-				newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions =
-					append(newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, matchExpression)
+				newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions = append(newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, matchExpression)
 			}
 		} else {
 			nodeLabelKey := strings.Trim(tmpNodeLabel[0], " ")
@@ -395,8 +394,7 @@ func GenerateNodeAffinity(nodeAffinity string) (*v1.NodeAffinity, error) {
 					Key:      nodeLabelKey,
 					Operator: v1.NodeSelectorOpExists,
 				}
-				newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions =
-					append(newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, matchExpression)
+				newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions = append(newNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, matchExpression)
 			}
 		}
 	}

--- a/pkg/operator/k8sutil/node_test.go
+++ b/pkg/operator/k8sutil/node_test.go
@@ -92,21 +92,22 @@ func TestValidNode(t *testing.T) {
 		nodeErr = createNode("nodeC", v1.NodeReady, clientset)
 		assert.Nil(t, nodeErr)
 
-		placement := cephv1.Placement{NodeAffinity: &v1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
-						MatchExpressions: []v1.NodeSelectorRequirement{
-							{
-								Key:      "testLabel",
-								Operator: v1.NodeSelectorOpIn,
-								Values:   []string{"nodeC"},
+		placement := cephv1.Placement{
+			NodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "testLabel",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"nodeC"},
+								},
 							},
 						},
 					},
 				},
 			},
-		},
 		}
 		validNodes := GetValidNodes(context.TODO(), storage, clientset, placement)
 		assert.Equal(t, len(validNodes), 1)
@@ -262,7 +263,8 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 	rookNodes = []cephv1.Node{
 		{Name: "node0"},
 		{Name: "node2"},
-		{Name: "node5"}}
+		{Name: "node5"},
+	}
 	nodes, err = GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 2)
@@ -273,7 +275,8 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 	rookNodes = []cephv1.Node{
 		{Name: "node0"},
 		{Name: "node1"},
-		{Name: "node2"}}
+		{Name: "node2"},
+	}
 	nodes, err = GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 3)
@@ -315,7 +318,8 @@ func TestRookNodesMatchingKubernetesNodes(t *testing.T) {
 	rookStorage.Nodes = []cephv1.Node{
 		{Name: "node0"},
 		{Name: "node1"},
-		{Name: "node2"}}
+		{Name: "node2"},
+	}
 	retNodes = RookNodesMatchingKubernetesNodes(rookStorage, k8sNodes)
 	assert.Len(t, retNodes, 3)
 	// this should return nodes named by hostname if that is available
@@ -327,7 +331,8 @@ func TestRookNodesMatchingKubernetesNodes(t *testing.T) {
 	rookStorage.Nodes = []cephv1.Node{
 		{Name: "node0-hostname"},
 		{Name: "node2"},
-		{Name: "node5"}}
+		{Name: "node5"},
+	}
 	retNodes = RookNodesMatchingKubernetesNodes(rookStorage, k8sNodes)
 	assert.Len(t, retNodes, 2)
 	assert.Contains(t, retNodes, cephv1.Node{Name: "node0-hostname"})
@@ -345,7 +350,8 @@ func TestRookNodesMatchingKubernetesNodes(t *testing.T) {
 	rookStorage.Nodes = []cephv1.Node{
 		{Name: "node0"},
 		{Name: "node1"},
-		{Name: "node2"}}
+		{Name: "node2"},
+	}
 	retNodes = RookNodesMatchingKubernetesNodes(rookStorage, k8sNodes)
 	assert.Len(t, retNodes, 3)
 	// this should return nodes named by hostname if that is available
@@ -542,18 +548,18 @@ func TestGetNotReadyKubernetesNodes(t *testing.T) {
 	ctx := context.TODO()
 	clientset := optest.New(t, 0)
 
-	//when there is no node
+	// when there is no node
 	nodes, err := GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(nodes))
 
-	//when all the nodes are in ready state
+	// when all the nodes are in ready state
 	clientset = optest.New(t, 2)
 	nodes, err = GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(nodes))
 
-	//when there is a not ready node
+	// when there is a not ready node
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "failed",

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -141,10 +141,12 @@ func AddUnreachableNodeToleration(podSpec *v1.PodSpec) {
 			tolerationSeconds = duration
 		}
 	}
-	urToleration := v1.Toleration{Key: "node.kubernetes.io/unreachable",
+	urToleration := v1.Toleration{
+		Key:               "node.kubernetes.io/unreachable",
 		Operator:          "Exists",
 		Effect:            "NoExecute",
-		TolerationSeconds: &tolerationSeconds}
+		TolerationSeconds: &tolerationSeconds,
+	}
 
 	for index, item := range podSpec.Tolerations {
 		if item.Key == "node.kubernetes.io/unreachable" {
@@ -337,14 +339,12 @@ func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, t
 	// Set pod anti-affinity rules when pod should never be
 	// co-located (e.g. HostNetworking, not AllowMultiplePerHost)
 	if requiredDuringScheduling {
-		paa.RequiredDuringSchedulingIgnoredDuringExecution =
-			append(paa.RequiredDuringSchedulingIgnoredDuringExecution, podAntiAffinity)
+		paa.RequiredDuringSchedulingIgnoredDuringExecution = append(paa.RequiredDuringSchedulingIgnoredDuringExecution, podAntiAffinity)
 	} else {
-		paa.PreferredDuringSchedulingIgnoredDuringExecution =
-			append(paa.PreferredDuringSchedulingIgnoredDuringExecution, v1.WeightedPodAffinityTerm{
-				Weight:          50,
-				PodAffinityTerm: podAntiAffinity,
-			})
+		paa.PreferredDuringSchedulingIgnoredDuringExecution = append(paa.PreferredDuringSchedulingIgnoredDuringExecution, v1.WeightedPodAffinityTerm{
+			Weight:          50,
+			PodAffinityTerm: podAntiAffinity,
+		})
 	}
 }
 

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -81,10 +81,12 @@ func TestGetPodPhaseMap(t *testing.T) {
 }
 
 func newToleration(defaultSeconds int64, tolerationKey string) v1.Toleration {
-	return v1.Toleration{Key: tolerationKey,
+	return v1.Toleration{
+		Key:               tolerationKey,
 		Operator:          "Exists",
 		Effect:            "NoExecute",
-		TolerationSeconds: &defaultSeconds}
+		TolerationSeconds: &defaultSeconds,
+	}
 }
 
 func TestAddUnreachableNodeToleration(t *testing.T) {
@@ -170,7 +172,6 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 
 	assert.Equal(t, 1, len(podSpec.Tolerations))
 	assert.Equal(t, expectedURToleration, podSpec.Tolerations[0])
-
 }
 
 func testPodSpecPlacement(t *testing.T, requiredDuringScheduling bool, req, pref int, placement *cephv1.Placement) {

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -18,9 +18,10 @@ limitations under the License.
 package k8sutil
 
 import (
+	"testing"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetServiceMonitor(t *testing.T) {

--- a/pkg/operator/k8sutil/pvc_test.go
+++ b/pkg/operator/k8sutil/pvc_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestExpandPVCIfRequired(t *testing.T) {
-
 	testcases := []struct {
 		label            string
 		currentPVCSize   string

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -57,7 +57,6 @@ func (info *OwnerInfo) validateOwner(object metav1.Object) error {
 	if objectNamespace == "" {
 		return fmt.Errorf("cluster-scoped resource %q must not have a namespaced resource %q in namespace %q",
 			object.GetName(), info.ownerRef.Name, info.ownerRefNamespace)
-
 	}
 	if info.ownerRefNamespace != objectNamespace {
 		return fmt.Errorf("cross-namespaced owner references are disallowed. resource %q is in namespace %q, owner %q is in %q",

--- a/pkg/operator/k8sutil/resources_test.go
+++ b/pkg/operator/k8sutil/resources_test.go
@@ -125,6 +125,7 @@ func TestYamlToContainerResource(t *testing.T) {
 	res, err = YamlToContainerResource(invalidData)
 	assert.Error(t, err)
 }
+
 func TestValidateOwner(t *testing.T) {
 	// global-scoped owner
 	ownerRef := &metav1.OwnerReference{}

--- a/pkg/operator/k8sutil/service.go
+++ b/pkg/operator/k8sutil/service.go
@@ -139,7 +139,6 @@ func ExportService(ctx context.Context, c *clusterd.Context, service *v1.Service
 	var exportedIP string
 	var serviceExportError error
 	exportedIP, err = GetExportedServiceIP(fmt.Sprintf("%s.%s.%s.svc.clusterset.local", clusterID, service.Name, service.Namespace))
-
 	if err != nil {
 		serviceExportError = errors.Wrapf(err, "failed to get exported service IP for %q", service.Name)
 		err := verifyExportedService(ctx, client, service.Name, service.Namespace)

--- a/pkg/operator/k8sutil/volume_test.go
+++ b/pkg/operator/k8sutil/volume_test.go
@@ -31,16 +31,22 @@ func TestPathToVolumeName(t *testing.T) {
 		{"convert to lower case", "ASDFGHJKLQWERTYUIOPZXCVBNM", "asdfghjklqwertyuiopzxcvbnm"},
 		{"preserve nums", "0123456789", "0123456789"},
 		{"preserve lower case", "qwertyuiopasdfghjklzxcvbnm", "qwertyuiopasdfghjklzxcvbnm"},
-		{"convert any non-lower-case-alphanum symbols to dash",
+		{
+			"convert any non-lower-case-alphanum symbols to dash",
 			"a/.;,=[]_~!@`#$%^&*()_+-<>?:\"\\'|}{z", // symbols on U.S. keyboard
-			"a---------------------------------z"},
-		{"various currency symbols", // only those written left-to-right
+			"a---------------------------------z",
+		},
+		{
+			"various currency symbols", // only those written left-to-right
 			"z£¢©®™¥€§฿₽₨₱¤₡₫ƒ₲₴₭č₾֏₣лвдине₤₺₼₥₦₱៛₹₪৳₸₩ła",
-			"z------------------------------------------a"},
+			"z------------------------------------------a",
+		},
 		{"full-width symbols", "q￠￥￦℃℉p", "q-----p"}, // only those written left-to-right
-		{"longer than 63 chars", // if you change the arg string, the hash on the end will change
+		{
+			"longer than 63 chars", // if you change the arg string, the hash on the end will change
 			"/this/is/some-path/.that/is_longer/than/$63/chars/1234567890/and/i'm/still/typing",
-			"this-is-some-path--that-i---7890-and-i-m-still-typing-b6b6f18b"},
+			"this-is-some-path--that-i---7890-and-i-m-still-typing-b6b6f18b",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -103,12 +103,11 @@ func SetFakeKubernetesVersion(clientset *fake.Clientset, semver string) {
 	if len(xyz) != 3 {
 		panic(fmt.Errorf("version not in 'vX.Y.Z' format: %s", semver))
 	}
-	fd.FakedServerVersion =
-		&version.Info{
-			Major:      xyz[0],
-			Minor:      xyz[1],
-			GitVersion: semver,
-		}
+	fd.FakedServerVersion = &version.Info{
+		Major:      xyz[0],
+		Minor:      xyz[1],
+		GitVersion: semver,
+	}
 }
 
 var (

--- a/pkg/operator/test/spec_test.go
+++ b/pkg/operator/test/spec_test.go
@@ -52,16 +52,20 @@ func TestArgumentsMatchExpected(t *testing.T) {
 		{"extra actuals", args{oneExp("-h"), act("-h", "-v")}, true},
 		{"complicated ; ok", args{
 			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
-			[]string{"-h", "-vvv", "-d", "3", "--name=kit", "--name", "sammy"}}, false},
+			[]string{"-h", "-vvv", "-d", "3", "--name=kit", "--name", "sammy"},
+		}, false},
 		{"complicated ; missing", args{
 			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
-			[]string{"-h", "-vvv", "-d", "3", "--name", "sammy"}}, true},
+			[]string{"-h", "-vvv", "-d", "3", "--name", "sammy"},
+		}, true},
 		{"complicated ; extra actuals", args{
 			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
-			[]string{"-h", "-vvv", "--i-am=extra", "-d", "3", "--name", "sammy"}}, true},
+			[]string{"-h", "-vvv", "--i-am=extra", "-d", "3", "--name", "sammy"},
+		}, true},
 		{"complicated ; double instance", args{
 			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
-			[]string{"-h", "-vvv", "-vvv", "-d", "3", "--name", "sammy"}}, true},
+			[]string{"-h", "-vvv", "-vvv", "-d", "3", "--name", "sammy"},
+		}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/test/volumes_test.go
+++ b/pkg/operator/test/volumes_test.go
@@ -48,6 +48,7 @@ func TestVolumeExists(t *testing.T) {
 func vols(v ...v1.Volume) []v1.Volume {
 	return v
 }
+
 func TestVolumeIsEmptyDir(t *testing.T) {
 	emptyVolume := v1.Volume{Name: "e", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
 	emptyAndHostVolume := v1.Volume{Name: "e&hp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}

--- a/pkg/util/dependents/dependents_test.go
+++ b/pkg/util/dependents/dependents_test.go
@@ -63,7 +63,6 @@ func TestDependentList(t *testing.T) {
 		containsExactlyOne(toString, "my-resource-1")
 		containsExactlyOne(toString, "my-resource-2")
 		containsExactlyOne(toString, "my-resource-3")
-
 	})
 
 	t.Run("multiple resources - multiple dependents", func(t *testing.T) {

--- a/pkg/util/display/bytes_test.go
+++ b/pkg/util/display/bytes_test.go
@@ -37,5 +37,4 @@ func TestBytesToString(t *testing.T) {
 	assert.Equal(t, "16.00 EiB", BytesToString(math.MaxUint64))
 	assert.Equal(t, uint64(50), BToMb(uint64(52428800)))
 	assert.Equal(t, uint64(52428800), MbTob(uint64(50)))
-
 }

--- a/pkg/util/exec/error.go
+++ b/pkg/util/exec/error.go
@@ -19,9 +19,10 @@ package exec
 
 import (
 	"fmt"
-	kexec "k8s.io/client-go/util/exec"
 	"os/exec"
 	"syscall"
+
+	kexec "k8s.io/client-go/util/exec"
 )
 
 // CephCLIError is Ceph CLI Error type

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -37,9 +37,7 @@ import (
 // TimeoutWaitingForMessage can be used to identify if an error is due to a timeout.
 const TimeoutWaitingForMessage = "exec timeout waiting for"
 
-var (
-	CephCommandsTimeout = 15 * time.Second
-)
+var CephCommandsTimeout = 15 * time.Second
 
 // Executor is the main interface for all the exec commands
 type Executor interface {

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -78,26 +78,38 @@ func TestExtractExitCode(t *testing.T) {
 		want     int
 		wantErr  bool
 	}{
-		{"*exec.ExitError",
+		{
+			"*exec.ExitError",
 			mockExecExitError(3),
-			3, noError},
+			3, noError,
+		},
 		/* {"exec.ExitError", // non-pointer case is impossible (won't compile) */
-		{"*kexec.CodeExitError (pointer)",
+		{
+			"*kexec.CodeExitError (pointer)",
 			&kexec.CodeExitError{Err: errors.New("some error"), Code: 4},
-			4, noError},
-		{"kexec.CodeExitError (non-pointer)",
+			4, noError,
+		},
+		{
+			"kexec.CodeExitError (non-pointer)",
 			kexec.CodeExitError{Err: errors.New("some error"), Code: 5},
-			5, noError},
-		{"*kerrors.StatusError",
+			5, noError,
+		},
+		{
+			"*kerrors.StatusError",
 			&kerrors.StatusError{ErrStatus: metav1.Status{Code: 6}},
-			6, noError},
+			6, noError,
+		},
 		/* {"kerrors.StatusError", // non-pointer case is impossible (won't compile) */
-		{"unknown error type with error code extractable from error message",
+		{
+			"unknown error type with error code extractable from error message",
 			errors.New("command terminated with exit code 7"),
-			7, noError},
-		{"unknown error type with no extractable error code",
+			7, noError,
+		},
+		{
+			"unknown error type with no extractable error code",
 			errors.New("command with no extractable error code even with an int here: 8"),
-			-1, expectError},
+			-1, expectError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -74,7 +74,6 @@ func (e *MockExecutor) ExecuteCommandWithOutput(command string, arg ...string) (
 
 // ExecuteCommandWithTimeout mocks ExecuteCommandWithTimeout
 func (e *MockExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error) {
-
 	if e.MockExecuteCommandWithTimeout != nil {
 		return e.MockExecuteCommandWithTimeout(time.Second, command, arg...)
 	}

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -24,7 +24,6 @@ import (
 // This is useful to run the commands in a job with `kubectl run ...` when running the operator outside
 // of Kubernetes and need to run tools that require running inside the cluster.
 type TranslateCommandExecutor struct {
-
 	// Executor is probably a exec.CommandExecutor that will run the translated commands
 	Executor Executor
 

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -31,10 +31,10 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "util")
 
 func WriteFile(filePath string, contentBuffer bytes.Buffer) error {
 	dir := filepath.Dir(filePath)
-	if err := os.MkdirAll(dir, 0744); err != nil {
+	if err := os.MkdirAll(dir, 0o744); err != nil {
 		return fmt.Errorf("failed to create config file directory at %s: %+v", dir, err)
 	}
-	if err := os.WriteFile(filePath, contentBuffer.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(filePath, contentBuffer.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to write config file to %s: %+v", filePath, err)
 	}
 
@@ -70,7 +70,7 @@ func CreateTempFile(content string) (*os.File, error) {
 	}
 
 	// Write content into file
-	err = os.WriteFile(file.Name(), []byte(content), 0400)
+	err = os.WriteFile(file.Name(), []byte(content), 0o400)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to write content into file")
 	}

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -26,9 +26,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-flags")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-flags")
 
 func VerifyRequiredFlags(cmd *cobra.Command, requiredFlags []string) error {
 	var missingFlags []string

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -134,13 +134,12 @@ func ListDevices(executor exec.Executor) ([]string, error) {
 
 // GetDevicePartitions gets partitions on a given device
 func GetDevicePartitions(device string, executor exec.Executor) (partitions []Partition, unusedSpace uint64, err error) {
-
 	var devicePath string
 	splitDevicePath := strings.Split(device, "/")
 	if len(splitDevicePath) == 1 {
-		devicePath = fmt.Sprintf("/dev/%s", device) //device path for OSD on devices.
+		devicePath = fmt.Sprintf("/dev/%s", device) // device path for OSD on devices.
 	} else {
-		devicePath = device //use the exact device path (like /mnt/<pvc-name>) in case of PVC block device
+		devicePath = device // use the exact device path (like /mnt/<pvc-name>) in case of PVC block device
 	}
 
 	output, err := executor.ExecuteCommandWithOutput("lsblk", devicePath,
@@ -339,7 +338,6 @@ func GetLVName(executor exec.Executor, devicePath string) (string, error) {
 
 // finds the disk uuid in the output of sgdisk
 func parseUUID(device, output string) (string, error) {
-
 	// find the line with the uuid
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -86,11 +86,9 @@ SUBSYSTEM=block
 `
 )
 
-var (
-	lsblkChildOutput = `NAME="ceph--cec981b8--2eca--45cd--bf91--a4472779f2a9-osd--data--428984b7--f94d--40cd--9cb7--1458e1613eab" MAJ:MIN="252:0" RM="0" SIZE="29G" RO="0" TYPE="lvm" MOUNTPOINT=""
+var lsblkChildOutput = `NAME="ceph--cec981b8--2eca--45cd--bf91--a4472779f2a9-osd--data--428984b7--f94d--40cd--9cb7--1458e1613eab" MAJ:MIN="252:0" RM="0" SIZE="29G" RO="0" TYPE="lvm" MOUNTPOINT=""
 NAME="vdb" MAJ:MIN="253:16" RM="0" SIZE="30G" RO="0" TYPE="disk" MOUNTPOINT=""
 NAME="vdb1" MAJ:MIN="253:17" RM="0" SIZE="30G" RO="0" TYPE="part" MOUNTPOINT=""`
-)
 
 func TestFindUUID(t *testing.T) {
 	output := `Disk /dev/sdb: 10485760 sectors, 5.0 GiB

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -56,10 +56,8 @@ func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
 		return "", fmt.Errorf("Unable to create block -- : %s", err)
-
 	}
 	return result, nil
-
 }
 
 func (b *BlockOperation) CreatePoolAndStorageClass(pvcNamespace, poolName, storageClassName, reclaimPolicy string) error {
@@ -131,10 +129,8 @@ func (b *BlockOperation) DeleteBlock(manifest string) (string, error) {
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
 		return "", fmt.Errorf("Unable to delete block -- : %s", err)
-
 	}
 	return result, nil
-
 }
 
 // List Function to list all the block images in all pools

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -140,7 +140,6 @@ func (b *BucketOperation) GetSecretKey(obcName string) (string, error) {
 	}
 	decode, _ := b64.StdEncoding.DecodeString(SecretKey)
 	return string(decode), nil
-
 }
 
 // Checks whether MaxObject is updated for ob

--- a/tests/framework/clients/cluster.go
+++ b/tests/framework/clients/cluster.go
@@ -24,7 +24,6 @@ import (
 
 // IsClusterHealthy determines if the Rook cluster is currently healthy or not.
 func IsClusterHealthy(testClient *TestClient, namespace string) (bool, error) {
-
 	status, err := testClient.Status(namespace)
 	if err != nil {
 		return false, err

--- a/tests/framework/clients/nfs.go
+++ b/tests/framework/clients/nfs.go
@@ -40,7 +40,6 @@ func CreateNFSOperation(k8sh *utils.K8sHelper, manifests installer.CephManifests
 
 // Create creates a filesystem in Rook
 func (n *NFSOperation) Create(namespace, name string, daemonCount int) error {
-
 	logger.Infof("creating the NFS pool")
 	if err := n.k8sh.ResourceOperation("apply", n.manifests.GetNFSPool()); err != nil {
 		return err

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -18,6 +18,7 @@ package clients
 
 import (
 	"fmt"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
@@ -40,7 +41,6 @@ func CreateObjectOperation(k8sh *utils.K8sHelper, manifests installer.CephManife
 
 // ObjectCreate Function to create a object store in rook
 func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32, tlsEnable bool, swiftAndKeystone bool) error {
-
 	logger.Info("creating the object store via CRD")
 
 	if err := o.k8sh.ResourceOperation("apply", o.manifests.GetObjectStore(storeName, int(replicaCount), rgwPort, tlsEnable, swiftAndKeystone)); err != nil {
@@ -58,7 +58,6 @@ func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32
 }
 
 func (o *ObjectOperation) Delete(namespace, storeName string) error {
-
 	logger.Infof("Deleting the object store via CRD")
 	if err := o.k8sh.DeleteResource("-n", namespace, "CephObjectStore", storeName); err != nil {
 		return err

--- a/tests/framework/clients/object_user.go
+++ b/tests/framework/clients/object_user.go
@@ -61,10 +61,10 @@ func (o *ObjectUserOperation) GetUser(namespace string, store string, userid str
 // UserSecretExists Function to check that user secret was created
 func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, userid string) bool {
 	message, err := o.k8sh.GetResource("-n", namespace, "secrets", "-l", "rook_object_store="+store, "-l", "user="+userid)
-	//GetResource(blah) returns success if blah is or is not found.
-	//err = success and found_sec not "No resources found." means it was found
-	//err = success and found_sec contains "No resources found." means it was not found
-	//err != success is another error
+	// GetResource(blah) returns success if blah is or is not found.
+	// err = success and found_sec not "No resources found." means it was found
+	// err = success and found_sec contains "No resources found." means it was not found
+	// err != success is another error
 	if err == nil && !strings.Contains(message, "No resources found") {
 		logger.Infof("Object User Secret Exists")
 		return true
@@ -75,7 +75,6 @@ func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, u
 
 // ObjectUserCreate Function to create a object store user in rook
 func (o *ObjectUserOperation) Create(userid, displayName, store, usercaps, maxsize string, maxbuckets, maxobjects int) error {
-
 	logger.Infof("creating the object store user via CRD")
 	if err := o.k8sh.ResourceOperation("apply", o.manifests.GetObjectStoreUser(userid, displayName, store, usercaps, maxsize, maxbuckets, maxobjects)); err != nil {
 		return err
@@ -84,7 +83,6 @@ func (o *ObjectUserOperation) Create(userid, displayName, store, usercaps, maxsi
 }
 
 func (o *ObjectUserOperation) Delete(namespace string, userid string) error {
-
 	logger.Infof("Deleting the object store user via CRD")
 	if err := o.k8sh.DeleteResource("-n", namespace, "CephObjectStoreUser", userid); err != nil {
 		return err

--- a/tests/framework/clients/rbd-mirror.go
+++ b/tests/framework/clients/rbd-mirror.go
@@ -39,7 +39,6 @@ func CreateRBDMirrorOperation(k8sh *utils.K8sHelper, manifests installer.CephMan
 
 // Create creates a rbd-mirror in Rook
 func (r *RBDMirrorOperation) Create(namespace, name string, daemonCount int) error {
-
 	logger.Infof("creating the RBDMirror daemons via CRD")
 	if err := r.k8sh.ResourceOperation("apply", r.manifests.GetRBDMirror(name, daemonCount)); err != nil {
 		return err

--- a/tests/framework/clients/read_write.go
+++ b/tests/framework/clients/read_write.go
@@ -69,7 +69,6 @@ func (f *ReadWriteOperation) Read(name string) (string, error) {
 	result, err := f.k8sh.Kubectl(args...)
 	if err != nil {
 		return "", fmt.Errorf("unable to write data to pod -- : %s", err)
-
 	}
 	return result, nil
 }

--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -90,9 +90,11 @@ func (h *CephInstaller) configureRookOperatorViaHelm(upgrade bool) error {
 func (h *CephInstaller) CreateRookCephClusterViaHelm() error {
 	return h.configureRookCephClusterViaHelm(false)
 }
+
 func (h *CephInstaller) UpgradeRookCephClusterViaHelm() error {
 	return h.configureRookCephClusterViaHelm(true)
 }
+
 func (h *CephInstaller) configureRookCephClusterViaHelm(upgrade bool) error {
 	values := map[string]interface{}{
 		"image": "rook/ceph:" + h.settings.RookVersion,

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -214,7 +214,6 @@ func (h *CephInstaller) Execute(command string, parameters []string, namespace s
 
 // CreateCephCluster creates rook cluster via kubectl
 func (h *CephInstaller) CreateCephCluster() error {
-
 	ctx := context.TODO()
 	var err error
 	h.settings.DataDirHostPath, err = h.initTestDir(h.settings.Namespace)
@@ -441,7 +440,7 @@ func (h *CephInstaller) initTestDir(namespace string) (string, error) {
 	// skip the test dir creation if we are not running under "/data"
 	if val != "/data" {
 		// Create the test dir on the local host
-		if err := os.MkdirAll(testDir, 0777); err != nil {
+		if err := os.MkdirAll(testDir, 0o777); err != nil {
 			return "", err
 		}
 
@@ -919,7 +918,7 @@ func (h *CephInstaller) checkCephHealthStatus() {
 
 	// The health status is not stable enough for the integration tests to rely on.
 	// We should enable this check if we can get the ceph status to be stable despite all the changing configurations performed by rook.
-	//assert.Equal(h.T(), "HEALTH_OK", clusterResource.Status.CephStatus.Health)
+	// assert.Equal(h.T(), "HEALTH_OK", clusterResource.Status.CephStatus.Health)
 	assert.NotEqual(h.T(), "", clusterResource.Status.CephStatus.LastChecked)
 
 	// Print the details if the health is not ok
@@ -959,7 +958,6 @@ func (h *CephInstaller) GatherAllRookLogs(testName string, namespaces ...string)
 
 // NewCephInstaller creates new instance of CephInstaller
 func NewCephInstaller(t func() *testing.T, clientset *kubernetes.Clientset, settings *TestCephSettings) *CephInstaller {
-
 	// By default set a cluster name that is different from the namespace so we don't rely on the namespace
 	// in expected places
 	if settings.ClusterName == "" {

--- a/tests/framework/utils/exec_utils.go
+++ b/tests/framework/utils/exec_utils.go
@@ -56,13 +56,11 @@ func ExecuteCommand(cmdStruct CommandArgs) CommandOut {
 	cmd.Env = append(cmd.Env, cmdStruct.EnvironmentVariable...)
 
 	stdOut, err := cmd.StdoutPipe()
-
 	if err != nil {
 		return CommandOut{StdErr: errBuffer.String(), StdOut: outBuffer.String(), Err: err}
 	}
 
 	stdin, err := cmd.StdinPipe()
-
 	if err != nil {
 		return CommandOut{Err: err}
 	}
@@ -78,7 +76,6 @@ func ExecuteCommand(cmdStruct CommandArgs) CommandOut {
 	}()
 
 	stdErr, err := cmd.StderrPipe()
-
 	if err != nil {
 		return CommandOut{StdErr: errBuffer.String(), StdOut: outBuffer.String(), Err: err}
 	}

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -39,7 +39,6 @@ type HelmHelper struct {
 func NewHelmHelper(helmPath string) *HelmHelper {
 	executor := &exec.CommandExecutor{}
 	return &HelmHelper{executor: executor, HelmPath: helmPath}
-
 }
 
 // Execute is wrapper for executing helm commands
@@ -51,7 +50,6 @@ func (h *HelmHelper) Execute(args ...string) (string, error) {
 
 	}
 	return result, nil
-
 }
 
 func createValuesFile(path string, values map[string]interface{}) error {
@@ -118,7 +116,6 @@ func (h *HelmHelper) InstallLocalHelmChart(upgrade bool, namespace, chart string
 }
 
 func (h *HelmHelper) InstallVersionedChart(namespace, chart, version string, values map[string]interface{}) error {
-
 	logger.Infof("adding rook-release helm repo")
 	cmdArgs := []string{"repo", "add", "rook-release", "https://charts.rook.io/release"}
 	_, err := h.Execute(cmdArgs...)

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -64,7 +64,7 @@ const (
 	RetryInterval = 5
 	// TestMountPath is the path inside a test pod where storage is mounted
 	TestMountPath = "/tmp/testrook"
-	//hostnameTestPrefix is a prefix added to the node hostname
+	// hostnameTestPrefix is a prefix added to the node hostname
 	hostnameTestPrefix = "test-prefix-this-is-a-very-long-hostname-"
 )
 
@@ -168,14 +168,11 @@ func (k8sh *K8sHelper) KubectlWithTimeout(timeout time.Duration, args ...string)
 
 // Kubectl is wrapper for executing kubectl commands and a timeout of 15 seconds
 func (k8sh *K8sHelper) Kubectl(args ...string) (string, error) {
-
 	return k8sh.KubectlWithTimeout(15, args...)
-
 }
 
 // KubectlWithStdin is wrapper for executing kubectl commands in stdin
 func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, error) {
-
 	cmdStruct := CommandArgs{Command: cmd, PipeToStdIn: stdin, CmdArgs: args}
 	cmdOut := ExecuteCommand(cmdStruct)
 
@@ -191,7 +188,6 @@ func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, e
 	}
 
 	return cmdOut.StdOut, nil
-
 }
 
 func getManifestFromURL(url string) (string, error) {
@@ -262,7 +258,6 @@ func (k8sh *K8sHelper) DeleteResource(args ...string) error {
 
 // WaitForCustomResourceDeletion waits for the CRD deletion
 func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace, name string, checkerFunc func() error) error {
-
 	// wait for the operator to finalize and delete the CRD
 	for i := 0; i < 90; i++ {
 		err := checkerFunc()
@@ -629,7 +624,6 @@ func (k8sh *K8sHelper) GetService(servicename string, namespace string) (*v1.Ser
 
 // IsCRDPresent returns true if custom resource definition is present
 func (k8sh *K8sHelper) IsCRDPresent(crdName string) bool {
-
 	cmdArgs := []string{"get", "crd", crdName}
 
 	for i := 0; i < RetryLoop; i++ {
@@ -833,10 +827,11 @@ func (k8sh *K8sHelper) PrintStorageClasses(detailed bool) {
 }
 
 func (k8sh *K8sHelper) GetPodNamesForApp(appName, namespace string) ([]string, error) {
-	args := []string{"get", "pod", "-n", namespace, "-l", fmt.Sprintf("app=%s", appName),
-		"-o", "jsonpath={.items[*].metadata.name}"}
+	args := []string{
+		"get", "pod", "-n", namespace, "-l", fmt.Sprintf("app=%s", appName),
+		"-o", "jsonpath={.items[*].metadata.name}",
+	}
 	result, err := k8sh.Kubectl(args...)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod names for app %s: %+v. output: %s", appName, err, result)
 	}
@@ -879,7 +874,6 @@ func (k8sh *K8sHelper) GetPodEvents(podNamePattern string, namespace string) (*v
 
 // IsPodInError returns true if a Pod is in error status with the given reason and contains the given message
 func (k8sh *K8sHelper) IsPodInError(podNamePattern, namespace, reason, containingMessage string) bool {
-
 	for i := 0; i < RetryLoop; i++ {
 		events, err := k8sh.GetPodEvents(podNamePattern, namespace)
 		if err != nil {
@@ -1015,7 +1009,6 @@ func (k8sh *K8sHelper) GetPVCStatus(namespace string, name string) (v1.Persisten
 	}
 
 	return pvc.Status.Phase, nil
-
 }
 
 // GetPVCVolumeName returns volume name of PVC
@@ -1040,7 +1033,6 @@ func (k8sh *K8sHelper) GetPVCAccessModes(namespace string, name string) ([]v1.Pe
 	}
 
 	return pvc.Status.AccessModes, nil
-
 }
 
 // GetPV returns PV by name
@@ -1125,13 +1117,11 @@ func (k8sh *K8sHelper) CheckPodCountAndState(podName string, namespace string, m
 	logger.Errorf("All pods with app Name %v not in %v phase ", podName, expectedPhase)
 	k8sh.PrintPodDescribe(namespace, "-l", listOpts.LabelSelector)
 	return false
-
 }
 
 // WaitUntilPodInNamespaceIsDeleted waits for 90s for a pod  in a namespace to be terminated
 // If the pod disappears within 90s true is returned,  if not false
 func (k8sh *K8sHelper) WaitUntilPodInNamespaceIsDeleted(podNamePattern string, namespace string) bool {
-
 	for i := 0; i < RetryLoop; i++ {
 		out, _ := k8sh.GetResource("-n", namespace, "pods", "-l", "app="+podNamePattern)
 		if !strings.Contains(out, podNamePattern) {
@@ -1163,7 +1153,6 @@ func (k8sh *K8sHelper) WaitUntilPodIsDeleted(name, namespace string) bool {
 // WaitUntilPVCIsBound waits for a PVC to be in bound state for 90 seconds
 // if PVC goes to Bound state within 90s True is returned, if not false
 func (k8sh *K8sHelper) WaitUntilPVCIsBound(namespace string, pvcname string) bool {
-
 	for i := 0; i < RetryLoop; i++ {
 		out, err := k8sh.GetPVCStatus(namespace, pvcname)
 		if err == nil {
@@ -1432,7 +1421,7 @@ func (k8sh *K8sHelper) createTestLogFile(platformName, name, namespace, testName
 	dir, _ := os.Getwd()
 	logDir := path.Join(dir, "_output/tests/")
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
-		err := os.MkdirAll(logDir, 0777)
+		err := os.MkdirAll(logDir, 0o777)
 		if err != nil {
 			logger.Errorf("Cannot get logs files dir for app : %v in namespace %v, err: %v", name, namespace, err)
 			return nil, err

--- a/tests/integration/ceph_auth_keystone_test.go
+++ b/tests/integration/ceph_auth_keystone_test.go
@@ -163,7 +163,6 @@ func (h *KeystoneAuthSuite) TestWithSwiftAndKeystone() {
 	objectStoreServicePrefix = objectStoreServicePrefixUniq
 	runSwiftE2ETest(h.T(), h.helper, h.k8shelper, h.installer, h.settings.Namespace, "default", 3, deleteStore, tls, swiftAndKeystone)
 	cleanUpTLSks(h)
-
 }
 
 func (h *KeystoneAuthSuite) TestWithS3AndKeystone() {

--- a/tests/integration/ceph_base_block_test.go
+++ b/tests/integration/ceph_base_block_test.go
@@ -298,8 +298,8 @@ func runBlockCSITest(helper *clients.TestClient, k8sh *utils.K8sHelper, s *suite
 	assert.NoError(s.T(), err)
 
 	// ** FIX: WHY IS THE RWO VOLUME NOT BEING FENCED??? The second pod is starting successfully with the same PVC
-	//require.True(s.T(), k8sh.IsPodInError(otherPod, defaultNamespace, "FailedMount", "Volume is already attached by pod"), "make sure block-test2 pod errors out while mounting the volume")
-	//logger.Infof("Block Storage successfully fenced")
+	// require.True(s.T(), k8sh.IsPodInError(otherPod, defaultNamespace, "FailedMount", "Volume is already attached by pod"), "make sure block-test2 pod errors out while mounting the volume")
+	// logger.Infof("Block Storage successfully fenced")
 
 	logger.Infof("step 8: Delete fenced pod")
 	err = k8sh.DeletePod(k8sutil.DefaultNamespace, otherPod)
@@ -404,8 +404,8 @@ func runBlockCSITestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s *s
 }
 
 func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s *suite.Suite, clusterInfo *client.ClusterInfo,
-	poolName, storageClassName, blockName string) {
-
+	poolName, storageClassName, blockName string,
+) {
 	// Check initial number of blocks
 	initialBlocks, err := helper.BlockClient.ListAllImages(clusterInfo)
 	require.NoError(s.T(), err)
@@ -421,7 +421,8 @@ func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s *suite.
 }
 
 func createAndWaitForPVC(helper *clients.TestClient, k8sh *utils.K8sHelper, s *suite.Suite, clusterInfo *client.ClusterInfo,
-	storageClassName, blockName string) {
+	storageClassName, blockName string,
+) {
 	err := helper.BlockClient.CreatePVC(defaultNamespace, blockName, storageClassName, "ReadWriteOnce", "1M")
 	require.NoError(s.T(), err)
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, blockName))

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -18,9 +18,8 @@ package integration
 
 import (
 	"fmt"
-	"time"
-
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/clients"
@@ -35,9 +34,7 @@ const (
 	defaultNamespace = "default"
 )
 
-var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", "integrationTest")
-)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "integrationTest")
 
 // Test to make sure all rook components are installed and Running
 func checkIfRookClusterIsInstalled(s *suite.Suite, k8sh *utils.K8sHelper, opNamespace, clusterNamespace string, mons int) {

--- a/tests/integration/ceph_base_keystone_test.go
+++ b/tests/integration/ceph_base_keystone_test.go
@@ -66,9 +66,7 @@ var testuserdata = map[string]map[string]string{
 }
 
 func InstallKeystoneInTestCluster(shelper *utils.K8sHelper, namespace string) error {
-
 	if err := initializePasswords(); err != nil {
-
 		return err
 	}
 
@@ -200,20 +198,16 @@ func InstallKeystoneInTestCluster(shelper *utils.K8sHelper, namespace string) er
 	}
 
 	for _, userdata := range testuserdata {
-
 		if err := shelper.ResourceOperation("apply", createOpenStackClient(namespace, userdata["project"], userdata["username"], userdata["password"])); err != nil {
 			logger.Errorf("Could not create openstack client deployment in namespace %s", namespace)
 			return err
 		}
-
 	}
 
 	return nil
-
 }
 
 func initializePasswords() error {
-
 	for user := range testuserdata {
 
 		var err error
@@ -228,7 +222,6 @@ func initializePasswords() error {
 	}
 
 	return nil
-
 }
 
 func createOpenStackClient(namespace string, project string, username string, password string) string {
@@ -298,7 +291,6 @@ spec:
 }
 
 func trustManagerBundle(namespace string) string {
-
 	return `apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
@@ -313,19 +305,15 @@ spec:
   target:
     secret:
       key: "cabundle"`
-
 }
 
 func installHelmChart(helmHelper *utils.HelmHelper, namespace string, chartName string, chart string, version string, settings ...string) error {
-
 	logger.Infof("installing helm chart %s with version %s", chart, version)
 
 	arguments := []string{"upgrade", "--install", "--debug", "--namespace", namespace, chartName, chart, "--version=" + version, "--wait"}
 
 	for _, setting := range settings {
-
 		arguments = append(arguments, "--set", setting)
-
 	}
 
 	_, err := helmHelper.Execute(arguments...)
@@ -335,11 +323,9 @@ func installHelmChart(helmHelper *utils.HelmHelper, namespace string, chartName 
 	}
 
 	return nil
-
 }
 
 func keystoneApiCaIssuer(namespace string) string {
-
 	return `apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -349,11 +335,9 @@ spec:
   ca:
     secretName: root-secret
 `
-
 }
 
 func keystoneApiCaCertificate(namespace string) string {
-
 	return `apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -370,11 +354,9 @@ spec:
     name: selfsigned-issuer
     kind: ClusterIssuer
     group: cert-manager.io`
-
 }
 
 func keystoneApiClusterIssuer(namespace string) string {
-
 	return `apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -383,11 +365,9 @@ metadata:
 spec:
   selfSigned: {}
 `
-
 }
 
 func keystoneService(namespace string) string {
-
 	return `apiVersion: v1
 kind: Service
 metadata:
@@ -409,11 +389,9 @@ spec:
   type: ClusterIP
 status:
   loadBalancer: {}`
-
 }
 
 func keystoneApiCertificate(namespace string) string {
-
 	return `
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -440,11 +418,9 @@ spec:
     name: my-ca-issuer
     kind: Issuer
 `
-
 }
 
 func keystoneDeployment(namespace string, adminpassword string) string {
-
 	return `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -575,11 +551,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: keystone-api-tls`
-
 }
 
 func getKeystoneConfig() map[string][]byte {
-
 	returnMap := make(map[string][]byte)
 
 	keystoneConfig := `[DEFAULT]
@@ -600,11 +574,9 @@ enabled = false`
 	returnMap["keystone.conf"] = []byte(keystoneConfig)
 
 	return returnMap
-
 }
 
 func getKeystoneApache2CM(namespace string) map[string]string {
-
 	returnMap := make(map[string]string)
 
 	apache2Config := `LoadModule mpm_event_module modules/mod_mpm_event.so
@@ -655,11 +627,9 @@ TraceEnable Off`
 	returnMap["apache2.conf"] = apache2Config
 
 	return returnMap
-
 }
 
 func CleanUpKeystoneInTestCluster(shelper *utils.K8sHelper, namespace string) {
-
 	// Un-Install keystone with yaook
 	err := shelper.DeleteResource("-n", namespace, "configmap", "keystone-apache2-conf")
 	if err != nil {
@@ -678,7 +648,6 @@ func CleanUpKeystoneInTestCluster(shelper *utils.K8sHelper, namespace string) {
 
 	//cert-manager related resources (including certificates and secrets) are not removed here
 	//(as they will be removed anyway on uninstalling cert-manager)
-
 }
 
 // Test Object StoreCreation on Rook that was installed via helm
@@ -696,100 +665,79 @@ func runSwiftE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHe
 	// test with user with read+write access (member-role)
 
 	t.Run("create container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "create", testContainerName,
 		)
-
 	})
 
 	t.Run("show container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "show", testContainerName,
 		)
-
 	})
 
 	t.Run("create local testfile", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"bash", "-c", "echo test-content > /tmp/testfile",
 		)
-
 	})
 
 	// openstack object create testContainerName /testfile
 	t.Run("create object in container (using the local testfile) (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "object", "create", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("list objects in container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "object", "list", testContainerName,
 		)
-
 	})
 
 	t.Run("show testfile object in container  (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "object", "show", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("save testfile object from container to local disk  (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "object", "save", "--file", "/tmp/testfile.saved", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("check testfile (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"bash", "-c", "diff /tmp/testfile /tmp/testfile.saved",
 		)
-
 	})
 
 	t.Run("delete object in container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "object", "delete", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("delete container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "delete", testContainerName,
 		)
-
 	})
 
 	// unauthorized (?) access
 	// create container (with alice)
 	t.Run("prepare container for unauthorized access test (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "create", testContainerName,
@@ -812,134 +760,107 @@ func runSwiftE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHe
 			testProjectName, "alice", true,
 			"openstack", "object", "list", testContainerName,
 		)
-
 	})
 
 	// try access container with id (with mallory, expect: denied)
 	t.Run("display a container (as unprivileged user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", false,
 			"openstack", "container", "show", testContainerName,
 		)
-
 	})
 
 	// try read access object with id (with mallory, expect: denied)
 	t.Run("show testfile object in container (as unprivileged user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", false,
 			"openstack", "object", "show", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	// try write access object with id (with mallory, expect: denied)
 	t.Run("create local testfile", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", true,
 			"bash", "-c", "echo bad-content > /tmp/testfile",
 		)
-
 	})
 
 	// openstack object create testContainerName /testfile
 	t.Run("create object in container (using the local testfile) (as unprivileged user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", false,
 			"openstack", "object", "create", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	// try deleting object (with mallory, expect: denied)
 	t.Run("delete object in container (as unprivileged user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", false,
 			"openstack", "object", "delete", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	// try deleting container (with mallory, expect: denied)
 	t.Run("delete container (as unprivileged user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "mallory", false,
 			"openstack", "container", "delete", testContainerName,
 		)
-
 	})
 
 	// try access container with id (with rook-user, expect: success)
 	t.Run("show container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "container", "show", testContainerName,
 		)
-
 	})
 
 	t.Run("create local testfile (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"bash", "-c", "echo test-content > /tmp/testfile",
 		)
-
 	})
 
 	t.Run("create local testfile (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"bash", "-c", "echo test-content > /tmp/testfile-rook-user",
 		)
-
 	})
 
 	// openstack object create testContainerName /testfile
 	// try write access object with id (with rook-user, expect: success)
 	t.Run("create object in container (using the local testfile) (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "create", testContainerName, "/tmp/testfile-rook-user",
 		)
-
 	})
 
 	t.Run("list objects in container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "list", testContainerName,
 		)
-
 	})
 
 	// try read access object with id (with rook-user, expect: success)
 	t.Run("show testfile object in container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "show", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("save testfile object from container to local disk (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "save", "--file", "/tmp/testfile.saved", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("check testfile (admin-user)", func(t *testing.T) {
@@ -947,31 +868,25 @@ func runSwiftE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHe
 			testProjectName, "carol", true,
 			"bash", "-c", "diff /tmp/testfile /tmp/testfile.saved",
 		)
-
 	})
 
 	// try deleting object (with rook-user, expect: success)
 	t.Run("delete object in container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "delete", testContainerName, "/tmp/testfile",
 		)
-
 	})
 
 	t.Run("delete object in container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "object", "delete", testContainerName, "/tmp/testfile-rook-user",
 		)
-
 	})
 
 	// try deleting container (with rook-user, expect: success)
 	t.Run("delete container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "carol", true,
 			"openstack", "container", "delete", testContainerName,
@@ -989,7 +904,6 @@ func testInOpenStackClient(t *testing.T, sh *utils.K8sHelper, namespace string, 
 
 	commandLine = append(commandLine, command...)
 	output, err := sh.KubectlWithTimeout(60, commandLine...)
-
 	if err != nil {
 		logger.Warningf("failed to execute command in openstack cli: %s: %s", commandLine, output)
 	}
@@ -997,26 +911,18 @@ func testInOpenStackClient(t *testing.T, sh *utils.K8sHelper, namespace string, 
 	logger.Infof("%s", output)
 
 	if expectNoError {
-
 		assert.NoError(t, err)
-
 	} else {
-
 		assert.Error(t, err)
-
 	}
-
 }
 
 func prepareE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelper, installer *installer.CephInstaller, namespace, storeName string, replicaSize int, deleteStore bool, enableTLS bool, swiftAndKeystone bool, testContainerName string) {
-
 	t.Run("create test project in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "project", "create", testProjectName,
 		)
-
 	})
 
 	for _, value := range testuserdata {
@@ -1033,16 +939,12 @@ func prepareE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHel
 		})
 
 		if value["role"] != "" {
-
 			t.Run("assign test user "+value["username"]+" to project "+value["project"]+" in keystone", func(t *testing.T) {
-
 				testInOpenStackClient(t, k8sh, namespace,
 					"admin", "admin", true,
 					"openstack", "role", "add", "--user", value["username"], "--project", value["project"], value["role"],
 				)
-
 			})
-
 		}
 
 	}
@@ -1050,62 +952,47 @@ func prepareE2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHel
 	createCephObjectStore(t, helper, k8sh, installer, namespace, storeName, replicaSize, enableTLS, swiftAndKeystone)
 
 	t.Run("create service swift in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "service", "create", "--name", "swift", "object-store",
 		)
-
 	})
 
 	t.Run("create internal swift endpoint in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "endpoint", "create", "--region", "default", "--enable", "swift", "internal", ""+rgwServiceUri(storeName, namespace)+"/foobar/v1",
 		)
-
 	})
 
 	t.Run("create admin swift endpoint in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "endpoint", "create", "--region", "default", "--enable", "swift", "admin", ""+rgwServiceUri(storeName, namespace)+"/foobar/v1",
 		)
-
 	})
 }
 
 func cleanupE2ETest(t *testing.T, k8sh *utils.K8sHelper, namespace, storeName string, deleteStore bool, testContainerName string) {
-
 	t.Run("Delete swift endpoints in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"bash", "-c", "openstack endpoint list -f json | jq '.[] | select(.\"Service Name\" == \"swift\") | .ID' -r | xargs openstack endpoint delete",
 		)
-
 	})
 
 	t.Run("Delete service swift in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "service", "delete", "swift",
 		)
-
 	})
 
 	if deleteStore {
-
 		t.Run("delete object store", func(t *testing.T) {
-
 			deleteObjectStore(t, k8sh, namespace, storeName)
 			assertObjectStoreDeletion(t, k8sh, namespace, storeName)
-
 		})
-
 	}
 
 	for _, value := range testuserdata {
@@ -1124,14 +1011,11 @@ func cleanupE2ETest(t *testing.T, k8sh *utils.K8sHelper, namespace, storeName st
 	}
 
 	t.Run("delete test project in keystone", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			"admin", "admin", true,
 			"openstack", "project", "delete", testProjectName,
 		)
-
 	})
-
 }
 
 func rgwServiceUri(storeName string, namespace string) string {
@@ -1150,12 +1034,10 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 	prepareE2ETest(t, helper, k8sh, installer, namespace, storeName, replicaSize, deleteStore, enableTLS, swiftAndKeystone, testContainerName)
 
 	t.Run("create container (with user being a member)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "create", testContainerName,
 		)
-
 	})
 
 	t.Run("create AWS config file", func(t *testing.T) {
@@ -1170,7 +1052,6 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 			testProjectName, "alice", true,
 			"bash", "-c", "aws --debug --endpoint-url=http://"+RgwServiceName(storeName)+"."+namespace+".svc s3api list-buckets",
 		)
-
 	})
 
 	t.Run("List bucket with S3", func(t *testing.T) {
@@ -1178,7 +1059,6 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 			testProjectName, "alice", true,
 			"bash", "-c", "aws --endpoint-url="+rgwServiceUri(storeName, namespace)+" s3api list-buckets | jq '.Buckets | .[].Name' -r | grep "+testContainerName,
 		)
-
 	})
 
 	t.Run("List file with S3 created by OS", func(t *testing.T) {
@@ -1194,11 +1074,9 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 			testProjectName, "alice", true,
 			"bash", "-c", "aws --endpoint-url="+rgwServiceUri(storeName, namespace)+" s3 ls s3://"+testContainerName+"| grep testfile2",
 		)
-
 	})
 
 	t.Run("Upload test file using S3", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"bash", "-c", "echo test-content > /tmp/testfile",
@@ -1208,7 +1086,6 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 			testProjectName, "alice", true,
 			"bash", "-c", "aws --endpoint-url="+rgwServiceUri(storeName, namespace)+" s3 cp /tmp/testfile s3://"+testContainerName+"/testfile",
 		)
-
 	})
 
 	t.Run("save testfile object from container to local disk", func(t *testing.T) {
@@ -1233,7 +1110,6 @@ func runS3E2ETest(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelpe
 	})
 
 	t.Run("delete container (admin-user)", func(t *testing.T) {
-
 		testInOpenStackClient(t, k8sh, namespace,
 			testProjectName, "alice", true,
 			"openstack", "container", "delete", testContainerName,

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -242,8 +242,8 @@ func assertObjectStoreDeletion(t *testing.T, k8sh *utils.K8sHelper, namespace, s
 
 func createCephObjectUser(
 	s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper,
-	namespace, storeName, userID string, checkQuotaAndCaps bool) {
-
+	namespace, storeName, userID string, checkQuotaAndCaps bool,
+) {
 	maxObjectInt, err := strconv.Atoi(maxObject)
 	assert.Nil(s.T(), err)
 	logger.Infof("creating CephObjectStore user %q for store %q in namespace %q", userID, storeName, namespace)
@@ -262,8 +262,8 @@ func createCephObjectUser(
 
 func checkCephObjectUser(
 	s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper,
-	namespace, storeName, userID string, checkQuotaAndCaps bool) {
-
+	namespace, storeName, userID string, checkQuotaAndCaps bool,
+) {
 	logger.Infof("checking object store \"%s/%s\" user %q", namespace, storeName, userID)
 	assert.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userID))
 
@@ -289,8 +289,10 @@ func generateRgwTlsCertSecret(t *testing.T, helper *clients.TestClient, k8sh *ut
 	root, err := utils.FindRookRoot()
 	require.NoError(t, err, "failed to get rook root")
 	tlscertdir := t.TempDir()
-	cmdArgs := utils.CommandArgs{Command: filepath.Join(root, "tests/scripts/generate-tls-config.sh"),
-		CmdArgs: []string{tlscertdir, rgwServiceName, namespace}}
+	cmdArgs := utils.CommandArgs{
+		Command: filepath.Join(root, "tests/scripts/generate-tls-config.sh"),
+		CmdArgs: []string{tlscertdir, rgwServiceName, namespace},
+	}
 	cmdOut := utils.ExecuteCommand(cmdArgs)
 	require.NoError(t, cmdOut.Err)
 	tlsKeyIn, err := os.ReadFile(filepath.Join(tlscertdir, rgwServiceName+".key"))

--- a/tests/integration/ceph_bucket_notification_test.go
+++ b/tests/integration/ceph_bucket_notification_test.go
@@ -158,7 +158,6 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 			assert.False(t, notificationReceived)
 			assert.Nil(t, err)
 		})
-
 	})
 
 	t.Run("check CephBucketNotification created for bucket", func(t *testing.T) {
@@ -250,9 +249,7 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey2)
 			assert.False(t, notificationReceived)
 			assert.Nil(t, err)
-
 		})
-
 	})
 
 	t.Run("add topic, notification to existing OBC", func(t *testing.T) {

--- a/tests/integration/ceph_cosi_test.go
+++ b/tests/integration/ceph_cosi_test.go
@@ -42,7 +42,6 @@ func testCOSIDriver(s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sH
 	t.Run("Creating CephCOSIDriver CRD", func(t *testing.T) {
 		err := helper.COSIClient.CreateCOSI()
 		assert.NoError(t, err, "failed to create Ceph COSI Driver CRD")
-
 	})
 
 	operatorNamespace := cephinstaller.Manifests.Settings().OperatorNamespace

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -227,6 +227,7 @@ func (s *CephMgrSuite) waitForOrchestrationModule() {
 	}
 	require.Nil(s.T(), err)
 }
+
 func (s *CephMgrSuite) TestDeviceLs() {
 	logger.Info("Testing .... <ceph orch device ls>")
 	deviceList, err := s.executeWithRetry([]string{"device", "ls"}, defaultTries)

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -150,8 +150,10 @@ func (s *MultiClusterDeploySuite) TestInstallingMultipleRookClusters() {
 func (s *MultiClusterDeploySuite) setupMultiClusterCore() {
 	root, err := utils.FindRookRoot()
 	require.NoError(s.T(), err, "failed to get rook root")
-	cmdArgs := utils.CommandArgs{Command: filepath.Join(root, localPathPVCmd),
-		CmdArgs: []string{installer.TestScratchDevice()}}
+	cmdArgs := utils.CommandArgs{
+		Command: filepath.Join(root, localPathPVCmd),
+		CmdArgs: []string{installer.TestScratchDevice()},
+	}
 	cmdOut := utils.ExecuteCommand(cmdArgs)
 	require.NoError(s.T(), cmdOut.Err)
 

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -47,9 +47,7 @@ const (
 	objectStoreTLSName           = "tls-test-store"
 )
 
-var (
-	objectStoreServicePrefix = "rook-ceph-rgw-"
-)
+var objectStoreServicePrefix = "rook-ceph-rgw-"
 
 func TestCephObjectSuite(t *testing.T) {
 	s := new(ObjectSuite)
@@ -107,6 +105,7 @@ func (s *ObjectSuite) TestWithTLS() {
 	runObjectE2ETest(s.helper, s.k8sh, s.installer, &s.Suite, s.settings.Namespace, tls, swiftAndKeystone)
 	cleanUpTLS(s)
 }
+
 func cleanUpTLS(s *ObjectSuite) {
 	err := s.k8sh.Clientset.CoreV1().Secrets(s.settings.Namespace).Delete(context.TODO(), objectTLSSecretName, metav1.DeleteOptions{})
 	if err != nil {

--- a/tests/integration/object/bucketowner/bucketowner.go
+++ b/tests/integration/object/bucketowner/bucketowner.go
@@ -193,7 +193,6 @@ func WaitForPodLogContainingText(k8sh *utils.K8sHelper, namespace string, select
 
 	if len(pods.Items) == 0 {
 		return fmt.Errorf("no pods found with labels %v in namespace %q", selector, namespace)
-
 	}
 
 	// if there are multiple pods, just pick the first one


### PR DESCRIPTION
neovim with null-ls/none-ls keeps reformatting the rook sources when I edit files, which I then try not to add into changesets. This has become a major irritation.  Instead of piecemeal reformatting one file at a time, lets do a bulk update.

This PR includes reformatting by:
- `gofumpt`

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
