### PR TITLE
operator: Set dns policy for host network if needed

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -118,6 +118,7 @@ spec:
 {{- end }}
 {{- if .Values.useOperatorHostNetwork }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -760,6 +760,10 @@ spec:
           #- name: LIB_BUCKET_PROVISIONER_THREADS
           #  value: "5"
 
+      # Uncomment these two settings to run the operator on the host network
+      # hostNetwork: true
+      # dnsPolicy: ClusterFirstWithHostNet
+
       volumes:
         - name: rook-config
           emptyDir: {}

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -687,8 +687,9 @@ spec:
           #- name: LIB_BUCKET_PROVISIONER_THREADS
           #  value: "5"
 
-      # Uncomment it to run rook operator on the host network
-      #hostNetwork: true
+      # Uncomment these two settings to run the operator on the host network
+      # hostNetwork: true
+      # dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - name: rook-config
           emptyDir: {}


### PR DESCRIPTION
When host network is enabled, the operator needs to set the dns policy to ClusterFirstWithHostNet so the request to the rgw endpoint will resolve properly.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14954

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
