### PR TITLE
docs: fix specific pool properties key name and config example

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
@@ -241,7 +241,7 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
 
 ### Add specific pool properties
 
-With `poolProperties` you can set any pool property:
+With `parameters` you can set any pool property:
 
 ```yaml
 spec:
@@ -254,7 +254,7 @@ For instance:
 ```yaml
 spec:
   parameters:
-    min_size: 1
+    min_size: "1"
 ```
 
 ### Erasure Coding


### PR DESCRIPTION
Fixes an example of setting specific pool properties where all values must be of type string. Also fixes the parameters key name.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
