### PR TITLE
core: replace gofmt with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -33,20 +33,11 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.62
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          args: -E gosec -E gofmt -E gofumpt --timeout=10m
-
+          # `version` is parsed by build/makelib/golang.mk
+          # Do not change the structure of this job without updating the parsing logic.
+          version: v2.0.2
           # actions/setup-go already handles caching
           skip-cache: true
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
 
   govulncheck:
     name: govulncheck

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           go-version: "1.23"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           # `version` is parsed by build/makelib/golang.mk
           # Do not change the structure of this job without updating the parsing logic.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,58 @@
+---
+version: "2"
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - gosec
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: "QF1003:" # could use tagged switch on errCode (staticcheck)
+      - linters:
+          - staticcheck
+        text: "ST1005:" # error strings should not be capitalized (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1008:" # could remove embedded field "Connection" from selector (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1007:" # could merge conditional assignment into variable declaration (staticcheck)
+      - linters:
+          - staticcheck
+        text: "ST1023:" # should omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1001:" # could apply De Morgan's law (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1002:" # could use tagged switch on args[0] (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1011:" # could omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1004:" # could use strings.ReplaceAll instead (staticcheck)
+      - linters:
+          - staticcheck
+        text: "ST1008:" # error should be returned as the last argument (staticcheck)
+      - linters:
+          - staticcheck
+        text: "ST1019" # package "github.com/rook/rook/pkg/daemon/ceph/client" is being imported more than once (staticcheck)
+      - linters:
+          - staticcheck
+        text: "QF1006:" # could lift into loop condition (staticcheck)
+formatters:
+  enable:
+    - gofmt
+    - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,10 @@ vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.vet
 
 fmt: ## Check formatting of go sources.
-	@$(MAKE) go.init
 	@$(MAKE) go.fmt
+
+fmt-fix:  ## Reformatting of go sources.
+	@$(MAKE) go.fmt-fix
 
 .PHONY: markdownlint
 markdownlint: ## Check formatting of documentation sources
@@ -164,10 +166,6 @@ markdownlint: ## Check formatting of documentation sources
 .PHONY: yamllint
 yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
-
-.PHONY: golangci-lint
-golangci-lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 
 .PHONY: lint
 lint: yamllint pylint shellcheck vet markdownlint golangci-lint ## Run various linters

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,14 @@ vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet
 
-fmt: ## Check formatting of go sources.
+fmt: $(YQ) ## Check formatting of go sources.
 	@$(MAKE) go.fmt
 
-fmt-fix:  ## Reformatting of go sources.
+fmt-fix: $(YQ) ## Reformatting of go sources.
 	@$(MAKE) go.fmt-fix
+ 
+golangci-lint: $(YQ)
+	@$(MAKE) go.golangci-lint
 
 .PHONY: markdownlint
 markdownlint: ## Check formatting of documentation sources

--- a/pkg/daemon/ceph/osd/kms/kmip.go
+++ b/pkg/daemon/ceph/osd/kms/kmip.go
@@ -51,7 +51,8 @@ const (
 	// cryptographicLength of the key.
 	cryptographicLength = 256
 
-	//nolint:gosec, value not credential, just configuration keys.
+	// value not credential, just configuration keys.
+	//nolint:gosec
 	kmipEndpoint         = "KMIP_ENDPOINT"
 	kmipTLSServerName    = "TLS_SERVER_NAME"
 	kmipReadTimeOut      = "READ_TIMEOUT"


### PR DESCRIPTION
This has the effect of running gofmt and gofumpt at the same time.

golangci-lint is upgraded from 1.62.x to 2.0.2.  Configuration has shifted from being inline in the gha workflow to `.golangci.yaml`.  The use of golangci-lint-action is retained as that action will annotate PRs with failure messages. All new warnings introduced between the two versions have been suppressed by configuration in `.golangci.yaml`.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
