### PR TITLE
rgw: use pod name in ops log filename

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -103,7 +103,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 	if c.spec.LogCollector.Enabled {
 		shareProcessNamespace := true
 		podSpec.Spec.ShareProcessNamespace = &shareProcessNamespace
-		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-mgr.%s", mgrConfig.DaemonID), c.clusterInfo.Namespace, c.spec))
+		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-mgr.%s", mgrConfig.DaemonID), c.clusterInfo.Namespace, c.spec, nil))
 	}
 
 	// Replace default unreachable node toleration

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -200,7 +200,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*corev1.Pod, er
 	if c.spec.LogCollector.Enabled {
 		shareProcessNamespace := true
 		podSpec.ShareProcessNamespace = &shareProcessNamespace
-		podSpec.Containers = append(podSpec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("%s.%s", cephMonCommand, monConfig.DaemonName), c.ClusterInfo.Namespace, c.spec))
+		podSpec.Containers = append(podSpec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("%s.%s", cephMonCommand, monConfig.DaemonName), c.ClusterInfo.Namespace, c.spec, nil))
 	}
 
 	// Replace default unreachable node toleration

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -715,7 +715,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 			shareProcessNamespace := true
 			podTemplateSpec.Spec.ShareProcessNamespace = &shareProcessNamespace
 		}
-		podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-osd.%s", osdID), c.clusterInfo.Namespace, c.spec))
+		podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-osd.%s", osdID), c.clusterInfo.Namespace, c.spec, nil))
 	}
 
 	podTemplateSpec.Spec.Containers[0] = opconfig.ConfigureStartupProbe(podTemplateSpec.Spec.Containers[0], c.spec.HealthCheck.StartupProbe[cephv1.KeyOSD])

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -57,7 +57,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 		// ceph-client.rbd-mirror.a.log
 		// <CLUSTER_FSID>-client.rbd-mirror-peer.log
 		logRotationFilter := "*-client.rbd-mirror*"
-		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(logRotationFilter, r.clusterInfo.Namespace, *r.cephClusterSpec))
+		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(logRotationFilter, r.clusterInfo.Namespace, *r.cephClusterSpec, nil))
 	}
 
 	// Replace default unreachable node toleration

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -799,7 +799,7 @@ func GetLogRotateConfig(c cephv1.ClusterSpec) (resource.Quantity, string) {
 }
 
 // LogCollectorContainer rotate logs
-func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec, additionalLogFiles ...string) *v1.Container {
+func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec, env []v1.EnvVar, additionalLogFiles ...string) *v1.Container {
 	maxLogSize, periodicity := GetLogRotateConfig(c)
 	rotation := "7"
 
@@ -829,11 +829,12 @@ func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec, additional
 		Resources:       cephv1.GetLogCollectorResources(c.Resources),
 		// We need a TTY for the bash job control (enabled by -m)
 		TTY: true,
+		Env: env,
 	}
 }
 
 // rgw operations will be logged in sidecar ops-log
-func RgwOpsLogSidecarContainer(opsLogFile, ns string, c cephv1.ClusterSpec, Resources v1.ResourceRequirements) *v1.Container {
+func RgwOpsLogSidecarContainer(opsLogFile, ns string, c cephv1.ClusterSpec, env []v1.EnvVar, Resources v1.ResourceRequirements) *v1.Container {
 	return &v1.Container{
 		Name: "ops-log",
 		Command: []string{
@@ -849,6 +850,7 @@ func RgwOpsLogSidecarContainer(opsLogFile, ns string, c cephv1.ClusterSpec, Reso
 		Resources:       Resources,
 		// We need a TTY for the bash job control (enabled by -m)
 		TTY: true,
+		Env: env,
 	}
 }
 

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -392,7 +392,7 @@ func TestLogCollectorContainer(t *testing.T) {
 
 	t.Run("Periodicity 1d and no MaxlogSize", func(t *testing.T) {
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d"}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "0", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -400,7 +400,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("Periodicity 1h and MaxlogSize 1M", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1M")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1h", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer("ceph-client.rbd-mirror.a", ns, c)
+		got := LogCollectorContainer("ceph-client.rbd-mirror.a", ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, "ceph-client.rbd-mirror.a", "hourly", "1M", "28", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -408,7 +408,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("Periodicity weekly and 1G MaxlogSize", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1Gi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "weekly", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "1073M", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -416,7 +416,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("MaxlogSize 1M and no Periodicity", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1Mi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -424,7 +424,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("10G MaxlogSize and Periodicity 1d", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("10G")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "10G", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -432,7 +432,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("10M MaxlogSize and Periodicity weekly", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("10Mi")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "weekly", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "weekly", "10M", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -440,7 +440,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("1M MaxlogSize and Periodicity 1d", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("1M")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -448,7 +448,7 @@ func TestLogCollectorContainer(t *testing.T) {
 	t.Run("500k MaxlogSize and Periodicity 1d", func(t *testing.T) {
 		maxsize, _ := resource.ParseQuantity("500K")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c)
+		got := LogCollectorContainer(daemonId, ns, c, nil)
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7", "")
 		assert.Equal(t, want, got.Command[5])
 	})
@@ -457,7 +457,7 @@ func TestLogCollectorContainer(t *testing.T) {
 		additionalLogFile := "/tmp/ceph_test_log_500KB.log"
 		maxsize, _ := resource.ParseQuantity("500K")
 		c := cephv1.ClusterSpec{LogCollector: cephv1.LogCollectorSpec{Enabled: true, Periodicity: "1d", MaxLogSize: &maxsize}}
-		got := LogCollectorContainer(daemonId, ns, c, additionalLogFile)
+		got := LogCollectorContainer(daemonId, ns, c, nil, additionalLogFile)
 
 		want := fmt.Sprintf(cronLogRotate, daemonId, "daily", "1M", "7", additionalLogFile)
 		assert.Equal(t, want, got.Command[5])

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -76,7 +76,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig, fsNamespacedname types.Na
 	if c.clusterSpec.LogCollector.Enabled {
 		shareProcessNamespace := true
 		podSpec.Spec.ShareProcessNamespace = &shareProcessNamespace
-		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-mds.%s", mdsConfig.DaemonID), c.clusterInfo.Namespace, *c.clusterSpec))
+		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-mds.%s", mdsConfig.DaemonID), c.clusterInfo.Namespace, *c.clusterSpec, nil))
 	}
 
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&podSpec.ObjectMeta)

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -55,7 +55,7 @@ func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, f
 	if r.cephClusterSpec.LogCollector.Enabled {
 		shareProcessNamespace := true
 		podSpec.Spec.ShareProcessNamespace = &shareProcessNamespace
-		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-%s", user), r.clusterInfo.Namespace, *r.cephClusterSpec))
+		podSpec.Spec.Containers = append(podSpec.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-%s", user), r.clusterInfo.Namespace, *r.cephClusterSpec, nil))
 	}
 
 	// Replace default unreachable node toleration

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -182,12 +182,6 @@ func (c *clusterConfig) generateMonConfigOptions(rgwConfig *rgwConfig) (map[stri
 	configOptions["rgw_zone"] = rgwConfig.Zone
 	configOptions["rgw_zonegroup"] = rgwConfig.ZoneGroup
 
-	if c.store.Spec.Gateway.OpsLogSidecar != nil {
-		configOptions["rgw_enable_ops_log"] = "true"
-	} else {
-		configOptions["rgw_enable_ops_log"] = "false"
-	}
-
 	configOptions, err := configureKeystoneAuthentication(rgwConfig, configOptions)
 	if err != nil {
 		return configOptions, err

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -107,7 +107,6 @@ func TestGenerateCephXUser(t *testing.T) {
 // RGW configs determined here are applied to the running RGW
 func Test_clusterConfig_generateMonConfigOptions(t *testing.T) {
 	defaultConfigs := map[string]string{
-		"rgw_enable_ops_log":         "false",
 		"rgw_enable_usage_log":       "true",
 		"rgw_log_nonexistent_bucket": "true",
 		"rgw_log_object_name_utc":    "true",

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -88,7 +89,24 @@ func TestPodSpecs(t *testing.T) {
 	info.CephVersion = cephver.Squid
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
 
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
+
 	c := &clusterConfig{
+		context:     &clusterd.Context{Executor: executor},
 		clusterInfo: info,
 		store:       store,
 		rookVersion: "rook/rook:myversion",
@@ -157,6 +175,22 @@ func TestSSLPodSpec(t *testing.T) {
 	info.Namespace = store.Namespace
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
 	store.Spec.Gateway.SecurePort = 443
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
+	context.Executor = executor
 
 	c := &clusterConfig{
 		clusterInfo: info,
@@ -715,7 +749,23 @@ func TestMakeRGWPodSpec(t *testing.T) {
 	store := simpleStore()
 	info := clienttest.CreateTestClusterInfo(1)
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
 	c := &clusterConfig{
+		context:     &clusterd.Context{Executor: executor},
 		store:       store,
 		rookVersion: "rook/rook:myversion",
 		clusterSpec: &cephv1.ClusterSpec{
@@ -772,6 +822,22 @@ func TestAWSServerSideEncryption(t *testing.T) {
 	info.CephVersion = cephver.CephVersion{Major: 17, Minor: 2, Extra: 3}
 	info.Namespace = store.Namespace
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
+	context.Executor = executor
 
 	c := &clusterConfig{
 		clusterInfo: info,
@@ -937,6 +1003,22 @@ func TestRgwCommandFlags(t *testing.T) {
 	info.CephVersion = cephver.CephVersion{Major: 18, Minor: 2, Extra: 0}
 	info.Namespace = store.Namespace
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
+	context.Executor = executor
 
 	c := &clusterConfig{
 		clusterInfo: info,
@@ -1549,6 +1631,22 @@ func TestRgwReadAffinity(t *testing.T) {
 	info.Namespace = store.Namespace
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
 
+	executorFunc := func(command string, args ...string) (string, error) {
+		idResponse := `{"id":"test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return idResponse, nil
+	}
+	executorFuncTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
+		testResponse := `{"id": "test-id"}`
+		logger.Infof("Execute: %s %v", command, args)
+		return testResponse, nil
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput:         executorFunc,
+		MockExecuteCommandWithCombinedOutput: executorFunc,
+		MockExecuteCommandWithTimeout:        executorFuncTimeout,
+	}
+	context.Executor = executor
 	c := &clusterConfig{
 		clusterInfo: info,
 		store:       store,


### PR DESCRIPTION
Closes #15538

Rotated rgw ops logs from test node:
```shell
atorubar@lima-rook:/var/lib/rook/rook-ceph/log$ ll
-rw-r--r-- 1  167  167   97180 Mar 28 17:32 ops-log.rook-ceph.rook-ceph-rgw-my-store-a-76d4476ccf-2rxq6.log
-rw-r--r-- 1  167  167  432702 Mar 28 16:55 ops-log.rook-ceph.rook-ceph-rgw-my-store-a-76d4476ccf-2rxq6.log.1.gz
-rw-r--r-- 1  167  167   97233 Mar 28 16:39 ops-log.rook-ceph.rook-ceph-rgw-my-store-a-76d4476ccf-2rxq6.log.2.gz
```

With the current implementation, there will be dangling logs when a pod is recreated.
Because log collector sidecar rotates only current pod logs, but this issue also happens with the old log filename (#14202).
I assume that there will be dangling logs anyway when rgw pod rescheduled to different node.
