### PR TITLE
tests: fix intermittent failure of TestWaitForDeploymentsToUpdate

### DIFF
--- a/pkg/operator/k8sutil/deployment_test.go
+++ b/pkg/operator/k8sutil/deployment_test.go
@@ -266,8 +266,8 @@ func TestWaitForDeploymentsToUpdate(t *testing.T) {
 		waitForDeploymentPeriod = oldPeriod
 		waitForDeploymentTimeout = oldTimeout
 	}()
-	waitForDeploymentPeriod = 1 * time.Millisecond
-	waitForDeploymentTimeout = 3 * time.Millisecond
+	waitForDeploymentPeriod = 3 * time.Millisecond
+	waitForDeploymentTimeout = 9 * time.Millisecond
 
 	timesCalled := 0
 	// generate a status that is not ready when first called but becomes ready later


### PR DESCRIPTION
The unit test `TestWaitForDeploymentsToUpdate` intermittently failed in the CI. The suspected root cause is clow CPUs in github CI runners.

This fixes the intermittent CI failure by increasing the timings in the test code.


**Issue resolved by this Pull Request:**
Resolves: #15583

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
