### PR TITLE
osd: fix pdbs in case of node drain

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -268,7 +268,6 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 				maxUnavailableOSDCount = 1
 			} else {
 				maxUnavailableOSDCount = len(downOSDs) + 1
-				resetPDBConfig(pdbStateMap)
 			}
 		} else {
 			maxUnavailableOSDCount = len(downOSDs) + 1


### PR DESCRIPTION
the maxunavailable count was getting reset back to 1 after 60 seconds. This PR prevents resetting of the maxUnavailable OSD count.

Tests:
- OSD.3 has 0 weight on node minikube. But Pgs are healthy

ID  CLASS  WEIGHT   TYPE NAME              STATUS  REWEIGHT  PRI-AFF
-1         0.02939  root default
-7               0      host minikube
 3    hdd        0          osd.3            down   1.00000  1.00000
-3         0.00980      host minikube-m02
 0    hdd  0.00980          osd.0              up   1.00000  1.00000
-5         0.00980      host minikube-m03
 1    hdd  0.00980          osd.1              up   1.00000  1.00000
-9         0.00980      host minikube-m04
 2    hdd  0.00980          osd.2              up   1.00000  1.00000

```

```
sh-5.1$ ceph status
  cluster:
    id:     f2be688f-76c0-426a-98de-619f2e866b72
    health: HEALTH_WARN
            1 osds down
            1 host (1 osds) down

  services:
    mon: 3 daemons, quorum a,b,c (age 61m)
    mgr: b(active, since 21m), standbys: a
    osd: 4 osds: 3 up (since 6m), 4 in (since 11m)
    rgw: 1 daemon active (1 hosts, 1 zones)

  data:
    pools:   9 pools, 185 pgs
    objects: 1.46k objects, 4.0 GiB
    usage:   13 GiB used, 27 GiB / 40 GiB avail
    pgs:     185 active+clean

sh-5.1$

```

- maxUnavailable is set to 2 and didn't change back to 1 afer reconcile

```
2025-04-02 05:59:35.417413 I | clusterdisruption-controller: node drain is detected. Requeue to ensure that correct PG status is read.
2025-04-02 05:59:35.417540 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 1
2025-04-02 05:59:36.362796 I | clusterdisruption-controller: reconciling osd pdb controller
2025-04-02 06:00:02.114548 I | clusterdisruption-controller: osd "rook-ceph-osd-3" is down on node "minikube" and a possible node drain is detected
2025-04-02 06:00:03.044796 I | clusterdisruption-controller: OSD(s) [3] are down but PGs are clean. PG Status: "all PGs in cluster are clean"
2025-04-02 06:00:03.044841 I | clusterdisruption-controller: node drain is detected. Requeue to ensure that correct PG status is read.
2025-04-02 06:00:03.044856 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 1
2025-04-02 06:00:03.981495 I | clusterdisruption-controller: reconciling osd pdb controller
2025-04-02 06:00:35.791026 I | clusterdisruption-controller: osd "rook-ceph-osd-3" is down on node "minikube" and a possible node drain is detected
2025-04-02 06:00:36.766293 I | clusterdisruption-controller: OSD(s) [3] are down but PGs are clean. PG Status: "all PGs in cluster are clean"
2025-04-02 06:00:36.768523 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 2
2025-04-02 06:00:37.757579 I | clusterdisruption-controller: reconciling osd pdb controller
2025-04-02 06:01:08.975658 I | clusterdisruption-controller: osd "rook-ceph-osd-3" is down on node "minikube" and a possible node drain is detected
2025-04-02 06:01:09.769481 I | clusterdisruption-controller: OSD(s) [3] are down but PGs are clean. PG Status: "all PGs in cluster are clean"
2025-04-02 06:01:09.772155 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 2
2025-04-02 06:01:10.558493 I | clusterdisruption-controller: reconciling osd pdb controller
2025-04-02 06:01:42.983697 I | clusterdisruption-controller: osd "rook-ceph-osd-3" is down on node "minikube" and a possible node drain is detected
2025-04-02 06:01:45.507584 I | clusterdisruption-controller: OSD(s) [3] are down but PGs are clean. PG Status: "all PGs in cluster are clean"
2025-04-02 06:01:45.521892 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 2
2025-04-02 06:01:46.441133 I | clusterdisruption-controller: reconciling osd pdb controller
2025-04-02 06:02:17.388275 I | clusterdisruption-controller: osd "rook-ceph-osd-3" is down on node "minikube" and a possible node drain is detected
2025-04-02 06:02:18.222178 I | clusterdisruption-controller: OSD(s) [3] are down but PGs are clean. PG Status: "all PGs in cluster are clean"
2025-04-02 06:02:18.222313 I | clusterdisruption-controller: `maxUnavailable` for the main OSD PDB is set to 2
2025-04-02 06:02:18.983325 I | clusterdisruption-controller: reconciling osd pdb controller
```

```
Every 2.0s: kubectl get pdb -n rook-ceph                                       dhcp53-151.lab.eng.blr.redhat.com: Wed Apr  2 11:33:42 2025

NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb   N/A             1                 1                     67m
rook-ceph-mon-pdb   N/A             1                 1                     68m
rook-ceph-osd       N/A             2                 1                     10m

```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #15601


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
