### PR TITLE
operator: decouple mon and mgr post-startup operations

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -31,7 +31,7 @@ const (
 
 var orchestratorInitWaitTime = 5 * time.Second
 
-// Ceph docs about the orchestrator modules: http://docs.ceph.com/docs/master/mgr/orchestrator_cli/
+// Ceph docs about the orchestrator modules: https://docs.ceph.com/en/latest/mgr/orchestrator/
 func (c *Cluster) configureOrchestratorModules() error {
 	if err := client.MgrEnableModule(c.context, c.clusterInfo, rookModuleName, true); err != nil {
 		return errors.Wrap(err, "failed to enable mgr rook module")


### PR DESCRIPTION
Fixes an ordering issue where spec.cephConfig settings failed to apply because the manager wasn't yet running. Moved the config logic from postMonStartupActions() to a new postMgrStartupActions() to ensure the mgr is ready before applying config, allowing successful reconciliation.

Adresses https://github.com/rook/rook/issues/15559

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
