### PR TITLE
core: Reconcile CRs only after the finalizer is added by Rook

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -158,9 +158,13 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	observedGeneration := cephClient.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephClient)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephClient)
 	if err != nil {
 		return reconcile.Result{}, *cephClient, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the cephclient %q after adding finalizer", cephClient.Name)
+		return reconcile.Result{}, *cephClient, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -127,9 +127,13 @@ func TestCephClientController(t *testing.T) {
 	// A Pool resource with metadata and spec.
 	cephClient := &cephv1.CephClient{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Name:       name,
+			Namespace:  namespace,
+			UID:        types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Finalizers: []string{"cephclient.ceph.rook.io"},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephClient",
 		},
 		Spec: cephv1.ClientSpec{
 			Caps: map[string]string{

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -274,9 +274,13 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephCluster)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephCluster)
 	if err != nil {
 		return reconcile.Result{}, *cephCluster, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the ceph cluster %q after adding finalizer", cephCluster.Name)
+		return reconcile.Result{}, *cephCluster, nil
 	}
 
 	// DELETE: the CR was deleted

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -183,7 +183,8 @@ func watchControllerPredicate[T *cephv1.CephCluster](ctx context.Context, c clie
 				return false
 
 			} else if objOld.GetGeneration() != objNew.GetGeneration() {
-				logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
+				logger.Debugf("reconciling CephCluster %q with changed generation", objNew.Name)
+				return true
 			}
 
 			return false

--- a/pkg/operator/ceph/controller/finalizer_test.go
+++ b/pkg/operator/ceph/controller/finalizer_test.go
@@ -46,9 +46,10 @@ func TestAddFinalizerIfNotPresent(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	assert.Empty(t, fakeObject.Finalizers)
-	err := AddFinalizerIfNotPresent(context.TODO(), cl, fakeObject)
+	generationUpdated, err := AddFinalizerIfNotPresent(context.TODO(), cl, fakeObject)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fakeObject.Finalizers)
+	assert.False(t, generationUpdated)
 }
 
 func TestRemoveFinalizer(t *testing.T) {

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -104,7 +104,8 @@ func WatchControllerPredicate[T client.Object](scheme *runtime.Scheme) predicate
 				logger.Debugf("resource %q: %q is going to be deleted", kind, nsName)
 				return true
 			} else if objOld.GetGeneration() != objNew.GetGeneration() {
-				logger.Debugf("skipping resource %q: %q, update event with unchanged spec", kind, nsName)
+				logger.Debugf("reconciling %s %q with changed generation", kind, nsName.String())
+				return true
 			}
 			return false
 		},

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -214,9 +214,13 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 	observedGeneration := cephFilesystem.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephFilesystem)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephFilesystem)
 	if err != nil {
 		return reconcile.Result{}, *cephFilesystem, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the filesystem %q after adding finalizer", cephFilesystem.Name)
+		return reconcile.Result{}, *cephFilesystem, nil
 	}
 
 	// The CR was just created, initialize status as 'Progressing'

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -165,8 +165,9 @@ func TestCephFilesystemController(t *testing.T) {
 	// A Pool resource with metadata and spec.
 	fs := &cephv1.CephFilesystem{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{"cephfilesystem.ceph.rook.io"},
 		},
 		Spec: cephv1.FilesystemSpec{
 			MetadataServer: cephv1.MetadataServerSpec{

--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -155,9 +155,13 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) reconcile(request reconcile.Requ
 	observedGeneration := cephFilesystemSubVolumeGroup.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephFilesystemSubVolumeGroup)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephFilesystemSubVolumeGroup)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the subvolume group %q after adding finalizer", cephFilesystemSubVolumeGroup.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestCephClientController(t *testing.T) {
+func TestFilesystemSubvolumeGroupController(t *testing.T) {
 	ctx := context.TODO()
 	// Set DEBUG logging
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
@@ -56,9 +56,13 @@ func TestCephClientController(t *testing.T) {
 	// A cephFilesystemSubVolumeGroup resource with metadata and spec.
 	cephFilesystemSubVolumeGroup := &cephv1.CephFilesystemSubVolumeGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Name:       name,
+			Namespace:  namespace,
+			UID:        types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Finalizers: []string{"cephfilesystemsubvolumegroup.ceph.rook.io"},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephFilesystemSubvolumeGroup",
 		},
 		Spec: cephv1.CephFilesystemSubVolumeGroupSpec{
 			FilesystemName: namespace,

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -176,9 +176,13 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 	observedGeneration := cephNFS.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephNFS)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephNFS)
 	if err != nil {
 		return reconcile.Result{}, *cephNFS, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the nfs %q after adding finalizer", cephNFS.Name)
+		return reconcile.Result{}, *cephNFS, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -141,8 +141,9 @@ func TestCephNFSController(t *testing.T) {
 	baseCephNFS := func() *cephv1.CephNFS {
 		return &cephv1.CephNFS{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
+				Name:       name,
+				Namespace:  namespace,
+				Finalizers: []string{"cephnfs.ceph.rook.io"},
 			},
 			Spec: cephv1.NFSGaneshaSpec{
 				RADOS: cephv1.GaneshaRADOSSpec{

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -293,9 +293,13 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	observedGeneration := cephObjectStore.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephObjectStore)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephObjectStore)
 	if err != nil {
 		return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the object store %q after adding finalizer", cephObjectStore.Name)
+		return reconcile.Result{}, *cephObjectStore, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -343,8 +343,9 @@ func TestCephObjectStoreController(t *testing.T) {
 		// A Pool resource with metadata and spec.
 		objectStore := &cephv1.CephObjectStore{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      store,
-				Namespace: namespace,
+				Name:       store,
+				Namespace:  namespace,
+				Finalizers: []string{"cephobjectstore.ceph.rook.io"},
 			},
 			Spec:     cephv1.ObjectStoreSpec{MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}, DataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}},
 			TypeMeta: controllerTypeMeta,
@@ -632,8 +633,9 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 
 	objectStore := &cephv1.CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      store,
-			Namespace: namespace,
+			Name:       store,
+			Namespace:  namespace,
+			Finalizers: []string{"cephobjectstore.ceph.rook.io"},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephObjectStore",

--- a/pkg/operator/ceph/object/topic/controller.go
+++ b/pkg/operator/ceph/object/topic/controller.go
@@ -121,9 +121,13 @@ func (r *ReconcileBucketTopic) reconcile(request reconcile.Request) (reconcile.R
 	observedGeneration := cephBucketTopic.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBucketTopic)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBucketTopic)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to add finalizer to CephBucketTopic %q", request.NamespacedName)
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the object bucket topic %q after adding finalizer", cephBucketTopic.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -71,8 +71,9 @@ func TestCephBucketTopicController(t *testing.T) {
 
 	bucketTopic := &cephv1.CephBucketTopic{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{"cephbuckettopic.ceph.rook.io"},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephBucketTopic",

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -245,9 +245,13 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	observedGeneration := cephObjectStoreUser.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephObjectStoreUser)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephObjectStoreUser)
 	if err != nil {
 		return reconcile.Result{}, *cephObjectStoreUser, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the object user %q after adding finalizer", cephObjectStoreUser.Name)
+		return reconcile.Result{}, *cephObjectStoreUser, nil
 	}
 
 	clusterNamespace := request.NamespacedName

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -113,8 +113,9 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	cephObjectStore := &cephv1.CephObjectStore{}
 	objectUser := &cephv1.CephObjectStoreUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{"cephobjectstoreuser.ceph.rook.io"},
 		},
 		Spec: cephv1.ObjectStoreUserSpec{
 			Store: store,

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -163,6 +163,7 @@ func TestCephObjectZoneController(t *testing.T) {
 			Name:       name,
 			Namespace:  namespace,
 			Generation: 0,
+			Finalizers: []string{"cephobjectzone.ceph.rook.io"},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephObjectZone",

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -189,9 +189,13 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	observedGeneration := cephBlockPool.ObjectMeta.Generation
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBlockPool)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBlockPool)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, *cephBlockPool, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the ceph block pool %q after adding finalizer", cephBlockPool.Name)
+		return reconcile.Result{}, *cephBlockPool, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -218,9 +218,13 @@ func TestCephBlockPoolController(t *testing.T) {
 	// A Pool resource with metadata and spec.
 	pool := &cephv1.CephBlockPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Name:       name,
+			Namespace:  namespace,
+			UID:        types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Finalizers: []string{"cephblockpool.ceph.rook.io"},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBlockPool",
 		},
 		Spec: cephv1.NamedBlockPoolSpec{
 			PoolSpec: cephv1.PoolSpec{

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -158,9 +158,13 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBlockPoolRadosNamespace)
+	generationUpdated, err := opcontroller.AddFinalizerIfNotPresent(r.opManagerContext, r.client, cephBlockPoolRadosNamespace)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
+	}
+	if generationUpdated {
+		logger.Infof("reconciling the rados namespace %q after adding finalizer", cephBlockPoolRadosNamespace.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// The CR was just created, initializing status fields

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -56,9 +56,13 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 	// A cephBlockPoolRadosNamespace resource with metadata and spec.
 	cephBlockPoolRadosNamespace := &cephv1.CephBlockPoolRadosNamespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Name:       name,
+			Namespace:  namespace,
+			UID:        types.UID("c47cac40-9bee-4d52-823b-ccd803ba5bfe"),
+			Finalizers: []string{"cephblockpoolradosnamespace.ceph.rook.io"},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBlockPoolRadosNamespace",
 		},
 		Spec: cephv1.CephBlockPoolRadosNamespaceSpec{
 			BlockPoolName: namespace,


### PR DESCRIPTION
- When finalizers are added to the CRs, a follow-up reconcile will be triggered due to the increased generation on the CR. Therefore, abort the initial reconcile when adding the finalizer, and allow the follow-up reconcile to complete the configuration.
- If the finalizer is added to the CR, proceed with the reconcile since the initial reconcile is skipped when the finalizer is added.
   
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13799

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
