### PR TITLE
osd: fix cleanup job disk shredding

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -758,6 +758,42 @@ jobs:
           kubectl -n rook-ceph delete cephcluster rook-ceph
           kubectl -n rook-ceph logs deploy/rook-ceph-operator
           tests/scripts/github-action-helper.sh wait_for_cleanup_pod
+          kubectl -n rook-ceph delete --ignore-not-found=true -f deploy/examples/operator.yaml
+          tests/scripts/github-action-helper.sh remove_cluster_prerequisites
+          lsblk
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          sudo head --bytes=60 ${BLOCK}1
+          sudo head --bytes=60 ${BLOCK}2
+          sudo head --bytes=60 /dev/loop1
+
+      - name: recreate cluster prerequisites
+        run: |
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          tests/scripts/localPathPV.sh "$BLOCK"
+          tests/scripts/loopDevicePV.sh 1
+          tests/scripts/github-action-helper.sh create_cluster_prerequisites
+
+      - name: redeploy cluster
+        run: |
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/operator.yaml
+          kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
+
+      - name: wait for prepare pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 3
+
+      - name: wait for ceph to be ready
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 3
+
+      - name: check-ownerreferences
+        run: tests/scripts/github-action-helper.sh check_ownerreferences
+
+      - name: teardown cluster with cleanup policy
+        run: |
+          kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
+          kubectl -n rook-ceph delete cephcluster rook-ceph
+          kubectl -n rook-ceph logs deploy/rook-ceph-operator
+          tests/scripts/github-action-helper.sh wait_for_cleanup_pod
           lsblk
           export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           sudo head --bytes=60 ${BLOCK}1
@@ -873,6 +909,14 @@ jobs:
           tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
           kubectl -n rook-ceph get pods
 
+      - name: teardown cluster with cleanup policy
+        run: |
+          tests/scripts/github-action-helper.sh delete_cluster
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          sudo head --bytes=60 ${BLOCK}1
+          sudo head --bytes=60 ${BLOCK}2
+          sudo lsblk
+
       - name: collect common logs
         if: always()
         uses: ./.github/workflows/collect-logs
@@ -933,10 +977,38 @@ jobs:
 
       - name: teardown cluster with cleanup policy
         run: |
-          kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
-          kubectl -n rook-ceph delete cephcluster rook-ceph
-          kubectl -n rook-ceph logs deploy/rook-ceph-operator
-          tests/scripts/github-action-helper.sh wait_for_cleanup_pod
+          tests/scripts/github-action-helper.sh delete_cluster
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          sudo head --bytes=60 ${BLOCK}1
+          sudo head --bytes=60 ${BLOCK}2
+          sudo lsblk
+
+      - name: recreate cluster prerequisites
+        run: |
+          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          tests/scripts/localPathPV.sh "$BLOCK"
+          tests/scripts/github-action-helper.sh create_cluster_prerequisites
+
+      - name: redeploy cluster
+        run: |
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/operator.yaml
+          yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].count" 2
+          yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].volumeClaimTemplates[0].spec.resources.requests.storage" 6Gi
+          kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/toolbox.yaml
+
+      - name: wait for prepare pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
+
+      - name: wait for ceph to be ready
+        run: |
+          tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+          kubectl -n rook-ceph get secrets
+          sudo lsblk
+
+      - name: teardown cluster with cleanup policy
+        run: |
+          tests/scripts/github-action-helper.sh delete_cluster
           export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           sudo head --bytes=60 ${BLOCK}1
           sudo head --bytes=60 ${BLOCK}2

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -163,6 +163,7 @@ spec:
       method: quick
       # dataSource indicate where to get random bytes from to write on the disk
       # possible choices are 'zero' (default) or 'random'
+      # the 'random' source only works with the 'complete' method, the 'quick' method will use the 'zero' source
       # using random sources will consume entropy from the system and will take much more time then the zero source
       dataSource: zero
       # iteration overwrite N times instead of the default (1)

--- a/design/ceph/ceph-cluster-cleanup.md
+++ b/design/ceph/ceph-cluster-cleanup.md
@@ -67,7 +67,8 @@ spec:
 - Local disk sanitization can be further configured by the admin with following options:
   - `method`: use `complete` to sanitize the entire disk and `quick` (default) to sanitize only ceph's metadata.
   - `dataSource`: indicate where to get random bytes from to write on the disk. Possible choices are `zero` (default) or `random`.
-  Using random sources will consume entropy from the system and will take much more time then the zero source.
+  The `random` source only works with the `complete` method. The `quick` method will use the `zero` source.
+  Using random sources will consume entropy from the system and will take much more time than the zero source.
   - `iteration`: overwrite N times instead of the default (1). Takes an integer value.
 - If `allowUninstallWithVolumes` is `false` (default), then operator would wait for the PVCs to be deleted before finally deleting the cluster.
 

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -282,7 +282,7 @@ func addEncryptionKey(context *clusterd.Context, disk, passphrase, newPassphrase
 		disk, output)
 }
 
-func removeEncryptedDevice(context *clusterd.Context, target string) error {
+func RemoveEncryptedDevice(context *clusterd.Context, target string) error {
 	args := []string{"remove", "--force", target}
 	output, err := context.Executor.ExecuteCommandWithTimeout(removeEncryptedDeviceCmdTimeOut, "dmsetup", args...)
 	// ignore error if no device was found.

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -263,7 +263,7 @@ func DestroyOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, id i
 		// remove the dm device
 		if osdInfo.Encrypted {
 			target := oposd.EncryptionDMName(pvcName, oposd.DmcryptBlockType)
-			err = removeEncryptedDevice(context, target)
+			err = RemoveEncryptedDevice(context, target)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to remove dm device %q", target)
 			}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -886,7 +886,7 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 			if osdDisk != nil {
 				deviceToWipe := osdDisk.RealPath
 				if encryptedBlock != "" {
-					err = removeEncryptedDevice(context, encryptedBlock)
+					err = RemoveEncryptedDevice(context, encryptedBlock)
 					if err != nil {
 						logger.Warningf("failed to remove stale dm device %q: %q", encryptedBlock, err)
 						continue
@@ -1130,7 +1130,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 				target := oposd.EncryptionDMName(pvcName, oposd.DmcryptBlockType)
 				// remove stale dm device left by previous OSD.
-				err = removeEncryptedDevice(context, target)
+				err = RemoveEncryptedDevice(context, target)
 				if err != nil {
 					logger.Warningf("failed to remove stale dm device %q: %q", target, err)
 				}


### PR DESCRIPTION
Fixes quick disk shredding by using `dd` to shred data at additional offsets where ceph metadata is duplicated. For full shred, the `shred` utility remains in use.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15546

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
