### PR TITLE
helm: Allow specifying an ingress object store port to override default

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -11,14 +11,3 @@ Return the target Kubernetes version.
 {{- define "capabilities.kubeVersion" -}}
 {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
 {{- end }}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "capabilities.ingress.apiVersion" -}}
-{{- if semverCompare "<1.19-0" (include "capabilities.kubeVersion" .) -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end }}
-{{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.cephObjectStores }}
 {{- if dig "ingress" "enabled" false . }}
 ---
-apiVersion: {{ include "capabilities.ingress.apiVersion" $ }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -16,16 +16,11 @@ spec:
         paths:
           - path: {{ .ingress.host.path | default "/" }}
             backend:
-{{- if (eq "networking.k8s.io/v1" (include "capabilities.ingress.apiVersion" $)) }}
               service:
                 name: rook-ceph-rgw-{{ .name }}
                 port:
                   number: {{ .spec.gateway.securePort | default .spec.gateway.port }}
             pathType: {{ .ingress.host.pathType | default "Prefix" }}
-{{- else }}
-              serviceName: rook-ceph-rgw-{{ .name }}
-              servicePort: {{ .spec.gateway.securePort | default .spec.gateway.port }}
-{{- end }}
   {{- with .ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -19,7 +19,7 @@ spec:
               service:
                 name: rook-ceph-rgw-{{ .name }}
                 port:
-                  number: {{ .spec.gateway.securePort | default .spec.gateway.port }}
+                  number: {{ .ingress.port | default .spec.gateway.securePort | default .spec.gateway.port }}
             pathType: {{ .ingress.host.pathType | default "Prefix" }}
   {{- with .ingress.ingressClassName }}
   ingressClassName: {{ . }}

--- a/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.dashboard.host }}
 ---
-apiVersion: {{ include "capabilities.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "clusterName" . }}-dashboard
@@ -15,7 +15,6 @@ spec:
         paths:
           - path: {{ .Values.ingress.dashboard.host.path | default "/" }}
             backend:
-{{- if (eq "networking.k8s.io/v1" (include "capabilities.ingress.apiVersion" .)) }}
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
@@ -25,14 +24,6 @@ spec:
                   name: http-dashboard
                   {{- end }}
             pathType: {{ .Values.ingress.dashboard.host.pathType | default "Prefix" }}
-{{- else }}
-              serviceName: rook-ceph-mgr-dashboard
-              {{- if .Values.cephClusterSpec.dashboard.ssl }}
-              servicePort: https-dashboard
-              {{- else }}
-              servicePort: http-dashboard
-              {{- end }}
-{{- end }}
   {{- if .Values.ingress.dashboard.ingressClassName }}
   ingressClassName: {{ .Values.ingress.dashboard.ingressClassName }}
   {{- end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -627,6 +627,9 @@ cephObjectStores:
     ingress:
       # Enable an ingress for the ceph-objectstore
       enabled: false
+      # The ingress port by default will be the object store's "securePort" (if set), or the gateway "port".
+      # To override those defaults, set this ingress port to the desired port.
+      # port: 80
       # annotations: {}
       # host:
       #   name: objectstore.example.com


### PR DESCRIPTION
The default object store ingress port will currently be set to the `securePort` (if set), or the `gateway` port field. To override that default, a new port field can be set on the ingress.
    
At the same time, we clean up some obsolete checks for the v1beta1 network api type, which has been long gone since K8s 1.22.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15347

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
