### PR TITLE
rbdmirror: fix the rados namespace health checkup

### DIFF
--- a/pkg/daemon/ceph/client/mirror_health.go
+++ b/pkg/daemon/ceph/client/mirror_health.go
@@ -112,8 +112,9 @@ func (c *mirrorChecker) CheckMirroringHealth() error {
 	}
 
 	// On success
-	c.UpdateStatusMirroring(mirrorStatus.Summary, mirrorInfo, snapSchedStatus, "")
-
+	if mirrorStatus.Summary != nil {
+		c.UpdateStatusMirroring(mirrorStatus.Summary, mirrorInfo, snapSchedStatus, "")
+	}
 	return nil
 }
 


### PR DESCRIPTION
there was very edge case, and that result in nil
point exception
During osd upgrades if mirror health check is called the mirror status cmd doesnt respond
So its important to check if the value exist
before getting its summary


Failure error: 
```
goroutine 1368 [running]:
github.com/rook/rook/pkg/daemon/ceph/client.(*mirrorChecker).CheckMirroringHealth(0xc002802e40)
/remote-source/rook/app/pkg/daemon/ceph/client/mirror_health.go:117 +0x13e
github.com/rook/rook/pkg/daemon/ceph/client.(*mirrorChecker).CheckMirroring(0xc002802e40,

{0x4672440, 0xc00188aa00}
)
/remote-source/rook/app/pkg/daemon/ceph/client/mirror_health.go:70 +0x3a
created by github.com/rook/rook/pkg/operator/ceph/pool/radosnamespace.(*ReconcileCephBlockPoolRadosNamespace).reconcileMirroring in goroutine 1170
/remote-source/rook/app/pkg/operator/ceph/pool/radosnamespace/controller.go:476 +0x64a
```

Rbd mirror was failing,
```
2025-04-08T07:00:55.248051181Z debug 2025-04-08T07:00:55.247+0000 7fb1edf14940 -1 Errors while parsing config file!
2025-04-08T07:00:55.248051181Z debug 2025-04-08T07:00:55.247+0000 7fb1edf14940 -1 can't open 96852b98-3118-4fdc-b295-aa125cc84532.conf: (2) No such file or directory
2025-04-08T07:00:55.999243678Z debug 2025-04-08T07:00:55.998+0000 7fb1e3e99640 -1 rbd::mirror::pool_watcher::RefreshEntitiesRequest 0x55a9f2e6e000 handle_mirror_group_list: failed to list mirrored groups: (95) Operation not supported
2025-04-08T07:00:55.999243678Z debug 2025-04-08T07:00:55.998+0000 7fb1e3e99640 -1 rbd::mirror::PoolWatcher: 0x55a9f18a5e00 handle_refresh_entities: failed to retrieve mirroring directory: (95) Operation not supported
2025-04-08T07:00:56.000178868Z debug 2025-04-08T07:00:55.999+0000 7fb1e3698640 -1 rbd::mirror::pool_watcher::RefreshEntitiesRequest 0x55a9f2e6e0c0 handle_mirror_group_list: failed to list mirrored groups: (95) Operation not supporte
```

ceph team confirm it because osds are not upgraded to version where remote rados namespace mirror changes are present
```
    versions:
      mds:
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 1
      mgr:
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 1
      mon:
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 3
      osd:
        ceph version 19.2.0-98.el9cp (d5c3cf625491b0bd76b4585e77aa0d907446f314) squid (stable): 9
      overall:
        ceph version 19.2.0-98.el9cp (d5c3cf625491b0bd76b4585e77aa0d907446f314) squid (stable): 9
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 7
      rbd-mirror:
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 1
      rgw:
        ceph version 19.2.1-84.el9cp (2cb93ce6a03e2f9c82030287d3dde9bc7f89a867) squid (stable): 1
```

So the point is to fix the nil point exception so osds can proceed upgrading, we are still not sure why the status cmd ran empty probably that is a ceph backlog, but rook has to take care of pointers everytime, so this change was needed


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
