### PR TITLE
core: update cephstatus fsmap gid type to uint64

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -149,7 +149,7 @@ type Fsmap struct {
 		Rank         int    `json:"rank"`
 		Name         string `json:"name"`
 		Status       string `json:"status"`
-		Gid          int    `json:"gid"`
+		Gid          uint64 `json:"gid"`
 	} `json:"by_rank"`
 	UpStandby int `json:"up:standby"`
 }

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -43,7 +43,7 @@ var statusFakeRaw = []byte(`{
 			  "rank": 0,
 			  "name": "myfs-b",
 			  "status": "up:active",
-			  "gid": 14716
+			  "gid": 13999249051405999408
 			}
 		  ],
 		  "up:standby": 1


### PR DESCRIPTION
Ceph uses uint64 (unsigned long) type for CephFS GID. Rook was using int, which was causing failures when the GID overflowed Rook's type. Update Rook's type to match Ceph's.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
