### PR TITLE
test: update ExecuteCommandWithTimeout unit test

### DIFF
--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -147,7 +147,7 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 		{
 			name: "test stdin",
 			args: args{
-				timeout: 30 * time.Second,
+				timeout: 2 * time.Second,
 				command: "cat",
 				stdin:   &testString,
 				arg:     []string{},
@@ -158,7 +158,7 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 		{
 			name: "test nil stdin",
 			args: args{
-				timeout: 30 * time.Second,
+				timeout: 2 * time.Second,
 				command: "echo",
 				stdin:   nil,
 				arg:     []string{testString},
@@ -167,12 +167,23 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test err return",
+			args: args{
+				timeout: 2 * time.Second,
+				command: "false",
+				stdin:   nil,
+				arg:     []string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "test timeout",
 			args: args{
-				timeout: 0 * time.Second,
-				command: "cat",
+				timeout: 5 * time.Millisecond,
+				command: "sleep",
 				stdin:   &testString,
-				arg:     []string{},
+				arg:     []string{"2"},
 			},
 			want:    "",
 			wantErr: true,


### PR DESCRIPTION
Update the unit test for ExecuteCommandWithTimeout(). This unit failed a CI run. This seems to have been a race condition where the previous `cat` command was returning quickly enough that it was available to the `select` statment at the same time as the timeout.

Resolve this issue by replacing the `cat` command with `sleep`, which will be guaranteed to take longer to return than the timeout, ensuring this race doesn't happen.

While working on the test, I also notice that the 30 second timeouts for other tests would be too long in the event the commands hang for any reason, so lower these to help ensure the CI won't time out due to unforeseen events.

Also add a missing unit test to ensure error returns (via `false` command) without timeouts are properly returned.

This unit test was observed to fail in this run: https://github.com/rook/rook/actions/runs/14452332657/job/40527718677?pr=15703

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
