### PR TITLE
core: fix logs to print correct OSD ID

### DIFF
--- a/pkg/operator/ceph/cluster/osd/key_rotation.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation.go
@@ -279,7 +279,7 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 			continue
 		}
 
-		logger.Infof("starting OSD key rotation cron job for osd %q", osd.ID)
+		logger.Infof("starting OSD key rotation cron job for osd %d", osd.ID)
 		cj, err := c.makeKeyRotationCronJob(pvcName, osd, osdProps)
 		if err != nil {
 			return errors.Wrap(err, "failed to make key rotation cron job")


### PR DESCRIPTION
use %d to print integer osd.ID

This will fix key-rotation job logs from printing invalid OSD ids like: 
```
op-osd: starting OSD key rotation cron job for osd '"'
op-osd: starting OSD key rotation cron job for osd '#'
op-osd: starting OSD key rotation cron job for osd '$'
op-osd: starting OSD key rotation cron job for osd '%'
op-osd: starting OSD key rotation cron job for osd '&'
op-osd: starting OSD key rotation cron job for osd '\''
op-osd: starting OSD key rotation cron job for osd '\x04'
op-osd: starting OSD key rotation cron job for osd '(' 
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
