### PR TITLE
ci: run selective disk cleanups in go CI tests

### DIFF
--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -8,6 +8,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true # removes old golang version but saves ~6GB
+        large-packages: false # takes a long time to run b/c package mgr
+        android: false # takes a long time to run b/c package mgr
+        dotnet: false # takes a long time to run b/c package mgr
+        haskell: false # takes a long time to run b/c package mgr
+
     - name: setup golang
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
The Ceph upgrade tests have been flaky or reliably failing for various Ceph/Rook versions due to mon out of space issues. Reinstate the disk cleanup action, but do not clean up items that rely on the package manager for removal. Package manager takes 2-4 minutes to operate and is likely not worth it, even for saving 15+ GB of space.

From testing with this configuration, we can save 11GB of space in about 8 seconds of runtime. This should (hopefully) be plenty of space to keep total disk usage below 95% and keep mons healthy, and the time needed is negligible.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
