### PR TITLE
build: Push arch specific images to the registries

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -180,12 +180,12 @@ publish.image.$(1).$(2):
 	@$(DOCKERCMD) push $(1)/ceph-$(2):$(VERSION)
 	@$(DOCKERCMD) push $(1)/ceph-$(2):$(BRANCH_NAME)
 
-publish.all.images: publish.image.$(1).$(2)
+publish.all.images.$(1): publish.image.$(1).$(2)
 endef
 $(foreach r,$(REGISTRIES), $(foreach a,$(IMAGE_ARCHS),$(eval $(call repo.targets,$(r),$(a)))))
 
 define repo.manifest.targets
-publish.manifest.image.$(1): $(MANIFEST_TOOL)
+publish.manifest.image.$(1): publish.all.images.$(1) $(MANIFEST_TOOL)
 	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(VERSION) --target $(1)/ceph:$(VERSION)
 	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(BRANCH_NAME) --target $(1)/ceph:$(BRANCH_NAME)
 


### PR DESCRIPTION
The arch specific images were not be pushed since the make target was missing.
Regression from #15742 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
