### PR TITLE
ci: increase logging and time for OBC lifecycle rm test

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -887,10 +887,12 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 
 		t.Run("lifecycle was removed from bucket", func(t *testing.T) {
 			var err error
-			utils.Retry(20, time.Second, "lifecycle is gone", func() bool {
-				_, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+			var o *s3.GetBucketLifecycleConfigurationOutput
+			utils.Retry(600, time.Second, "lifecycle is gone", func() bool {
+				o, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
 					Bucket: &bucketName,
 				})
+				t.Logf("GetBucketLifecycleConfiguration() out: %#v", *o)
 				if aerr, ok := err.(awserr.Error); ok {
 					return aerr.Code() == "NoSuchLifecycleConfiguration"
 				}


### PR DESCRIPTION
Nightly CI has been failing recently having issues with removing a bucket's lifecycle config after initially applying it. A Ceph RGW issue is suspected, but more information is needed. Attempt a longer timeout, to see if it is a slow async process. Also log the returned info to see if it is helpful.

This commit is intended to be eventually reverted, but it must be checked into master so that nightly CI runs provide the needed info.

Related: https://github.com/rook/rook/issues/15741

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
