### PR TITLE
Revert "ci: increase logging and time for OBC lifecycle rm test"

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -887,12 +887,10 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 
 		t.Run("lifecycle was removed from bucket", func(t *testing.T) {
 			var err error
-			var o *s3.GetBucketLifecycleConfigurationOutput
-			utils.Retry(600, time.Second, "lifecycle is gone", func() bool {
-				o, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+			utils.Retry(20, time.Second, "lifecycle is gone", func() bool {
+				_, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
 					Bucket: &bucketName,
 				})
-				t.Logf("GetBucketLifecycleConfiguration() out: %#v", *o)
 				if aerr, ok := err.(awserr.Error); ok {
 					return aerr.Code() == "NoSuchLifecycleConfiguration"
 				}


### PR DESCRIPTION
Reverts rook/rook#15776

We were able to capture sufficient information to help the Ceph RGW team determine the issue. The 5 minute timeout and extra unnecessary e2e logging can now be reverted.