### PR TITLE
    build: add a script for setting the release version in examples, charts,  and docs

### DIFF
--- a/build/release/README.md
+++ b/build/release/README.md
@@ -43,6 +43,7 @@ The first time a new release branch is made, the branch is created from `master`
 tag it, and push the tag upstream.
 
 Example:
+
 ```console
 BRANCH_NAME=release-1.13
 git fetch —all
@@ -78,6 +79,14 @@ After the PR is merged, you can tag the release with the beta tag (`v1.13.0-beta
 ### Tagging a New Release
 
 **IMPORTANT** Before tagging the release, open a new PR to update the documentation and example manifest tags to the release version.
+
+The script `set-release-ver.sh` can help preparing these changes.
+It takes the new version as its only argument for invocation.
+
+example:
+```console
+tests/scripts/set-release-ver.sh v1.17.2
+```
 
 To publish a new patch release build, follow these steps:
 

--- a/tests/scripts/set-release-ver.sh
+++ b/tests/scripts/set-release-ver.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script updates example and documentation files to use the new
+# release version (TO_TAG) instead the old one (FROM_TAG) in preparation for a release.
+# The script will usually be run on a release branch.
+
+TO_TAG="$1"
+
+FROM_TAG=$(grep "docker.io/rook/ceph" deploy/examples/images.txt | awk -F : '{ print $2 }')
+
+echo "Updating from $FROM_TAG to $TO_TAG..."
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rook_root="${scriptdir}/../.."
+SED="${rook_root}/build/sed-in-place"
+
+FILES_DOCS=(
+ Documentation/Getting-Started/quickstart.md
+ Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+)
+FILES_CHARTS=(
+ deploy/charts/rook-ceph/values.yaml
+)
+FILES_EXAMPLES=(
+ deploy/examples/*.yaml
+ deploy/examples/images.txt
+)
+
+$SED "s/ $FROM_TAG / $TO_TAG /g" "${FILES_DOCS[@]}"
+$SED "s/tag: $FROM_TAG/tag: $TO_TAG/g" "${FILES_CHARTS[@]}"
+$SED "s/docker.io\/rook\/ceph:$FROM_TAG/docker.io\/rook\/ceph:$TO_TAG/g" "${FILES_EXAMPLES[@]}"
+
+# Special processing for upgrade documentation
+
+# Use a different FROM_TAG for some of the upgrade documentation updates
+# Extract it from a line that shows the version in this form (with the backticks):
+#  `rook-version=v1.17.0`
+FROM_TAG_UPGRADE=$(grep "\`rook-version=" Documentation/Upgrade/rook-upgrade.md | awk -F = '{ print $2 }' | awk -F "\`" '{ print $1 }')
+
+$SED -e "s/rook\/ceph:$FROM_TAG/rook\/ceph:$TO_TAG/g" \
+     -e "s/rook-version=$FROM_TAG/rook-version=$TO_TAG/g" \
+     -e "s/--branch $FROM_TAG/--branch $TO_TAG/g" \
+  Documentation/Upgrade/rook-upgrade.md
+
+echo "Updating upgrade guide from $FROM_TAG_UPGRADE to $TO_TAG..."
+
+$SED -e "s/rook-version=$FROM_TAG_UPGRADE/rook-version=$TO_TAG/g" \
+    -e "s/rook\/ceph:$FROM_TAG_UPGRADE/rook\/ceph:$TO_TAG/g" \
+    -e "s/\`$FROM_TAG_UPGRADE\`/\`$TO_TAG\`/g" \
+    -e "s/when Rook $FROM_TAG_UPGRADE/when Rook $TO_TAG/g" \
+  Documentation/Upgrade/rook-upgrade.md
+
+echo "Done! Now you can open a PR with these changes."


### PR DESCRIPTION
**Description of changes:**  
  This is adds the first incarnation of  of a script to prepare examples and docs for a new release.

    invocation in principle: set-release-ver.sh NEW_VER
    concrete example: set-release-ver.sh v1.16.8

The originating version ios auto-detected.

**Issues resolved by this PR:** 

Resolves #15749 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
