### PR TITLE
doc: update COSI controller link to new repository location

### DIFF
--- a/Documentation/Storage-Configuration/Object-Storage-RGW/cosi.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/cosi.md
@@ -12,7 +12,7 @@ The Ceph COSI driver provisions buckets for object storage. This document instru
 COSI requires:
 
 1. A running Rook [object store](object-storage.md)
-2. [COSI controller](https://github.com/kubernetes-sigs/container-object-storage-interface-controller#readme)
+2. [COSI controller](https://github.com/kubernetes-sigs/container-object-storage-interface#readme)
 
 Deploy the COSI controller with these commands:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->
The old COSI controller link pointed to container-object-storage-interface-controller, which has been moved.
This PR updates the link to container-object-storage-interface .
Fixes #15783 

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
