### PR TITLE
object: fail CephObjectStoreUser reconciliation if no CephCluster is found

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -559,6 +559,8 @@ const (
 	ReconcileFailed ConditionReason = "ReconcileFailed"
 	// ReconcileStarted represents when a resource reconciliation started.
 	ReconcileStarted ConditionReason = "ReconcileStarted"
+	// ReconcileRequeuing represents when a resource reconciliation requeue.
+	ReconcileRequeuing ConditionReason = "ReconcileRequeuing"
 
 	// DeletingReason represents when Rook has detected a resource object should be deleted.
 	DeletingReason ConditionReason = "Deleting"

--- a/pkg/operator/ceph/reporting/reporting.go
+++ b/pkg/operator/ceph/reporting/reporting.go
@@ -156,6 +156,10 @@ func ReportReconcileResult(
 			// intent.
 			return reconcileResponse, nil
 		}
+	} else if reconcileResponse.Requeue {
+		msg := fmt.Sprintf("requeuing %s %q", kind, nsName)
+		logger.Debug(msg)
+		recorder.Event(objCopy, corev1.EventTypeNormal, string(cephv1.ReconcileRequeuing), msg)
 	} else {
 		successMsg := fmt.Sprintf("successfully configured %s %q", kind, nsName)
 

--- a/pkg/operator/ceph/reporting/reporting_test.go
+++ b/pkg/operator/ceph/reporting/reporting_test.go
@@ -93,7 +93,9 @@ func TestReportReconcileResult(t *testing.T) {
 	reconcileRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}
 
 	successMsg := `successfully configured CephCluster "rook-ceph/my-cluster"`
+	requeueMsg := `requeuing CephCluster "rook-ceph/my-cluster"`
 	successEvent := `Normal ReconcileSucceeded ` + successMsg
+	requeueEvent := `Normal ReconcileRequeuing ` + requeueMsg
 
 	fakeErr := errors.New("fake-err")
 	errorMsg := `failed to reconcile CephCluster "rook-ceph/my-cluster". fake-err`
@@ -131,9 +133,9 @@ func TestReportReconcileResult(t *testing.T) {
 			cephCluster, inResult, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, inResult, result)
-		assert.Equal(t, successMsg, strings.TrimSpace(logBuf.String()))
+		assert.Equal(t, requeueMsg, strings.TrimSpace(logBuf.String()))
 		assert.Len(t, recorder.Events, 1)
-		assert.Equal(t, successEvent, <-recorder.Events)
+		assert.Equal(t, requeueEvent, <-recorder.Events)
 	})
 
 	t.Run("failed reconcile with requeue", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

This PR updates the `reconcile()` function to check if a `CephCluster` exists in the target namespace before proceeding.
If no `CephCluster` is found, the reconciliation now fails and updates the status to `ReconcileFailed`.

Fixes: #15751 

Tested locally with private image docker.io/oviner/rook:obcuser27
```
1.Delete minikube
$ minikube delete --all --purge

2. Start minikube wiht kvm2:
$ minikube start --disk-size=10g --extra-disks=1 --driver kvm2

3. Change code

4.buid image
$ make build

5.Tag and Push image to dockerhub:
$ docker image tag build-f71a90a4/ceph-amd64:latest oviner/rook:obcuser27
$ docker push oviner/rook:obcuser27

6.Edit deploy/examples/operator.yaml

        - name: rook-ceph-operator
          image: docker.io/oviner/rook:obcuser27
          imagePullPolicy: Always

7.Create resources and opertor with my private image
$ cd deploy/examples/
$ kubectl create -f crds.yaml -f common.yaml -f operator.yaml

8.Create a test CephCluster on rook-ceph-cluster namespace
$ kubectl create namespace rook-ceph-cluster
$ kubectl create -f cluster-test.yaml 

apiVersion: ceph.rook.io/v1
kind: CephCluster
metadata:
  name: my-cluster
  namespace: rook-ceph-cluster

9.Deploy the COSI controller:
$ kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-api
$ kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-controller

10.Create CephObjectStoreUser
$ cd deploy/examples/cosi
$ kubectl create -f cephcosidriver.yaml

11.Configure ROOK_LOG_LEVEL = DEBUG
kind: ConfigMap
apiVersion: v1
metadata:
 name: rook-ceph-operator-config
 namespace: rook-ceph 
data:
 ROOK_LOG_LEVEL: DEBUG
 
12.Check Rook operator logs
 $ kubectl logs rook-ceph-operator-54c4c5d9b7-dcvq9 -n rook-ceph | grep CephObjectStoreUser
2025-04-27 16:03:21.521610 E | ceph-object-store-user-controller: failed to reconcile CephObjectStoreUser "rook-ceph/cosi". no CephCluster found in namespace "rook-ceph"
```

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
