### PR TITLE
ceph: Update caps to include executable permission

### DIFF
--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -98,7 +98,7 @@ func cephCSIKeyringCephFSNodeCaps() []string {
 	return []string{
 		"mon", "allow r",
 		"mgr", "allow rw",
-		"osd", "allow rw tag cephfs *=*",
+		"osd", "allow rwx tag cephfs metadata=*, allow rw tag cephfs data=*",
 		"mds", "allow rw",
 	}
 }

--- a/pkg/operator/ceph/csi/secrets_test.go
+++ b/pkg/operator/ceph/csi/secrets_test.go
@@ -34,7 +34,7 @@ func TestCephCSIKeyringRBDProvisionerCaps(t *testing.T) {
 
 func TestCephCSIKeyringCephFSNodeCaps(t *testing.T) {
 	caps := cephCSIKeyringCephFSNodeCaps()
-	assert.Equal(t, caps, []string{"mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs *=*", "mds", "allow rw"})
+	assert.Equal(t, caps, []string{"mon", "allow r", "mgr", "allow rw", "osd", "allow rwx tag cephfs metadata=*, allow rw tag cephfs data=*", "mds", "allow rw"})
 }
 
 func TestCephCSIKeyringCephFSProvisionerCaps(t *testing.T) {


### PR DESCRIPTION
ceph-csi uses an exclusive lock for cryptfs operations. This needs the x capability on the metadata pool.

See also https://github.com/ceph/ceph-csi/issues/4728#issuecomment-2835111872

**Issue resolved by this Pull Request:**
Resolves #15283

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
