### PR TITLE
osd: Fix removal when cluster in different namespace

### DIFF
--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -44,10 +44,13 @@ type ClusterInfo struct {
 	// ExternalMons - external montiros listed in CephCluster.spec.mon.externalMonIDs when Rook managing local cluster.
 	ExternalMons map[string]*MonInfo
 	CephVersion  cephver.CephVersion
-	Namespace    string
-	OwnerInfo    *k8sutil.OwnerInfo
+	// Rook operator namespace.
+	Namespace string
+	OwnerInfo *k8sutil.OwnerInfo
 	// Hide the name of the cluster since in 99% of uses we want to use the cluster namespace.
 	// If the CR name is needed, access it through the NamespacedName() method.
+	// Since it's almost always the same as the cluster namespace, the name is
+	// also being returned by the ClusterNamespace() method.
 	name              string
 	OsdUpgradeTimeout time.Duration
 	NetworkSpec       cephv1.NetworkSpec
@@ -105,6 +108,13 @@ func (c *ClusterInfo) NamespacedName() types.NamespacedName {
 		panic("name is not set on the clusterInfo")
 	}
 	return types.NamespacedName{Namespace: c.Namespace, Name: c.name}
+}
+
+func (c *ClusterInfo) ClusterNamespace() string {
+	if c.name != "" {
+		return c.name
+	}
+	return c.Namespace
 }
 
 // AdminClusterInfo() creates a ClusterInfo with the basic info to access the cluster


### PR DESCRIPTION
The `rook ceph osd remove` command would try to delete Deployments and PersistentVolumeClaims in the same namespace as the Rook operator, which would fail with

```
cephosd: failed to fetch the deployment "rook-ceph-osd-0". deployments.apps "rook-ceph-osd-0" not found
```

if the Ceph cluster is deployed in a different namespace.

This commit makes `rook ceph osd remove` look for Deployments and PersistentVolumeClaims in the namespace named after the cluster itself, which is the standard pattern.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
