### PR TITLE
block: Add more deletion conditions to blockpool and radosnamespace status

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -3388,6 +3388,18 @@ SnapshotScheduleStatusSpec
 <em>(Optional)</em>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditions</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.Condition">
+[]Condition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.CephBlockPoolStatus">CephBlockPoolStatus
@@ -5149,7 +5161,7 @@ The default is not set.</p>
 <h3 id="ceph.rook.io/v1.Condition">Condition
 </h3>
 <p>
-(<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBlockPoolStatus">CephBlockPoolStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus</a>, <a href="#ceph.rook.io/v1.ClusterStatus">ClusterStatus</a>, <a href="#ceph.rook.io/v1.ObjectStoreStatus">ObjectStoreStatus</a>, <a href="#ceph.rook.io/v1.Status">Status</a>)
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBlockPoolRadosNamespaceStatus">CephBlockPoolRadosNamespaceStatus</a>, <a href="#ceph.rook.io/v1.CephBlockPoolStatus">CephBlockPoolStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus</a>, <a href="#ceph.rook.io/v1.ClusterStatus">ClusterStatus</a>, <a href="#ceph.rook.io/v1.ObjectStoreStatus">ObjectStoreStatus</a>, <a href="#ceph.rook.io/v1.Status">Status</a>)
 </p>
 <div>
 <p>Condition represents a status condition on any Rook-Ceph Custom Resource.</p>
@@ -5275,6 +5287,22 @@ deletion.</p>
 <td><p>ObjectHasNoDependentsReason represents when a resource object has no dependents that are
 blocking deletion.</p>
 </td>
+</tr><tr><td><p>&#34;PoolEmpty&#34;</p></td>
+<td><p>PoolEmptyReason represents when a pool does not contain images or snapshots that are blocking
+deletion.</p>
+</td>
+</tr><tr><td><p>&#34;PoolNotEmpty&#34;</p></td>
+<td><p>PoolNotEmptyReason represents when a pool contains images or snapshots that are blocking
+deletion.</p>
+</td>
+</tr><tr><td><p>&#34;RadosNamespaceEmpty&#34;</p></td>
+<td><p>RadosNamespaceEmptyReason represents when a rados namespace does not contain images or snapshots that are blocking
+deletion.</p>
+</td>
+</tr><tr><td><p>&#34;RadosNamespaceNotEmpty&#34;</p></td>
+<td><p>RadosNamespaceNotEmptyReason represents when a rados namespace contains images or snapshots that are blocking
+deletion.</p>
+</td>
 </tr><tr><td><p>&#34;ReconcileFailed&#34;</p></td>
 <td><p>ReconcileFailed represents when a resource reconciliation failed.</p>
 </td>
@@ -5316,8 +5344,14 @@ blocking deletion.</p>
 </tr><tr><td><p>&#34;Failure&#34;</p></td>
 <td><p>ConditionFailure represents Failure state of an object</p>
 </td>
+</tr><tr><td><p>&#34;PoolDeletionIsBlocked&#34;</p></td>
+<td><p>ConditionPoolDeletionIsBlocked represents when deletion of the object is blocked.</p>
+</td>
 </tr><tr><td><p>&#34;Progressing&#34;</p></td>
 <td><p>ConditionProgressing represents Progressing state of an object</p>
+</td>
+</tr><tr><td><p>&#34;RadosNamespaceDeletionIsBlocked&#34;</p></td>
+<td><p>ConditionRadosNSDeletionIsBlocked represents when deletion of the object is blocked.</p>
 </td>
 </tr><tr><td><p>&#34;Ready&#34;</p></td>
 <td><p>ConditionReady represents Ready state of an object</p>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -104,6 +104,28 @@ spec:
             status:
               description: Status represents the status of a CephBlockPool Rados Namespace
               properties:
+                conditions:
+                  items:
+                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is a reason for a condition
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType represent a resource's status
+                        type: string
+                    type: object
+                  type: array
                 info:
                   additionalProperties:
                     type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -107,6 +107,28 @@ spec:
             status:
               description: Status represents the status of a CephBlockPool Rados Namespace
               properties:
+                conditions:
+                  items:
+                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is a reason for a condition
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType represent a resource's status
+                        type: string
+                    type: object
+                  type: array
                 info:
                   additionalProperties:
                     type: string

--- a/pkg/apis/ceph.rook.io/v1/namespace.go
+++ b/pkg/apis/ceph.rook.io/v1/namespace.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+const (
+	ImplicitNamespaceKey = "<implicit>"
+	ImplicitNamespaceVal = ""
+)
+
+func GetRadosNamespaceName(cephBlockPoolRadosNamespace *CephBlockPoolRadosNamespace) string {
+	if cephBlockPoolRadosNamespace.Spec.Name == ImplicitNamespaceKey {
+		return ImplicitNamespaceVal
+	} else if cephBlockPoolRadosNamespace.Spec.Name != "" {
+		return cephBlockPoolRadosNamespace.Spec.Name
+	}
+	return cephBlockPoolRadosNamespace.Name
+}

--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -95,6 +95,10 @@ func (p *CephBlockPool) GetStatusConditions() *[]Condition {
 	return &p.Status.Conditions
 }
 
+func (p *CephBlockPoolRadosNamespace) GetStatusConditions() *[]Condition {
+	return &p.Status.Conditions
+}
+
 // SnapshotSchedulesEnabled returns whether snapshot schedules are desired
 func (p *MirroringSpec) SnapshotSchedulesEnabled() bool {
 	return len(p.SnapshotSchedules) > 0

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -574,6 +574,12 @@ const (
 	// PoolEmptyReason represents when a pool does not contain images or snapshots that are blocking
 	// deletion.
 	PoolEmptyReason ConditionReason = "PoolEmpty"
+	// RadosNamespaceNotEmptyReason represents when a rados namespace contains images or snapshots that are blocking
+	// deletion.
+	RadosNamespaceNotEmptyReason ConditionReason = "RadosNamespaceNotEmpty"
+	// RadosNamespaceEmptyReason represents when a rados namespace does not contain images or snapshots that are blocking
+	// deletion.
+	RadosNamespaceEmptyReason ConditionReason = "RadosNamespaceEmpty"
 )
 
 // ConditionType represent a resource's status
@@ -597,6 +603,8 @@ const (
 	ConditionDeletionIsBlocked ConditionType = "DeletionIsBlocked"
 	// ConditionPoolDeletionIsBlocked represents when deletion of the object is blocked.
 	ConditionPoolDeletionIsBlocked ConditionType = "PoolDeletionIsBlocked"
+	// ConditionRadosNSDeletionIsBlocked represents when deletion of the object is blocked.
+	ConditionRadosNSDeletionIsBlocked ConditionType = "RadosNamespaceDeletionIsBlocked"
 )
 
 // ClusterState represents the state of a Ceph Cluster
@@ -3542,6 +3550,7 @@ type CephBlockPoolRadosNamespaceStatus struct {
 	MirroringInfo *MirroringInfoSpec `json:"mirroringInfo,omitempty"`
 	// +optional
 	SnapshotScheduleStatus *SnapshotScheduleStatusSpec `json:"snapshotScheduleStatus,omitempty"`
+	Conditions             []Condition                 `json:"conditions,omitempty"`
 }
 
 // Represents the source of a volume to mount.

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -568,6 +568,12 @@ const (
 	// ObjectHasNoDependentsReason represents when a resource object has no dependents that are
 	// blocking deletion.
 	ObjectHasNoDependentsReason ConditionReason = "ObjectHasNoDependents"
+	// PoolNotEmptyReason represents when a pool contains images or snapshots that are blocking
+	// deletion.
+	PoolNotEmptyReason ConditionReason = "PoolNotEmpty"
+	// PoolEmptyReason represents when a pool does not contain images or snapshots that are blocking
+	// deletion.
+	PoolEmptyReason ConditionReason = "PoolEmpty"
 )
 
 // ConditionType represent a resource's status
@@ -589,6 +595,8 @@ const (
 
 	// ConditionDeletionIsBlocked represents when deletion of the object is blocked.
 	ConditionDeletionIsBlocked ConditionType = "DeletionIsBlocked"
+	// ConditionPoolDeletionIsBlocked represents when deletion of the object is blocked.
+	ConditionPoolDeletionIsBlocked ConditionType = "PoolDeletionIsBlocked"
 )
 
 // ClusterState represents the state of a Ceph Cluster

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -502,6 +502,13 @@ func (in *CephBlockPoolRadosNamespaceStatus) DeepCopyInto(out *CephBlockPoolRado
 		*out = new(SnapshotScheduleStatusSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -53,10 +53,8 @@ type Images struct {
 }
 
 const (
-	mirrorModeDisabled   = "disabled"
-	mirrorModeInitOnly   = "init-only"
-	ImplicitNamespaceKey = "<implicit>"
-	ImplicitNamespaceVal = ""
+	mirrorModeDisabled = "disabled"
+	mirrorModeInitOnly = "init-only"
 )
 
 var (
@@ -398,8 +396,8 @@ func EnableRBDRadosNamespaceMirroring(context *clusterd.Context, clusterInfo *Cl
 		return errors.Errorf("ceph version %q does not support mirroring in rados namespace %q with --remote-namespace flag, supported version are v20 and above.", clusterInfo.CephVersion.String(), poolAndRadosNamespaceName)
 	}
 
-	if remoteNamespace != nil && *remoteNamespace == ImplicitNamespaceKey {
-		*remoteNamespace = ImplicitNamespaceVal
+	if remoteNamespace != nil && *remoteNamespace == cephv1.ImplicitNamespaceKey {
+		*remoteNamespace = cephv1.ImplicitNamespaceVal
 	}
 
 	args := []string{"mirror", "pool", "enable", poolAndRadosNamespaceName, mode}

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -220,22 +220,42 @@ func CreatePoolWithPGs(context *clusterd.Context, clusterInfo *ClusterInfo, clus
 		true /* enableECOverwrite */)
 }
 
+func IsPoolEmpty(context *clusterd.Context, clusterInfo *ClusterInfo, name string) (bool, error) {
+	logger.Debugf("checking if pool %q is empty", name)
+	isEmpty, err := checkIsPoolEmpty(context, clusterInfo, name)
+	if err != nil {
+		return false, err
+	}
+	return isEmpty, nil
+}
+
 func checkForImagesInPool(context *clusterd.Context, clusterInfo *ClusterInfo, name string) error {
+	isEmpty, err := checkIsPoolEmpty(context, clusterInfo, name)
+	if err != nil {
+		return err
+	}
+	if isEmpty {
+		return nil
+	}
+	return errors.Errorf("pool %q contains images/snapshots", name)
+}
+
+func checkIsPoolEmpty(context *clusterd.Context, clusterInfo *ClusterInfo, name string) (bool, error) {
 	var err error
 	logger.Debugf("checking any images/snapshots present in pool %q", name)
 	stats, err := GetPoolStatistics(context, clusterInfo, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "No such file or directory") {
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "failed to list images/snapshots in pool %s", name)
+		return false, errors.Wrapf(err, "failed to list images/snapshots in pool %s", name)
 	}
 	if stats.Images.Count == 0 && stats.Images.SnapCount == 0 {
 		logger.Infof("no images/snapshots present in pool %q", name)
-		return nil
+		return true, nil
 	}
 
-	return errors.Errorf("pool %q contains images/snapshots", name)
+	return false, nil
 }
 
 // DeletePool purges a pool from Ceph

--- a/pkg/daemon/ceph/client/radosnamespace.go
+++ b/pkg/daemon/ceph/client/radosnamespace.go
@@ -69,25 +69,27 @@ func getRadosNamespaceStatistics(context *clusterd.Context, clusterInfo *Cluster
 	return &poolStats, nil
 }
 
-func checkForImagesInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, namespaceName string) error {
+// checkForImagesInRadosNamespace checks if there are any images or snapshots in the specified rados namespace.
+// If there are images or snapshots, it returns true and an error with details.
+func checkForImagesInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, namespaceName string) (bool, error) {
 	logger.Debugf("checking any images/snapshots present in pool %s/%s in k8s namespace %q", poolName, namespaceName, clusterInfo.Namespace)
 	stats, err := getRadosNamespaceStatistics(context, clusterInfo, poolName, namespaceName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list images/snapshots in pool %s/%s", poolName, namespaceName)
+		return false, errors.Wrapf(err, "failed to list images/snapshots in pool %s/%s", poolName, namespaceName)
 	}
 	if stats.Images.Count == 0 && stats.Images.SnapCount == 0 {
 		logger.Infof("no images/snapshots present in pool %s/%s in k8s namespace %q", poolName, namespaceName, clusterInfo.Namespace)
-		return nil
+		return false, nil
 	}
 
-	return errors.Errorf("pool %s/%s contains %d images and %d snapshots", poolName, namespaceName, stats.Images.Count, stats.Images.SnapCount)
+	return true, errors.Errorf("pool %s/%s contains %d images and %d snapshots", poolName, namespaceName, stats.Images.Count, stats.Images.SnapCount)
 }
 
 // DeleteRadosNamespace delete a rados namespace.
-func DeleteRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, namespaceName string) error {
-	err := checkForImagesInRadosNamespace(context, clusterInfo, poolName, namespaceName)
+func DeleteRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, namespaceName string) (bool, error) {
+	containsImages, err := checkForImagesInRadosNamespace(context, clusterInfo, poolName, namespaceName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to check if pool %s/%s has rbd images", poolName, namespaceName)
+		return containsImages, errors.Wrapf(err, "failed to check if pool %s/%s has rbd images", poolName, namespaceName)
 	}
 	logger.Infof("deleting rados namespace %s/%s in k8s namespace %q", poolName, namespaceName, clusterInfo.Namespace)
 	args := []string{"namespace", "remove", "--pool", poolName, "--namespace", namespaceName}
@@ -97,12 +99,12 @@ func DeleteRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, p
 	if err != nil {
 		code, ok := exec.ExitStatus(err)
 		if !ok || code != int(syscall.ENOENT) {
-			return errors.Wrapf(err, "failed to delete rados namespace %s/%s. %s", poolName, namespaceName, output)
+			return false, errors.Wrapf(err, "failed to delete rados namespace %s/%s. %s", poolName, namespaceName, output)
 		}
 	}
 
 	logger.Infof("successfully deleted rados namespace %s/%s in k8s namespace %q", poolName, namespaceName, clusterInfo.Namespace)
-	return nil
+	return false, nil
 }
 
 // ListRadosNamespacesInPool lists the rados namespaces in a pool

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/util/dependents"
 	"github.com/rook/rook/pkg/util/exec"
 
 	"github.com/pkg/errors"
@@ -254,15 +255,10 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	poolSpec := cephBlockPool.ToNamedPoolSpec()
 	// DELETE: the CR was deleted
 	if !cephBlockPool.GetDeletionTimestamp().IsZero() {
-		deps, err := cephBlockPoolDependents(r.context, r.clusterInfo, cephBlockPool)
-		if err != nil {
-			return reconcile.Result{}, *cephBlockPool, err
-		}
-		if !deps.Empty() {
-			err := reporting.ReportDeletionBlockedDueToDependents(r.opManagerContext, logger, r.client, cephBlockPool, deps)
+		if err := r.handleDeletionBlocked(cephBlockPool, &cephCluster); err != nil {
 			return opcontroller.WaitForRequeueIfFinalizerBlocked, *cephBlockPool, err
 		}
-		reporting.ReportDeletionNotBlockedDueToDependents(r.opManagerContext, logger, r.client, r.recorder, cephBlockPool)
+
 		// If the ceph block pool is still in the map, we must remove it during CR deletion
 		// We must remove it first otherwise the checker will panic since the status/info will be nil
 		r.cancelMirrorMonitoring(cephBlockPool)
@@ -272,12 +268,6 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		logger.Infof("deleting pool %q", poolSpec.Name)
 		err = deletePool(r.context, clusterInfo, &poolSpec)
 		if err != nil {
-			if opcontroller.ForceDeleteRequested(cephBlockPool.GetAnnotations()) {
-				cleanupErr := r.cleanup(cephBlockPool, &cephCluster)
-				if cleanupErr != nil {
-					return reconcile.Result{}, *cephBlockPool, errors.Wrapf(cleanupErr, "failed to create clean up job for ceph blockpool %q", cephBlockPool.Name)
-				}
-			}
 			return opcontroller.ImmediateRetryResult, *cephBlockPool, errors.Wrapf(err, "failed to delete pool %q. ", cephBlockPool.Name)
 		}
 
@@ -415,6 +405,63 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	// Return and do not requeue
 	logger.Debug("done reconciling")
 	return reconcile.Result{}, *cephBlockPool, nil
+}
+
+// handlePoolDeletionBlocked updates the blockpool CR status with conditions about
+// whether the pool is empty or has dependents that block deletion.
+// If the pool is not empty and force deletion is specified, create a cleanup job
+// to delete the images and snapshots forcefully.
+func (r *ReconcileCephBlockPool) handleDeletionBlocked(cephBlockPool *cephv1.CephBlockPool, cephCluster *cephv1.CephCluster) error {
+	poolSpec := cephBlockPool.ToNamedPoolSpec()
+	deletionBlocked := false
+
+	isEmpty, err := cephclient.IsPoolEmpty(r.context, r.clusterInfo, poolSpec.Name)
+	if err != nil {
+		return err
+	}
+	var emptyCondition cephv1.Condition
+	if isEmpty {
+		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(false, fmt.Sprintf("pool %q is empty and can be deleted", poolSpec.Name))
+	} else {
+		deletionBlocked = true
+		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(true, fmt.Sprintf("pool %q contains images or snapshots and cannot be deleted", poolSpec.Name))
+	}
+	logger.Info(emptyCondition.Message)
+
+	deps, err := cephBlockPoolDependents(r.context, r.clusterInfo, cephBlockPool)
+	if err != nil {
+		return err
+	}
+	var depCondition cephv1.Condition
+	if deps.Empty() {
+		_, _, depCondition = reporting.GenerateConditionUnblockedDueToDependents(cephBlockPool)
+	} else {
+		deletionBlocked = true
+		_, _, depCondition = reporting.GenerateConditionBlockedDueToDependents(cephBlockPool, deps)
+	}
+	logger.Info(depCondition.Message)
+
+	nsName := types.NamespacedName{Namespace: cephBlockPool.Namespace, Name: cephBlockPool.Name}
+	err = reporting.UpdateStatusConditionsWithRetry(
+		r.opManagerContext, r.client, cephBlockPool, nsName, cephBlockPool.Kind, emptyCondition, depCondition)
+	if err != nil {
+		logger.Warningf("failed to update %q status with deletion blocked conditions: %v", nsName.String(), err)
+	}
+
+	if !isEmpty {
+		// Force deletion if desired
+		if opcontroller.ForceDeleteRequested(cephBlockPool.GetAnnotations()) {
+			cleanupErr := r.cleanup(cephBlockPool, cephCluster)
+			if cleanupErr != nil {
+				return errors.Wrapf(cleanupErr, "failed to create clean up job for ceph blockpool %q", cephBlockPool.Name)
+			}
+		}
+	}
+
+	if deletionBlocked {
+		return errors.Errorf("pool %q cannot be deleted because it is not empty or has dependents", cephBlockPool.Name)
+	}
+	return nil
 }
 
 func (r *ReconcileCephBlockPool) reconcileCreatePool(clusterInfo *cephclient.ClusterInfo, cephCluster *cephv1.ClusterSpec, cephBlockPool *cephv1.CephBlockPool) (reconcile.Result, error) {

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -415,19 +415,6 @@ func (r *ReconcileCephBlockPool) handleDeletionBlocked(cephBlockPool *cephv1.Cep
 	poolSpec := cephBlockPool.ToNamedPoolSpec()
 	deletionBlocked := false
 
-	isEmpty, err := cephclient.IsPoolEmpty(r.context, r.clusterInfo, poolSpec.Name)
-	if err != nil {
-		return err
-	}
-	var emptyCondition cephv1.Condition
-	if isEmpty {
-		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(false, fmt.Sprintf("pool %q is empty and can be deleted", poolSpec.Name))
-	} else {
-		deletionBlocked = true
-		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(true, fmt.Sprintf("pool %q contains images or snapshots and cannot be deleted", poolSpec.Name))
-	}
-	logger.Info(emptyCondition.Message)
-
 	deps, err := cephBlockPoolDependents(r.context, r.clusterInfo, cephBlockPool)
 	if err != nil {
 		return err
@@ -440,6 +427,20 @@ func (r *ReconcileCephBlockPool) handleDeletionBlocked(cephBlockPool *cephv1.Cep
 		_, _, depCondition = reporting.GenerateConditionBlockedDueToDependents(cephBlockPool, deps)
 	}
 	logger.Info(depCondition.Message)
+
+	radosNamespaces := deps.OfKind(radosNamespacesKeyName)
+	isEmpty, emptyMessage, err := cephclient.IsPoolEmpty(r.context, r.clusterInfo, poolSpec.Name, radosNamespaces)
+	if err != nil {
+		return err
+	}
+	var emptyCondition cephv1.Condition
+	if isEmpty {
+		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(false, emptyMessage)
+	} else {
+		deletionBlocked = true
+		emptyCondition = dependents.DeletionBlockedDueToNonEmptyPoolCondition(true, emptyMessage)
+	}
+	logger.Info(emptyCondition.Message)
 
 	nsName := types.NamespacedName{Namespace: cephBlockPool.Namespace, Name: cephBlockPool.Name}
 	err = reporting.UpdateStatusConditionsWithRetry(

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -27,7 +27,6 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
-	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -38,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -106,6 +106,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 		context:          c,
 		opManagerContext: ctx,
 		opConfig:         opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
+		recorder:         record.NewFakeRecorder(5),
 	}
 
 	// Mock request to simulate Reconcile() being called on an event for a
@@ -142,6 +143,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
 
 	t.Run("error - no ceph cluster", func(t *testing.T) {
+		// Create pool for updating status
+		_, err := c.RookClientset.CephV1().CephBlockPoolRadosNamespaces(namespace).Create(ctx, cephBlockPoolRadosNamespace, metav1.CreateOptions{})
+		assert.NoError(t, err)
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
@@ -152,7 +156,11 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 		// Create a fake client to mock API calls.
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 		// Create a ReconcileCephBlockPoolRadosNamespace object with the scheme and fake client.
-		r = &ReconcileCephBlockPoolRadosNamespace{client: cl, scheme: s, context: c, opManagerContext: context.TODO(), opConfig: opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"}}
+		r = &ReconcileCephBlockPoolRadosNamespace{
+			client: cl, scheme: s, context: c, opManagerContext: context.TODO(),
+			recorder: record.NewFakeRecorder(5),
+			opConfig: opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
+		}
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
@@ -227,6 +235,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		// Enable CSI
@@ -279,6 +288,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			context:          c,
 			opManagerContext: ctx,
 			opConfig:         opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
+			recorder:         record.NewFakeRecorder(5),
 		}
 
 		// Enable CSI
@@ -346,6 +356,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -392,6 +403,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -442,6 +454,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -492,6 +505,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -544,6 +558,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -600,6 +615,7 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 			opManagerContext:       context.TODO(),
 			opConfig:               opcontroller.OperatorConfig{Image: "ceph/ceph:v14.2.9"},
 			radosNamespaceContexts: make(map[string]*mirrorHealth),
+			recorder:               record.NewFakeRecorder(5),
 		}
 
 		res, err := r.Reconcile(ctx, req)
@@ -629,9 +645,9 @@ func TestGetRadosNamespaceName(t *testing.T) {
 			"implicit-namespace",
 			cephv1.CephBlockPoolRadosNamespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "cr-name1"},
-				Spec:       cephv1.CephBlockPoolRadosNamespaceSpec{Name: cephclient.ImplicitNamespaceKey},
+				Spec:       cephv1.CephBlockPoolRadosNamespaceSpec{Name: cephv1.ImplicitNamespaceKey},
 			},
-			cephclient.ImplicitNamespaceVal,
+			cephv1.ImplicitNamespaceVal,
 		},
 		{
 			"valid-namespace",
@@ -653,8 +669,8 @@ func TestGetRadosNamespaceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getRadosNamespaceName(&tt.args); got != tt.want {
-				t.Errorf("getRadosNamespaceName() = %v, want %v", got, tt.want)
+			if got := cephv1.GetRadosNamespaceName(&tt.args); got != tt.want {
+				t.Errorf("GetRadosNamespaceName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/operator/ceph/reporting/status.go
+++ b/pkg/operator/ceph/reporting/status.go
@@ -51,14 +51,17 @@ func UpdateStatus(client client.Client, obj client.Object) error {
 // UpdateStatusCondition updates (or adds to) the status condition to the given object. The object
 // is updated with the latest version from the server on a successful update.
 func UpdateStatusCondition(
-	client client.Client, obj statusConditionGetter, newCond cephv1.Condition,
+	client client.Client, obj statusConditionGetter, newConditions ...cephv1.Condition,
 ) error {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 	nsName := fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 
-	cephv1.SetStatusCondition(obj.GetStatusConditions(), newCond)
+	for _, newCondition := range newConditions {
+		cephv1.SetStatusCondition(obj.GetStatusConditions(), newCondition)
+	}
+
 	if err := UpdateStatus(client, obj); err != nil {
-		return errors.Wrapf(err, "failed to update %s %q status condition %s=%s", kind, nsName, newCond.Type, newCond.Status)
+		return errors.Wrapf(err, "failed to update %s %q status conditions", kind, nsName)
 	}
 
 	return nil

--- a/pkg/operator/ceph/reporting/status_test.go
+++ b/pkg/operator/ceph/reporting/status_test.go
@@ -114,20 +114,38 @@ func TestUpdateStatusCondition(t *testing.T) {
 			Phase: cephv1.ConditionDeleting,
 		},
 	}
+	fakeBlock := &cephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "mypool",
+			Namespace:  "rook-ceph",
+			Finalizers: []string{},
+		},
+		Status: &cephv1.CephBlockPoolStatus{
+			Phase: cephv1.ConditionDeleting,
+		},
+	}
 	nsName := types.NamespacedName{
 		Namespace: fakeObject.Namespace,
 		Name:      fakeObject.Name,
 	}
+	poolName := types.NamespacedName{
+		Namespace: fakeBlock.Namespace,
+		Name:      fakeBlock.Name,
+	}
 
 	s := scheme.Scheme
-	s.AddKnownTypes(cephv1.SchemeGroupVersion, fakeObject)
-	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(fakeObject.DeepCopy()).Build()
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, fakeObject, fakeBlock)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(fakeObject.DeepCopy(), fakeBlock.DeepCopy()).Build()
 
-	// get version of the object in the fake object tracker
+	// get version of the objects in the fake object tracker
 	getObj := &cephv1.CephObjectStore{}
 	err := cl.Get(context.TODO(), nsName, getObj)
 	assert.NoError(t, err)
 	assert.Zero(t, len(getObj.Status.Conditions))
+	getBlock := &cephv1.CephBlockPool{}
+	err = cl.Get(context.TODO(), poolName, getBlock)
+	assert.NoError(t, err)
+	assert.Zero(t, len(getBlock.Status.Conditions))
 
 	t.Run("add new status", func(t *testing.T) {
 		getObj := &cephv1.CephObjectStore{}
@@ -150,6 +168,40 @@ func TestUpdateStatusCondition(t *testing.T) {
 		assert.Equal(t, v1.ConditionTrue, cond.Status)
 		assert.Equal(t, cephv1.ConditionReason("start"), cond.Reason)
 		assert.Equal(t, "start", cond.Message)
+	})
+
+	t.Run("add two statuses", func(t *testing.T) {
+		getObj := &cephv1.CephBlockPool{}
+		err := cl.Get(context.TODO(), poolName, getObj)
+		assert.NoError(t, err)
+
+		blockedCond := cephv1.Condition{
+			Type:    cephv1.ConditionDeletionIsBlocked,
+			Status:  v1.ConditionTrue,
+			Reason:  cephv1.ConditionReason("dep"),
+			Message: "there is a dependency",
+		}
+		emptyCond := cephv1.Condition{
+			Type:    cephv1.ConditionPoolDeletionIsBlocked,
+			Status:  v1.ConditionTrue,
+			Reason:  cephv1.ConditionReason("notempty"),
+			Message: "images are in the pool",
+		}
+
+		err = UpdateStatusCondition(cl, getObj, blockedCond, emptyCond)
+		assert.NoError(t, err)
+
+		err = cl.Get(context.TODO(), poolName, getObj)
+		assert.NoError(t, err)
+		cond := getObj.Status.Conditions[0]
+		assert.Equal(t, v1.ConditionTrue, cond.Status)
+		assert.Equal(t, blockedCond.Reason, cond.Reason)
+		assert.Equal(t, blockedCond.Message, cond.Message)
+
+		cond = getObj.Status.Conditions[1]
+		assert.Equal(t, v1.ConditionTrue, cond.Status)
+		assert.Equal(t, emptyCond.Reason, cond.Reason)
+		assert.Equal(t, emptyCond.Message, cond.Message)
 	})
 
 	t.Run("update status", func(t *testing.T) {

--- a/pkg/util/dependents/dependents.go
+++ b/pkg/util/dependents/dependents.go
@@ -55,6 +55,21 @@ func DeletionBlockedDueToNonEmptyPoolCondition(blocked bool, message string) cep
 	}
 }
 
+func DeletionBlockedDueToNonEmptyRadosNSCondition(blocked bool, message string) cephv1.Condition {
+	status := corev1.ConditionFalse
+	reason := cephv1.RadosNamespaceEmptyReason
+	if blocked {
+		status = corev1.ConditionTrue
+		reason = cephv1.RadosNamespaceNotEmptyReason
+	}
+	return cephv1.Condition{
+		Type:    cephv1.ConditionRadosNSDeletionIsBlocked,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
 // A DependentList represents a list of dependents of a resource. Each dependent has a plural Kind
 // and a list of names of dependent resources.
 type DependentList struct {

--- a/pkg/util/dependents/dependents.go
+++ b/pkg/util/dependents/dependents.go
@@ -40,6 +40,21 @@ func DeletionBlockedDueToDependentsCondition(blocked bool, message string) cephv
 	}
 }
 
+func DeletionBlockedDueToNonEmptyPoolCondition(blocked bool, message string) cephv1.Condition {
+	status := corev1.ConditionFalse
+	reason := cephv1.PoolEmptyReason
+	if blocked {
+		status = corev1.ConditionTrue
+		reason = cephv1.PoolNotEmptyReason
+	}
+	return cephv1.Condition{
+		Type:    cephv1.ConditionPoolDeletionIsBlocked,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
 // A DependentList represents a list of dependents of a resource. Each dependent has a plural Kind
 // and a list of names of dependent resources.
 type DependentList struct {


### PR DESCRIPTION
1. BlockPool CR: Add condition for deletion blocked with images. When the blockpool is deleted and there are images or
snapshots in the pool, the deletion is blocked by the finalizer until they are all removed. The condition added to the cephblockpool status previously only indicated if there were radosnamespace dependencies. A new condition is now added to describe if there are images or snapshots in any rados namespace of the pool.
2. RadosNamespace CR: Add condition describing blocking deletion for the rados namespace. When a rados namespace is deleted, it cannot be purged until its images and snapshots are deleted. Now a condition is being added to the rados namespace CR status so the user does not need to read the operator log to discover the cause.

 <!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
