### PR TITLE
osd: osd should watch for pvc resize

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1463,7 +1463,7 @@ func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch pvc for mon %q", m.ResourceName)
 		}
-		k8sutil.ExpandPVCIfRequired(c.ClusterInfo.Context, c.context.Client, desiredPvc, existingPvc)
+		_ = k8sutil.ExpandPVCIfRequired(c.ClusterInfo.Context, c.context.Client, desiredPvc, existingPvc)
 	}
 
 	logger.Infof("deployment for mon %s already exists. updating if needed",

--- a/pkg/operator/k8sutil/pvc_test.go
+++ b/pkg/operator/k8sutil/pvc_test.go
@@ -108,6 +108,12 @@ func TestExpandPVCIfRequired(t *testing.T) {
 
 		desiredPVC.Spec.Resources.Requests[v1.ResourceStorage] = apiresource.MustParse(tc.desiredPVCSize)
 
+		desiredPVC.Status = v1.PersistentVolumeClaimStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): apiresource.MustParse("2Mi"),
+			},
+		}
+
 		ExpandPVCIfRequired(context.TODO(), cl, desiredPVC, existingPVC)
 
 		// get existing PVC


### PR DESCRIPTION
With a osd resize operation, currently pvc and pv may takes more time then expected.
And so the osd dont get resized and need manual re-start as currently we don't have a watch on osd's
controller that watches pv and get it resized.

add a wait time till pvc is not resized

closes: https://github.com/rook/rook/issues/15755

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
