### PR TITLE
build: move se-release-ver script to better place

### DIFF
--- a/build/release/README.md
+++ b/build/release/README.md
@@ -85,7 +85,7 @@ It takes the new version as its only argument for invocation.
 
 example:
 ```console
-tests/scripts/set-release-ver.sh v1.17.2
+build/release/set-release-ver.sh v1.17.2
 ```
 
 To publish a new patch release build, follow these steps:

--- a/build/release/set-release-ver.sh
+++ b/build/release/set-release-ver.sh
@@ -12,8 +12,7 @@ FROM_TAG=$(grep "docker.io/rook/ceph" deploy/examples/images.txt | awk -F : '{ p
 echo "Updating from $FROM_TAG to $TO_TAG..."
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rook_root="${scriptdir}/../.."
-SED="${rook_root}/build/sed-in-place"
+SED="${scriptdir}/../sed-in-place"
 
 FILES_DOCS=(
  Documentation/Getting-Started/quickstart.md


### PR DESCRIPTION
Recently (in PR #15781 , a  script `set-release-ver.sh`was added in a somewhat unnatural place `tests/scripts` .
This moves it to a more natural location `build/release`.



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
