### PR TITLE
ci: Only publish docs in master and tagged releases

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -51,7 +51,14 @@ PLATFORMS ?= $(ALL_PLATFORMS)
 
 # "helm" flavor is for pushing to s3/https endpoint
 # "charts" flavor is for pushing to oci endpoint
-FLAVORS ?= output images docs helm charts
+FLAVORS ?= output images helm charts
+
+# Only publish the docs if in master branch or if this is a tagged release.
+ifeq ($(shell echo $(BRANCH_NAME)),master)
+FLAVORS += docs
+else ifeq ($(TAGGED_RELEASE),true)
+FLAVORS += docs
+endif
 
 DOCKER_REGISTRY ?= docker.io/rook
 QUAY_REGISTRY ?= quay.io/rook


### PR DESCRIPTION
Until now, docs have been published for every master and release branch build. This can lead to confusion if a new feature is backported to the release branch and the docs are published to the website, even though the feature will not be available until the next tagged release.

This does have the effect that small doc-only fixes will not be in the latest release docs until we actually tag a release.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15161

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
