### PR TITLE
Revert "ci: only publish docs in master and tagged releases"

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -51,14 +51,7 @@ PLATFORMS ?= $(ALL_PLATFORMS)
 
 # "helm" flavor is for pushing to s3/https endpoint
 # "charts" flavor is for pushing to oci endpoint
-FLAVORS ?= output images helm charts
-
-# Only publish the docs if in master branch or if this is a tagged release.
-ifeq ($(shell echo $(BRANCH_NAME)),master)
-FLAVORS += docs
-else ifeq ($(TAGGED_RELEASE),true)
-FLAVORS += docs
-endif
+FLAVORS ?= output images docs helm charts
 
 DOCKER_REGISTRY ?= docker.io/rook
 QUAY_REGISTRY ?= quay.io/rook


### PR DESCRIPTION
The v1.17.2 docs publish failed. Reverting this for now and will investigate the fix separately to get the v1.17.2 release finished for now...

This reverts commit 28fa387dff189b5b8ec949bb136538229bc24d29.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
