### PR TITLE
osd: use file instead of env as a secret

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -164,6 +164,23 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 		if err != nil {
 			return errors.Wrap(err, "failed to set kek as an environment variable")
 		}
+		input, err := os.ReadFile("/etc/dmcrypt/luks_key")
+		if err != nil {
+			return errors.Wrap(err, "failed to read encryption secret file /etc/dmcrypt")
+		}
+		err = os.Setenv(oposd.CephVolumeEncryptedKeyEnvVarName, string(input))
+		if err != nil {
+			return errors.Wrap(err, "failed to set dmcrypt encryption key env variable for ceph-volume")
+		}
+		oldVar := os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName + "_OLD")
+		newVar := os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName)
+		logger.Infof("OLD == NEW? %t", oldVar == newVar)
+		logger.Infof("OLD ENV VAR: %s", oldVar)
+		logger.Infof("NEW ENV VAR: %s", newVar)
+
+		logger.Info(string(input))
+		logger.Info()
+		logger.Info()
 	}
 
 	// Print dmsetup version

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -316,6 +316,11 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				if err != nil {
 					return "", "", "", errors.Wrap(err, "failed to set dmcrypt encryption key env variable for ceph-volume")
 				}
+				oldVar := os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName + "_OLD")
+				newVar := os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName)
+				logger.Infof("OLD == NEW? %t", oldVar == newVar)
+				logger.Infof("OLD ENV VAR: %s", oldVar)
+				logger.Infof("NEW ENV VAR: %s", newVar)
 
 				logger.Info(string(input))
 				logger.Info()

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"gopkg.in/ini.v1"
@@ -189,19 +190,19 @@ func pvcNameEnvVar(pvcName string) v1.EnvVar {
 	return v1.EnvVar{Name: PVCNameEnvVarName, Value: pvcName}
 }
 
-// func cephVolumeRawEncryptedEnvVarFromSecret(osdProps osdProperties) v1.EnvVar {
-// 	return v1.EnvVar{
-// 		Name: CephVolumeEncryptedKeyEnvVarName,
-// 		ValueFrom: &v1.EnvVarSource{
-// 			SecretKeyRef: &v1.SecretKeySelector{
-// 				LocalObjectReference: v1.LocalObjectReference{
-// 					Name: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
-// 				},
-// 				Key: kms.OsdEncryptionSecretNameKeyName,
-// 			},
-// 		},
-// 	}
-// }
+func cephVolumeRawEncryptedEnvVarFromSecret(osdProps osdProperties) v1.EnvVar {
+	return v1.EnvVar{
+		Name: CephVolumeEncryptedKeyEnvVarName + "_OLD",
+		ValueFrom: &v1.EnvVarSource{
+			SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
+				},
+				Key: kms.OsdEncryptionSecretNameKeyName,
+			},
+		},
+	}
+}
 
 func cephVolumeEnvVar() []v1.EnvVar {
 	return []v1.EnvVar{

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"gopkg.in/ini.v1"
@@ -190,19 +189,19 @@ func pvcNameEnvVar(pvcName string) v1.EnvVar {
 	return v1.EnvVar{Name: PVCNameEnvVarName, Value: pvcName}
 }
 
-func cephVolumeRawEncryptedEnvVarFromSecret(osdProps osdProperties) v1.EnvVar {
-	return v1.EnvVar{
-		Name: CephVolumeEncryptedKeyEnvVarName,
-		ValueFrom: &v1.EnvVarSource{
-			SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
-				},
-				Key: kms.OsdEncryptionSecretNameKeyName,
-			},
-		},
-	}
-}
+// func cephVolumeRawEncryptedEnvVarFromSecret(osdProps osdProperties) v1.EnvVar {
+// 	return v1.EnvVar{
+// 		Name: CephVolumeEncryptedKeyEnvVarName,
+// 		ValueFrom: &v1.EnvVarSource{
+// 			SecretKeyRef: &v1.SecretKeySelector{
+// 				LocalObjectReference: v1.LocalObjectReference{
+// 					Name: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
+// 				},
+// 				Key: kms.OsdEncryptionSecretNameKeyName,
+// 			},
+// 		},
+// 	}
+// }
 
 func cephVolumeEnvVar() []v1.EnvVar {
 	return []v1.EnvVar{

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -298,14 +298,14 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 				}
 				envVars = append(envVars, kms.ConfigToEnvVar(c.spec)...)
 				if c.spec.Security.KeyManagementService.IsKMIPKMS() {
-					// envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
+					envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
 					_, volmeMountsKMIP := kms.KMIPVolumeAndMount(c.spec.Security.KeyManagementService.TokenSecretName)
 					volumeMounts = append(volumeMounts, volmeMountsKMIP)
 					_, volMount := c.getEncryptionVolumeForDmcrypt(osdProps)
 					volumeMounts = append(volumeMounts, volMount)
 				}
 			} else {
-				// envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
+				envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
 				_, volMount := c.getEncryptionVolumeForDmcrypt(osdProps)
 				volumeMounts = append(volumeMounts, volMount)
 			}

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -128,8 +128,12 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 				if c.spec.Security.KeyManagementService.IsKMIPKMS() {
 					volumeKMIP, _ := kms.KMIPVolumeAndMount(c.spec.Security.KeyManagementService.TokenSecretName)
 					volumes = append(volumes, volumeKMIP)
+					vol, _ := c.getEncryptionVolumeForDmcrypt(osdProps)
+					volumes = append(volumes, vol)
 				}
 			}
+			vol, _ := c.getEncryptionVolumeForDmcrypt(osdProps)
+			volumes = append(volumes, vol)
 		}
 	} else {
 		// If not running on PVC we mount the rootfs of the host to validate the presence of the LVM package
@@ -294,12 +298,16 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 				}
 				envVars = append(envVars, kms.ConfigToEnvVar(c.spec)...)
 				if c.spec.Security.KeyManagementService.IsKMIPKMS() {
-					envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
+					// envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
 					_, volmeMountsKMIP := kms.KMIPVolumeAndMount(c.spec.Security.KeyManagementService.TokenSecretName)
 					volumeMounts = append(volumeMounts, volmeMountsKMIP)
+					_, volMount := c.getEncryptionVolumeForDmcrypt(osdProps)
+					volumeMounts = append(volumeMounts, volMount)
 				}
 			} else {
-				envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
+				// envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
+				_, volMount := c.getEncryptionVolumeForDmcrypt(osdProps)
+				volumeMounts = append(volumeMounts, volMount)
 			}
 		}
 	} else {

--- a/pkg/operator/ceph/cluster/osd/volumes.go
+++ b/pkg/operator/ceph/cluster/osd/volumes.go
@@ -233,3 +233,30 @@ func (c *Cluster) getEncryptionVolume(osdProps osdProperties) (v1.Volume, v1.Vol
 
 	return volume, volumeMounts
 }
+
+func (c *Cluster) getEncryptionVolumeForDmcrypt(osdProps osdProperties) (v1.Volume, v1.VolumeMount) {
+	// Generate volume
+	volume := v1.Volume{
+		Name: osdEncryptionVolName,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
+				Items: []v1.KeyToPath{
+					{
+						Key:  kms.OsdEncryptionSecretNameKeyName,
+						Path: encryptionKeyFileName,
+					},
+				},
+			},
+		},
+	}
+
+	// Mounts /etc/ceph/luks_key
+	volumeMounts := v1.VolumeMount{
+		Name:      osdEncryptionVolName,
+		ReadOnly:  true,
+		MountPath: "/etc/dmcrypt",
+	}
+
+	return volume, volumeMounts
+}


### PR DESCRIPTION
osd prepare job spec contains osd encryption secret as a env which can be security issue, let's mount that secret as a file and use in job spec instead of env var.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
