### PR TITLE
RGW: fix do-not-reconcile label

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -109,6 +109,11 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string, 
 		return errors.Wrap(err, "failed to check for RGWs to skip reconcile")
 	}
 
+	if rgwsToSkipReconcile.Has(c.store.Name) {
+		logger.Warningf("skipping reconcile of rgw deployment %q with label %q", c.store.Name, cephv1.SkipReconcileLabelKey)
+		return nil
+	}
+
 	// start a new deployment and scale up
 	// We force a single deployment and later set the deployment replica to the "instances" value
 	desiredRgwInstances := 1
@@ -116,11 +121,6 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string, 
 		var err error
 
 		daemonLetterID := k8sutil.IndexToName(i)
-
-		if rgwsToSkipReconcile.Has(daemonLetterID) {
-			logger.Warningf("skipping reconcile of rgw daemon %q with label %q", daemonLetterID, cephv1.SkipReconcileLabelKey)
-			return nil
-		}
 
 		// Each rgw is id'ed by <store_name>-<letterID>
 		daemonName := fmt.Sprintf("%s-%s", c.store.Name, daemonLetterID)


### PR DESCRIPTION
fix do-not-reconcile label to prevent RGW deployment reconcile if `ceph.rook.io/do-not-reconcile:<storeName>` is applied.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #15850


Testing: 

Tried upgrading ceph version after adding the label: 

```
labels:
    app: rook-ceph-rgw
    app.kubernetes.io/component: cephobjectstores.ceph.rook.io
    app.kubernetes.io/created-by: rook-ceph-operator
    app.kubernetes.io/instance: my-store
    app.kubernetes.io/managed-by: rook-ceph-operator
    app.kubernetes.io/name: ceph-rgw
    app.kubernetes.io/part-of: my-store
    ceph-version: 19.2.0-0
    ceph.rook.io/do-not-reconcile: my-store  <---- don't reconcile label
    ceph_daemon_id: my-store
    ceph_daemon_type: rgw
    rgw: my-store
    rook-version: v1.17.0-alpha.0.180.g0f9d37e23-dirty
    rook.io/operator-namespace: rook-ceph
    rook_cluster: rook-ceph
    rook_object_store: my-store

```

```
 versions:
        mgr:
          ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 2
        mon:
          ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 3
        osd:
          ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 6
        overall:
          ceph version 19.2.0 (16063ff2022298c9300e49a547a16ffda59baf13) squid (stable): 3
          ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 11
        rgw:
          ceph version 19.2.0 (16063ff2022298c9300e49a547a16ffda59baf13) squid (stable): 3
```
RGW daemons, expectedly, didn't reconcile to upgrade the ceph version. 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
