### PR TITLE
mgr: Continue cluster reconcile even if prometheus not installed causing service monitor to fail creation

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -323,7 +323,9 @@ func (c *Cluster) reconcileServices() error {
 	// enable monitoring if `monitoring: enabled: true`
 	if c.spec.Monitoring.Enabled {
 		if err := c.EnableServiceMonitor(); err != nil {
-			return errors.Wrap(err, "failed to enable service monitor")
+			// We don't want to return an error to block the cluster reconcile
+			// since monitoring is an optional service.
+			logger.Errorf("failed to enable service monitor, prometheus may need to be installed. %v", err)
 		}
 	}
 


### PR DESCRIPTION
When monitoring is enabled, if the service monitor fails creation, the reconcile will fail and rook will never create the OSDs. A number of users have been blocked during install due to this issue. Let's allow reconcile of the full cluster even in this error case. After they install prometheus, they would then need to trigger a reconcile again perhaps by restarting the rook operator to enable the service monitor.

Resolves #15837 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
