### PR TITLE
csi: enable CSI Metadata Injection by Default

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -172,9 +172,9 @@ func (r *ReconcileCSI) setParams() error {
 		CSIParam.EnableCSIEncryption = true
 	}
 
-	CSIParam.CSIEnableMetadata = false
-	if strings.EqualFold(k8sutil.GetOperatorSetting("CSI_ENABLE_METADATA", "false"), "true") {
-		CSIParam.CSIEnableMetadata = true
+	CSIParam.CSIEnableMetadata = true
+	if strings.EqualFold(k8sutil.GetOperatorSetting("CSI_ENABLE_METADATA", "true"), "false") {
+		CSIParam.CSIEnableMetadata = false
 	}
 
 	if strings.EqualFold(k8sutil.GetOperatorSetting("CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY", rollingUpdate), onDelete) {

--- a/pkg/operator/ceph/csi/operator_config_test.go
+++ b/pkg/operator/ceph/csi/operator_config_test.go
@@ -87,5 +87,5 @@ func TestReconcileCSI_createOrUpdateOperatorConfig(t *testing.T) {
 
 	err = cl.Get(context.TODO(), types.NamespacedName{Name: opConfigCRName, Namespace: r.opConfig.OperatorNamespace}, opConfig)
 	assert.NoError(t, err)
-	assert.Equal(t, *opConfig.Spec.DriverSpecDefaults.EnableMetadata, false)
+	assert.Equal(t, *opConfig.Spec.DriverSpecDefaults.EnableMetadata, true)
 }


### PR DESCRIPTION
This PR sets CSI_ENABLE_METADATA to true by default in the Rook configuration, ensuring that the  `--setmetadata=true` flag is added to CSI nodeplugin pods

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
