### PR TITLE
core: fix golangci-lint check ST1005

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,9 +21,6 @@ linters:
         text: "QF1003:" # could use tagged switch on errCode (staticcheck)
       - linters:
           - staticcheck
-        text: "ST1005:" # error strings should not be capitalized (staticcheck)
-      - linters:
-          - staticcheck
         text: "QF1008:" # could remove embedded field "Connection" from selector (staticcheck)
       - linters:
           - staticcheck

--- a/pkg/daemon/util/cmdreporter.go
+++ b/pkg/daemon/util/cmdreporter.go
@@ -65,7 +65,7 @@ type CmdReporter struct {
 // NewCmdReporter creates a new CmdReporter and returns an error if cmd, configMapName, or Namespace aren't specified.
 func NewCmdReporter(context context.Context, clientset kubernetes.Interface, cmd, args []string, configMapName, namespace string) (*CmdReporter, error) {
 	if clientset == nil {
-		return nil, fmt.Errorf("Kubernetes client interface was not specified")
+		return nil, fmt.Errorf("kubernetes client interface was not specified")
 	}
 	if len(cmd) == 0 || cmd[0] == "" {
 		return nil, fmt.Errorf("cmd was not specified")
@@ -226,8 +226,8 @@ func (r *CmdReporter) saveToConfigMap(stdout, stderr string, retcode int) error 
 		cm.Labels[k8sutil.AppAttr] = CmdReporterAppName
 	} else if ok && app != "" && app != CmdReporterAppName {
 		// label is set and not equal to the cmd-reporter app name
-		return fmt.Errorf("ConfigMap [%s] already has label [%s] that differs from cmd-reporter's "+
-			"label [%s]; this may indicate that it is not safe for cmd-reporter to modify the ConfigMap.",
+		return fmt.Errorf("configMap [%s] already has label [%s] that differs from cmd-reporter's "+
+			"label [%s]; this may indicate that it is not safe for cmd-reporter to modify the ConfigMap",
 			r.configMapName, fmt.Sprintf("%s=%s", k8sutil.AppAttr, app), fmt.Sprintf("%s=%s", k8sutil.AppAttr, CmdReporterAppName))
 	}
 

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -1400,10 +1400,10 @@ func ValidateObjectStorePoolsConfig(metadataPool, dataPool cephv1.PoolSpec, shar
 		return err
 	}
 	if !EmptyPool(dataPool) && sharedPools.DataPoolName != "" {
-		return fmt.Errorf("invalidObjStorePoolConfig: object store dataPool and sharedPools.dataPool=%s are mutually exclusive. Only one of them can be set.", sharedPools.DataPoolName)
+		return fmt.Errorf("invalidObjStorePoolConfig: object store dataPool and sharedPools.dataPool=%s are mutually exclusive. Only one of them can be set", sharedPools.DataPoolName)
 	}
 	if !EmptyPool(metadataPool) && sharedPools.MetadataPoolName != "" {
-		return fmt.Errorf("invalidObjStorePoolConfig: object store metadataPool and sharedPools.metadataPool=%s are mutually exclusive. Only one of them can be set.", sharedPools.MetadataPoolName)
+		return fmt.Errorf("invalidObjStorePoolConfig: object store metadataPool and sharedPools.metadataPool=%s are mutually exclusive. Only one of them can be set", sharedPools.MetadataPoolName)
 	}
 	return nil
 }

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -129,7 +129,7 @@ func New(
 		return nil, fmt.Errorf("command [%+v] must be specified", cfg.cmd)
 	}
 	if cfg.rookImage == "" || cfg.runImage == "" {
-		return nil, fmt.Errorf("Rook image [%s] and run image [%s] must be specified", cfg.rookImage, cfg.runImage)
+		return nil, fmt.Errorf("rook image [%s] and run image [%s] must be specified", cfg.rookImage, cfg.runImage)
 	}
 
 	job, err := cfg.initJobSpec()

--- a/pkg/operator/test/spec.go
+++ b/pkg/operator/test/spec.go
@@ -52,22 +52,22 @@ func ArgumentsMatchExpected(actualArgs []string, expectedArgs [][]string) error 
 		validArgMatcher := strings.Join(arg, " ")
 		// We join each individual argument together the same was as the big string
 		if validArgMatcher == "" {
-			return fmt.Errorf("Expected argument %v evaluated to empty string; ArgumentsMatchExpected() doesn't know what to do", arg)
+			return fmt.Errorf("expected argument %v evaluated to empty string; ArgumentsMatchExpected() doesn't know what to do", arg)
 		}
 		matches := strings.Count(fullArgString, validArgMatcher)
 		if matches > 1 {
-			return fmt.Errorf("More than one instance of flag '%s' in: %s; ArgumentsMatchExpected() doesn't know what to do",
+			return fmt.Errorf("more than one instance of flag '%s' in: %s; ArgumentsMatchExpected() doesn't know what to do",
 				validArgMatcher, fullArgString)
 		} else if matches == 1 {
 			// Remove the instance of the valid match so we can't match to it any more
 			fullArgString = strings.Replace(fullArgString, validArgMatcher, "", 1)
 		} else { // zero matches
-			return fmt.Errorf("Expected argument '%s' missing in: %s\n(It's possible the same arg is in expectedArgs twice.)",
+			return fmt.Errorf("expected argument '%s' missing in: %s\n(It's possible the same arg is in expectedArgs twice.)",
 				validArgMatcher, strings.Join(actualArgs, " "))
 		}
 	}
 	if remainingArgs := strings.Trim(fullArgString, " "); remainingArgs != "" {
-		return fmt.Errorf("The actual arguments have additional args specified: %s", remainingArgs)
+		return fmt.Errorf("the actual arguments have additional args specified: %s", remainingArgs)
 	}
 	return nil
 }

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -55,7 +55,7 @@ func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 	args := []string{"apply", "-f", "-"}
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
-		return "", fmt.Errorf("Unable to create block -- : %s", err)
+		return "", fmt.Errorf("unable to create block -- : %s", err)
 	}
 	return result, nil
 }
@@ -128,7 +128,7 @@ func (b *BlockOperation) DeleteBlock(manifest string) (string, error) {
 	args := []string{"delete", "-f", "-"}
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
-		return "", fmt.Errorf("Unable to delete block -- : %s", err)
+		return "", fmt.Errorf("unable to delete block -- : %s", err)
 	}
 	return result, nil
 }

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -126,7 +126,7 @@ func (b *BucketOperation) GetAccessKey(obcName string) (string, error) {
 	args := []string{"get", "secret", obcName, "-o", "jsonpath={@.data.AWS_ACCESS_KEY_ID}"}
 	AccessKey, err := b.k8sh.Kubectl(args...)
 	if err != nil {
-		return "", fmt.Errorf("Unable to find access key -- %s", err)
+		return "", fmt.Errorf("unable to find access key -- %s", err)
 	}
 	decode, _ := b64.StdEncoding.DecodeString(AccessKey)
 	return string(decode), nil
@@ -136,7 +136,7 @@ func (b *BucketOperation) GetSecretKey(obcName string) (string, error) {
 	args := []string{"get", "secret", obcName, "-o", "jsonpath={@.data.AWS_SECRET_ACCESS_KEY}"}
 	SecretKey, err := b.k8sh.Kubectl(args...)
 	if err != nil {
-		return "", fmt.Errorf("Unable to find secret key-- %s", err)
+		return "", fmt.Errorf("unable to find secret key-- %s", err)
 	}
 	decode, _ := b64.StdEncoding.DecodeString(SecretKey)
 	return string(decode), nil

--- a/tests/framework/clients/client.go
+++ b/tests/framework/clients/client.go
@@ -90,5 +90,5 @@ func (c *ClientOperation) Update(clusterInfo *client.ClusterInfo, clientName str
 		time.Sleep(2 * time.Second)
 	}
 
-	return nil, fmt.Errorf("Unable to update client")
+	return nil, fmt.Errorf("unable to update client")
 }

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -74,7 +74,7 @@ func (o *ObjectOperation) GetEndPointUrl(namespace string, storeName string) (st
 	args := []string{"get", "svc", "-n", namespace, "-l", fmt.Sprintf("rgw=%s", storeName), "-o", "jsonpath={.items[*].spec.clusterIP}"}
 	EndPointUrl, err := o.k8sh.Kubectl(args...)
 	if err != nil {
-		return "", fmt.Errorf("Unable to find rgw end point-- %s", err)
+		return "", fmt.Errorf("unable to find rgw end point-- %s", err)
 	}
 	return fmt.Sprintf("%s:%d", EndPointUrl, rgwPort), nil
 }

--- a/tests/framework/utils/env.go
+++ b/tests/framework/utils/env.go
@@ -32,7 +32,7 @@ func TestRetryNumber() int {
 	count := GetEnvVarWithDefault("RETRY_MAX", "55")
 	number, err := strconv.Atoi(count)
 	if err != nil {
-		panic(fmt.Errorf("Error when converting to numeric value %v", err))
+		panic(fmt.Errorf("error when converting to numeric value %v", err))
 	}
 	return number
 }

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -46,7 +46,7 @@ func (h *HelmHelper) Execute(args ...string) (string, error) {
 	result, err := h.executor.ExecuteCommandWithOutput(h.HelmPath, args...)
 	if err != nil {
 		logger.Errorf("Errors Encountered while executing helm command %v: %v", result, err)
-		return result, fmt.Errorf("Failed to run helm command on args %v : %v , err -> %v", args, result, err)
+		return result, fmt.Errorf("failed to run helm command on args %v : %v , err -> %v", args, result, err)
 
 	}
 	return result, nil
@@ -164,7 +164,7 @@ func (h *HelmHelper) DeleteLocalRookHelmChart(namespace, deployName string) erro
 	_, err := h.Execute(cmdArgs...)
 	if err != nil {
 		logger.Errorf("could not delete helm chart with name  %v : %v", deployName, err)
-		return fmt.Errorf("Failed to delete helm chart with name  %v : %v", deployName, err)
+		return fmt.Errorf("failed to delete helm chart with name  %v : %v", deployName, err)
 	}
 
 	return nil

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -161,7 +161,7 @@ func (k8sh *K8sHelper) KubectlWithTimeout(timeout time.Duration, args ...string)
 			// allow the tests to continue if we were deleting a resource that timed out
 			return result, nil
 		}
-		return result, fmt.Errorf("Failed to run: %s %v : %v", cmd, args, err)
+		return result, fmt.Errorf("failed to run: %s %v : %v", cmd, args, err)
 	}
 	return result, nil
 }
@@ -181,7 +181,7 @@ func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, e
 		if strings.Contains(cmdOut.Err.Error(), "(NotFound)") || strings.Contains(cmdOut.StdErr, "(NotFound)") {
 			return cmdOut.StdErr, kerrors.NewNotFound(schema.GroupResource{}, "")
 		}
-		return cmdOut.StdErr, fmt.Errorf("Failed to run stdin: %s %v : %v", cmd, args, cmdOut.StdErr)
+		return cmdOut.StdErr, fmt.Errorf("failed to run stdin: %s %v : %v", cmd, args, cmdOut.StdErr)
 	}
 	if cmdOut.StdOut == "" {
 		return cmdOut.StdErr, nil
@@ -239,7 +239,7 @@ func (k8sh *K8sHelper) ResourceOperation(action string, manifest string) error {
 		return nil
 	}
 	logger.Errorf("Failed to execute kubectl %v -- %v", args, err)
-	return fmt.Errorf("Could Not create resource in args : %v -- %v", args, err)
+	return fmt.Errorf("could Not create resource in args : %v -- %v", args, err)
 }
 
 // DeletePod performs a kubectl delete pod on the given pod
@@ -273,7 +273,7 @@ func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace, name string, che
 		return err
 	}
 	logger.Errorf("gave up deleting custom resource %q ", name)
-	return fmt.Errorf("Timed out waiting for deletion of custom resource %q", name)
+	return fmt.Errorf("timed out waiting for deletion of custom resource %q", name)
 }
 
 // DeleteResource performs a kubectl delete on give args.
@@ -287,7 +287,7 @@ func (k8sh *K8sHelper) DeleteResourceAndWait(wait bool, args ...string) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("Could Not delete resource in k8s -- %v", err)
+	return fmt.Errorf("could Not delete resource in k8s -- %v", err)
 }
 
 // GetResource performs a kubectl get on give args
@@ -297,7 +297,7 @@ func (k8sh *K8sHelper) GetResource(args ...string) (string, error) {
 	if err == nil {
 		return result, nil
 	}
-	return result, fmt.Errorf("Could Not get resource in k8s -- %v", err)
+	return result, fmt.Errorf("could Not get resource in k8s -- %v", err)
 }
 
 func (k8sh *K8sHelper) CreateNamespace(namespace string) error {
@@ -345,7 +345,7 @@ func (k8sh *K8sHelper) WaitForPodCount(label, namespace string, count int) error
 		logger.Infof("waiting for %d pods (found %d) with label %s in namespace %s", count, len(pods.Items), label, namespace)
 		time.Sleep(RetryInterval * time.Second)
 	}
-	return fmt.Errorf("Giving up waiting for pods with label %s in namespace %s", label, namespace)
+	return fmt.Errorf("giving up waiting for pods with label %s in namespace %s", label, namespace)
 }
 
 func (k8sh *K8sHelper) WaitForStatusPhase(namespace, kind, name, desiredPhase string, timeout time.Duration) error {
@@ -416,7 +416,7 @@ func (k8sh *K8sHelper) WaitForLabeledPodsToRunWithRetries(label string, namespac
 	} else {
 		k8sh.PrintPodDescribe(namespace, lastPod.Name)
 	}
-	return fmt.Errorf("Giving up waiting for pod with label %s in namespace %s to be running", label, namespace)
+	return fmt.Errorf("giving up waiting for pod with label %s in namespace %s to be running", label, namespace)
 }
 
 // WaitUntilPodWithLabelDeleted returns true if a Pod is deleted within 90s else returns false
@@ -617,7 +617,7 @@ func (k8sh *K8sHelper) GetService(servicename string, namespace string) (*v1.Ser
 	ctx := context.TODO()
 	result, err := k8sh.Clientset.CoreV1().Services(namespace).Get(ctx, servicename, getOpts)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot find service %s in namespace %s, err-- %v", servicename, namespace, err)
+		return nil, fmt.Errorf("cannot find service %s in namespace %s, err-- %v", servicename, namespace, err)
 	}
 	return result, nil
 }
@@ -848,7 +848,7 @@ func (k8sh *K8sHelper) GetPodDetails(podNamePattern string, namespace string) (s
 	}
 	result, err := k8sh.Kubectl(args...)
 	if err != nil || strings.Contains(result, "No resources found") {
-		return "", fmt.Errorf("Cannot find pod in with name like %s in namespace : %s -- %v", podNamePattern, namespace, err)
+		return "", fmt.Errorf("cannot find pod in with name like %s in namespace : %s -- %v", podNamePattern, namespace, err)
 	}
 	return strings.TrimSpace(result), nil
 }
@@ -860,7 +860,7 @@ func (k8sh *K8sHelper) GetPodEvents(podNamePattern string, namespace string) (*v
 	result, err := k8sh.Clientset.CoreV1().RESTClient().Get().RequestURI(uri).DoRaw(ctx)
 	if err != nil {
 		logger.Errorf("Cannot get events for pod %v in namespace %v, err: %v", podNamePattern, namespace, err)
-		return nil, fmt.Errorf("Cannot get events for pod %s in namespace %s, err: %v", podNamePattern, namespace, err)
+		return nil, fmt.Errorf("cannot get events for pod %s in namespace %s, err: %v", podNamePattern, namespace, err)
 	}
 
 	events := v1.EventList{}
@@ -901,12 +901,12 @@ func (k8sh *K8sHelper) GetPodHostIP(podNamePattern string, namespace string) (st
 	podList, err := k8sh.Clientset.CoreV1().Pods(namespace).List(ctx, listOpts)
 	if err != nil {
 		logger.Errorf("Cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
-		return "", fmt.Errorf("Cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
+		return "", fmt.Errorf("cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
 	}
 
 	if len(podList.Items) < 1 {
 		logger.Errorf("Cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
-		return "", fmt.Errorf("Cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
+		return "", fmt.Errorf("cannot get hostIp for app : %v in namespace %v, err: %v", podNamePattern, namespace, err)
 	}
 	return podList.Items[0].Status.HostIP, nil
 }
@@ -918,7 +918,7 @@ func (k8sh *K8sHelper) GetServiceNodePort(serviceName string, namespace string) 
 	svc, err := k8sh.Clientset.CoreV1().Services(namespace).Get(ctx, serviceName, getOpts)
 	if err != nil {
 		logger.Errorf("Cannot get service : %v in namespace %v, err: %v", serviceName, namespace, err)
-		return "", fmt.Errorf("Cannot get service : %v in namespace %v, err: %v", serviceName, namespace, err)
+		return "", fmt.Errorf("cannot get service : %v in namespace %v, err: %v", serviceName, namespace, err)
 	}
 	np := svc.Spec.Ports[0].NodePort
 	return strconv.FormatInt(int64(np), 10), nil
@@ -931,7 +931,7 @@ func (k8sh *K8sHelper) IsStorageClassPresent(name string) (bool, error) {
 	if strings.Contains(result, name) {
 		return true, nil
 	}
-	return false, fmt.Errorf("Storageclass %s not found, err ->%v", name, err)
+	return false, fmt.Errorf("storageclass %s not found, err ->%v", name, err)
 }
 
 func (k8sh *K8sHelper) IsDefaultStorageClassPresent() (bool, error) {

--- a/tests/integration/object/bucketowner/bucketowner.go
+++ b/tests/integration/object/bucketowner/bucketowner.go
@@ -206,7 +206,7 @@ func WaitForPodLogContainingText(k8sh *utils.K8sHelper, namespace string, select
 
 	logStream, err := req.Stream(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to stream logs from pod %q: %v", selectedPod.Name, err)
+		return fmt.Errorf("failed to stream logs from pod %q: %v", selectedPod.Name, err)
 	}
 	defer logStream.Close()
 
@@ -220,7 +220,7 @@ func WaitForPodLogContainingText(k8sh *utils.K8sHelper, namespace string, select
 	}
 	// Check for scanner error (could be context timeout, etc.)
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("Error reading log stream: %v", err)
+		return fmt.Errorf("error reading log stream: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
does the following fixes:

- remove ST1005 from the list of active staticcheck rules ✅ 
- fix uppercase at beginning of strings. ✅ 
- remove punctuation at the end of strings. ✅ 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
