### PR TITLE
core: fix golangci-lint check ST1023 QF1011

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,16 +27,10 @@ linters:
         text: "QF1007:" # could merge conditional assignment into variable declaration (staticcheck)
       - linters:
           - staticcheck
-        text: "ST1023:" # should omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
-      - linters:
-          - staticcheck
         text: "QF1001:" # could apply De Morgan's law (staticcheck)
       - linters:
           - staticcheck
         text: "QF1002:" # could use tagged switch on args[0] (staticcheck)
-      - linters:
-          - staticcheck
-        text: "QF1011:" # could omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
       - linters:
           - staticcheck
         text: "QF1004:" # could use strings.ReplaceAll instead (staticcheck)

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"strings"
@@ -83,9 +82,7 @@ func TestGenerateClient(t *testing.T) {
 	}
 
 	client, caps := genClientEntity(p)
-	equal := bytes.Compare([]byte(client), []byte("client.client1"))
-	var res bool = equal == 0
-	assert.True(t, res)
+	assert.Equal(t, []byte(client), []byte("client.client1"))
 	assert.True(t, strings.Contains(strings.Join(caps, " "), "osd allow *"))
 	assert.True(t, strings.Contains(strings.Join(caps, " "), "mon allow rw"))
 	assert.True(t, strings.Contains(strings.Join(caps, " "), "mds allow rwx"))
@@ -102,9 +99,7 @@ func TestGenerateClient(t *testing.T) {
 	}
 
 	client, _ = genClientEntity(p2)
-	equal = bytes.Compare([]byte(client), []byte("client.client2"))
-	res = equal == 0
-	assert.True(t, res)
+	assert.Equal(t, []byte(client), []byte("client.client2"))
 }
 
 func TestCephClientController(t *testing.T) {

--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -148,7 +148,7 @@ func TestSetEnforceHostNetwork(t *testing.T) {
 	assert.False(t, EnforceHostNetwork())
 
 	// test invalid setting
-	var value string = "foo"
+	value := "foo"
 	logger.Infof("testing invalid value'%v' for %v", value, enforceHostNetworkSettingName)
 	os.Setenv(enforceHostNetworkSettingName, value)
 	SetEnforceHostNetwork()
@@ -176,7 +176,7 @@ func TestSetRevisionHistoryLimit(t *testing.T) {
 		assert.Nil(t, RevisionHistoryLimit())
 	})
 
-	var value string = "foo"
+	value := "foo"
 	t.Run("ROOK_REVISION_HISTORY_LIMIT: test invalid value 'foo'", func(t *testing.T) {
 		os.Setenv(revisionHistoryLimitSettingName, value)
 		SetRevisionHistoryLimit()

--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -117,7 +117,7 @@ func setNetworkCIDRs(clusterdCtx *clusterd.Context, clusterInfo *cephclient.Clus
 
 	logger.Infof("ensuring cluster %q %q network is configured to use CIDR(s) %q", ns, cephNet, settingVal)
 	if len(cidrs) > 0 {
-		var s monStoreInterface = getMonStoreFunc(clusterdCtx, clusterInfo)
+		s := getMonStoreFunc(clusterdCtx, clusterInfo)
 		changed, err := s.SetIfChanged("global", settingKey, settingVal)
 		if err != nil {
 			return errors.Wrapf(err, "failed to set CIDR(s) %q on cluster %q %q network", settingVal, cephNet, ns)

--- a/pkg/operator/k8sutil/resources_test.go
+++ b/pkg/operator/k8sutil/resources_test.go
@@ -72,7 +72,7 @@ func TestMergeResourceRequirements(t *testing.T) {
 }
 
 func TestYamlToContainerResourceArray(t *testing.T) {
-	var validData string = `
+	validData := `
 - name: rbdplugin
   resource:
     requests:
@@ -93,7 +93,7 @@ func TestYamlToContainerResourceArray(t *testing.T) {
 	assert.Len(t, res, 2)
 	assert.NoError(t, err)
 
-	var invalidData string = `
+	invalidData := `
 	invalid:
 	  data: 512Mi
 	invalid:
@@ -105,7 +105,7 @@ func TestYamlToContainerResourceArray(t *testing.T) {
 }
 
 func TestYamlToContainerResource(t *testing.T) {
-	var validData string = `
+	validData := `
   resources:
     requests:
       memory: 512Mi
@@ -116,7 +116,7 @@ func TestYamlToContainerResource(t *testing.T) {
 	res, err := YamlToContainerResource(validData)
 	assert.NoError(t, err)
 	assert.Equal(t, res.Requests.Memory().String(), "512Mi")
-	var invalidData string = `
+	invalidData := `
 	invalid:
 	  data: 512Mi
 	invalid:


### PR DESCRIPTION
This PR updates variable declarations to follow Go idiomatic style as enforced by `gofumpt` and `staticcheck`. Specifically:

- Removes explicit type declarations when the type can be inferred from the right-hand side.
- Replaces `var foo type = value` with the short declaration syntax `foo := value`.
- Cleans up `.golangci.yaml` by removing the ignored linter checks for these cases (`ST1023`, `QF1011`), since the code has  been updated to comply with them.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
