### PR TITLE
doc: recorrect the document ‘host_network’ to 'cluster_network'

### DIFF
--- a/Documentation/CRDs/Cluster/network-providers.md
+++ b/Documentation/CRDs/Cluster/network-providers.md
@@ -50,7 +50,7 @@ for data traffic. Use `addressRanges` to specify this. For example:
         - "192.168.200.0/24"
 ```
 
-This `public` and `cluster` translate directly to Ceph's `public_network` and `host_network`
+This `public` and `cluster` translate directly to Ceph's `public_network` and `cluster_network`
 configurations.
 
 The default network provider cannot make use of these configurations.


### PR DESCRIPTION
This should be `cluster_network` rather than `host_network`. Ceph has not configuration called `host_network`.

**Checklist:**

- [* ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
