### PR TITLE
core: improve reporting for reconcile requeue cases

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5306,6 +5306,9 @@ deletion.</p>
 </tr><tr><td><p>&#34;ReconcileFailed&#34;</p></td>
 <td><p>ReconcileFailed represents when a resource reconciliation failed.</p>
 </td>
+</tr><tr><td><p>&#34;ReconcileRequeuing&#34;</p></td>
+<td><p>ReconcileRequeuing represents when a resource reconciliation requeue.</p>
+</td>
 </tr><tr><td><p>&#34;ReconcileStarted&#34;</p></td>
 <td><p>ReconcileStarted represents when a resource reconciliation started.</p>
 </td>

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -559,7 +559,8 @@ const (
 	ReconcileFailed ConditionReason = "ReconcileFailed"
 	// ReconcileStarted represents when a resource reconciliation started.
 	ReconcileStarted ConditionReason = "ReconcileStarted"
-
+	// ReconcileRequeuing represents when a resource reconciliation requeue.
+	ReconcileRequeuing ConditionReason = "ReconcileRequeuing"
 	// DeletingReason represents when Rook has detected a resource object should be deleted.
 	DeletingReason ConditionReason = "Deleting"
 	// ObjectHasDependentsReason represents when a resource object has dependents that are blocking

--- a/pkg/operator/ceph/reporting/reporting.go
+++ b/pkg/operator/ceph/reporting/reporting.go
@@ -156,6 +156,10 @@ func ReportReconcileResult(
 			// intent.
 			return reconcileResponse, nil
 		}
+	} else if reconcileResponse.Requeue {
+		msg := fmt.Sprintf("requeuing %s %q", kind, nsName)
+		logger.Debug(msg)
+		recorder.Event(objCopy, corev1.EventTypeNormal, string(cephv1.ReconcileRequeuing), msg)
 	} else {
 		successMsg := fmt.Sprintf("successfully configured %s %q", kind, nsName)
 

--- a/pkg/operator/ceph/reporting/reporting_test.go
+++ b/pkg/operator/ceph/reporting/reporting_test.go
@@ -94,6 +94,8 @@ func TestReportReconcileResult(t *testing.T) {
 
 	successMsg := `successfully configured CephCluster "rook-ceph/my-cluster"`
 	successEvent := `Normal ReconcileSucceeded ` + successMsg
+	requeueMsg := `requeuing CephCluster "rook-ceph/my-cluster"`
+	requeueEvent := `Normal ReconcileRequeuing ` + requeueMsg
 
 	fakeErr := errors.New("fake-err")
 	errorMsg := `failed to reconcile CephCluster "rook-ceph/my-cluster". fake-err`
@@ -131,9 +133,9 @@ func TestReportReconcileResult(t *testing.T) {
 			cephCluster, inResult, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, inResult, result)
-		assert.Equal(t, successMsg, strings.TrimSpace(logBuf.String()))
+		assert.Equal(t, requeueMsg, strings.TrimSpace(logBuf.String()))
 		assert.Len(t, recorder.Events, 1)
-		assert.Equal(t, successEvent, <-recorder.Events)
+		assert.Equal(t, requeueEvent, <-recorder.Events)
 	})
 
 	t.Run("failed reconcile with requeue", func(t *testing.T) {


### PR DESCRIPTION
* When a Reconcile returns a Requeue result without an error (e.g. due to a missing CephCluster),
  the previous logic reported it as a **successful reconcile**.
* This was **misleading** and made it hard to understand the actual controller behavior.
* This change adds a new condition to:

  * Log a "requeuing" message
  * Emit a `"ReconcileRequeuing"` event
    when `reconcileResponse.Requeue` is `true` and `err` is `nil`.
* This ensures **more accurate event reporting** and improves **observability** across all controllers using `ReportReconcileResult`.

Fixes: #15751 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
