### PR TITLE
osd: Debug log for long image names in label

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -331,7 +331,7 @@ func createValidImageVersionLabel(image string) string {
 	cephImageVersion := re.ReplaceAllString(image, "_")
 
 	if validation.IsValidLabelValue(cephImageVersion) != nil {
-		logger.Infof("image %q contains invalid character, skipping adding label", image)
+		logger.Debugf("image %q contains invalid character, skipping adding label", image)
 		cephImageVersion = ""
 	}
 	return cephImageVersion


### PR DESCRIPTION
If the image name is too long we log a verbose message about the label that we can just log now as debug level.

I saw this message many times when looking through a customer log today, and it was not helpful.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
