### PR TITLE
core: fix golangci-lint check QF1004

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,9 +33,6 @@ linters:
         text: "QF1002:" # could use tagged switch on args[0] (staticcheck)
       - linters:
           - staticcheck
-        text: "QF1004:" # could use strings.ReplaceAll instead (staticcheck)
-      - linters:
-          - staticcheck
         text: "ST1008:" # error should be returned as the last argument (staticcheck)
       - linters:
           - staticcheck

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -152,7 +152,7 @@ func GetCrushHostName(context *clusterd.Context, clusterInfo *ClusterInfo, osdID
 
 // NormalizeCrushName replaces . with -
 func NormalizeCrushName(name string) string {
-	return strings.Replace(name, ".", "-", -1)
+	return strings.ReplaceAll(name, ".", "-")
 }
 
 // Obtain the cluster-wide default crush root from the cluster spec

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -320,8 +320,8 @@ func legacyDeviceSetPVCID(deviceSetName string, setIndex int) string {
 // This is the new function that generates the labels
 // It includes the pvcTemplateName in it
 func deviceSetPVCID(deviceSetName, pvcTemplateName string, setIndex int) string {
-	cleanName := strings.Replace(pvcTemplateName, " ", "-", -1)
-	deviceSetName = strings.Replace(deviceSetName, ".", "-", -1)
+	cleanName := strings.ReplaceAll(pvcTemplateName, " ", "-")
+	deviceSetName = strings.ReplaceAll(deviceSetName, ".", "-")
 	return fmt.Sprintf("%s-%s-%d", deviceSetName, cleanName, setIndex)
 }
 

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -89,7 +89,7 @@ var (
 // when they are specified as "some config key" in one section, "some_config_key" in another
 // section, and "some-config-key" in yet another section.
 func normalizeKey(key string) string {
-	return strings.Replace(strings.Replace(key, " ", "_", -1), "-", "_", -1)
+	return strings.ReplaceAll(strings.ReplaceAll(key, " ", "_"), "-", "_")
 }
 
 // NewFlag returns the key-value pair in the format of a Ceph command line-compatible flag.
@@ -97,7 +97,7 @@ func NewFlag(key, value string) string {
 	// A flag is a normalized key with underscores replaced by dashes.
 	// "debug default" ~normalize~> "debug_default" ~to~flag~> "debug-default"
 	n := normalizeKey(key)
-	f := strings.Replace(n, "_", "-", -1)
+	f := strings.ReplaceAll(n, "_", "-")
 	return fmt.Sprintf("--%s=%s", f, value)
 }
 

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -354,7 +354,7 @@ func (c *Cluster) scaleDownDeployments(replicas int32, activeCount int32, desire
 				logger.Errorf("failed to delete mds deployment. %v", err)
 			}
 
-			daemonName := strings.Replace(d.GetName(), fmt.Sprintf("%s-", AppName), "", -1)
+			daemonName := strings.ReplaceAll(d.GetName(), fmt.Sprintf("%s-", AppName), "")
 			err := c.DeleteMdsCephObjects(daemonName)
 			if err != nil {
 				logger.Errorf("%v", err)

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -91,7 +91,7 @@ func (c *clusterConfig) portString() string {
 
 func generateCephXUser(name string) string {
 	user := strings.TrimPrefix(name, AppName)
-	return "client.rgw" + strings.Replace(user, "-", ".", -1)
+	return "client.rgw" + strings.ReplaceAll(user, "-", ".")
 }
 
 func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -249,7 +249,7 @@ func TestConfigureStoreWithSharedPools(t *testing.T) {
 				zoneGetCalled = true
 				if sharedDataPoolAlreadySet == "" && sharedMetaPoolAlreadySet == "" {
 					replaceDataPool := "rgw-data-pool:store-a.buckets.data"
-					return strings.Replace(objectZoneJson, replaceDataPool, "datapool:store-a.buckets.data", -1), nil
+					return strings.ReplaceAll(objectZoneJson, replaceDataPool, "datapool:store-a.buckets.data"), nil
 				}
 				return fmt.Sprintf(objectZoneSharedPoolsJsonTempl, sharedMetaPoolAlreadySet, sharedDataPoolAlreadySet), nil
 			} else if args[1] == "set" {

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -56,7 +56,7 @@ func SetFlagsFromEnv(flags *pflag.FlagSet, prefix string) {
 	var errorFlag bool
 	var err error
 	flags.VisitAll(func(f *pflag.Flag) {
-		envVar := prefix + "_" + strings.Replace(strings.ToUpper(f.Name), "-", "_", -1)
+		envVar := prefix + "_" + strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_")
 		value := os.Getenv(envVar)
 		if value != "" {
 			// Set the environment variable. Will override default values, but be overridden by command line parameters.

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -376,7 +376,7 @@ func parseKeyValuePairString(propsRaw string) map[string]string {
 		if len(kvp) == 2 {
 			// first element is the final key, second element is the final value
 			// (don't forget to remove surrounding quotes from the value)
-			propMap[kvp[0]] = strings.Replace(kvp[1], `"`, "", -1)
+			propMap[kvp[0]] = strings.ReplaceAll(kvp[1], `"`, "")
 		}
 	}
 

--- a/tests/framework/utils/snapshot.go
+++ b/tests/framework/utils/snapshot.go
@@ -69,7 +69,7 @@ func (k8sh *K8sHelper) snapshotController(action string) error {
 	if err != nil {
 		return err
 	}
-	controllerManifest = strings.Replace(controllerManifest, "canary", snapshotterVersion, -1)
+	controllerManifest = strings.ReplaceAll(controllerManifest, "canary", snapshotterVersion)
 	logger.Infof("snapshot controller: %s", controllerManifest)
 
 	_, err = k8sh.KubectlWithStdin(controllerManifest, action, "-f", "-")

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -313,7 +313,7 @@ func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {
 	if installer.TestLogCollectionLevel() == "all" {
 		s.k8sh.PrintPodDescribe(s.namespace)
 	}
-	n := strings.Replace(s.T().Name(), "/", "_", -1) + testSuffix
+	n := strings.ReplaceAll(s.T().Name(), "/", "_") + testSuffix
 	s.installer.GatherAllRookLogs(n, systemNamespace, s.namespace)
 }
 


### PR DESCRIPTION
This PR replaces deprecated calls to `strings.Replace(..., -1)` with the more idiomatic `strings.ReplaceAll`, improving code readability and compliance with modern Go best practices. It also removes the related `QF1004` staticcheck linter exclusion.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
