### PR TITLE
core: fix golangci-lint check ST1008

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,9 +33,6 @@ linters:
         text: "QF1002:" # could use tagged switch on args[0] (staticcheck)
       - linters:
           - staticcheck
-        text: "ST1008:" # error should be returned as the last argument (staticcheck)
-      - linters:
-          - staticcheck
         text: "ST1019" # package "github.com/rook/rook/pkg/daemon/ceph/client" is being imported more than once (staticcheck)
       - linters:
           - staticcheck

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -201,15 +201,15 @@ func (h *CephInstaller) CreateRookToolbox(manifests CephManifests) (err error) {
 }
 
 // Execute a command in the ceph toolbox
-func (h *CephInstaller) Execute(command string, parameters []string, namespace string) (error, string) {
+func (h *CephInstaller) Execute(command string, parameters []string, namespace string) (string, error) {
 	clusterInfo := client.AdminTestClusterInfo(namespace)
 	cmd, args := client.FinalizeCephCommandArgs(command, clusterInfo, parameters, h.k8shelper.MakeContext().ConfigDir)
 	result, err := h.k8shelper.MakeContext().Executor.ExecuteCommandWithOutput(cmd, args...)
 	if err != nil {
 		logger.Warningf("Error executing command %q: <%v>", command, err)
-		return err, result
+		return result, err
 	}
-	return nil, result
+	return result, nil
 }
 
 // CreateCephCluster creates rook cluster via kubectl

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -178,7 +178,7 @@ func createCephObjectStore(t *testing.T, helper *clients.TestClient, k8sh *utils
 		assert.Nil(t, err)
 
 		for _, objectStore := range objectStores.Items {
-			err, output := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.GetName())}, namespace)
+			output, err := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.GetName())}, namespace)
 			logger.Infof("output: %s", output)
 			if err != nil {
 				// Just log the error until we get a more reliable way to wait for the user to be created

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -117,7 +117,7 @@ func (s *CephMgrSuite) executeWithRetry(command []string, maxRetries int) (strin
 	tries := 0
 	orchestratorCommand := append([]string{"orch"}, command...)
 	for {
-		err, output := s.installer.Execute("ceph", orchestratorCommand, s.namespace)
+		output, err := s.installer.Execute("ceph", orchestratorCommand, s.namespace)
 		tries++
 		if err != nil {
 			if maxRetries == 1 {
@@ -150,7 +150,7 @@ volumeBindingMode: WaitForFirstConsumer
 `
 	err := s.k8sh.ResourceOperation("apply", localStorageClass)
 	if err == nil {
-		err, _ = s.installer.Execute("ceph", []string{"config", "set", "mgr", "mgr/rook/storage_class", storageClassName}, s.namespace)
+		_, err = s.installer.Execute("ceph", []string{"config", "set", "mgr", "mgr/rook/storage_class", storageClassName}, s.namespace)
 		if err == nil {
 			logger.Infof("Storage class %q set in manager config", storageClassName)
 		} else {
@@ -163,7 +163,7 @@ volumeBindingMode: WaitForFirstConsumer
 
 func (s *CephMgrSuite) enableOrchestratorModule() {
 	logger.Info("Enabling Rook orchestrator module: <ceph mgr module enable rook --force>")
-	err, output := s.installer.Execute("ceph", []string{"mgr", "module", "enable", "rook", "--force"}, s.namespace)
+	output, err := s.installer.Execute("ceph", []string{"mgr", "module", "enable", "rook", "--force"}, s.namespace)
 	logger.Infof("output: %s", output)
 	if err != nil {
 		logger.Infof("Failed to enable rook orchestrator module: %q", err)

--- a/tests/integration/object/bucketowner/bucketowner.go
+++ b/tests/integration/object/bucketowner/bucketowner.go
@@ -342,7 +342,7 @@ func TestObjectBucketClaimBucketOwner(t *testing.T, k8sh *utils.K8sHelper, insta
 
 		// the rgw admin api is used to verify bucket ownership
 		t.Run("setup rgw admin api client", func(t *testing.T) {
-			err, output := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
+			output, err := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
 			require.NoError(t, err)
 
 			// extract api creds from json output

--- a/tests/integration/object/user/userkeys/userkeys.go
+++ b/tests/integration/object/user/userkeys/userkeys.go
@@ -371,7 +371,7 @@ func TestObjectStoreUserKeys(t *testing.T, k8sh *utils.K8sHelper, installer *ins
 		})
 
 		t.Run("setup rgw admin api client", func(t *testing.T) {
-			err, output := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
+			output, err := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
 			require.NoError(t, err)
 
 			// extract api creds from json output

--- a/tests/integration/object/util/sns/sns.go
+++ b/tests/integration/object/util/sns/sns.go
@@ -54,7 +54,7 @@ func (r *snsResolverV2) ResolveEndpoint(ctx context.Context, params sns.Endpoint
 }
 
 func GetS3Credentials(objectStore *cephv1.CephObjectStore, installer *installer.CephInstaller) (string, string, error) {
-	err, output := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
+	output, err := installer.Execute("radosgw-admin", []string{"user", "info", "--uid=dashboard-admin", fmt.Sprintf("--rgw-realm=%s", objectStore.Name)}, objectStore.Namespace)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get user info")
 	}


### PR DESCRIPTION
This PR includes the following changes:

    Updates the return signature of the `Execute` method in `CephInstaller` from `(error, string)` to `(string, error)`, aligning with Go's idiomatic practice of returning the main result before the error.

    Refactors all existing calls to `Execute` throughout the integration tests and supporting code to reflect the new return order.

    Removes the `ST1008` linter exception from `.golangci.yaml`, as the updated return signature now complies with this `staticcheck` recommendation.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
