### PR TITLE
osd: don't set dmcrypt env in prepare pod job spec

### DIFF
--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -70,13 +70,6 @@ func setKEKinEnv(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo)
 	// pick it up
 	clusterSpec := &v1.ClusterSpec{Security: v1.SecuritySpec{KeyManagementService: v1.KeyManagementServiceSpec{ConnectionDetails: kms.ConfigEnvsToMapString()}}}
 
-	// If KMS is not enabled this code does not need to run since we attach the KEK value from the
-	// Kubernetes Secret in the provision pod spec (mounted as an environment variable)
-	if !clusterSpec.Security.KeyManagementService.IsEnabled() {
-		logger.Debug("cluster-wide encryption is enabled with kubernetes secrets and the kek is attached to the provision env spec")
-		return nil
-	}
-
 	// The ibm key protect library does not read any environment variables, so we must set the
 	// service api key (coming from the secret mounted as environment variable) in the KMS
 	// connection details. These details are used to build the client connection

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"gopkg.in/ini.v1"
@@ -188,20 +187,6 @@ func encryptedDeviceEnvVar(encryptedDevice bool) v1.EnvVar {
 
 func pvcNameEnvVar(pvcName string) v1.EnvVar {
 	return v1.EnvVar{Name: PVCNameEnvVarName, Value: pvcName}
-}
-
-func cephVolumeRawEncryptedEnvVarFromSecret(osdProps osdProperties) v1.EnvVar {
-	return v1.EnvVar{
-		Name: CephVolumeEncryptedKeyEnvVarName,
-		ValueFrom: &v1.EnvVarSource{
-			SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: kms.GenerateOSDEncryptionSecretName(osdProps.pvc.ClaimName),
-				},
-				Key: kms.OsdEncryptionSecretNameKeyName,
-			},
-		},
-	}
 }
 
 func cephVolumeEnvVar() []v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -293,12 +293,9 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 				}
 				envVars = append(envVars, kms.ConfigToEnvVar(c.spec)...)
 				if c.spec.Security.KeyManagementService.IsKMIPKMS() {
-					envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
 					_, volmeMountsKMIP := kms.KMIPVolumeAndMount(c.spec.Security.KeyManagementService.TokenSecretName)
 					volumeMounts = append(volumeMounts, volmeMountsKMIP)
 				}
-			} else {
-				envVars = append(envVars, cephVolumeRawEncryptedEnvVarFromSecret(osdProps))
 			}
 		}
 	} else {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

this commit remove the code which sets the dmcrypt encryption
key from secret as environment variable in the prepare pod job
spec. Now, the env will be set under function `setKEKinEnv`, which
tries to reads secret from k8s first method `c.IsK8s()`under
`GetSecret` and then check for KMS to ready and apply env directly.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
