### PR TITLE
chart: quote object store ingress host

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - host: {{ .ingress.host.name }}
+    - host: {{ .ingress.host.name | quote }}
       http:
         paths:
           - path: {{ .ingress.host.path | default "/" }}


### PR DESCRIPTION
This change allows to use wildcard for object ingress configuration. Allows to use virtual-host style bucket URLs with ingress.

For instance, setting `*.mydomain.com` as the ingress host causes the helm templating to fail.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
