### PR TITLE
nfs: fix the skip reconcile call

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -994,7 +994,7 @@ func GetDaemonsToSkipReconcile(ctx context.Context, clusterd *clusterd.Context, 
 	result := sets.New[string]()
 	for _, deployment := range deployments.Items {
 		if daemonID, ok := deployment.Labels[daemonName]; ok {
-			logger.Infof("found %s %q pod to skip reconcile", daemonID, daemonName)
+			logger.Infof("found %q %q pod to skip reconcile", daemonID, daemonName)
 			result.Insert(daemonID)
 		}
 	}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -63,7 +63,7 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
 	for i := 0; i < n.Spec.Server.Active; i++ {
 		id := k8sutil.IndexToName(i)
 
-		if nfsToSkipReconcile.Has(id) {
+		if nfsToSkipReconcile.Has(fmt.Sprintf("%s-%s", n.Name, id)) {
 			logger.Warningf("skipping reconcile of nfs daemon %q with label %q", id, cephv1.SkipReconcileLabelKey)
 			continue
 		}

--- a/pkg/operator/ceph/nfs/nfs_test.go
+++ b/pkg/operator/ceph/nfs/nfs_test.go
@@ -216,7 +216,7 @@ func TestReconcileCephNFS_upCephNFS(t *testing.T) {
 func TestUpCephNFS_SkipsReconcile(t *testing.T) {
 	ns := "skip-nfs-test"
 	s := scheme.Scheme
-	daemonID := "a"
+	daemonID := "my-nfs-a"
 
 	clientset := k8sfake.NewSimpleClientset()
 	client := fake.NewClientBuilder().WithScheme(s).Build()


### PR DESCRIPTION
currently nfs is used as the unique selector
for daemon id, which returns  nfs: ocs-storagecluster-cephnfs-a

Updating the has() to function to check the same label value
(n.Name + "-" + id)



<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
