### PR TITLE
helm: Add custom labels for toolbox deployment in rook-ceph-cluster chart

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -81,6 +81,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `toolbox.containerSecurityContext` | Toolbox container security context | `{"capabilities":{"drop":["ALL"]},"runAsGroup":2016,"runAsNonRoot":true,"runAsUser":2016}` |
 | `toolbox.enabled` | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md) | `false` |
 | `toolbox.image` | Toolbox image, defaults to the image used by the Ceph cluster | `nil` |
+| `toolbox.labels` | Toolbox labels | `{}` |
 | `toolbox.priorityClassName` | Set the priority class for the toolbox if desired | `nil` |
 | `toolbox.resources` | Toolbox resources | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
 | `toolbox.tolerations` | Toolbox tolerations | `[]` |

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }} # namespace:cluster
   labels:
     app: rook-ceph-tools
+    {{- if .Values.toolbox.labels }}
+    {{- toYaml .Values.toolbox.labels | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
 {{- if .Values.revisionHistoryLimit }}
@@ -19,6 +22,9 @@ spec:
     metadata:
       labels:
         app: rook-ceph-tools
+        {{- if .Values.toolbox.labels }}
+        {{- toYaml .Values.toolbox.labels | nindent 8 }}
+        {{- end }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- $network := .Values.cephClusterSpec.network | default dict -}}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -30,6 +30,8 @@ toolbox:
   tolerations: []
   # -- Toolbox affinity
   affinity: {}
+  # -- Toolbox labels
+  labels: {}
   # -- Toolbox container security context
   containerSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Allow to assign custom labels for toolbox deployment. Some audit policies require specific labels for all kubernetes objects.