### PR TITLE
nfs: add a old uuid check for nfs config

### DIFF
--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -96,7 +96,7 @@ func getGaneshaConfig(n *cephv1.CephNFS, version cephver.CephVersion, name strin
 	nodeID := getNFSNodeID(n, name)
 	userID := getNFSUserID(nodeID)
 	url := getRadosURL(n)
-	return `
+	config := `
 NFS_CORE_PARAM {
 	Enable_NLM = false;
 	Enable_RQUOTA = false;
@@ -137,7 +137,18 @@ RGW {
 }
 
 %url	` + url + `
+
 `
+
+	if version.IsAtLeast(cephver.Tentacle) {
+		config += `
+Ceph {
+	use_old_uuid = true;
+}
+`
+	}
+
+	return config
 }
 
 func ganeshaKrbConfigBlock(kerberosSpec *cephv1.KerberosSpec) string {


### PR DESCRIPTION
adding the use_old_uuid is because upgraded
cluster has to maintain the uuid of older reclaims
that have happened, and NFS has changed the
uuid logic if don't turn it on(use_old_uuid = false)
it will provide more robust settings internally

But for older reclaims maintenace always turning it om
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
