### PR TITLE
ci: Test tentacle devel in daily builds

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -129,7 +129,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -209,7 +209,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -249,7 +249,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -289,7 +289,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephObjectSuite
         run: |
@@ -329,7 +329,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -370,7 +370,7 @@ jobs:
         uses: ./.github/workflows/integration-test-config-latest-k8s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.28.4"
+          kubernetes-version: "1.33.1"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -191,6 +191,46 @@ jobs:
           name: ceph-smoke-suite-squid-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
+  smoke-suite-tentacle-devel:
+    if: github.repository == 'rook/rook'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: consider debugging
+        uses: ./.github/workflows/tmate_debug
+        with:
+          use-tmate: ${{ secrets.USE_TMATE }}
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-config-latest-k8s
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          kubernetes-version: "1.28.4"
+
+      - name: TestCephSmokeSuite
+        run: |
+          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="tentacle-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
+
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="smoke-ns"
+          export OPERATOR_NAMESPACE="smoke-ns-system"
+          tests/scripts/collect-logs.sh
+
+      - name: Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: ceph-smoke-suite-tentacle-artifact
+          path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
   smoke-suite-ceph-main:
     if: github.repository == 'rook/rook'
     runs-on: ubuntu-22.04

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -43,11 +43,13 @@ import (
 
 const (
 	// test with the latest releases
-	reefTestImage  = "quay.io/ceph/ceph:v18"
-	squidTestImage = "quay.io/ceph/ceph:v19"
+	reefTestImage     = "quay.io/ceph/ceph:v18"
+	squidTestImage    = "quay.io/ceph/ceph:v19"
+	tentacleTestImage = "quay.io/ceph/ceph:v20"
 	// test with the current development versions
-	reefDevelTestImage  = "quay.ceph.io/ceph-ci/ceph:reef"
-	squidDevelTestImage = "quay.ceph.io/ceph-ci/ceph:squid"
+	reefDevelTestImage     = "quay.ceph.io/ceph-ci/ceph:reef"
+	squidDevelTestImage    = "quay.ceph.io/ceph-ci/ceph:squid"
+	tentacleDevelTestImage = "quay.ceph.io/ceph-ci/ceph:tentacle"
 	// test with the latest Ceph main image
 	mainTestImage      = "quay.ceph.io/ceph-ci/ceph:main"
 	cephOperatorLabel  = "app=rook-ceph-operator"
@@ -71,6 +73,8 @@ var (
 	ReefDevelVersion             = cephv1.CephVersionSpec{Image: reefDevelTestImage}
 	SquidVersion                 = cephv1.CephVersionSpec{Image: squidTestImage}
 	SquidDevelVersion            = cephv1.CephVersionSpec{Image: squidDevelTestImage}
+	TentacleVersion              = cephv1.CephVersionSpec{Image: tentacleTestImage}
+	TentacleDevelVersion         = cephv1.CephVersionSpec{Image: tentacleDevelTestImage, AllowUnsupported: true}
 	MainVersion                  = cephv1.CephVersionSpec{Image: mainTestImage, AllowUnsupported: true}
 	volumeReplicationBaseURL     = fmt.Sprintf("https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/%s/config/crd/bases/", volumeReplicationVersion)
 	volumeReplicationCRDURL      = volumeReplicationBaseURL + "replication.storage.openshift.io_volumereplications.yaml"
@@ -97,6 +101,8 @@ func ReturnCephVersion() cephv1.CephVersionSpec {
 		return ReefDevelVersion
 	case "squid-devel":
 		return SquidDevelVersion
+	case "tentacle-devel":
+		return TentacleDevelVersion
 	default:
 		// Default to the latest stable version
 		return SquidVersion


### PR DESCRIPTION
With the tentacle release approaching, let's start running the Rook tests against the tentacle devel images to catch if any issues.

When tentacle is finally released, we will have more changes to support it, similar to #14454 from supporting Squid. 

Also, the daily ci was only running on K8s 1.28.4, now update it to 1.33.1.
 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
