### PR TITLE
build: add make  target markdownlint.fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ golangci-lint: $(YQ)
 markdownlint: ## Check formatting of documentation sources
 	markdownlint-cli2 "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
 
+.PHONY: markdownlint.fix
+markdownlint.fix: ## Check and fix formatting of documentation sources
+	markdownlint-cli2 "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs
+
 .PHONY: yamllint
 yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings


### PR DESCRIPTION
**Description Of Changes:**

This change adds a new make target `markdownlint.fix`

now `make markdownlint.fix` can be run  locally to
fix markdownlint CI failures.

Like the `markdownlint`target, this requires `markdownlint-cli2` to be installed locally.





**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
