### PR TITLE
doc: fixup bullet points on rgw docs

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -192,6 +192,7 @@ The gateway settings correspond to the RGW daemon settings.
     secret's data: `insecureSkipVerify: true` to skip the certificate verification. It is not
     recommended to enable this option since TLS is susceptible to machine-in-the-middle attacks unless
     custom verification is used.
+
 * `caBundleRef`: If specified, this is the name of the Kubernetes secret (type `opaque`) that
     contains additional custom ca-bundle to use. The secret must be in the same namespace as the Rook
     cluster. Rook will look in the secret provided at the `cabundle` key name. This bundle is used used by RGW to verify


### PR DESCRIPTION
In #15961 I updated the rgw docs, but I was looking at the published docs and the bulleting is broken now for Gateway Settings. When I was working on the PR I was just using the markdown preview in my editor and wan't using the `docs-preview` target. It turns out that the markdown editor and mkdocs render things differently.

This PR fixes the bullet formatting and I verified the fix by running `make docs-preview` on my box and double checking the local website.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
