### PR TITLE
rbd: blocklist rns image watchers

### DIFF
--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -126,3 +126,23 @@ func TestListImageLogLevelDebug(t *testing.T) {
 	assert.True(t, listCalled)
 	listCalled = false
 }
+
+func TestGetWatcherIPs(t *testing.T) {
+	rbdStatus := RBDStatus{
+		Watchers: []struct {
+			Address string "json:\"address\""
+		}{
+			{
+				Address: "192.168.39.137:0/3762982934",
+			},
+			{
+				Address: "192.168.39.136:0/3762982934",
+			},
+		},
+	}
+
+	res := rbdStatus.GetWatcherIPs()
+	assert.Equal(t, 2, len(res))
+	assert.Equal(t, "192.168.39.137", res[0])
+	assert.Equal(t, "192.168.39.136", res[1])
+}

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -466,3 +466,13 @@ func GetOSDMetadata(context *clusterd.Context, clusterInfo *ClusterInfo) (*[]OSD
 	}
 	return &osdMetadata, nil
 }
+
+// BlocklistIP blocklists the IP for predefined duration
+func BlocklistIP(context *clusterd.Context, clusterInfo *ClusterInfo, ip, duration string) error {
+	args := []string{"osd", "blocklist", "add", ip, duration}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to blockist IP %q", ip)
+	}
+	return nil
+}


### PR DESCRIPTION
When force-deletion annotation is added to CephRadosNamespace CR, then blocklist any watchers on the Namespace images in order to remove the image from the trash

Testing: 
- added `rook.io/force-deletion: "true"` annotation to the CephRadosNamespace CR. 
- Deleted the CR. 

Logs from cleanup job. 

---------------------------
❯ kubectl logs cleanup-radosnamespace-replicapool-namespace-a-j5jrn -n rook-ceph
2025/06/17 16:08:53 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
2025-06-17 16:08:53.450373 I | rookcmd: starting Rook v1.17.0-alpha.0.299.gdbf0834c8-dirty with arguments '/usr/local/bin/rook ceph clean CephBlockPoolRadosNamespace'
2025-06-17 16:08:53.450420 I | rookcmd: flag values: --help=false, --log-level=DEBUG
2025-06-17 16:08:53.455916 I | cleanup: starting clean up of CephBlockPoolRadosNamespace "namespace-a" resources in cephblockpool "replicapool"
2025-06-17 16:08:53.456091 D | exec: Running command: rbd ls -l replicapool --namespace namespace-a --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json
2025-06-17 16:08:53.686297 D | exec: Running command: rbd status replicapool/csi-vol-2777c469-eb0a-4e1a-a3d1-f556519de74c --namespace namespace-a --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json
2025-06-17 16:08:53.834972 I | cleanup: watcher IPs for image "csi-vol-2777c469-eb0a-4e1a-a3d1-f556519de74c" in pool "replicapool" in namespace "namespace-a": [10.244.0.1]
2025-06-17 16:08:53.835056 I | cleanup: client IPs : map[10.244.0.1:{}]
2025-06-17 16:08:53.835573 I | cleanup: blocklist client IP "10.244.0.1" for images in pool "replicapool" in namespace "namespace-a"
2025-06-17 16:08:53.835740 D | exec: Running command: ceph osd blocklist add 10.244.0.1 1200 --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json
2025-06-17 16:08:55.069227 I | cleanup: successfully blocklisted client IP "10.244.0.1" in pool "replicapool" in namespace "namespace-a"
2025-06-17 16:08:55.069280 D | exec: Running command: rbd snap ls replicapool/csi-vol-2777c469-eb0a-4e1a-a3d1-f556519de74c --namespace namespace-a --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json
2025-06-17 16:08:55.251799 D | exec: Running command: rbd trash mv replicapool/csi-vol-2777c469-eb0a-4e1a-a3d1-f556519de74c --namespace namespace-a --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-17 16:09:06.536135 D | exec: Running command: ceph rbd task add trash remove replicapool/namespace-a/123dc4c85ddc --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json
2025-06-17 16:09:07.399729 I | cleanup: successfully cleaned up CephBlockPoolRadosNamespace "namespace-a" resources in cephblockpool "replicapool"


------------------------------------------

Rados Namespace was deleted successfully. 

```
❯ kubectl delete cephrns -n rook-ceph namespace-a
cephblockpoolradosnamespace.ceph.rook.io "namespace-a" deleted
❯ kubectl get  cephrns -n rook-ceph namespace-a
Error from server (NotFound): cephblockpoolradosnamespaces.ceph.rook.io "namespace-a" not found
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
