### PR TITLE
ci: enable linting of the rook-ceph-cluster chart

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -43,4 +43,4 @@ jobs:
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --charts=./deploy/charts/rook-ceph --validate-yaml=false --validate-maintainers=false
+        run: make helm.lint

--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,13 @@ markdownlint.fix: ## Check and fix formatting of documentation sources
 yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
 
+.PHONY: helm.lint
+
+helm.lint: ## Check the helm charts
+	ct lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false
+
 .PHONY: lint
-lint: yamllint pylint shellcheck checkmake vet markdownlint golangci-lint ## Run various linters
+lint: yamllint pylint shellcheck checkmake vet markdownlint golangci-lint helm.lint  ## Run various linters
 
 .PHONY: pylint
 pylint:


### PR DESCRIPTION
**Description:** 
Previously, only the rook-ceph operator chart was linted in the CI.

With this change, the rook-ceph-cluster chart is linted additionally.

or developer convenience, The linting is realized via a new make target
    `helm.lint`that can easily be invoked locally if the chart-testing tool
    `ct` is available.
    

**Issue resolved by this Pull Request:**

Resolves: #15966



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
