### PR TITLE
build: allow make build for different arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ do.build.platform.%:
 do.build.parallel: $(foreach p,$(PLATFORMS_TO_BUILD_FOR), do.build.platform.$(p))
 
 build: build.common ## Only build for linux platform
-	@$(MAKE) go.build PLATFORM=linux_$(GOHOSTARCH)
-	@$(MAKE) -C images PLATFORM=linux_$(GOHOSTARCH)
+	@$(MAKE) go.build PLATFORM=linux_$(GOARCH)
+	@$(MAKE) -C images PLATFORM=linux_$(GOARCH)
 
 build.all: build.common ## Build source code for all platforms.
 ifneq ($(GOHOSTARCH),amd64)


### PR DESCRIPTION
Allow `make build` to perform cross-architecture builds by using `make GOARCH=<arch> build`.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
