### PR TITLE
doc: switch linux minikube driver from kvm2 to qemu2

### DIFF
--- a/Documentation/Contributing/development-environment.md
+++ b/Documentation/Contributing/development-environment.md
@@ -18,7 +18,7 @@ issues deploying Rook.
 
 To install Minikube follow the [official
 guide](https://minikube.sigs.k8s.io/docs/start/). It is recommended to use the
-kvm2 driver when running on a Linux machine and the hyperkit driver when running on a MacOS. Both
+qemu2 driver when running on a Linux machine and the hyperkit driver when running on a MacOS. Both
 allow to create and attach additional disks to the virtual machine. This is required for the Ceph
 OSD to consume one drive.  We don't recommend any other drivers for Rook. You will need a Minikube
 version 1.23 or higher.
@@ -27,7 +27,7 @@ Starting the cluster on Minikube is as simple as running:
 
 ```console
 # On Linux
-minikube start --disk-size=40g --extra-disks=1 --driver kvm2
+minikube start --disk-size=40g --extra-disks=1 --driver qemu2
 
 # On MacOS with Intel processor
 minikube start --disk-size=40g --extra-disks=1 --driver hyperkit


### PR DESCRIPTION
update the developer guide to use the `qemu2` driver instead of `kvm2` for minikube on linux.

Fixes: #16032 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
