### PR TITLE
monitoring: CephPGImbalance alert to consider OSD size

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -243,13 +243,29 @@ groups:
           type: "ceph_default"
       - alert: "CephPGImbalance"
         annotations:
-          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count."
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} in device class {{ $labels.device_class }} deviates by more than 30% from average PG count when the PG count is scaled by relative OSD size."
           summary: "PGs are not balanced across OSDs"
         expr: |
           abs(
-            ((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) /
-            on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-          ) * on (ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+            (
+              (
+                (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+              ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+            ) -
+            on(job) group_left avg(
+              (
+                (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+              ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+            ) by(job)
+          ) /
+          on(job) group_left clamp_min(
+            avg(
+              (
+                (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+              ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+            ) by(job),
+            1
+          ) * on(ceph_daemon) group_left(device_class, hostname) ceph_osd_metadata > 0.30
         for: "5m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.4.5"

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -247,13 +247,29 @@ spec:
             type: "ceph_default"
         - alert: "CephPGImbalance"
           annotations:
-            description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count."
+            description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} in device class {{ $labels.device_class }} deviates by more than 30% from average PG count when the PG count is scaled by relative OSD size."
             summary: "PGs are not balanced across OSDs"
           expr: |
             abs(
-              ((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) /
-              on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-            ) * on (ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+              (
+                (
+                  (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+                ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+              ) -
+              on(job) group_left avg(
+                (
+                  (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+                ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+              ) by(job)
+            ) /
+            on(job) group_left clamp_min(
+              avg(
+                (
+                  (ceph_osd_numpg > 0) / clamp_min(ceph_osd_stat_bytes, 1)
+                ) * on(job) group_left max(ceph_osd_stat_bytes) by(job)
+              ) by(job),
+              1
+            ) * on(ceph_daemon) group_left(device_class, hostname) ceph_osd_metadata > 0.30
           for: "5m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.4.5"


### PR DESCRIPTION
The CephPGImbalance alert has been updated to consider the relative size of OSDs when calculating the imbalance. This change ensures that the alert is more accurate by scaling the PG count by the relative OSD size, rather than just comparing raw counts.

Additionally, the alert is now grouped by device class in addition to hostname.

I am not sure how best to test this change, but I did update the `localrules.yaml` on my cluster that has the `CephPGImbalance` alert firing and the alert (as expected) is now clear. Unfortunately, I only have a single device class of OSDs, so I can't validate that grouping is working but I'm pretty confident it should be.
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13257 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] ~Documentation has been updated, if necessary.~
- [ ] ~Unit tests have been added, if necessary.~
- [ ] ~Integration tests have been added, if necessary.~
