### PR TITLE
object: allow deletion of CephObjectStoreUser even if secret is missing

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -315,7 +315,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 
 	referencedSecrets := &map[types.UID]*corev1.Secret{}
 	// Set any provided key pair(s)
-	if len(cephObjectStoreUser.Spec.Keys) > 0 {
+	if cephObjectStoreUser.GetDeletionTimestamp().IsZero() && len(cephObjectStoreUser.Spec.Keys) > 0 {
 		var keys *[]admin.UserKeySpec
 		keys, referencedSecrets, err = r.generateUserKeySpec(cephObjectStoreUser)
 		if err != nil {


### PR DESCRIPTION
skip key generation during reconcile if CephObjectStoreUser is being deleted to allow cleanup when referenced secret is missing

Fixes: #16007 


Test on local machine with private image `quay.io/oviner/rook:jun22_2`  
```
1.Create a cluster:
$ minikube start --disk-size=10g --extra-disks=1 --driver=qemu2

2.Create resources and opertor with my private image
$ cd deploy/examples/
$ kubectl apply -f crds.yaml -f common.yaml -f operator.yaml -f cluster-test.yaml  -f toolbox.yaml

3.Create CephObjectStore
---
# CephObjectStore definition
apiVersion: ceph.rook.io/v1
kind: CephObjectStore
metadata:
  name: my-store
  namespace: rook-ceph
spec:
  metadataPool:
    replicated:
      size: 1
  dataPool:
    replicated:
      size: 1
  preservePoolsOnDelete: true
  gateway:
    port: 80
    instances: 1
---

$ kubectl get CephObjectStore -n rook-ceph 
NAME       PHASE   ENDPOINT                                         SECUREENDPOINT   AGE
my-store   Ready   http://rook-ceph-rgw-my-store.rook-ceph.svc:80                    25s

4.Create CephObjectStoreUser with secret:

$ kubectl get CephObjectStoreUser -n rook-ceph 
NAME          PHASE   AGE
custom-user   Ready   27s

---
# Secret for CephObjectStoreUser credentials
apiVersion: v1
kind: Secret
metadata:
  name: custom-user-keys
  namespace: rook-ceph
  labels:
    ceph-user: "true"
data:
  accessKey: Y3VzdG9tYWNjZXNza2V5   # base64 for "customaccesskey"
  secretKey: Y3VzdG9tc2VjcmV0a2V5   # base64 for "customsecretkey"
---
# CephObjectStoreUser that references the secret and object store
apiVersion: ceph.rook.io/v1
kind: CephObjectStoreUser
metadata:
  name: custom-user
  namespace: rook-ceph
  labels:
    ceph-user: "true"
spec:
  store: my-store
  displayName: "user for external apps"
  capabilities:
    user: "*"
    bucket: "*"
  keys:
  - accessKeyRef:
      name: custom-user-keys
      key: accessKey
    secretKeyRef:
      name: custom-user-keys
      key: secretKey


5.Move rook operator to debug mode:
$ kubectl patch cm rook-ceph-operator-config -n rook-ceph --type merge -p '{"data":{"ROOK_LOG_LEVEL":"DEBUG"}}'
configmap/rook-ceph-operator-config patched

6.Delete the secret
$ kubectl -n rook-ceph delete secret custom-user-keys
secret "custom-user-keys" deleted

7.Delete the CephObjectStoreUser  [working]
$ kubectl -n rook-ceph delete cephobjectstoreuser custom-user 
cephobjectstoreuser.ceph.rook.io "custom-user" deleted

8.Check operator logs:

2025-06-22 06:42:37.829437 E | ceph-object-store-user-controller: failed to reconcile CephObjectStoreUser "rook-ceph/custom-user". failed to generate UserKeySpec for "custom-user": failed to get secret value: failed to get secret "rook-ceph/custom-user-keys": Secret "custom-user-keys" not found
2025-06-22 06:42:40.393004 I | ceph-spec: parsing mon endpoints: a=10.100.16.199:6789
2025-06-22 06:42:40.586479 E | ceph-object-store-user-controller: failed to reconcile failed to generate UserKeySpec for "custom-user": failed to get secret value: failed to get secret "rook-ceph/custom-user-keys": Secret "custom-user-keys" not found
2025-06-22 06:42:40.586496 E | ceph-object-store-user-controller: failed to reconcile CephObjectStoreUser "rook-ceph/custom-user". failed to generate UserKeySpec for "custom-user": failed to get secret value: failed to get secret "rook-ceph/custom-user-keys": Secret "custom-user-keys" not found
2025-06-22 06:42:43.095523 I | ceph-spec: parsing mon endpoints: a=10.100.16.199:6789
2025-06-22 06:42:43.418713 I | ceph-object-store-user-controller: ceph object user "custom-user" deleted successfully
2025-06-22 06:42:43.418755 I | ceph-spec: removing finalizer "cephobjectstoreuser.ceph.rook.io" on "custom-user"
2025-06-22 06:42:43.431939 I | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" matched on delete, reconciling

On DEBUG level:
2025-06-22 07:00:56.725986 E | ceph-object-store-user-controller: failed to reconcile failed to generate UserKeySpec for "custom-user": failed to get secret value: failed to get secret "rook-ceph/custom-user-keys": Secret "custom-user-keys" not found
2025-06-22 07:00:56.725995 E | ceph-object-store-user-controller: failed to reconcile CephObjectStoreUser "rook-ceph/custom-user". failed to generate UserKeySpec for "custom-user": failed to get secret value: failed to get secret "rook-ceph/custom-user-keys": Secret "custom-user-keys" not found
2025-06-22 07:01:07.229732 D | ceph-spec: update event for "CephObjectStoreUser": "rook-ceph/custom-user"
2025-06-22 07:01:07.230005 D | ceph-spec: resource "CephObjectStoreUser": "rook-ceph/custom-user" is going to be deleted
2025-06-22 07:01:07.230298 D | ceph-spec: "ceph-object-store-user-controller": CephCluster resource "my-cluster" found in namespace "rook-ceph"
2025-06-22 07:01:07.230344 D | ceph-spec: "ceph-object-store-user-controller": ceph status is "HEALTH_OK", operator is ready to run ceph command, reconciling
2025-06-22 07:01:07.231904 D | ceph-spec: found existing monitor secrets for cluster rook-ceph
2025-06-22 07:01:07.233605 I | ceph-spec: parsing mon endpoints: a=10.100.16.199:6789
2025-06-22 07:01:07.233637 D | ceph-spec: loaded: maxMonID=0, extMons=map[], mons=map[a:0xc000b86360], assignment=&{Schedule:map[a:0xc000b6e100]}
2025-06-22 07:01:07.233668 D | ceph-object-store-user-controller: found CephObjectStore "my-store" referenced by CephObjectStoreUser "rook-ceph/custom-user"
2025-06-22 07:01:07.233703 D | ceph-object-store-user-controller: CephObjectStore exists
2025-06-22 07:01:07.233781 D | ceph-object-store-user-controller: 1 RGW pods found where object store user "custom-user" is created
2025-06-22 07:01:07.233796 D | ceph-object-store-user-controller: found CephObjectStore "my-store" referenced by CephObjectStoreUser "rook-ceph/custom-user"
2025-06-22 07:01:07.233805 D | ceph-object-controller: creating s3 user object "rgw-admin-ops-user" for object store "my-store"
2025-06-22 07:01:07.233812 D | ceph-object-controller: creating s3 user "rgw-admin-ops-user"
2025-06-22 07:01:07.233819 D | exec: Running command: radosgw-admin user create --uid rgw-admin-ops-user --display-name RGW Admin Ops User --caps buckets=*;users=*;usage=read;metadata=read;zone=read --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-22 07:01:07.331116 D | ceph-object-controller: getting s3 user "rgw-admin-ops-user"
2025-06-22 07:01:07.331141 D | exec: Running command: radosgw-admin user info --uid rgw-admin-ops-user --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-22 07:01:07.423863 D | ceph-object-store-user-controller: deleting object store user "rook-ceph/custom-user"
2025-06-22 07:01:07.432367 I | ceph-object-store-user-controller: ceph object user "custom-user" deleted successfully
2025-06-22 07:01:07.432476 I | ceph-spec: removing finalizer "cephobjectstoreuser.ceph.rook.io" on "custom-user"
2025-06-22 07:01:07.438349 D | ceph-spec: delete event for "CephObjectStoreUser": "rook-ceph/custom-user"
2025-06-22 07:01:07.438513 D | ceph-object-store-user-controller: successfully configured CephObjectStoreUser "rook-ceph/custom-user"
2025-06-22 07:01:07.438566 D | ceph-object-store-user-controller: CephObjectStoreUser resource not found. Ignoring since object must be deleted.
2025-06-22 07:01:07.438572 D | ceph-object-store-user-controller: successfully configured CephObjectStoreUser "rook-ceph/custom-user"
2025-06-22 07:01:07.446094 D | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" did not match on delete
2025-06-22 07:01:07.446108 D | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" did not match on delete
2025-06-22 07:01:07.446216 I | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" matched on delete, reconciling
2025-06-22 07:01:07.446362 D | ceph-object-store-user-controller: CephObjectStoreUser resource not found. Ignoring since object must be deleted.
2025-06-22 07:01:07.446420 D | ceph-object-store-user-controller: successfully configured CephObjectStoreUser "rook-ceph/custom-user"
2025-06-22 07:01:07.446497 D | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" did not match on delete
2025-06-22 07:01:07.446543 D | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" did not match on delete
2025-06-22 07:01:07.446570 D | ceph-spec: object "rook-ceph-object-user-my-store-custom-user" did not match on delete

```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
