### PR TITLE
    build: merge helm indexes instead of recreating for every release

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -120,9 +120,14 @@ HELM_URL := $(HELM_BASE_URL)/$(HELM_CHANNEL)
 promote.helm: $(HELM)
 #	copy existing charts to a temp dir, then combine with new charts, reindex, and upload
 	$(S3_SYNC) s3://$(HELM_S3_BUCKET)/$(HELM_CHANNEL) $(HELM_TEMP)
+	# delete unnecessary files:
+	rm -fr $(HELM_TEMP)/*tgz
+	# rename current index to distinguish the previous file.
+	mv $(HELM_TEMP)/index.yaml $(HELM_TEMP)/previous_index.yaml
 	$(S3_SYNC) s3://$(S3_BUCKET)/build/$(BRANCH_NAME)/$(VERSION)/charts $(HELM_TEMP)
-	$(HELM) repo index --url $(HELM_URL) --merge $(HELM_TEMP)/index.yaml $(HELM_TEMP)
-	$(S3_SYNC_DEL) $(HELM_TEMP) s3://$(HELM_S3_BUCKET)/$(HELM_CHANNEL)
+	$(HELM) repo index --url $(HELM_URL) --merge $(HELM_TEMP)/previous_index.yaml $(HELM_TEMP)
+	rm -f $(HELM_TEMP)/previous_index.yaml
+	$(S3_SYNC) $(HELM_TEMP) s3://$(HELM_S3_BUCKET)/$(HELM_CHANNEL)
 	rm -fr $(HELM_TEMP)
 
 # set the helm cart version number.


### PR DESCRIPTION
**Description of Changes:** 

    A new helm repo index was created from scratch for every new release
    which meant that the release timestamps in the index were basically all
    identical.

    This change intends to fix that by merging the new index with the
    existing one

The first attempt to fix this (PR #16033) did not work properly. This change is intended to fix the issue for good by closing  the gap the previuous PR has left.

**Issue resolved by this Pull Request:**
Resolves #15604 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
