### PR TITLE
helm: support the six most recent helm versions

### DIFF
--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions: ["v1.28.15", "v1.33.0"]
+        helm-version: ["v3.13.3", "v3.18.3"]
+        kubernetes-versions: ["v1.33.0"]
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,7 +39,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
-          version: v3.18.2
+          version: ${{ matrix.helm-version }}
 
       - name: consider debugging
         uses: ./.github/workflows/tmate_debug

--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -13,7 +13,7 @@ This chart is a simple packaging of templates that will optionally create Rook r
 
 ## Prerequisites
 
-* Helm 3.x
+* Helm 3.13+
 * Install the [Rook Operator chart](operator-chart.md)
 
 ## Installing

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -16,7 +16,7 @@ This chart is a simple packaging of templates that will optionally create Rook r
 
 ## Prerequisites
 
-* Helm 3.x
+* Helm 3.13+
 * Install the [Rook Operator chart](operator-chart.md)
 
 ## Installing

--- a/Documentation/Helm-Charts/operator-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/operator-chart.gotmpl.md
@@ -11,7 +11,7 @@ This chart bootstraps a [rook-ceph-operator](https://github.com/rook/rook) deplo
 
 ## Prerequisites
 
-* Helm 3.x
+* Helm 3.13+
 
 See the [Helm support matrix](https://helm.sh/docs/topics/version_skew/) for more details.
 

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -14,7 +14,7 @@ This chart bootstraps a [rook-ceph-operator](https://github.com/rook/rook) deplo
 
 ## Prerequisites
 
-* Helm 3.x
+* Helm 3.13+
 
 See the [Helm support matrix](https://helm.sh/docs/topics/version_skew/) for more details.
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,3 +4,6 @@
 
 
 ## Features
+
+
+- Previously, only the latest version of helm was tested and the docs stated only version 3.x of helm as a prerequisite. Now rook supports the six most recent minor versions of helm along with their their patch updates. Explicitly, helm versions 3.13 and newer are supported.


### PR DESCRIPTION
**Description Of changes:**

So far, rook CI has only tested a specific version of helm (the latest one). And the documentation mentioned  version `3.x` only. 

This change lets the CI test the six most recent versions of helm and also
mention this level of support in the docs.



**Issue resolved by this Pull Request:**
Resolves #15980

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
