### PR TITLE
csi: Provide a flag to skip csi user creation

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -3120,6 +3120,19 @@ CSICephFSSpec
 <p>CephFS defines CSI Driver settings for CephFS driver.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>skipUserCreation</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SkipUserCreation determines whether CSI users and their associated secrets should be skipped.
+If set to true, the user must manually manage these secrets.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.Capacity">Capacity

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1560,6 +1560,11 @@ spec:
                           description: Enables read affinity for CSI driver.
                           type: boolean
                       type: object
+                    skipUserCreation:
+                      description: |-
+                        SkipUserCreation determines whether CSI users and their associated secrets should be skipped.
+                        If set to true, the user must manually manage these secrets.
+                      type: boolean
                   type: object
                 dashboard:
                   description: Dashboard settings

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1558,6 +1558,11 @@ spec:
                           description: Enables read affinity for CSI driver.
                           type: boolean
                       type: object
+                    skipUserCreation:
+                      description: |-
+                        SkipUserCreation determines whether CSI users and their associated secrets should be skipped.
+                        If set to true, the user must manually manage these secrets.
+                      type: boolean
                   type: object
                 dashboard:
                   description: Dashboard settings

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -255,6 +255,10 @@ type CSIDriverSpec struct {
 	// CephFS defines CSI Driver settings for CephFS driver.
 	// +optional
 	CephFS CSICephFSSpec `json:"cephfs,omitempty"`
+	// SkipUserCreation determines whether CSI users and their associated secrets should be skipped.
+	// If set to true, the user must manually manage these secrets.
+	// +optional
+	SkipUserCreation bool `json:"skipUserCreation,omitempty"`
 }
 
 // CSICephFSSpec defines the settings for CephFS CSI driver.

--- a/pkg/operator/ceph/csi/secrets_test.go
+++ b/pkg/operator/ceph/csi/secrets_test.go
@@ -17,9 +17,17 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"testing"
 
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestCephCSIKeyringRBDNodeCaps(t *testing.T) {
@@ -40,4 +48,79 @@ func TestCephCSIKeyringCephFSNodeCaps(t *testing.T) {
 func TestCephCSIKeyringCephFSProvisionerCaps(t *testing.T) {
 	caps := cephCSIKeyringCephFSProvisionerCaps()
 	assert.Equal(t, caps, []string{"mon", "allow r, allow command 'osd blocklist'", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*", "mds", "allow *"})
+}
+
+func Test_deleteOwnedCSISecretsByCephCluster(t *testing.T) {
+	const (
+		namespace   = "rook-ceph"
+		cephCluster = "my-ceph-cluster"
+	)
+
+	// Create fake client
+	clientset := k8sfake.NewSimpleClientset()
+
+	// Cluster context
+	clusterContext := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	clusterInfo := &client.ClusterInfo{
+		OwnerInfo: k8sutil.NewOwnerInfoWithOwnerRef(&metav1.OwnerReference{
+			APIVersion: "ceph.rook.io/v1",
+			Kind:       "CephCluster",
+			Name:       cephCluster,
+		}, namespace),
+	}
+	clusterInfo.Namespace = namespace
+	clusterInfo.SetName(cephCluster)
+
+	ctx := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	k := keyring.GetSecretStore(ctx, clusterInfo, clusterInfo.OwnerInfo)
+
+	// create csi secrets
+	err := createOrUpdateCSISecret(clusterInfo, "", "", "", "", k)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Remove ownerRef from the CsiCephFSNodeSecret to ensure it won't get deleted
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), CsiCephFSProvisionerSecret, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	secret.OwnerReferences = nil
+	secret.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: "ceph.rook.io/v1",
+			Kind:       "CephClient",
+			Name:       "test-client",
+		},
+	})
+	_, err = clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = deleteOwnedCSISecretsByCephCluster(clusterContext, clusterInfo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify owned secret is deleted
+	secrets := []string{CsiRBDNodeSecret, CsiRBDProvisionerSecret, CsiCephFSNodeSecret}
+	for _, secretName := range secrets {
+		_, err = clientset.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err == nil {
+			t.Errorf("expected owned secret %q to be deleted", secretName)
+		}
+	}
+	// Verify unowned secret still exists
+	_, err = clientset.CoreV1().Secrets(namespace).Get(context.TODO(), CsiCephFSProvisionerSecret, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		t.Errorf("expected unowned secret %q to still exist", CsiCephFSProvisionerSecret)
+	}
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Added a flag in cephcluster CR CSI section whether the user wants the Rook to manage the csi users and secrets or create them on own.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
