### PR TITLE
object: mark realm as default to avoid zone creation

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-realm-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-realm-crd.md
@@ -30,3 +30,4 @@ spec:
 
 * `pull`: This optional section is for the pulling the realm for another ceph cluster.
     * `endpoint`: The endpoint in the realm from another ceph cluster you want to pull from. This endpoint must be in the master zone of the master zone group of the realm.
+* `defaultRealm`: When set to true, Rook will mark the CephObjectStore's realm as the default realm in the Ceph cluster. Only one realm can be marked default. Ceph does not allow default to be unassigned after it is assigned; a different realm can be marked default instead.

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -96,6 +96,10 @@ When the `zone` section is set pools with the object stores name will not be cre
     This is useful for applications that need object store credentials to be created in their own namespace,
     where neither OBCs nor COSI is being used to create buckets. The default is empty.
 
+### Realm
+
+* `defaultRealm`: When set to true, Rook will mark the CephObjectStore's realm as the default realm in the Ceph cluster. Only one realm can be marked default. Ceph does not allow default to be unassigned after it is assigned; a different realm can be marked default instead.
+
 ## Auth Settings
 
 The `auth`-section allows the configuration of authentication providers in addition to the regular authentication mechanism.
@@ -399,7 +403,7 @@ spec:
       rgw_s3_auth_use_ldap: "true" # bool
     rgwConfigFromSecret:
       rgw_keystone_barbican_password: # name of rgw option with secret value
-        name: "barbican-secret" # name of K8s secret 
+        name: "barbican-secret" # name of K8s secret
         key: "password" # key of secret value in K8s secret.Data map[string]string
     rgwCommandFlags:
       rgw_dmclock_auth_res: "100.0" # float
@@ -478,7 +482,7 @@ The sample configuration below demonstrates how to securely handle secret config
     rgwConfig:
       rgw_barbican_url: "http://barbican.example.com:9311"
       rgw_keystone_barbican_domain: "domain"
-      rgw_keystone_barbican_project: "project" 
+      rgw_keystone_barbican_project: "project"
       rgw_keystone_barbican_user: "user"
     rgwConfigFromSecret:
       rgw_keystone_barbican_password:

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1780,6 +1780,18 @@ PullSpec
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>defaultRealm</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set this realm as the default in Ceph. Only one realm should be default.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2024,6 +2036,21 @@ ObjectStoreHostingSpec
 <p>Hosting settings for the object store.
 A common use case for hosting configuration is to inform Rook of endpoints that support DNS
 wildcards, which in turn allows virtual host-style bucket addressing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>defaultRealm</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set this realm as the default in Ceph. Only one realm should be default.
+Do not set this true on more than one CephObjectStore.
+This may not be set when zone is also specified; in this case, the realm
+referenced by the zone&rsquo;s zonegroup should configure defaulting behavior.</p>
 </td>
 </tr>
 </table>
@@ -10718,6 +10745,18 @@ PullSpec
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>defaultRealm</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set this realm as the default in Ceph. Only one realm should be default.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ObjectSharedPoolsSpec">ObjectSharedPoolsSpec
@@ -11089,6 +11128,21 @@ ObjectStoreHostingSpec
 <p>Hosting settings for the object store.
 A common use case for hosting configuration is to inform Rook of endpoints that support DNS
 wildcards, which in turn allows virtual host-style bucket addressing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>defaultRealm</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set this realm as the default in Ceph. Only one realm should be default.
+Do not set this true on more than one CephObjectStore.
+This may not be set when zone is also specified; in this case, the realm
+referenced by the zone&rsquo;s zonegroup should configure defaulting behavior.</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11256,6 +11256,9 @@ spec:
               description: ObjectRealmSpec represent the spec of an ObjectRealm
               nullable: true
               properties:
+                defaultRealm:
+                  description: Set this realm as the default in Ceph. Only one realm should be default.
+                  type: boolean
                 pull:
                   description: PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm
                   properties:
@@ -11591,6 +11594,13 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                defaultRealm:
+                  description: |-
+                    Set this realm as the default in Ceph. Only one realm should be default.
+                    Do not set this true on more than one CephObjectStore.
+                    This may not be set when zone is also specified; in this case, the realm
+                    referenced by the zone's zonegroup should configure defaulting behavior.
+                  type: boolean
                 gateway:
                   description: The rgw pod info
                   nullable: true
@@ -13396,6 +13406,9 @@ spec:
                     - name
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: defaultRealm must not be true when zone.name is set (multisite configuration)
+                  rule: '!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)'
             status:
               description: ObjectStoreStatus represents the status of a Ceph Object Store resource
               properties:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11248,6 +11248,9 @@ spec:
               description: ObjectRealmSpec represent the spec of an ObjectRealm
               nullable: true
               properties:
+                defaultRealm:
+                  description: Set this realm as the default in Ceph. Only one realm should be default.
+                  type: boolean
                 pull:
                   description: PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm
                   properties:
@@ -11582,6 +11585,13 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                defaultRealm:
+                  description: |-
+                    Set this realm as the default in Ceph. Only one realm should be default.
+                    Do not set this true on more than one CephObjectStore.
+                    This may not be set when zone is also specified; in this case, the realm
+                    referenced by the zone's zonegroup should configure defaulting behavior.
+                  type: boolean
                 gateway:
                   description: The rgw pod info
                   nullable: true
@@ -13387,6 +13397,9 @@ spec:
                     - name
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: defaultRealm must not be true when zone.name is set (multisite configuration)
+                  rule: '!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)'
             status:
               description: ObjectStoreStatus represents the status of a Ceph Object Store resource
               properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1653,6 +1653,7 @@ type CephObjectStoreList struct {
 }
 
 // ObjectStoreSpec represent the spec of a pool
+// +kubebuilder:validation:XValidation:rule="!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)",message="defaultRealm must not be true when zone.name is set (multisite configuration)"
 type ObjectStoreSpec struct {
 	// The metadata pool settings
 	// +optional
@@ -1716,6 +1717,13 @@ type ObjectStoreSpec struct {
 	// +nullable
 	// +optional
 	Hosting *ObjectStoreHostingSpec `json:"hosting,omitempty"`
+
+	// Set this realm as the default in Ceph. Only one realm should be default.
+	// Do not set this true on more than one CephObjectStore.
+	// This may not be set when zone is also specified; in this case, the realm
+	// referenced by the zone's zonegroup should configure defaulting behavior.
+	// +optional
+	DefaultRealm bool `json:"defaultRealm,omitempty"`
 }
 
 // ObjectSharedPoolsSpec represents object store pool info when configuring RADOS namespaces in existing pools.
@@ -2340,6 +2348,10 @@ type CephObjectRealmList struct {
 // ObjectRealmSpec represent the spec of an ObjectRealm
 type ObjectRealmSpec struct {
 	Pull PullSpec `json:"pull,omitempty"`
+
+	// Set this realm as the default in Ceph. Only one realm should be default.
+	// +optional
+	DefaultRealm bool `json:"defaultRealm,omitempty"`
 }
 
 // PullSpec represents the pulling specification of a Ceph Object Storage Gateway Realm

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -629,6 +629,12 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 		if err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed to create object store %q", cephObjectStore.Name)
 		}
+		if cephObjectStore.Spec.DefaultRealm {
+			logger.Debugf("marking realm %q as default for object store %q", realmName, cephObjectStore.Name)
+			if err := SetDefaultRealm(objContext, realmName); err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to set realm %q as default", realmName)
+			}
+		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -1057,6 +1057,7 @@ func getreturnErrString() []string {
 func Test_createMultisiteConfigurations(t *testing.T) {
 	executor := getExecutor()
 	returnErrString := getreturnErrString()
+	store := &cephv1.CephObjectStore{}
 	for i := 0; i < 4; i++ {
 		ctx := &clusterd.Context{
 			Executor: executor[i],
@@ -1064,7 +1065,7 @@ func Test_createMultisiteConfigurations(t *testing.T) {
 		objContext := NewContext(ctx, &client.ClusterInfo{Namespace: "my-cluster"}, "my-store")
 		realmArg := fmt.Sprintf("--rgw-realm=%s", objContext.Realm)
 
-		err := createMultisiteConfigurations(objContext, "realm", realmArg, "create")
+		err := createMultisiteConfigurations(objContext, store, "realm", realmArg, "create")
 		if i == 0 {
 			assert.NoError(t, err)
 		} else {

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -210,6 +210,15 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
+	// Set the realm as default if specified and supported
+	if cephObjectRealm.Spec.DefaultRealm {
+		objCtx := object.NewContext(r.context, r.clusterInfo, cephObjectRealm.Namespace)
+		if err := object.SetDefaultRealm(objCtx, cephObjectRealm.Name); err != nil {
+			return reconcile.Result{}, *cephObjectRealm, errors.Wrapf(err,
+				"failed to set realm %q as default", cephObjectRealm.Name)
+		}
+	}
+
 	// update ObservedGeneration in status at the end of reconcile
 	// Set Ready status, we are done reconciling
 	r.updateStatus(observedGeneration, request.NamespacedName, k8sutil.ReadyStatus)


### PR DESCRIPTION
add defaultRealm field to cephobjectstore to allow rook to mark the created realm as default. this prevents ceph from auto-creating a "default" zonegroup and zone when the default is not explicitly set. affects only non-multisite setups.

Fixes: #15984

Tested locally on my machine:
```
1.Create a simple object store named my-store:
apiVersion: ceph.rook.io/v1
kind: CephObjectStore
metadata:
  name: my-store
  namespace: rook-ceph
spec:
  defaultRealm: true
  metadataPool:
    replicated:
      size: 1
  dataPool:
    replicated:
      size: 1
  gateway:
    port: 80
    instances: 1

2.  Wait until the RGW pod is running
$ oc -n rook-ceph get pods -l rook_object_store=my-store 
NAME                                       READY   STATUS    RESTARTS   AGE
rook-ceph-rgw-my-store-a-f4c675596-mlttz   0/1     Running   0          4s

3. check if we have a default realm set at this point. [yes]
oviner~/test$ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
bash-5.1$ radosgw-admin realm list
{
    "default_info": "9388d675-2636-4ad4-8e5b-cd508c8acea2",
    "realms": [
        "my-store"
    ]
}
bash-5.1$ radosgw-admin zonegroup list
{
    "default_info": "b49578ed-7363-4e73-be40-0eb7153f1c4a",
    "zonegroups": [
        "my-store"
    ]
}
bash-5.1$ radosgw-admin zone list
{
    "default_info": "af4fd1fb-faac-49e0-8f99-b9ba259a4833",
    "zones": [
        "my-store"
    ]
}
bash-5.1$ radosgw-admin bucket stats
[]
bash-5.1$ radosgw-admin bucket stats
[]
bash-5.1$ radosgw-admin realm list
{
    "default_info": "9388d675-2636-4ad4-8e5b-cd508c8acea2",
    "realms": [
        "my-store"
    ]
}
bash-5.1$ radosgw-admin zonegroup list
{
    "default_info": "b49578ed-7363-4e73-be40-0eb7153f1c4a",
    "zonegroups": [
        "my-store"
    ]
}
bash-5.1$ radosgw-admin zone list
{
    "default_info": "af4fd1fb-faac-49e0-8f99-b9ba259a4833",
    "zones": [
        "my-store"
    ]
}

4. Check rook-ceph operator logs:
2025-06-28 10:40:09.988758 I | ceph-object-controller: configuring object store "my-store"
2025-06-28 10:40:09.988778 D | ceph-object-controller: setting multisite configuration for object-store my-store
2025-06-28 10:40:09.988787 D | ceph-object-controller: creating realm, zone group, zone for object-store my-store
2025-06-28 10:40:09.988799 D | exec: Running command: radosgw-admin realm get --rgw-realm=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.054649 I | ceph-object-controller: marking object store "my-store" as default realm
2025-06-28 10:40:10.054666 D | exec: Running command: radosgw-admin realm create --rgw-realm=my-store --default --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.113637 D | ceph-object-controller: created "realm" "--rgw-realm=my-store"
2025-06-28 10:40:10.113660 D | exec: Running command: radosgw-admin zonegroup get --rgw-zonegroup=my-store --rgw-realm=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.156775 I | ceph-object-controller: marking object store "my-store" as default realm
2025-06-28 10:40:10.156792 D | exec: Running command: radosgw-admin zonegroup create --master --rgw-realm=my-store --endpoints=http://rook-ceph-rgw-my-store.rook-ceph.svc:80 --rgw-zonegroup=my-store --default --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.209869 D | ceph-object-controller: created "zonegroup" "--rgw-zonegroup=my-store"
2025-06-28 10:40:10.209892 D | exec: Running command: radosgw-admin zone get --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.253442 I | ceph-object-controller: marking object store "my-store" as default realm
2025-06-28 10:40:10.253461 D | exec: Running command: radosgw-admin zone create --master --endpoints=http://rook-ceph-rgw-my-store.rook-ceph.svc:80 --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --default --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.310293 D | ceph-object-controller: created "zone" "--rgw-zone=my-store"
2025-06-28 10:40:10.310308 I | ceph-object-controller: Object store "my-store": realm=my-store, zonegroup=my-store, zone=my-store
2025-06-28 10:40:10.310312 D | ceph-object-controller: no shared pools to configure for store "rook-ceph/my-store"
2025-06-28 10:40:10.310320 D | exec: Running command: radosgw-admin period get --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.384908 D | exec: Running command: radosgw-admin period update --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.439973 D | ceph-object-controller: RGW config period diff:
map[string]any{
  	... // 2 ignored entries
- 	"master_zone":      string(""),
+ 	"master_zone":      string("af4fd1fb-faac-49e0-8f99-b9ba259a4833"),
- 	"master_zonegroup": string(""),
+ 	"master_zonegroup": string("b49578ed-7363-4e73-be40-0eb7153f1c4a"),
  	"period_config":    map[string]any{"anonymous_ratelimit": map[string]any{"enabled": bool(false), "max_read_bytes": float64(0), "max_read_ops": float64(0), "max_write_bytes": float64(0), ...}, "bucket_quota": map[string]any{"check_on_raw": bool(false), "enabled": bool(false), "max_objects": float64(-1), "max_size": float64(-1), ...}, "bucket_ratelimit": map[string]any{"enabled": bool(false), "max_read_bytes": float64(0), "max_read_ops": float64(0), "max_write_bytes": float64(0), ...}, "user_quota": map[string]any{"check_on_raw": bool(false), "enabled": bool(false), "max_objects": float64(-1), "max_size": float64(-1), ...}, ...},
  	"period_map": map[string]any{
  		"id":             string("32d6f23c-ca1c-4623-bff3-99003c869dd0"),
- 		"short_zone_ids": []any{},
+ 		"short_zone_ids": []any{
+ 			map[string]any{
+ 				"key": string("af4fd1fb-faac-49e0-8f99-b9ba259a4833"),
+ 				"val": float64(1.034084817e+09),
+ 			},
+ 		},
- 		"zonegroups": []any{},
+ 		"zonegroups": []any{
+ 			map[string]any{
+ 				"api_name":            string("my-store"),
+ 				"default_placement":   string("default-placement"),
+ 				"enabled_features":    []any{string("notification_v2"), string("resharding")},
+ 				"endpoints":           []any{string("http://rook-ceph-rgw-my-store.rook-ceph.svc:80")},
+ 				"hostnames":           []any{},
+ 				"hostnames_s3website": []any{},
+ 				"id":                  string("b49578ed-7363-4e73-be40-0eb7153f1c4a"),
+ 				"is_master":           bool(true),
+ 				"master_zone":         string("af4fd1fb-faac-49e0-8f99-b9ba259a4833"),
+ 				"name":                string("my-store"),
+ 				"placement_targets": []any{
+ 					map[string]any{
+ 						"name":            string("default-placement"),
+ 						"storage_classes": []any{...},
+ 						"tags":            []any{},
+ 					},
+ 				},
+ 				"realm_id":    string("9388d675-2636-4ad4-8e5b-cd508c8acea2"),
+ 				"sync_policy": map[string]any{"groups": []any{}},
+ 				"zones": []any{
+ 					map[string]any{
+ 						"bucket_index_max_shards": float64(11),
+ 						"endpoints":               []any{...},
+ 						"id":                      string("af4fd1fb-faac-49e0-8f99-b9ba259a"...),
+ 						"log_data":                bool(false),
+ 						...
+ 					},
+ 				},
+ 			},
+ 		},
  	},
  	... // 2 ignored and 2 identical entries
  }
2025-06-28 10:40:10.439988 I | ceph-object-controller: committing changes to RGW configuration period for CephObjectStore "rook-ceph/my-store"
2025-06-28 10:40:10.439994 D | exec: Running command: radosgw-admin period update --commit --rgw-realm=my-store --rgw-zonegroup=my-store --rgw-zone=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --name=client.admin --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2025-06-28 10:40:10.559781 I | ceph-object-controller: configuration for object-store my-store is complete
2025-06-28 10:40:10.559795 I | ceph-object-controller: creating object store "my-store" in namespace "rook-ceph"
2025-06-28 10:40:10.561666 I | cephclient: getting or creating ceph auth key "client.rgw.my.store.a"
```

Tested locally:
```
Tested loaclly CephObjectRealm with defaultRealm:
#################################################################################################################
# Create an object store with settings for a test environment. Only a single OSD is required in this example.
#  kubectl create -f object-multisite-test.yaml
#################################################################################################################
apiVersion: ceph.rook.io/v1
kind: CephObjectRealm
metadata:
  name: realm-a
  namespace: rook-ceph # namespace:cluster
spec:
  defaultRealm: true
---
apiVersion: ceph.rook.io/v1
kind: CephObjectZoneGroup
metadata:
  name: zonegroup-a
  namespace: rook-ceph # namespace:cluster
spec:
  realm: realm-a
---
apiVersion: ceph.rook.io/v1
kind: CephObjectZone
metadata:
  name: zone-a
  namespace: rook-ceph # namespace:cluster
spec:
  zoneGroup: zonegroup-a
  metadataPool:
    failureDomain: host
    replicated:
      size: 1
      requireSafeReplicaSize: false
  dataPool:
    failureDomain: host
    replicated:
      size: 1
      requireSafeReplicaSize: false
    parameters:
      compression_mode: none
  # recommended to set this value if ingress used for exposing rgw endpoints
  # customEndpoints:
  #   - "http://rgw-a.fqdn"
  # if the pools need to be removed from backend enable following setting
  # preservePoolsOnDelete: false
---
apiVersion: ceph.rook.io/v1
kind: CephObjectStore
metadata:
  name: multisite-store
  namespace: rook-ceph # namespace:cluster
spec:
  gateway:
    port: 80
    # securePort: 443
    instances: 1
  zone:
    name: zone-a


$ kubectl create -f /home/oviner/go/src/github.com/rook/rook/deploy/examples/object-multisite-test.yaml
cephobjectrealm.ceph.rook.io/realm-a created
cephobjectzonegroup.ceph.rook.io/zonegroup-a created
cephobjectzone.ceph.rook.io/zone-a created
cephobjectstore.ceph.rook.io/multisite-store created

$ kubectl get -n rook-ceph cephobjectstore.ceph.rook.io/multisite-store
NAME              PHASE   ENDPOINT                                                SECUREENDPOINT   AGE
multisite-store   Ready   http://rook-ceph-rgw-multisite-store.rook-ceph.svc:80                    76s

$ kubectl get -n rook-ceph cephobjectzonegroup.ceph.rook.io/zonegroup-a
NAME          PHASE   AGE
zonegroup-a   Ready   2m51s

$ kubectl get -n rook-ceph cephobjectzone.ceph.rook.io/zone-a
NAME     PHASE   AGE
zone-a   Ready   3m13s

$ kubectl get -n rook-ceph cephobjectstore.ceph.rook.io/multisite-store
NAME              PHASE   ENDPOINT                                                SECUREENDPOINT   AGE
multisite-store   Ready   http://rook-ceph-rgw-multisite-store.rook-ceph.svc:80                    3m23s

$ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
bash-5.1$ radosgw-admin realm list
{
    "default_info": "2e70137f-8b55-4940-9199-a6b01b437c07",
    "realms": [
        "realm-a"
    ]
}
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
