### PR TITLE
core: option to override the ceph user name in cephClient CR

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -214,7 +214,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 
 	// DELETE: the CR was deleted
 	if !cephClient.GetDeletionTimestamp().IsZero() {
-		logger.Debugf("deleting pool %q", cephClient.Name)
+		logger.Debugf("deleting client %q", cephClient.Name)
 		err := r.deleteClient(cephClient)
 		if err != nil {
 			return reconcile.Result{}, *cephClient, errors.Wrapf(err, "failed to delete ceph client %q", cephClient.Name)
@@ -284,7 +284,8 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 
 // Create the client
 func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient, shouldRotateCephxKeys bool) error {
-	logger.Infof("creating client %s in namespace %s", cephClient.Name, cephClient.Namespace)
+	clientName := getClientName(cephClient)
+	logger.Infof("creating client %s in namespace %s", clientName, cephClient.Namespace)
 
 	// Generate the CephX details
 	clientEntity, caps := genClientEntity(cephClient)
@@ -294,12 +295,12 @@ func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient
 	if err != nil {
 		key, err = cephclient.AuthGetOrCreateKey(r.context, r.clusterInfo, clientEntity, caps)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create client %q", cephClient.Name)
+			return errors.Wrapf(err, "failed to create client %q", clientName)
 		}
 	} else {
 		err = cephclient.AuthUpdateCaps(r.context, r.clusterInfo, clientEntity, caps)
 		if err != nil {
-			return errors.Wrapf(err, "client %q exists, failed to update client caps", cephClient.Name)
+			return errors.Wrapf(err, "client %q exists, failed to update client caps", clientName)
 		}
 	}
 
@@ -324,7 +325,7 @@ func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient
 			},
 		},
 		StringData: map[string]string{
-			cephClient.Name: key,
+			clientName: key,
 			// CSI requires userID and userKey in secret
 			"userID":  cephClient.Name,
 			"userKey": key,
@@ -374,20 +375,24 @@ func (r *ReconcileCephClient) reconcileCephClientSecret(
 
 // Delete the client
 func (r *ReconcileCephClient) deleteClient(cephClient *cephv1.CephClient) error {
-	logger.Infof("deleting client object %q", cephClient.Name)
-	if err := cephclient.AuthDelete(r.context, r.clusterInfo, generateClientName(cephClient.Name)); err != nil {
-		return errors.Wrapf(err, "failed to delete client %q", cephClient.Name)
+	clientName := getClientName(cephClient)
+	logger.Infof("deleting client object %q", clientName)
+
+	if err := cephclient.AuthDelete(r.context, r.clusterInfo, generateClientName(clientName)); err != nil {
+		return errors.Wrapf(err, "failed to delete client %q", clientName)
 	}
 
-	logger.Infof("deleted client %q", cephClient.Name)
+	logger.Infof("deleted client %q", clientName)
 	return nil
 }
 
 // ValidateClient the client arguments
 func ValidateClient(context *clusterd.Context, cephClient *cephv1.CephClient) error {
-	reservedNames := regexp.MustCompile("^admin$|^rgw.*$|^rbd-mirror$|^osd.[0-9]*$|^bootstrap-(mds|mgr|mon|osd|rgw|^rbd-mirror)$")
-	if reservedNames.Match([]byte(cephClient.Name)) {
-		return errors.Errorf("ignoring reserved name %q", cephClient.Name)
+	reservedNames := regexp.MustCompile("^admin$|^rgw.*$|^rbd-mirror$|^osd.[0-9]*$|^bootstrap-(mds|mgr|mon|osd|rgw|rbd-mirror)$|^rbd-mirror-peer$")
+	clientName := getClientName(cephClient)
+	// validate the Client name
+	if reservedNames.Match([]byte(clientName)) {
+		return errors.Errorf("ignoring reserved name %q", clientName)
 	}
 
 	// Validate Spec
@@ -409,7 +414,15 @@ func genClientEntity(cephClient *cephv1.CephClient) (string, []string) {
 		caps = append(caps, name, cap)
 	}
 
-	return generateClientName(cephClient.Name), caps
+	return generateClientName(getClientName(cephClient)), caps
+}
+
+func getClientName(cephClient *cephv1.CephClient) string {
+	name := cephClient.Name
+	if cephClient.Spec.Name != "" {
+		name = cephClient.Spec.Name
+	}
+	return name
 }
 
 func generateClientName(name string) string {

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -385,10 +385,6 @@ func (r *ReconcileCephClient) deleteClient(cephClient *cephv1.CephClient) error 
 
 // ValidateClient the client arguments
 func ValidateClient(context *clusterd.Context, cephClient *cephv1.CephClient) error {
-	// Validate name
-	if cephClient.Name == "" {
-		return errors.New("missing name")
-	}
 	reservedNames := regexp.MustCompile("^admin$|^rgw.*$|^rbd-mirror$|^osd.[0-9]*$|^bootstrap-(mds|mgr|mon|osd|rgw|^rbd-mirror)$")
 	if reservedNames.Match([]byte(cephClient.Name)) {
 		return errors.Errorf("ignoring reserved name %q", cephClient.Name)

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -62,16 +62,6 @@ func TestValidateClient(t *testing.T) {
 	err := ValidateClient(context, &p)
 	assert.NotNil(t, err)
 
-	// must specify name
-	p = cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Namespace: "myns"}}
-	err = ValidateClient(context, &p)
-	assert.NotNil(t, err)
-
-	// must specify namespace
-	p = cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Name: "client1"}}
-	err = ValidateClient(context, &p)
-	assert.NotNil(t, err)
-
 	// succeed with caps properly defined
 	p = cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Name: "client1", Namespace: "myns"}}
 	p.Spec.Caps = map[string]string{

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -104,6 +104,22 @@ func TestGenerateClient(t *testing.T) {
 
 	client, _ = genClientEntity(p2)
 	assert.Equal(t, []byte(client), []byte("client.client2"))
+
+	// test client name override
+	p = &cephv1.CephClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client1", Namespace: "myns"},
+		Spec: cephv1.ClientSpec{
+			Name: "client-override",
+			Caps: map[string]string{
+				"osd": "allow *",
+				"mon": "allow rw",
+				"mds": "allow rwx",
+			},
+		},
+	}
+
+	client, _ = genClientEntity(p)
+	assert.Equal(t, []byte(client), []byte("client.client-override"))
 }
 
 func TestCephClientController(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

This is a missing functionlity in Rook to user override names for the ceph user, The kubernetes CR validation and the ceph user name validations are completely different. There are possibilities to create ceph user for example with name `my_user` this is a valid ceph user name but this name is not allowed in the kubernetes CR names. Implementing a feature to allow the option to override the client user names in the ceph client CR. 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
