### PR TITLE
docs: have a StorageClass consume SubVolumeGroup

### DIFF
--- a/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
@@ -64,3 +64,21 @@ If any setting is unspecified, a suitable default will be used automatically.
 !!! note
     Only one out of (export, distributed, random) can be set at a time.
     By default pinning is set with value: `distributed=1`.
+
+## Create a storage class for the subvolume group
+
+* Create a CephFilesystem CR 
+* Create a CephFilesystemSubvolumegroup CR 
+* Extract the `clusterID` from the status of the CephFilesystemSubvolumegroup CR:
+
+    ```bash
+    kubectl -n rook-ceph get cephfilesystemsubvolumegroup <name> -o jsonpath="{.status.info.clusterID}"
+    ```
+    
+    ```yaml
+    status:
+        info:
+            clusterID: 80fc4f4bacc064be641633e6ed25ba7e
+    ```
+
+* Set the `clusterID` in the `StorageClass`, `VolumeSnapshotClass`, and `VolumeGroupSnapshotClass` to this value instead of the name of the cluster namespace


### PR DESCRIPTION
Adds guide for how to create a `StorageClass` that consumes a `SubVolumeGroup`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #14355 


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
