### PR TITLE
osd: treat non existing OSD nodes as drained

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -490,6 +490,9 @@ func (r *ReconcileClusterDisruption) getOSDFailureDomains(clusterInfo *cephclien
 // hasOSDNodeDrained returns true if OSD pod is not assigned to any node or if the OSD node is not schedulable
 func hasOSDNodeDrained(ctx context.Context, c client.Client, osdNodeName string) (bool, error) {
 	node, err := getNode(ctx, c, osdNodeName)
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get node %q", osdNodeName)
 	}


### PR DESCRIPTION
If the node for an OSD does not exist within kubernetes, the PDB reconciliation logic will fail to make progress. This can be problematic as new OSDs added to the cluster may not be protected by OSD PDBs after they are added since the PDB reconcilation logic is failing.

The solution is to treat non existing OSD nodes as drained which is logically consistent with treating unschedulable OSD nodes as drained as you cannot schedule a pod onto a node which does not exist.

Fixes: #16086

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
