### PR TITLE
core: correct return order for CurrentAndDesiredCephVersion

### DIFF
--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -125,7 +125,7 @@ func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, job
 		return nil, nil, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
 	}
 
-	return desiredCephVersion, &runningMonDaemonVersion, nil
+	return &runningMonDaemonVersion, desiredCephVersion, nil
 }
 
 func ErrorCephUpgradingRequeue(runningCephVersion, desiredCephVersion *cephver.CephVersion) error {


### PR DESCRIPTION
Currently CurrentAndDesiredCephVersion() returns
desired and running version, but all function
calls use the opposite return order.

Update the function to return the order as used by callers.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
