### PR TITLE
rbdmirror: with multus gen file on remote container

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -39,6 +39,7 @@ const (
 	CephTool = "ceph"
 	// RBDTool is the name of the CLI tool for 'rbd'
 	RBDTool = "rbd"
+	Tool    = "tool"
 	// RadosTool is the name of the CLI tool for 'rados'
 	RadosTool = "rados"
 	// Kubectl is the name of the CLI tool for 'kubectl'
@@ -168,6 +169,18 @@ func NewGaneshaRadosGraceCommand(context *clusterd.Context, clusterInfo *Cluster
 	return cmd
 }
 
+func NewCommand(context *clusterd.Context, clusterInfo *ClusterInfo, args []string) *CephToolCommand {
+	cmd := newCephToolCommand(Tool, context, clusterInfo, args)
+	cmd.JsonOutput = false
+
+	// When Multus is enabled, the rados tool should run inside the proxy container
+	if clusterInfo.NetworkSpec.IsMultus() {
+		cmd.RemoteExecution = true
+	}
+
+	return cmd
+}
+
 func (c *CephToolCommand) run() ([]byte, error) {
 	// Return if the context has been canceled
 	if c.clusterInfo.Context.Err() != nil {
@@ -197,6 +210,8 @@ func (c *CephToolCommand) run() ([]byte, error) {
 		switch c.tool {
 		case RBDTool, RadosTool, GaneshaRadosGraceTool:
 			// do not add format option
+		case Tool:
+			// do nothing
 		default:
 			args = append(args, "--format", "plain")
 		}
@@ -207,9 +222,13 @@ func (c *CephToolCommand) run() ([]byte, error) {
 
 	// NewRBDCommand does not use the --out-file option so we only check for remote execution here
 	// Still forcing the check for the command if the behavior changes in the future
-	if command == RBDTool || command == RadosTool || command == GaneshaRadosGraceTool {
+	if command == RBDTool || command == RadosTool || command == GaneshaRadosGraceTool || command == Tool {
 		if c.RemoteExecution {
-			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
+			if command == Tool {
+				output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeoutTool(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, args...)
+			} else {
+				output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(c.clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
+			}
 			if err != nil {
 				err = errors.Errorf("%s", err.Error())
 			}

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -85,15 +86,27 @@ func ImportRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 		return err
 	}() //nolint // we don't want to return here
 
+	content, err := ioutil.ReadFile(tokenFilePath.Name())
+	if err != nil {
+		return fmt.Errorf("failed to read local file: %w", err)
+	}
+
+	command := fmt.Sprintf("echo '%s' > %s", string(content), tokenFilePath.Name())
+	copyargs := []string{command}
+	cmd := NewCommand(context, clusterInfo, copyargs)
+	output, err := cmd.RunWithTimeout(exec.CephCommandsTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to add rbd-mirror peer token for pool %q. %s", poolName, output)
+	}
+
 	// Build command
 	args := []string{"mirror", "pool", "peer", "bootstrap", "import", poolName, tokenFilePath.Name()}
 	if direction != "" {
 		args = append(args, "--direction", direction)
 	}
-	cmd := NewRBDCommand(context, clusterInfo, args)
-
+	cmd = NewRBDCommand(context, clusterInfo, args)
 	// Run command
-	output, err := cmd.RunWithTimeout(exec.CephCommandsTimeout)
+	output, err = cmd.RunWithTimeout(exec.CephCommandsTimeout)
 	if err != nil {
 		return errors.Wrapf(err, "failed to add rbd-mirror peer token for pool %q. %s", poolName, output)
 	}

--- a/pkg/util/exec/exec_pod.go
+++ b/pkg/util/exec/exec_pod.go
@@ -133,3 +133,7 @@ func execute(ctx context.Context, method string, url *url.URL, config *rest.Conf
 func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeout(ctx context.Context, appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
 	return e.ExecCommandInContainerWithFullOutput(ctx, appLabel, containerName, namespace, append([]string{"timeout", strconv.Itoa(int(CephCommandsTimeout.Seconds()))}, cmd...)...)
 }
+
+func (e *RemotePodCommandExecutor) ExecCommandInContainerWithFullOutputWithTimeoutTool(ctx context.Context, appLabel, containerName, namespace string, cmd ...string) (string, string, error) {
+	return e.ExecCommandInContainerWithFullOutput(ctx, appLabel, containerName, namespace, append([]string{"sh", "-c"}, cmd...)...)
+}


### PR DESCRIPTION
In case of RDR with multus, the file which contains peer connection details need to generated on mgr proxy remote since rbd commands in multus, commands are run via mgr proxy container and not the rook operator pod.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
