### PR TITLE
operator: add missing udev env to discover pod

### DIFF
--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	discoverDaemonUdev = "DISCOVER_DAEMON_UDEV_BLACKLIST"
+	DiscoverDaemonUdev = "DISCOVER_DAEMON_UDEV_BLACKLIST"
 )
 
 var (
@@ -200,7 +200,7 @@ func udevBlockMonitor(c chan struct{}, period time.Duration) {
 	// get discoverDaemonUdevBlacklist from the environment variable
 	// if user doesn't provide any regex; generate the default regex
 	// else use the regex provided by user
-	discoverUdev := os.Getenv(discoverDaemonUdev)
+	discoverUdev := os.Getenv(DiscoverDaemonUdev)
 	if discoverUdev == "" {
 		discoverUdev = "(?i)dm-[0-9]+,(?i)rbd[0-9]+,(?i)nbd[0-9]+"
 	}

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -147,6 +147,7 @@ func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, disco
 								k8sutil.NamespaceEnvVar(),
 								k8sutil.NodeEnvVar(),
 								k8sutil.NameEnvVar(),
+								{Name: discoverDaemon.DiscoverDaemonUdev, Value: os.Getenv(discoverDaemon.DiscoverDaemonUdev)},
 							},
 						},
 					},

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -80,7 +80,7 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	volumeMounts := agentDS.Spec.Template.Spec.Containers[0].VolumeMounts
 	assert.Equal(t, 3, len(volumeMounts))
 	envs := agentDS.Spec.Template.Spec.Containers[0].Env
-	assert.Equal(t, 3, len(envs))
+	assert.Equal(t, 4, len(envs))
 	image := agentDS.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, "rook/rook:myversion", image)
 	assert.Nil(t, agentDS.Spec.Template.Spec.Tolerations)


### PR DESCRIPTION
currently, we're setting the env `DISCOVER_DAEMON_UDEV_BLACKLIST` in operator.yaml but we're not reading from the operator env and setting the value to discover pod env.

Before, notice the different value in the discover pod env and the operator pod env
```
 kc logs rook-discover-vchfq | grep "using the regular expressions"
2025-07-08 11:11:11.060410 I | rook-discover: using the regular expressions ["(?i)dm-[0-9]+" "(?i)rbd[0-9]+" "(?i)nbd[0-9]+"]


~/go/src/github.com/rook/deploy/examples
srai@fedora ~ (master) $ kc exec  -it rook-ceph-operator-6d56bdf6d4-b6qql -- printenv | grep DISCOVER_DAEMON_UDEV_BLACKLIST
DISCOVER_DAEMON_UDEV_BLACKLIST=(?i)dm-[0-9]+,(?i)rbd[0-9]+,(?i)nbd[0-8]+
```

After
```
kc exec  -it rook-ceph-operator-884d86cc7-hnpkg -- printenv | grep DISCOVER_DAEMON_UDEV_BLACKLIST
DISCOVER_DAEMON_UDEV_BLACKLIST=(?i)dm-[0-9]+,(?i)rbd[0-9]+,(?i)nbd[0-8]+


~/go/src/github.com/rook/deploy/examples
srai@fedora ~ (master) $ kc logs rook-discover-gbnj2 | grep "using the regular expressions"
2025-07-08 11:21:41.034589 I | rook-discover: using the regular expressions ["(?i)dm-[0-9]+" "(?i)rbd[0-9]+" "(?i)nbd[0-8]+"]

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16077


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
