### PR TITLE
osd: Exclude labels with a value of null from the topology string

### DIFF
--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -102,7 +102,7 @@ func extractTopologyFromLabels(labels map[string]string) (map[string]string, str
 	// for the topology affinity
 	for _, label := range allKubernetesTopologyLabels {
 		topologyID := kubernetesTopologyLabelToCRUSHLabel(label)
-		if value, ok := labels[label]; ok {
+		if value, ok := labels[label]; ok && value != "" {
 			topology[topologyID] = value
 			if topologyID != "host" {
 				topologyAffinity = formatTopologyAffinity(label, value)


### PR DESCRIPTION
fix: Exclude labels with a value of null from the topology string to avoid the OSD startup failing to parse crush_location.
    
    Signed-off-by: chentao.2022 <chentao.2022@bytedance.com>


Resolves #
https://github.com/rook/rook/issues/16108
