### PR TITLE
osd: exclude down OSDs from main PDB when cluster is clean

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -19,6 +19,8 @@ package clusterdisruption
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,7 +44,9 @@ import (
 
 const (
 	// osdPDBAppName is that app label value for pdbs targeting osds
-	osdPDBAppName                    = "rook-ceph-osd"
+	osdPDBAppName = "rook-ceph-osd"
+	// osdPDBOsdIdLabel is the label on osd pods for pdbs targeting specific osd ids
+	osdPDBOsdIdLabel                 = "osd"
 	drainingFailureDomainKey         = "draining-failure-domain"
 	drainingFailureDomainDurationKey = "draining-failure-domain-duration"
 	setNoOut                         = "set-no-out"
@@ -69,7 +73,7 @@ func (r *ReconcileClusterDisruption) deletePDB(pdb client.Object) error {
 
 // createDefaultPDBforOSD creates a single PDB for all OSDs with maxUnavailable=1
 // This allows all OSDs in a single failure domain to go down.
-func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string, maxUnavailable int) error {
+func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string, excludeOSDs []int) error {
 	cephCluster, ok := r.clusterMap.GetCluster(namespace)
 	if !ok {
 		return errors.Errorf("failed to find the namespace %q in the clustermap", namespace)
@@ -79,14 +83,31 @@ func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string, ma
 		Name:      osdPDBAppName,
 		Namespace: namespace,
 	}
+	excludeOSDsValues := make([]string, len(excludeOSDs))
+	for i, excludeOSD := range excludeOSDs {
+		excludeOSDsValues[i] = strconv.Itoa(excludeOSD)
+	}
 	selector := &metav1.LabelSelector{
-		MatchLabels: map[string]string{k8sutil.AppAttr: osdPDBAppName},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			// require the pod to be an OSD pod
+			{
+				Key:      k8sutil.AppAttr,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{osdPDBAppName},
+			},
+			// don't consider pods for excluded OSD IDs
+			{
+				Key:      osdPDBOsdIdLabel,
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   excludeOSDsValues,
+			},
+		},
 	}
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: objectMeta,
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MaxUnavailable: &intstr.IntOrString{IntVal: int32(maxUnavailable)}, // nolint:gosec // G115 - no overflow is expected for maxUnavailable count
+			MaxUnavailable: &intstr.IntOrString{IntVal: 1},
 			Selector:       selector,
 		},
 	}
@@ -101,7 +122,7 @@ func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string, ma
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("all PGs are active+clean. Restoring default OSD pdb settings")
-			logger.Infof("creating the default pdb %q with maxUnavailable=%d for all osd", osdPDBAppName, maxUnavailable)
+			logger.Infof("creating the default pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
 			return r.createPDB(pdb)
 		}
 		return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
@@ -245,15 +266,16 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 	}
 
 	osdDown := len(downOSDs) > 0
-	maxUnavailableOSDCount := 1
+	// OSDs which should be excluded from the default PDB. This is done when there are no active drains and all PGs are
+	// active+clean, but there are some down OSDs. In that case we exclude the down OSDs from the PDB otherwise all drains
+	// in the cluster would be blocked until the down OSDs came back.
+	excludeOSDs := make([]int, 0)
 
 	// switch block to update the PDB state config map based on the PG status and running OSDs
 	switch {
 	case !osdDown && pgClean:
 		logger.Infof("OSDs are up and PGs are clean. PG status: %q", pgHealthMsg)
-		maxUnavailableOSDCount = 1
 		resetPDBConfig(pdbStateMap)
-
 	case osdDown && pgClean:
 		logger.Infof("OSD(s) %v are down but PGs are clean. PG Status: %q", downOSDs, pgHealthMsg)
 		// In case of a node drain event, the OSD pods can get drained rapidly and it would take some time for rook to fetch
@@ -265,15 +287,13 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 			}
 			if time.Since(lastNodeDrainTimeStamp) < 60*time.Second {
 				logger.Infof("node drain is detected. Requeue to ensure that correct PG status is read.")
-				maxUnavailableOSDCount = 1
 			} else {
-				maxUnavailableOSDCount = len(downOSDs) + 1
+				excludeOSDs = slices.Clone(downOSDs)
 			}
 		} else {
-			maxUnavailableOSDCount = len(downOSDs) + 1
+			excludeOSDs = slices.Clone(downOSDs)
 			resetPDBConfig(pdbStateMap)
 		}
-
 	case osdDown && !pgClean:
 		setPDBConfig(pdbStateMap, osdDownFailureDomains, nodeDrainFailureDomains)
 		logger.Infof("OSD(s) %v are down and PGs are not clean. PGs Status: %q", downOSDs, pgHealthMsg)
@@ -294,9 +314,9 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 			return reconcile.Result{}, errors.Wrap(err, "failed to handle active drains")
 		}
 	} else if pdbStateMap.Data[drainingFailureDomainKey] == "" {
-		logger.Infof("`maxUnavailable` for the main OSD PDB is set to %d", maxUnavailableOSDCount)
+		logger.Infof("`maxUnavailable` for the main OSD PDB is set to 1")
 		// delete all blocking OSD pdb and restore the default OSD pdb
-		err = r.handleInactiveDrains(allFailureDomains, failureDomainType, clusterInfo.Namespace, maxUnavailableOSDCount)
+		err = r.handleInactiveDrains(allFailureDomains, failureDomainType, clusterInfo.Namespace, excludeOSDs)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to handle inactive drains")
 		}
@@ -347,8 +367,8 @@ func (r *ReconcileClusterDisruption) handleActiveDrains(allFailureDomains []stri
 	return nil
 }
 
-func (r *ReconcileClusterDisruption) handleInactiveDrains(allFailureDomains []string, failureDomainType, namespace string, maxUnavailable int) error {
-	err := r.createDefaultPDBforOSD(namespace, maxUnavailable)
+func (r *ReconcileClusterDisruption) handleInactiveDrains(allFailureDomains []string, failureDomainType, namespace string, excludeOSDs []int) error {
+	err := r.createDefaultPDBforOSD(namespace, excludeOSDs)
 	if err != nil {
 		return errors.Wrap(err, "failed to create default pdb")
 	}

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -283,6 +284,7 @@ func TestReconcilePDBForOSD(t *testing.T) {
 		expectedSetNoOutValue             string
 		expectedOSDPDBCount               int
 		expectedMaxUnavailableCount       int
+		excludedOSDs                      []string
 		expectedDrainingFailureDomainName string
 	}{
 		{
@@ -356,18 +358,20 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			expectedDrainingFailureDomainName: "",
 		},
 		{
-			name:                  "case 6: Cluster is healthy but OSDs are down. MaxUnavailable should be set to 1 + number of down OSDs",
+			name:                  "case 6: Cluster is healthy but OSDs are down. MaxUnavailable should be set to 1 and down OSDs excluded from PDB",
 			fakeCephStatus:        healthyCephStatus,
 			allFailureDomains:     []string{"zone-1", "zone-2", "zone-3"},
 			osdDownFailureDomains: []string{},
-			// OSD 0 and 1 are down but ceph health is good. So maxUnavailable should be set to 3.
+			// OSD 0 and 1 are down but ceph health is good. Max unavailable should be set to 1, and we should exclude OSD
+			// 0 and 1 from the default PDB.
 			downOSDs:                          []int{0, 1},
 			configMap:                         fakePDBConfigMap("zone-1"),
 			activeNodeDrains:                  []string{},
 			pgHealthyRegex:                    "",
 			expectedSetNoOutValue:             "",
 			expectedOSDPDBCount:               1,
-			expectedMaxUnavailableCount:       3,
+			expectedMaxUnavailableCount:       1,
+			excludedOSDs:                      []string{"0", "1"},
 			expectedDrainingFailureDomainName: "",
 		},
 	}
@@ -405,6 +409,20 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			assert.Equal(t, tc.expectedOSDPDBCount, len(existingPDBsV1.Items))
 			for _, pdb := range existingPDBsV1.Items {
 				assert.Equal(t, tc.expectedMaxUnavailableCount, pdb.Spec.MaxUnavailable.IntValue())
+				if len(tc.excludedOSDs) > 0 {
+					assert.Equal(t, []metav1.LabelSelectorRequirement{
+						{
+							Key:      k8sutil.AppAttr,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{osdPDBAppName},
+						},
+						{
+							Key:      osdPDBOsdIdLabel,
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   tc.excludedOSDs,
+						},
+					}, pdb.Spec.Selector.MatchExpressions)
+				}
 			}
 			// assert that config map is updated with correct failure domain
 			existingConfigMaps := &corev1.ConfigMapList{}


### PR DESCRIPTION
Currently, when there are down OSDs but all PGs are clean we add the number of downed OSDs ot the main PDB maxUnavailable. For example if OSDs 1,3,5 are down and all PGs are clean we create the following PDB:
```yaml
  maxUnavailable: 4
  selector:
    matchLabels:
      app: rook-ceph-osd
```

This is potentially dangerous as there can be race conditions which can break the cluster, for example:
1. A new node is added to the cluster with 4 OSDs
2. Those OSDs are down as they have not started up and joined the cluster yet
3. All PGs are healthy as the new OSDs haven't started yet and they are new
4. The rook operator sets maxUnavailable to 5 on the OSD PDB
5. The new OSDs move from down to up as they start
6. Something in the cluster starts a disruption (eviction request)
7. Any 5 OSDs can be disrupted as maxUnavilable is still 5 and the downed OSDs are now up
8. If the 5 disrupted OSDs contain all the replicas of a PG it will cause the PG to go down

To better protect from this scenario, we can instead exclude the downed OSDs from the main PDB instead of adding to maxUnavailable.
```yaml
  maxUnavailable: 1
  selector:
    matchExpressions:
    - key: app
      operator: In
      values: ["rook-ceph-osd"]
    - key: osd
      operator: NotIn
      values: ["1", "3", "5"]
```

This allows drains to still process when there are downed OSDs and PGs are clean without allowing the non-downed OSDs to be disrupted.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
