### PR TITLE
mds: use bash for executing liveness probe script

### DIFF
--- a/pkg/operator/ceph/file/mds/livenessprobe.go
+++ b/pkg/operator/ceph/file/mds/livenessprobe.go
@@ -74,7 +74,7 @@ func generateMDSLivenessProbeExecDaemon(daemonID, filesystemName, keyring string
 		ProbeHandler: v1.ProbeHandler{
 			Exec: &v1.ExecAction{
 				Command: []string{
-					"sh",
+					"bash",
 					"-c",
 					mdsLivenessProbeCmd,
 				},


### PR DESCRIPTION
The MDS liveness probe script is [executed inline](https://github.com/rook/rook/blob/98287f5a74e7cdf589ab392e3d17fbdc5d08126d/pkg/operator/ceph/file/mds/livenessprobe.go#L79) using `sh -c`, so the shebang present in the script has no effect.

If the container image does not have `/bin/sh` symlinked to `/bin/bash` the liveness probe will always fail:

```
Events:
  Type     Reason     Age                From     Message
  ----     ------     ----               ----     -------
  Warning  Unhealthy  56m (x3 over 57m)  kubelet  Liveness probe failed: Error: MDS ID not present in MDS map
dumped fsmap epoch 1991
sh: 24: [[: not found
sh: 24: ==: not found
```

~This PR updates the script to use only POSIX standard features so it will work without Bash. I have also updated the shebang for reference purposes only, to make it clear that no Bash features should be used here.~

This PR updates the invocation to use `bash` instead.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
