### PR TITLE
Update SecurityContextConstraints for rook-ceph helm chart

### DIFF
--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -38,6 +38,10 @@ volumes:
 users:
   # A user needs to be added for each rook service account.
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-system
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-default
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-mgr
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-osd
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-rgw 
 ---
 # scc for the CSI driver
 kind: SecurityContextConstraints


### PR DESCRIPTION
The rook-ceph SecurityContextConstraints in the rook-ceph helm chart does not include all the users necessary for a successful deployment. Specifically, rook-ceph-default, rook-ceph-mgr, rook-ceph-osd, and rook-ceph-rgw are listed in the operator-openshift.yaml example file (https://github.com/rook/rook/blob/master/deploy/examples/operator-openshift.yaml) but are not included in the helm chart. This pr adds these users.

Release notes, documentation, and tests have not been updated. Happy to update them if you think it's necessary.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15981

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
