### PR TITLE
pool: remove noisy debug log from rbd stats config

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -603,7 +603,6 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 	}
 	existingStatsPoolsList := strings.Split(existingStatsPools, ",")
 	enableStatsForPools := generateStatsPoolList(existingStatsPoolsList, rookStatsPools, removePools)
-	logger.Debugf("RBD per-image IO statistics will be collected for pools: %v", enableStatsForPools)
 	if len(enableStatsForPools) == 0 {
 		err = monStore.Delete("mgr", "mgr/prometheus/rbd_stats_pools")
 	} else {


### PR DESCRIPTION
Removes the debug log that prints the rbd_stats_pools list. 
When debug_ms=10 is enabled, this log may include irrelevant Ceph internal messages due to combined output from the config set. 
This helps reduce log clutter in the operator pod when collecting RBD stats.

#16151


Test Procedure:
```
1.Change code and build privat image:
	logger.Debugf("RBD per-image IO statistics will be collected f*********************************************oded_1 enableStatsForPools = %v oded_2**************************************************", enableStatsForPools)


2.Configure ceph with debug_ms=10
$ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
bash-5.1$ ceph config set global debug_ms 10

3.Configure pool with enableRBDStats=true

apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: pool1
  namespace: rook-ceph # namespace:cluster
spec:
  enableRBDStats: true
  failureDomain: osd
  replicated:
    size: 1
$ kubectl create -f cephblockpool_stat.yaml 
cephblockpool.ceph.rook.io/pool1 created

4.Check logs vi rook-ceph operator pod

2025-07-22 14:51:33.665126 D | ceph-block-pool-controller: RBD per-image IO statistics will be collected f*********************************************oded_1 enableStatsForPools =  "format": "json"} v 0)
2025-07-22T14:51:33.652+0000 7fd4deffd640 10 -- 10.244.0.3:0/3688986857 >> [v2:10.103.66.46:3300/0, "format": "json"} v 0) -- 0x7fd4b4005420 con 0x7fd4e0071a10
2025-07-22T14:51:33.651+0000 7fd4e5800640  5 --2- 10.244.0.3:0/3688986857 >> [v2:10.103.66.46:3300/0, "format": "json"}]=0  v10)
2025-07-22T14:51:33.653+0000 7fd4bffff640  1 -- 10.244.0.3:0/3688986857 <== mon.0 v2:10.103.66.46:3300/0 7 ==== mon_command_ack([{"prefix": "config get", "format": "json"}]=0  v10) ==== 131+0+1 (secure 0 0 0) 0x7fd4c806cd80 con 0x7fd4e0071a10
2025-07-22T14:51:33.653+0000 7fd4bffff640 10 -- 10.244.0.3:0/3688986857 dispatch_throttle_release 132 to dispatch throttler 132/104857600
.....
.....
.....
76382,v1:10.244.0.10:6801/218776382] gid=4322 global_seq=40 features_supported=3f03cffffffdffff features_required=800000000000000 flags=1 cookie=0
2025-07-22T14:51:33.519+0000 7fd4de7fc640 10 --2- 10.244.0.3:0/3688986857 >> [v2:10.244.0.10:6800/218776382,v1:10.244.0.10:6801/218776382] new 0x7fd4cc039e30
2025-07-22T14:51:33.514+0000 7fd4bffff640 10 -- 10.244.0.3:0/3688986857 dispatch_throttle_release 47448 to dispatch throttler 47448/104857600
2025-07-22T14:51:33.514+0000 7fd4de7fc640 10 -- 10.244.0.3:0/3688986857 >> [v2:10.244.0.10:6800/218776382 oded_2**************************************************

```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
