### PR TITLE
core: automate rotate crashcollector  cephx keys

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5082,6 +5082,19 @@ CephxStatusWithKeyCount
 <p>CSI shows the CephX key status for Ceph-CSI components.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>crashCollector</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CephxStatus">
+CephxStatus
+</a>
+</em>
+</td>
+<td>
+<p>Crash Collector represents the cephx key rotation status of the crash collector daemon</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ClusterSecuritySpec">ClusterSecuritySpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -5927,6 +5927,28 @@ spec:
                 cephx:
                   description: ClusterCephxStatus defines the cephx key rotation status of various daemons on the cephCluster resource
                   properties:
+                    crashCollector:
+                      description: Crash Collector represents the cephx key rotation status of the crash collector daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
                     csi:
                       description: CSI shows the CephX key status for Ceph-CSI components.
                       properties:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -5925,6 +5925,28 @@ spec:
                 cephx:
                   description: ClusterCephxStatus defines the cephx key rotation status of various daemons on the cephCluster resource
                   properties:
+                    crashCollector:
+                      description: Crash Collector represents the cephx key rotation status of the crash collector daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
                     csi:
                       description: CSI shows the CephX key status for Ceph-CSI components.
                       properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -746,9 +746,10 @@ type ClusterCephxStatus struct {
 	Mgr *CephxStatus `json:"mgr,omitempty"`
 	// RBDMirrorPeer represents the cephx key rotation status of the `rbd-mirror-peer` user
 	RBDMirrorPeer *CephxStatus `json:"rbdMirrorPeer,omitempty"`
-
 	// CSI shows the CephX key status for Ceph-CSI components.
 	CSI *CephxStatusWithKeyCount `json:"csi,omitempty"`
+	// Crash Collector represents the cephx key rotation status of the crash collector daemon
+	CrashCollector *CephxStatus `json:"crashCollector,omitempty"`
 }
 
 // MonSpec represents the specification of the monitor

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2090,6 +2090,11 @@ func (in *ClusterCephxStatus) DeepCopyInto(out *ClusterCephxStatus) {
 		*out = new(CephxStatusWithKeyCount)
 		**out = **in
 	}
+	if in.CrashCollector != nil {
+		in, out := &in.CrashCollector, &out.CrashCollector
+		*out = new(CephxStatus)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -803,6 +803,7 @@ func initClusterCephxStatus(c *clusterd.Context, cluster *cephv1.CephCluster) er
 		CSI: &cephv1.CephxStatusWithKeyCount{
 			CephxStatus: uninitializedStatus,
 		},
+		CrashCollector: &uninitializedStatus,
 	}
 
 	if err := reporting.UpdateStatus(c.Client, cluster); err != nil {

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -20,12 +20,15 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -52,7 +55,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.C
 	k := keyring.GetSecretStore(context, clusterInfo, clusterInfo.OwnerInfo)
 
 	// Create CrashCollector Ceph key
-	crashCollectorSecretKey, err := createCrashCollectorKeyring(k)
+	crashCollectorSecretKey, err := createCrashCollectorKeyring(k, context, clusterInfo)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %q ceph keyring", crashCollectorKeyringUsername)
 	}
@@ -72,13 +75,64 @@ func cephCrashCollectorKeyringCaps() []string {
 	}
 }
 
-func createCrashCollectorKeyring(s *keyring.SecretStore) (string, error) {
+func createCrashCollectorKeyring(s *keyring.SecretStore, context *clusterd.Context, clusterInfo *client.ClusterInfo) (string, error) {
 	key, err := s.GenerateKey(crashCollectorKeyringUsername, cephCrashCollectorKeyringCaps())
 	if err != nil {
 		return "", err
 	}
 
+	clusterObj := &cephv1.CephCluster{}
+	if err := context.Client.Get(clusterInfo.Context, clusterInfo.NamespacedName(), clusterObj); err != nil {
+		return "", errors.Wrapf(err, "failed to get cluster %v", clusterInfo.NamespacedName())
+	}
+	// TODO: for rotation WithCephVersionUpdate fix this to have the right runningCephVersion and desiredCephVersion
+	shouldRotateCephxKeys, err := keyring.ShouldRotateCephxKeys(
+		clusterObj.Spec.Security.CephX.Daemon,
+		clusterInfo.CephVersion, clusterInfo.CephVersion,
+		*clusterObj.Status.Cephx.CrashCollector,
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to check if cephx keys should be rotated for crash collector %q", crashCollectorKeyringUsername)
+	}
+
+	if shouldRotateCephxKeys {
+		logger.Infof("rotating cephx key for crash collector %q", crashCollectorKeyringUsername)
+		newKey, err := s.RotateKey(crashCollectorKeyringUsername)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to rotate cephx key for crash collector %q", crashCollectorKeyringUsername)
+		} else {
+			key = newKey
+		}
+	}
+
+	err = updateCrashCollectorCephxStatus(context, clusterInfo, shouldRotateCephxKeys)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to update crash collector cephx status for cluster %q", clusterInfo.Namespace)
+	}
+
 	return key, nil
+}
+
+func updateCrashCollectorCephxStatus(context *clusterd.Context, clusterInfo *client.ClusterInfo, didRotate bool) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cluster := &cephv1.CephCluster{}
+		if err := context.Client.Get(clusterInfo.Context, clusterInfo.NamespacedName(), cluster); err != nil {
+			return errors.Wrapf(err, "failed to get cluster %v to update the conditions.", clusterInfo.NamespacedName())
+		}
+		updatedStatus := keyring.UpdatedCephxStatus(didRotate, cluster.Spec.Security.CephX.Daemon, clusterInfo.CephVersion, *cluster.Status.Cephx.CrashCollector)
+		cluster.Status.Cephx.CrashCollector = &updatedStatus
+		if err := reporting.UpdateStatus(context.Client, cluster); err != nil {
+			return errors.Wrap(err, "failed to update cluster cephx status for crash collector daemon")
+		}
+		logger.Debugf("successfully updated the crash collector cephx status for cluster in namespace %q to %+v", cluster.Namespace, cluster.Status.Cephx.CrashCollector)
+
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to update cluster cephx status for crash collector daemon")
+	}
+
+	return nil
 }
 
 func createOrUpdateCrashCollectorSecret(clusterInfo *client.ClusterInfo, crashCollectorSecretKey string, k *keyring.SecretStore) error {

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring_test.go
@@ -17,9 +17,19 @@ limitations under the License.
 package nodedaemon
 
 import (
+	"context"
 	"testing"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCephCrashCollectorKeyringCaps(t *testing.T) {
@@ -30,4 +40,96 @@ func TestCephCrashCollectorKeyringCaps(t *testing.T) {
 func TestExporterKeyringCaps(t *testing.T) {
 	caps := createExporterKeyringCaps()
 	assert.Equal(t, caps, []string{"mon", "allow profile ceph-exporter", "mgr", "allow r", "osd", "allow r", "mds", "allow r"})
+}
+
+func TestCreateCrashCollectorKeyring(t *testing.T) {
+	clusterContext := &clusterd.Context{}
+	ctx := context.TODO()
+	clusterInfo := &cephclient.ClusterInfo{
+		Context:     ctx,
+		Namespace:   "rook-ceph",
+		CephVersion: cephver.Reef,
+	}
+
+	clusterInfo.SetName("mycluster")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
+
+	// create a sample ceph cluster at add to fake controller
+	status := keyring.UninitializedCephxStatus()
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: "rook-ceph",
+		},
+		Spec: cephv1.ClusterSpec{
+			Security: cephv1.ClusterSecuritySpec{
+				CephX: cephv1.ClusterCephxConfig{
+					Daemon: cephv1.CephxConfig{
+						KeyRotationPolicy: "KeyGeneration",
+						KeyGeneration:     1,
+					},
+				},
+			},
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: "",
+			CephVersion: &cephv1.ClusterVersion{
+				Version: "14.2.9-0",
+			},
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
+			Cephx: &cephv1.ClusterCephxStatus{
+				CrashCollector: &status,
+			},
+		},
+	}
+
+	objects := []runtime.Object{
+		cephCluster,
+	}
+	s := runtime.NewScheme()
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+	clusterContext.Client = cl
+
+	rotatedKeyJson := `[{"key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="}]`
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return `{"key":"AQCvzWBeIV9lFRAAninzm+8XFxbSfTiPwoX50g=="}`, nil
+			}
+			if args[0] == "auth" && args[1] == "rotate" {
+				t.Logf("rotating key and returning: %s", rotatedKeyJson)
+				return rotatedKeyJson, nil
+			}
+
+			return "", nil
+		},
+	}
+	clusterContext.Executor = executor
+
+	k := keyring.GetSecretStore(clusterContext, clusterInfo, clusterInfo.OwnerInfo)
+	key1, err := createCrashCollectorKeyring(k, clusterContext, clusterInfo)
+	assert.NoError(t, err)
+	assert.Equal(t, "AQCvzWBeIV9lFRAAninzm+8XFxbSfTiPwoX50g==", key1)
+
+	// do key rotation
+	err = clusterContext.Client.Get(ctx, clusterInfo.NamespacedName(), cephCluster)
+	assert.NoError(t, err)
+	cephCluster.Spec.Security.CephX.Daemon.KeyGeneration = 2
+	err = cl.Update(ctx, cephCluster)
+	assert.NoError(t, err)
+	clusterInfo.CephVersion = cephver.CephVersion{Major: 20, Minor: 2, Extra: 0}
+	key2, err := createCrashCollectorKeyring(k, clusterContext, clusterInfo)
+	assert.NoError(t, err)
+	assert.Equal(t, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", key2)
+
+	// verify that the cephx status is updated
+	// get the cluster again to ensure we have the latest status
+	updatedCluster := &cephv1.CephCluster{}
+	err = clusterContext.Client.Get(ctx, clusterInfo.NamespacedName(), updatedCluster)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(2), updatedCluster.Status.Cephx.CrashCollector.KeyGeneration)
 }


### PR DESCRIPTION
rotate cephx keys based on keyRotationPolicy
and update cephxStatus for the crashcollector daemon pods.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
