### PR TITLE
core: improve cleanup of /var/lib/rook during cluster teardown

### DIFF
--- a/pkg/daemon/ceph/cleanup/hostpath.go
+++ b/pkg/daemon/ceph/cleanup/hostpath.go
@@ -35,6 +35,24 @@ func StartHostPathCleanup(namespaceDir, dataDirHostPath, monSecret string) {
 	}
 
 	cleanMonDirs(dataDirHostPath, monSecret)
+	cleanExporterDir(dataDirHostPath)
+}
+
+func cleanExporterDir(dataDirHostPath string) {
+	exporterDir := path.Join(dataDirHostPath, "exporter")
+
+	// Check if the exporter directory exists
+	if _, err := os.Stat(exporterDir); os.IsNotExist(err) {
+		logger.Infof("exporter directory %q does not exist, skipping cleanup", exporterDir)
+		return
+	}
+
+	// Attempt to delete it
+	if err := os.RemoveAll(exporterDir); err != nil {
+		logger.Errorf("failed to clean up exporter directory %q. %v", exporterDir, err)
+	} else {
+		logger.Infof("successfully cleaned up exporter directory %q", exporterDir)
+	}
 }
 
 func cleanMonDirs(dataDirHostPath, monSecret string) {


### PR DESCRIPTION
Extend `StartHostPathCleanup` to remove additional directories under `/var/lib/rook`

```
Tested with original code:
1.Create cephcluster CR on minkube

2.Check /var/lib/rook/ dir content:
$ minikube ssh
$ ls /var/lib/rook/
exporter  mon-a  rook-ceph

3. patched cephcluster with cleanupPolicy
$ kubectl -n rook-ceph patch cephcluster my-cluster --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
cephcluster.ceph.rook.io/my-cluster patched

4.Delete the CephCluster CR.
$ kubectl delete -n rook-ceph cephblockpool builtin-mgr
cephblockpool.ceph.rook.io "builtin-mgr" deleted

$ kubectl -n rook-ceph delete cephcluster my-cluster
cephcluster.ceph.rook.io "my-cluster" deleted

5.Check job status:
$ kubectl get jobs -n rook-ceph 
NAME                           STATUS     COMPLETIONS   DURATION   AGE
cluster-cleanup-job-minikube   Complete   1/1           5s         122m

6.Check /var/lib/rook/ dic content:
$ minikube ssh
$ ls /var/lib/rook/
exporter


Tested with updated code:
1. followed same steps
2. confirmed /var/lib/rook/ was fully cleaned:
   (empty)
$ oc logs -n rook-ceph cluster-cleanup-job-minikube-qvcnv 
2025/07/30 13:53:46 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
2025-07-30 13:53:46.576888 I | rookcmd: starting Rook v1.17.0-alpha.0.428.gbc7206b58-dirty with arguments '/usr/local/bin/rook ceph clean host'
2025-07-30 13:53:46.576901 I | rookcmd: flag values: --cluster-fsid=b7cdfd89-32c1-4430-9a1d-d7234fddf1c4, --data-dir-host-path=/var/lib/rook, --help=false, --log-level=DEBUG, --mon-secret=*****, --namespace-dir=rook-ceph, --sanitize-data-source=zero, --sanitize-iteration=1, --sanitize-method=quick
2025-07-30 13:53:46.576902 I | cephcmd: starting cluster clean up
2025-07-30 13:53:46.577073 I | cleanup: successfully cleaned up "/var/lib/rook/rook-ceph" directory
2025-07-30 13:53:46.577369 I | cleanup: successfully cleaned up the mon directory "/var/lib/rook/mon-a" on the dataDirHostPath "/var/lib/rook"
2025-07-30 13:53:46.577413 I | cleanup: successfully cleaned up exporter directory "/var/lib/rook/exporter"
2025-07-30 13:53:46.577762 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log lvm list  --format json
2025-07-30 13:53:46.730899 D | cephosd: {}
2025-07-30 13:53:46.730923 I | cephosd: 0 ceph-volume lvm osd devices configured on this node
2025-07-30 13:53:46.730941 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list --format json
2025-07-30 13:53:48.042981 D | cephosd: {
    "33af1763-aff9-4bb6-af00-93c6b7f7355b": {
        "ceph_fsid": "b7cdfd89-32c1-4430-9a1d-d7234fddf1c4",
        "device": "/dev/vda",
        "osd_id": 0,
        "osd_uuid": "33af1763-aff9-4bb6-af00-93c6b7f7355b",
        "type": "bluestore"
    }
}
2025-07-30 13:53:48.043044 I | cephosd: 1 ceph-volume raw osd devices configured on this node
2025-07-30 13:53:48.043051 I | cleanup: sanitizing osd 0 disk "/dev/vda"
2025-07-30 13:53:48.043095 D | exec: Running command: ceph-volume lvm zap /dev/vda
2025-07-30 13:53:48.552262 I | cleanup: --> Zapping: /dev/vda
--> --destroy was not specified, but zapping a whole device will remove the partition table
--> Removing all BlueStore signature on /dev/vda if any...
Running command: /usr/bin/ceph-bluestore-tool zap-device --dev /dev/vda --yes-i-really-really-mean-it
Running command: /usr/bin/dd if=/dev/zero of=/dev/vda bs=1M count=10 conv=fsync
--> Zapping successful for: <Raw Device: /dev/vda>
2025-07-30 13:53:48.552277 I | cleanup: successfully executed sanitization command for osd disk "/dev/vda"

```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
