### PR TITLE
exporter: automate rotate exporter cephx keys

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5095,6 +5095,19 @@ CephxStatus
 <p>Crash Collector represents the cephx key rotation status of the crash collector daemon</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>cephExporter</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.CephxStatus">
+CephxStatus
+</a>
+</em>
+</td>
+<td>
+<p>Ceph Exporter represents the cephx key rotation status of the ceph exporter daemon</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ClusterSecuritySpec">ClusterSecuritySpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -5927,6 +5927,28 @@ spec:
                 cephx:
                   description: ClusterCephxStatus defines the cephx key rotation status of various daemons on the cephCluster resource
                   properties:
+                    cephExporter:
+                      description: Ceph Exporter represents the cephx key rotation status of the ceph exporter daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
                     crashCollector:
                       description: Crash Collector represents the cephx key rotation status of the crash collector daemon
                       properties:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -5925,6 +5925,28 @@ spec:
                 cephx:
                   description: ClusterCephxStatus defines the cephx key rotation status of various daemons on the cephCluster resource
                   properties:
+                    cephExporter:
+                      description: Ceph Exporter represents the cephx key rotation status of the ceph exporter daemon
+                      properties:
+                        keyCephVersion:
+                          description: |-
+                            KeyCephVersion reports the Ceph version that created the current generation's keys. This is
+                            same string format as reported by `CephCluster.status.version.version` to allow them to be
+                            compared. E.g., `20.2.0-0`.
+                            For all newly-created resources, this field set to the version of Ceph that created the key.
+                            The special value "Uninitialized" indicates that keys are being created for the first time.
+                            An empty string indicates that the version is unknown, as expected in brownfield deployments.
+                          type: string
+                        keyGeneration:
+                          description: |-
+                            KeyGeneration represents the CephX key generation for the last successful reconcile.
+                            For all newly-created resources, this field is set to `1`.
+                            When keys are rotated due to any rotation policy, the generation is incremented or updated to
+                            the configured policy generation.
+                            Generation `0` indicates that keys existed prior to the implementation of key tracking.
+                          format: int32
+                          type: integer
+                      type: object
                     crashCollector:
                       description: Crash Collector represents the cephx key rotation status of the crash collector daemon
                       properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -750,6 +750,8 @@ type ClusterCephxStatus struct {
 	CSI *CephxStatusWithKeyCount `json:"csi,omitempty"`
 	// Crash Collector represents the cephx key rotation status of the crash collector daemon
 	CrashCollector *CephxStatus `json:"crashCollector,omitempty"`
+	// Ceph Exporter represents the cephx key rotation status of the ceph exporter daemon
+	CephExporter *CephxStatus `json:"cephExporter,omitempty"`
 }
 
 // MonSpec represents the specification of the monitor

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2095,6 +2095,11 @@ func (in *ClusterCephxStatus) DeepCopyInto(out *ClusterCephxStatus) {
 		*out = new(CephxStatus)
 		**out = **in
 	}
+	if in.CephExporter != nil {
+		in, out := &in.CephExporter, &out.CephExporter
+		*out = new(CephxStatus)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -804,6 +804,7 @@ func initClusterCephxStatus(c *clusterd.Context, cluster *cephv1.CephCluster) er
 			CephxStatus: uninitializedStatus,
 		},
 		CrashCollector: &uninitializedStatus,
+		CephExporter:   &uninitializedStatus,
 	}
 
 	if err := reporting.UpdateStatus(c.Client, cluster); err != nil {


### PR DESCRIPTION
rotate cephx keys based on keyRotationPolicy
and update cephxStatus for the ceph exporter daemon pods.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
