### PR TITLE
 ci: Enable mergify to open backports and automerge for 1.18 

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,65 +15,6 @@ pull_request_rules:
       comment:
         message: Hi @{{author}}, this pull request was opened against a release branch, is it expected? Normally patches should go in the master branch first and then be backported to release branches.
 
-  # release-1.14 branch
-  - name: automerge backport release-1.14
-    conditions:
-      - author=mergify[bot]
-      - base=release-1.14
-      - label!=do-not-merge
-      - "status-success=DCO"
-      - "check-success=linux-build-all (1.21)"
-      - "check-success=linux-build-all (1.22)"
-      - "check-success=unittests"
-      - "check-success=golangci-lint"
-      - "check-success=codegen"
-      - "check-success=codespell"
-      - "check-success=lint"
-      - "check-success=modcheck"
-      - "check-success=Shellcheck"
-      - "check-success=yaml-linter"
-      - "check-success=lint-test"
-      - "check-success=gen-rbac"
-      - "check-success=crds-gen"
-      - "check-success=docs-check"
-      - "check-success=pylint"
-      - "check-success=canary-tests / canary (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / raw-disk-with-object (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / two-osds-in-device (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / osd-with-metadata-partition-device (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / osd-with-metadata-device (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / lvm (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / pvc (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / pvc-db (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / pvc-db-wal (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc-db (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc-db-wal (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc-kms-vault-token-auth (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc-kms-vault-k8s-auth (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / lvm-pvc (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / multi-cluster-mirroring (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / rgw-multisite-testing (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / encryption-pvc-kms-ibm-kp (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / multus-cluster-network (quay.io/ceph/ceph:v18)"
-      - "check-success=canary-tests / csi-hostnetwork-disabled (quay.io/ceph/ceph:v18)"
-      - "check-success=TestCephSmokeSuite (v1.25.16)"
-      - "check-success=TestCephSmokeSuite (v1.30.0)"
-      - "check-success=TestCephHelmSuite (v1.25.16)"
-      - "check-success=TestCephHelmSuite (v1.30.0)"
-      - "check-success=TestCephMultiClusterDeploySuite (v1.30.0)"
-      - "check-success=TestCephObjectSuite (v1.30.0)"
-      - "check-success=TestCephUpgradeSuite (v1.25.16)"
-      - "check-success=TestCephUpgradeSuite (v1.30.0)"
-      - "check-success=TestHelmUpgradeSuite (v1.25.16)"
-      - "check-success=TestHelmUpgradeSuite (v1.30.0)"
-    actions:
-      merge:
-        method: merge
-      dismiss_reviews: {}
-      delete_head_branch: {}
-
   # release-1.15 branch
   - name: automerge backport release-1.15
     conditions:
@@ -311,15 +252,6 @@ pull_request_rules:
         method: merge
       dismiss_reviews: {}
       delete_head_branch: {}
-
-  # release-1.14 branch
-  - actions:
-      backport:
-        branches:
-          - release-1.14
-    conditions:
-      - label=backport-release-1.14
-    name: backport release-1.14
 
   # release-1.15 branch
   - actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -252,6 +252,66 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
+  # release-1.18 branch
+  - name: automerge backport release-1.18
+    conditions:
+      - author=mergify[bot]
+      - base=release-1.18
+      - label!=do-not-merge
+      - "status-success=DCO"
+      - "check-success=codegen"
+      - "check-success=codespell"
+      - "check-success=crds-gen"
+      - "check-success=docs-check"
+      - "check-success=gen-rbac"
+      - "check-success=golangci-lint"
+      - "check-success=govulncheck"
+      - "check-success=lint"
+      - "check-success=lint-test"
+      - "check-success=linux-build-all (1.24)"
+      - "check-success=misspell"
+      - "check-success=modcheck"
+      - "check-success=pylint"
+      - "check-success=Shellcheck"
+      - "check-success=unittests"
+      - "check-success=yaml-linter"
+      - "check-success=canary-tests / canary (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc-db (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc-db-wal (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc-kms-ibm-kp (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc-kms-vault-k8s-auth (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / encryption-pvc-kms-vault-token-auth (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / lvm (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / lvm-pvc (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / multi-cluster-mirroring (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / multus-public-and-cluster (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / osd-with-metadata-device (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / osd-with-metadata-partition-device (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / pvc (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / pvc-db (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / pvc-db-wal (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / raw-disk-with-object (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / two-object-one-zone (quay.io/ceph/ceph:v19)"
+      - "check-success=canary-tests / two-osds-in-device (quay.io/ceph/ceph:v19)"
+      - "check-success=TestCephHelmSuite (v3.13.3, v1.33.0)"
+      - "check-success=TestCephHelmSuite (v3.18.3, v1.33.0)"
+      - "check-success=TestCephMultiClusterDeploySuite (v1.33.0)"
+      - "check-success=TestCephObjectSuite (v1.28.15)"
+      - "check-success=TestCephObjectSuite (v1.33.0)"
+      - "check-success=TestCephSmokeSuite (v1.28.15)"
+      - "check-success=TestCephSmokeSuite (v1.33.0)"
+      - "check-success=TestCephUpgradeSuite (v1.28.15)"
+      - "check-success=TestCephUpgradeSuite (v1.33.0)"
+      - "check-success=TestHelmUpgradeSuite (v1.28.15)"
+      - "check-success=TestHelmUpgradeSuite (v1.33.0)"
+    actions:
+      merge:
+        method: merge
+      dismiss_reviews: {}
+      delete_head_branch: {}
+
   # release-1.14 branch
   - actions:
       backport:
@@ -287,3 +347,12 @@ pull_request_rules:
     conditions:
       - label=backport-release-1.17
     name: backport release-1.17
+
+  # release-1.18 branch
+  - actions:
+      backport:
+        branches:
+          - release-1.18
+    conditions:
+      - label=backport-release-1.18
+    name: backport release-1.18


### PR DESCRIPTION
 1. Add 1.18 branch for mergify to open backports and automatically merge when approved
 2. Remove 1.14 branch from mergify backport rules.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  3. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  4. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  5. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
