### PR TITLE
object: fix bucket policy in sync detection

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -754,7 +754,7 @@ func (p *Provisioner) setBucketPolicy(additionalConfig *additionalConfigSpec) er
 		livePolicy = policyResp.Policy
 	}
 
-	diff := cmp.Diff(&livePolicy, additionalConfig.bucketPolicy)
+	diff := cmp.Diff(livePolicy, additionalConfig.bucketPolicy)
 	if diff == "" {
 		// policy is in sync
 		return nil


### PR DESCRIPTION
A typo was causing the operator to attempt to sync bucket policy when the state was already in sync. This resulted in the operator carrying out unnecessary work and logging activity with no user visible change resulting.

Resolves #16219 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
