### PR TITLE
csi: Create cephconnection CR with name of the cluster namespace

### DIFF
--- a/pkg/operator/ceph/csi/ceph_connection.go
+++ b/pkg/operator/ceph/csi/ceph_connection.go
@@ -32,11 +32,11 @@ import (
 )
 
 func CreateUpdateCephConnection(c client.Client, clusterInfo *cephclient.ClusterInfo, clusterSpec cephv1.ClusterSpec) error {
-	logger.Infof("Configuring ceph connection CR %q in namespace %q", clusterInfo.NamespacedName().Name, clusterInfo.NamespacedName().Namespace)
+	// Create a cephconnection CR in the namespace of the operator, with the namespace of the cephcluster CR
 	csiCephConnection := &csiopv1.CephConnection{}
-
-	csiCephConnection.Name = clusterInfo.NamespacedName().Name
+	csiCephConnection.Name = clusterInfo.NamespacedName().Namespace
 	csiCephConnection.Namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
+	logger.Infof("Configuring ceph connection CR %q in namespace %q", csiCephConnection.Name, csiCephConnection.Namespace)
 
 	spec, err := generateCephConnSpec(c, clusterInfo, csiCephConnection.Spec, clusterSpec)
 	if err != nil {

--- a/pkg/operator/ceph/csi/ceph_connection_test.go
+++ b/pkg/operator/ceph/csi/ceph_connection_test.go
@@ -69,7 +69,7 @@ func TestCreateUpdateCephConnection(t *testing.T) {
 	assert.NoError(t, err)
 
 	// When no RBDMirror is created
-	err = cl.Get(context.TODO(), types.NamespacedName{Name: c.NamespacedName().Name, Namespace: c.NamespacedName().Namespace}, csiCephConnection)
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: ns, Namespace: ns}, csiCephConnection)
 	assert.NoError(t, err)
 	assert.Equal(t, csiCephConnection.Spec.RbdMirrorDaemonCount, 0)
 
@@ -96,7 +96,7 @@ func TestCreateUpdateCephConnection(t *testing.T) {
 	assert.NoError(t, err)
 
 	// When RBDMirror is created
-	err = cl.Get(context.TODO(), types.NamespacedName{Name: c.NamespacedName().Name, Namespace: c.NamespacedName().Namespace}, csiCephConnection)
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: ns, Namespace: ns}, csiCephConnection)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, csiCephConnection.Spec.RbdMirrorDaemonCount)
 }


### PR DESCRIPTION
The cephconnection CR expects to be created with the name of the namespace where the cephcluster CR is found, so the CSI driver can find the cluster when provisioning the volume.

When testing with cluster-test.yaml (which sets the cluster name to `my-cluster` instead of the same as the namespace `rook-ceph`), I saw the error when the pvc was attempting to be provisioned:
```
failed to provision volume with StorageClass "rook-ceph-block": 
rpc error: code = InvalidArgument desc = failed to fetch monitor list using clusterID (rook-ceph): 
error fetching configuration for cluster ID "rook-ceph": open /etc/ceph-csi-config/config.json: no such file or directory
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
