### PR TITLE
csi: use cluster namespace for cephConn

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -182,7 +182,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		if err != nil {
 			return errors.Wrap(err, "failed to create/update cephConnection")
 		}
-		err = csi.CreateDefaultClientProfile(c.context.Client, cluster.ClusterInfo, cluster.ClusterInfo.NamespacedName())
+		err = csi.CreateDefaultClientProfile(c.context.Client, cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to create/update default client profile")
 		}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1190,7 +1190,7 @@ func (c *Cluster) saveMonConfig() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create/update cephConnection")
 		}
-		err = csi.CreateDefaultClientProfile(c.context.Client, c.ClusterInfo, c.ClusterInfo.NamespacedName())
+		err = csi.CreateDefaultClientProfile(c.context.Client, c.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to create/update default client profile")
 		}

--- a/pkg/operator/ceph/csi/ceph_connection.go
+++ b/pkg/operator/ceph/csi/ceph_connection.go
@@ -38,7 +38,7 @@ func CreateUpdateCephConnection(c client.Client, clusterInfo *cephclient.Cluster
 	csiCephConnection.Namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
 	logger.Infof("Configuring ceph connection CR %q in namespace %q", csiCephConnection.Name, csiCephConnection.Namespace)
 
-	spec, err := generateCephConnSpec(c, clusterInfo, csiCephConnection.Spec, clusterSpec)
+	spec, err := generateCephConnSpec(c, clusterInfo, clusterSpec)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set ceph connection CR %q in namespace %q", csiCephConnection.Name, clusterInfo.Namespace)
 	}
@@ -68,12 +68,12 @@ func CreateUpdateCephConnection(c client.Client, clusterInfo *cephclient.Cluster
 	return nil
 }
 
-func generateCephConnSpec(c client.Client, clusterInfo *cephclient.ClusterInfo, csiClusterConnSpec csiopv1.CephConnectionSpec, clusterSpec cephv1.ClusterSpec) (csiopv1.CephConnectionSpec, error) {
+func generateCephConnSpec(c client.Client, clusterInfo *cephclient.ClusterInfo, clusterSpec cephv1.ClusterSpec) (csiopv1.CephConnectionSpec, error) {
+	csiClusterConnSpec := csiopv1.CephConnectionSpec{}
+
 	if clusterSpec.CSI.ReadAffinity.Enabled {
-		csiClusterConnSpec = csiopv1.CephConnectionSpec{
-			ReadAffinity: &csiopv1.ReadAffinitySpec{
-				CrushLocationLabels: clusterSpec.CSI.ReadAffinity.CrushLocationLabels,
-			},
+		csiClusterConnSpec.ReadAffinity = &csiopv1.ReadAffinitySpec{
+			CrushLocationLabels: clusterSpec.CSI.ReadAffinity.CrushLocationLabels,
 		}
 	}
 

--- a/pkg/operator/ceph/csi/config_test.go
+++ b/pkg/operator/ceph/csi/config_test.go
@@ -52,7 +52,6 @@ func TestCreateUpdateClientProfile(t *testing.T) {
 	c.SetName(c.Namespace)
 	t.Setenv(k8sutil.PodNamespaceEnvVar, ns)
 
-	clusterName := "testClusterName"
 	cephBlockPoolRadosNamespacedName := types.NamespacedName{Namespace: ns, Name: "cephBlockPoolRadosNames"}
 	cephSubVolGrpNamespacedName := types.NamespacedName{Namespace: ns, Name: "cephSubVolumeGroupNames"}
 	csiOpClientProfile := &csiopv1.ClientProfile{}
@@ -66,10 +65,10 @@ func TestCreateUpdateClientProfile(t *testing.T) {
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
-	err := CreateUpdateClientProfileRadosNamespace(context.TODO(), cl, c, cephBlockPoolRadosNamespacedName.Name, cephBlockPoolRadosNamespacedName.Name, clusterName)
+	err := CreateUpdateClientProfileRadosNamespace(context.TODO(), cl, c, cephBlockPoolRadosNamespacedName.Name, cephBlockPoolRadosNamespacedName.Name)
 	assert.NoError(t, err)
 
-	err = CreateUpdateClientProfileSubVolumeGroup(context.TODO(), cl, c, cephSubVolGrpNamespacedName.Name, cephSubVolGrpNamespacedName.Name, clusterName)
+	err = CreateUpdateClientProfileSubVolumeGroup(context.TODO(), cl, c, cephSubVolGrpNamespacedName.Name, cephSubVolGrpNamespacedName.Name)
 	assert.NoError(t, err)
 
 	err = cl.Get(context.TODO(), cephBlockPoolRadosNamespacedName, csiOpClientProfile)

--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) reconcile(request reconcile.Requ
 		}
 		r.updateStatus(observedGeneration, namespacedName, cephv1.ConditionReady)
 		if csi.EnableCSIOperator() {
-			err = csi.CreateUpdateClientProfileSubVolumeGroup(r.clusterInfo.Context, r.client, r.clusterInfo, cephFilesystemSubVolumeGroupName, buildClusterID(cephFilesystemSubVolumeGroup), cephCluster.Name)
+			err = csi.CreateUpdateClientProfileSubVolumeGroup(r.clusterInfo.Context, r.client, r.clusterInfo, cephFilesystemSubVolumeGroupName, buildClusterID(cephFilesystemSubVolumeGroup))
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to create ceph csi-op config CR for subvolume")
 			}
@@ -326,7 +326,7 @@ func (r *ReconcileCephFilesystemSubVolumeGroup) reconcile(request reconcile.Requ
 	r.updateStatus(observedGeneration, request.NamespacedName, cephv1.ConditionReady)
 
 	if csi.EnableCSIOperator() {
-		err = csi.CreateUpdateClientProfileSubVolumeGroup(r.clusterInfo.Context, r.client, r.clusterInfo, cephFilesystemSubVolumeGroupName, buildClusterID(cephFilesystemSubVolumeGroup), cephCluster.Name)
+		err = csi.CreateUpdateClientProfileSubVolumeGroup(r.clusterInfo.Context, r.client, r.clusterInfo, cephFilesystemSubVolumeGroupName, buildClusterID(cephFilesystemSubVolumeGroup))
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to create ceph csi-op config CR for subvolumeGroup")
 		}

--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -289,7 +289,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 		}
 		r.updateStatus(r.client, namespacedName, cephv1.ConditionReady)
 		if csi.EnableCSIOperator() {
-			err = csi.CreateUpdateClientProfileRadosNamespace(r.clusterInfo.Context, r.client, r.clusterInfo, radosNamespaceName, buildClusterID(radosNamespace), cephCluster.Name)
+			err = csi.CreateUpdateClientProfileRadosNamespace(r.clusterInfo.Context, r.client, r.clusterInfo, radosNamespaceName, buildClusterID(radosNamespace))
 			if err != nil {
 				return reconcile.Result{}, radosNamespace, errors.Wrap(err, "failed to create ceph csi-op config CR for RadosNamespace")
 			}
@@ -353,7 +353,7 @@ func (r *ReconcileCephBlockPoolRadosNamespace) reconcile(request reconcile.Reque
 	r.updateStatus(r.client, namespacedName, cephv1.ConditionReady)
 
 	if csi.EnableCSIOperator() {
-		err = csi.CreateUpdateClientProfileRadosNamespace(r.clusterInfo.Context, r.client, r.clusterInfo, radosNamespaceName, buildClusterID(radosNamespace), cephCluster.Name)
+		err = csi.CreateUpdateClientProfileRadosNamespace(r.clusterInfo.Context, r.client, r.clusterInfo, radosNamespaceName, buildClusterID(radosNamespace))
 		if err != nil {
 			return reconcile.Result{}, radosNamespace, errors.Wrap(err, "failed to create ceph csi-op config CR for RadosNamespace")
 		}


### PR DESCRIPTION
CephConnection CR is created with the kubernetes namespace name as its the unique name in the entire cluster.
 This PR removes unwanted input parameters and adjust the namespace name for the cephConnection CR.


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
