### PR TITLE
csi: use clusterNamespace instead of cluster name

### DIFF
--- a/pkg/operator/ceph/csi/config.go
+++ b/pkg/operator/ceph/csi/config.go
@@ -43,7 +43,7 @@ func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Clien
 	csiOpClientProfile.Namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
 	csiOpClientProfile.Spec = csiopv1.ClientProfileSpec{
 		CephConnectionRef: v1.LocalObjectReference{
-			Name: clusterName,
+			Name: clusterInfo.Namespace,
 		},
 		Rbd: &csiopv1.RbdConfigSpec{
 			RadosNamespace: cephBlockPoolRadosNamespaceName,
@@ -105,7 +105,7 @@ func generateProfileSubVolumeGroupSpec(clusterInfo *cephclient.ClusterInfo, ceph
 	csiOpClientProfile.Namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
 	csiOpClientProfile.Spec = csiopv1.ClientProfileSpec{
 		CephConnectionRef: v1.LocalObjectReference{
-			Name: clusterName,
+			Name: clusterInfo.Namespace,
 		},
 		CephFs: &csiopv1.CephFsConfigSpec{
 			SubVolumeGroup: cephFilesystemSubVolumeGroupName,
@@ -141,7 +141,7 @@ func CreateDefaultClientProfile(c client.Client, clusterInfo *cephclient.Cluster
 	csiOpClientProfile.Namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
 	csiOpClientProfile.Spec = csiopv1.ClientProfileSpec{
 		CephConnectionRef: v1.LocalObjectReference{
-			Name: namespaced.Name,
+			Name: clusterInfo.Namespace,
 		},
 	}
 


### PR DESCRIPTION
currently, `CreateDefaultClientProfile`, `CreateUpdateClientProfileRadosNamespace` and `CreateUpdateClientProfileSubVolumeGroup` is using cephCluster name instead of cephCluster Namespace. This commit fixes this.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
