### PR TITLE
csi: update cephfs user and key in secret

### DIFF
--- a/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md
+++ b/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md
@@ -225,11 +225,6 @@ You can do that using the following recipe.
 
 ### Shared volume creation
 
-* In the `rook` namespace, create a copy of the secret `rook-csi-cephfs-node`, name it `rook-csi-cephfs-node-user`
-.
-* Edit your new secret, changing the name of the keys (keep the value as it is):
-    * `adminID` -> `userID`
-    * `adminKey` -> `userKey`
 * Create the PVC you want to share, for example:
 
 ```yaml
@@ -299,7 +294,6 @@ spec:
     * Modify the volumeHandle. Again append the targeted namespace.
     * Add the `staticVolume: "true"` entry to the volumeAttributes.
     * Add the rootPath entry to the volumeAttributes, with the same content as `subvolumePath`.
-    * In the `nodeStageSecretRef` section, change the name to point to the secret you created earlier, `rook-csi-cephfs-node-user`.
     * Remove the unnecessary information before applying the YAML (claimRef, managedFields,...):
 
 Your YAML should look like this:

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -14,26 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import errno
-import sys
-import json
 import argparse
+import configparser
+import errno
+import hmac
+import json
 import re
 import subprocess
-import hmac
-import configparser
+import sys
+from base64 import encodebytes as encodestring
+from email.utils import formatdate
 from hashlib import sha1 as sha
+from io import StringIO
+from ipaddress import IPv4Address, ip_address
 from os import linesep as LINESEP
 from os import path
-from email.utils import formatdate
+from urllib.parse import urlencode as urlencode
+from urllib.parse import urlparse
+
 import requests
 from requests.auth import AuthBase
-from io import StringIO
-from urllib.parse import urlparse
-from urllib.parse import urlencode as urlencode
-from ipaddress import ip_address
-from ipaddress import IPv4Address
-from base64 import encodebytes as encodestring
 
 ModuleNotFoundError = ImportError
 
@@ -1908,11 +1908,11 @@ class RadosJSON:
                     "name": f"rook-{self.out_map['CSI_CEPHFS_PROVISIONER_SECRET_NAME']}",
                     "kind": "Secret",
                     "data": {
-                        "adminID": self.get_user_id(
+                        "userID": self.get_user_id(
                             self.out_map["CSI_CEPHFS_PROVISIONER_SECRET_NAME"],
                             generation,
                         ),
-                        "adminKey": self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"],
+                        "userKey": self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"],
                     },
                 }
             )
@@ -1926,10 +1926,10 @@ class RadosJSON:
                     "name": f"rook-{self.out_map['CSI_CEPHFS_NODE_SECRET_NAME']}",
                     "kind": "Secret",
                     "data": {
-                        "adminID": self.get_user_id(
+                        "userID": self.get_user_id(
                             self.out_map["CSI_CEPHFS_NODE_SECRET_NAME"], generation
                         ),
-                        "adminKey": self.out_map["CSI_CEPHFS_NODE_SECRET"],
+                        "userKey": self.out_map["CSI_CEPHFS_NODE_SECRET"],
                     },
                 }
             )

--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -254,15 +254,15 @@ function importCsiCephFSNodeSecret() {
       generic \
       --type="kubernetes.io/rook" \
       "rook-""$CSI_CEPHFS_NODE_SECRET_NAME" \
-      --from-literal=adminID="$userID" \
-      --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
+      --from-literal=userID="$userID" \
+      --from-literal=userKey="$CSI_CEPHFS_NODE_SECRET"
   else
     echo "secret 'rook-$CSI_CEPHFS_NODE_SECRET_NAME' already exists"
       $KUBECTL -n "$NAMESPACE" \
       patch \
       secret \
       "rook-$CSI_CEPHFS_NODE_SECRET_NAME" \
-      -p "{\"stringData\":{\"adminID\":\"$userID\",\"adminKey\":\"$CSI_CEPHFS_NODE_SECRET\"}}"
+      -p "{\"stringData\":{\"userID\":\"$userID\",\"userKey\":\"$CSI_CEPHFS_NODE_SECRET\"}}"
     fi
 }
 
@@ -275,15 +275,15 @@ function importCsiCephFSProvisionerSecret() {
       generic \
       --type="kubernetes.io/rook" \
       "rook-""$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-      --from-literal=adminID="$userID" \
-      --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+      --from-literal=userID="$userID" \
+      --from-literal=userKey="$CSI_CEPHFS_PROVISIONER_SECRET"
   else
     echo "secret 'rook-$CSI_CEPHFS_PROVISIONER_SECRET_NAME' already exists"
     $KUBECTL -n "$NAMESPACE" \
       patch \
       secret \
       "rook-$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-      -p "{\"stringData\":{\"adminID\":\"$userID\",\"adminKey\":\"$CSI_CEPHFS_NODE_SECRET\"}}"
+      -p "{\"stringData\":{\"userID\":\"$userID\",\"userKey\":\"$CSI_CEPHFS_NODE_SECRET\"}}"
   fi
 }
 

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -325,12 +325,9 @@ func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient
 		},
 		StringData: map[string]string{
 			cephClient.Name: key,
-			// CSI requires userID and userKey for RBD
+			// CSI requires userID and userKey in secret
 			"userID":  cephClient.Name,
 			"userKey": key,
-			// CSI requires adminID and adminKey for CephFS
-			"adminID":  cephClient.Name,
-			"adminKey": key,
 		},
 		Type: k8sutil.RookType,
 	}

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -318,8 +318,6 @@ func TestCephClientController(t *testing.T) {
 	assert.NotEmpty(t, cephClientSecret.StringData)
 	assert.Contains(t, cephClientSecret.StringData, "userID")
 	assert.Contains(t, cephClientSecret.StringData, "userKey")
-	assert.Contains(t, cephClientSecret.StringData, "adminID")
-	assert.Contains(t, cephClientSecret.StringData, "adminKey")
 }
 
 func TestBuildUpdateStatusInfo(t *testing.T) {

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -160,28 +160,30 @@ func cephCSIKeyringCephFSProvisionerCaps() []string {
 }
 
 func createOrUpdateCSISecret(clusterInfo *client.ClusterInfo, csiSecretContent csiSecretStore, k *keyring.SecretStore) error {
+	const userID = "userID"
+	const userKey = "userKey"
 	csiRBDProvisionerSecrets := map[string][]byte{
 		// userID is expected for the rbd provisioner driver
-		"userID":  []byte(csiSecretContent[CsiRBDProvisionerSecret].Name),
-		"userKey": []byte(csiSecretContent[CsiRBDProvisionerSecret].Key),
+		userID:  []byte(csiSecretContent[CsiRBDProvisionerSecret].Name),
+		userKey: []byte(csiSecretContent[CsiRBDProvisionerSecret].Key),
 	}
 
 	csiRBDNodeSecrets := map[string][]byte{
 		// userID is expected for the rbd node driver
-		"userID":  []byte(csiSecretContent[CsiRBDNodeSecret].Name),
-		"userKey": []byte(csiSecretContent[CsiRBDNodeSecret].Key),
+		userID:  []byte(csiSecretContent[CsiRBDNodeSecret].Name),
+		userKey: []byte(csiSecretContent[CsiRBDNodeSecret].Key),
 	}
 
 	csiCephFSProvisionerSecrets := map[string][]byte{
-		// adminID is expected for the cephfs provisioner driver
-		"adminID":  []byte(csiSecretContent[CsiCephFSProvisionerSecret].Name),
-		"adminKey": []byte(csiSecretContent[CsiCephFSProvisionerSecret].Key),
+		// userID is expected for the cephfs provisioner driver
+		userID:  []byte(csiSecretContent[CsiCephFSProvisionerSecret].Name),
+		userKey: []byte(csiSecretContent[CsiCephFSProvisionerSecret].Key),
 	}
 
 	csiCephFSNodeSecrets := map[string][]byte{
-		// adminID is expected for the cephfs node driver
-		"adminID":  []byte(csiSecretContent[CsiCephFSNodeSecret].Name),
-		"adminKey": []byte(csiSecretContent[CsiCephFSNodeSecret].Key),
+		// userID is expected for the cephfs node driver
+		userID:  []byte(csiSecretContent[CsiCephFSNodeSecret].Name),
+		userKey: []byte(csiSecretContent[CsiCephFSNodeSecret].Key),
 	}
 
 	keyringSecretMap := make(map[string]map[string][]byte)


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
cephCSI already deprecated the adminID and adminKey keys in the secrets and to be backward compatible it still supports the adminID and  adminKey but it logs the warning, updating the  secrets created by Rook to use userID and userKey
instead of adminID and adminKey.

Resolves #16175 
Resolves #16285 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**

--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
