### PR TITLE
core: skip staticcheck sa1019 for aws-sdk-go v1 deprecation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,9 @@ linters:
       - linters:
           - staticcheck
         text: "Requeue is deprecated"
+      - linters:
+          - staticcheck
+        text: "Use aws-sdk-go-v2" # aws-sdk-go v1 deprecated warning
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
update `.golangci.yaml` to exclude staticcheck `sa1019` warnings for aws-sdk-go v1 until migration to v2 is completed

#14869 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
