### PR TITLE
pool: fix cephblockpool remove when related pool is already removed

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -242,6 +242,20 @@ func IsPoolEmpty(context *clusterd.Context, clusterInfo *ClusterInfo, name strin
 	return true, fmt.Sprintf("pool %q is empty and can be deleted", name), nil
 }
 
+func IsPoolPresent(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string) (bool, error) {
+	pools, err := ListPoolSummaries(context, clusterInfo)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list pools")
+	}
+
+	for _, pool := range pools {
+		if pool.Name == poolName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func checkForImagesInPool(context *clusterd.Context, clusterInfo *ClusterInfo, name string) error {
 	isEmpty, err := checkIsPoolEmpty(context, clusterInfo, name)
 	if err != nil {


### PR DESCRIPTION

When removeing CephBlockPool check first that related ceph pool is exist in cluster, since it may be manually removed by mistake.

Related-Issue: #16328
Signed-off-by: Denis Egorenko <degorenko@mirantis.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
