### PR TITLE
csi: fix the prior key count for csi key rotation

### DIFF
--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -120,6 +120,9 @@ func createCSIKeyring(
 	allKeyWithBaseName = deduplicate(allKeyWithBaseName)
 
 	currentKeyCount := len(allKeyWithBaseName) - len(keysDeleted)
+	if currentKeyCount <= 0 {
+		logger.Warningf("currentKeyCount is %d is less than or equal to 0; this could be due to an error in key generation", currentKeyCount)
+	}
 
 	return latestClientId, key, currentKeyCount, shouldRotate, nil
 }
@@ -312,7 +315,7 @@ func updateCephStatusWithCephxStatus(context *clusterd.Context, clusterInfo *cli
 			return errors.Wrapf(err, "failed to retrieve cephCluster %q to update CSICephxStatus", namespacedName.Namespace)
 		}
 		cephCluster.Status.Cephx.CSI.CephxStatus = cephxStatus
-		cephCluster.Status.Cephx.CSI.PriorKeyCount = uint8(currentKeyCount) //nolint:gosec // disable G115
+		cephCluster.Status.Cephx.CSI.PriorKeyCount = uint8(getPriorKeyCount(currentKeyCount)) //nolint:gosec // disable G115
 
 		if err := reporting.UpdateStatus(context.Client, cephCluster); err != nil {
 			return errors.Wrapf(err, "failed to update cephCluster %q to update csi cephx status to %q in namespace %q", namespacedName.Name, cephxStatus, namespacedName.Namespace)
@@ -325,6 +328,10 @@ func updateCephStatusWithCephxStatus(context *clusterd.Context, clusterInfo *cli
 
 	logger.Debugf("successfully updated Ceph cluster %q status with CSI Cephx status in namespace %q", namespacedName.Name, namespacedName.Namespace)
 	return nil
+}
+
+func getPriorKeyCount(currentKeyCount int) int {
+	return max(0, currentKeyCount-1)
 }
 
 // getCsiKeyRotationInfo runs the `ceph auth ls` command to fetch all the keys and filter out the keys with same base name. Example

--- a/pkg/operator/ceph/csi/secrets_test.go
+++ b/pkg/operator/ceph/csi/secrets_test.go
@@ -522,3 +522,22 @@ func TestParseCsiClient(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPriorKeyCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyCount int
+		want     int
+	}{
+		{"keyGen 0", 0, 0},
+		{"keyGen 1", 1, 0},
+		{"keyGen 2", 2, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPriorKeyCount(tt.keyCount)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
fix the prior key count status for the csi
key rotation

closes: https://github.com/rook/rook/issues/16321

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
