### PR TITLE
helm: Enable host network for OpenShift if needed

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
@@ -8,10 +8,13 @@ metadata:
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 allowHostPID: false
-# set to true if running rook with host networking enabled
+{{- if eq .Values.cephClusterSpec.network.provider "host" }}
+allowHostNetwork: true
+allowHostPorts: true
+{{- else }}
 allowHostNetwork: false
-# set to true if running rook with the provider as host
 allowHostPorts: false
+{{- end }}
 priority:
 allowedCapabilities: ["MKNOD"]
 allowHostIPC: true

--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -8,10 +8,13 @@ metadata:
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 allowHostPID: false
-# set to true if running rook with host networking enabled
+{{- if .Values.useOperatorHostNetwork }}
+allowHostNetwork: true
+allowHostPorts: true
+{{- else }}
 allowHostNetwork: false
-# set to true if running rook with the provider as host
 allowHostPorts: false
+{{- end }}
 priority:
 allowedCapabilities: ["MKNOD"]
 allowHostIPC: true


### PR DESCRIPTION
The securityContextConstraints require setting whether host networking and host port access is needed by the ceph cluster service accounts. The helm chart now allows enabling this mode with the settings:
- rook-ceph chart: `useOperatorHostNetwork: true`
- rook-ceph-cluster chart: `cephClusterSpec.network.provider: host`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15981

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
