### PR TITLE
core: delete bootstrap keys

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -525,6 +525,11 @@ func (c *cluster) postMonStartupActions() error {
 		return errors.Wrap(err, "failed to create cluster rbd bootstrap peer token")
 	}
 
+	// Delete the client.bootstrap-* keys. These keys are created automatically by Ceph and are unused.
+	// Ceph might remove these keys in the future. It is safe for Rook to remove them if they exist.
+	// client.bootstrap-osd is used by Rook and is not removed here.
+	c.deleteBootstrapKeys()
+
 	return nil
 }
 
@@ -869,4 +874,16 @@ func initClusterCephxStatus(c *cluster) error {
 		return nil
 	})
 	return err
+}
+
+func (c *cluster) deleteBootstrapKeys() {
+	bootstrapKeys := []string{"client.bootstrap-mds", "client.bootstrap-mgr", "client.bootstrap-rbd", "client.bootstrap-rbd-mirror", "client.bootstrap-rgw"}
+	for _, bootstrapkey := range bootstrapKeys {
+		err := client.AuthDelete(c.context, c.ClusterInfo, bootstrapkey)
+		if err != nil {
+			logger.Debugf("failed to delete bootstrap key %q in the namespace %q. Error: %v", bootstrapkey, c.Namespace, err)
+		} else {
+			logger.Infof("successfully deleted bootstrap key %q in the namespace %q", bootstrapkey, c.Namespace)
+		}
+	}
 }


### PR DESCRIPTION
Delete the client.boostrap.* keys. These keys are not created by rook so it can't rotate them. This PR just delete these keys in the postMonStartUpAction.

Testing:

```
**Before:** 
sh-5.1$ ceph auth ls | grep bootstrap
client.bootstrap-mds
        caps: [mon] allow profile bootstrap-mds
client.bootstrap-mgr
        caps: [mon] allow profile bootstrap-mgr
client.bootstrap-osd
        caps: [mon] allow profile bootstrap-osd
client.bootstrap-rbd
        caps: [mon] allow profile bootstrap-rbd
client.bootstrap-rbd-mirror
        caps: [mon] allow profile bootstrap-rbd-mirror
client.bootstrap-rgw
        caps: [mon] allow profile bootstrap-rgw
sh-5.1$



**Rook logs for deleting the bootstrap keys:**

2025-08-28 04:14:23.249040 I | cephclient: deleting ceph auth "client.bootstrap-mds"
2025-08-28 04:14:23.894103 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-mds" in the namespace "rook-ceph"
2025-08-28 04:14:23.894171 I | cephclient: deleting ceph auth "client.bootstrap-mgr"
2025-08-28 04:14:24.376137 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-mgr" in the namespace "rook-ceph"
2025-08-28 04:14:24.376197 I | cephclient: deleting ceph auth "client.bootstrap-rbd"
2025-08-28 04:14:25.086693 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rbd" in the namespace "rook-ceph"
2025-08-28 04:14:25.086802 I | cephclient: deleting ceph auth "client.bootstrap-rbd-mirror"
2025-08-28 04:14:25.658211 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rbd-mirror" in the namespace "rook-ceph"
2025-08-28 04:14:25.658258 I | cephclient: deleting ceph auth "client.bootstrap-rgw"
2025-08-28 04:14:26.284718 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rgw" in the namespace "rook-ceph"


**After:** 
sh-5.1$ ceph auth ls | grep bootstrap
client.bootstrap-osd
        caps: [mon] allow profile bootstrap-osd
sh-5.1$




**Restarting the operator does not have show any errors when trying to delete the non existent bootstrap keys.** 

2025-08-28 04:23:47.913317 I | cephclient: deleting ceph auth "client.bootstrap-mds"
2025-08-28 04:23:49.030561 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-mds" in the namespace "rook-ceph"
2025-08-28 04:23:49.030601 I | cephclient: deleting ceph auth "client.bootstrap-mgr"
2025-08-28 04:23:50.281871 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-mgr" in the namespace "rook-ceph"
2025-08-28 04:23:50.281910 I | cephclient: deleting ceph auth "client.bootstrap-rbd"
2025-08-28 04:23:51.402010 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rbd" in the namespace "rook-ceph"
2025-08-28 04:23:51.403042 I | cephclient: deleting ceph auth "client.bootstrap-rbd-mirror"
2025-08-28 04:23:52.643383 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rbd-mirror" in the namespace "rook-ceph"
2025-08-28 04:23:52.649781 I | cephclient: deleting ceph auth "client.bootstrap-rgw"
2025-08-28 04:23:53.692497 I | ceph-cluster-controller: successfully deleted bootstrap key "client.bootstrap-rgw" in the namespace "rook-ceph"

``` 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
