### PR TITLE
build: use cosign to sign the images/helm charts

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -15,6 +15,7 @@ defaults:
 permissions:
   contents: read
   packages: write
+  id-token: write  # for cosign OIDC keyless signing
 
 jobs:
   push-image-to-container-registry:
@@ -35,6 +36,9 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # master
         with:
           platforms: all
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@4ea7c83ed23e5b1b86ff0db87c63b87e4d72c410 # v3.8.0
 
       - name: log in to container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -156,6 +156,7 @@ define chart.targets
 promote.chart.$(1).$(2):
 	@echo === helm push $(2) to $(1)
 	$(HELM) push $(HELM_OUTPUT_DIR)/$(2)-$(HELM_CHART_VERSION).tgz oci://$(1)
+	cosign sign --yes $(1)/$(2):$(HELM_CHART_VERSION)
 promote.all.charts: promote.chart.$(1).$(2)
 endef
 $(foreach r,$(REGISTRIES), $(foreach c,$(HELM_CHARTS),$(eval $(call chart.targets,$(r),$(c)))))
@@ -184,6 +185,8 @@ build.all.images: build.image.$(1).$(2)
 publish.image.$(1).$(2):
 	@$(DOCKERCMD) push $(1)/ceph-$(2):$(VERSION)
 	@$(DOCKERCMD) push $(1)/ceph-$(2):$(BRANCH_NAME)
+	cosign sign --yes $(1)/ceph-$(2):$(VERSION)
+	cosign sign --yes $(1)/ceph-$(2):$(BRANCH_NAME)
 
 publish.all.images.$(1): publish.image.$(1).$(2)
 endef
@@ -193,11 +196,12 @@ define repo.manifest.targets
 publish.manifest.image.$(1): publish.all.images.$(1) $(MANIFEST_TOOL)
 	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(VERSION) --target $(1)/ceph:$(VERSION)
 	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(BRANCH_NAME) --target $(1)/ceph:$(BRANCH_NAME)
+	cosign sign --yes $(1)/ceph:$(VERSION)
+	cosign sign --yes $(1)/ceph:$(BRANCH_NAME)
 
 publish.images: publish.manifest.image.$(1)
 endef
 $(foreach r,$(REGISTRIES),$(eval $(call repo.manifest.targets,$(r))))
-
 
 build.images: build.all.images
 build.charts: build.all.charts


### PR DESCRIPTION
this commit added changes to use cosign to sign the docker images and the helm charts being published to different the oci repos. This will enhance software supply chain security by enabling signing and verification of container images, ensuring their authenticity and integrity

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #15558


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
