### PR TITLE
csi: Generate default crush topology labels

### DIFF
--- a/pkg/operator/ceph/csi/ceph_connection.go
+++ b/pkg/operator/ceph/csi/ceph_connection.go
@@ -18,11 +18,13 @@ package csi
 
 import (
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/topology"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
@@ -72,8 +74,13 @@ func generateCephConnSpec(c client.Client, clusterInfo *cephclient.ClusterInfo, 
 	csiClusterConnSpec := csiopv1.CephConnectionSpec{}
 
 	if clusterSpec.CSI.ReadAffinity.Enabled {
+		crushLabels := clusterSpec.CSI.ReadAffinity.CrushLocationLabels
+		if len(crushLabels) == 0 {
+			logger.Debug("using default crush topology labels")
+			crushLabels = strings.Split(topology.GetDefaultTopologyLabels(), ",")
+		}
 		csiClusterConnSpec.ReadAffinity = &csiopv1.ReadAffinitySpec{
-			CrushLocationLabels: clusterSpec.CSI.ReadAffinity.CrushLocationLabels,
+			CrushLocationLabels: crushLabels,
 		}
 	}
 


### PR DESCRIPTION
The csi read affinity requires the crush topology labels to be specified in the cephconnection CR. If they are not specified by the user, rook can generate the default topology labels instead of expecting them.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16365

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
