### PR TITLE
build: fix/improve an error message

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -108,7 +108,7 @@ ifeq ($(filter help clean distclean prune go.clean, $(MAKECMDGOALS)),)
 .PHONY: go.check
 go.check:
 ifneq ($(shell $(GO) version | grep -q -E '\bgo($(GO_SUPPORTED_VERSIONS))\b' && echo 0 || echo 1), 0)
-	$(error unsupported: $(GO_FULL_VERSION). Please make install one of the following supported version: '$(GO_SUPPORTED_VERSIONS)')
+	$(error unsupported: $(GO_FULL_VERSION). Please install one of the following supported versions: '$(GO_SUPPORTED_VERSIONS)')
 endif
 
 -include go.check


### PR DESCRIPTION
The error message issued by `make` when the available golang was ont one of the supported versions was somewhat confusion or even broken.

This change fixes the message.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
