### PR TITLE
csi: Always initialize CSI driver names

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"path"
 	"strings"
 	"time"
@@ -312,26 +311,6 @@ func (r *ReconcileCSI) startDrivers(ownerInfo *k8sutil.OwnerInfo) error {
 		Param:     CSIParam,
 		Namespace: r.opConfig.OperatorNamespace,
 	}
-
-	if strings.HasSuffix(tp.DriverNamePrefix, ".") {
-		// As operator is adding a dot at the end of the prefix, we should not
-		// allow the user to add a dot at the end of the prefix. as it will
-		// result in two dots at the end of the prefix. which cases the csi
-		// driver name creation failure
-		return errors.Errorf("driver name prefix %q should not end with a dot", tp.DriverNamePrefix)
-	}
-
-	err = validateCSIDriverNamePrefix(r.opManagerContext, r.context.Clientset, r.opConfig.OperatorNamespace, tp.DriverNamePrefix)
-	if err != nil {
-		return err
-	}
-	// Add a dot at the end of the prefix for having the driver name prefix
-	// with format <prefix>.<driver-name>
-	tp.DriverNamePrefix = fmt.Sprintf("%s.", tp.DriverNamePrefix)
-
-	CephFSDriverName = tp.DriverNamePrefix + cephFSDriverSuffix
-	RBDDriverName = tp.DriverNamePrefix + rbdDriverSuffix
-	NFSDriverName = tp.DriverNamePrefix + nfsDriverSuffix
 
 	tp.Param.MountCustomCephConf = CustomCSICephConfigExists
 
@@ -662,10 +641,6 @@ func (r *ReconcileCSI) startDrivers(ownerInfo *k8sutil.OwnerInfo) error {
 }
 
 func (r *ReconcileCSI) stopDrivers() error {
-	RBDDriverName = fmt.Sprintf("%s.rbd.csi.ceph.com", r.opConfig.OperatorNamespace)
-	CephFSDriverName = fmt.Sprintf("%s.cephfs.csi.ceph.com", r.opConfig.OperatorNamespace)
-	NFSDriverName = fmt.Sprintf("%s.nfs.csi.ceph.com", r.opConfig.OperatorNamespace)
-
 	if !EnableRBD || EnableCSIOperator() {
 		logger.Debugf("either EnableRBD if `false` or EnableCSIOperator is `true`, `EnableRBD is %t` and `EnableCSIOperator is %t", EnableRBD, EnableCSIOperator())
 		err := r.deleteCSIDriverResources(CsiRBDPlugin, csiRBDProvisioner, "csi-rbdplugin-metrics", RBDDriverName)


### PR DESCRIPTION
The driver names were only being initialized in certain code paths where the drivers were being started and stopped. However, another code path relied on those names being set. Now, we initialize the driver names every time the CSI params are initialized, instead of initializing the names separately.

The pitfalls of package vars... 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
