### PR TITLE
csi: Set the cephfs kernel mount options when network encryption is enabled

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/cluster.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster.go
@@ -33,6 +33,17 @@ func (c *ClusterSpec) RequireMsgr2() bool {
 	return false
 }
 
+// RequireMsgr2 checks if the network settings require the msgr2 protocol
+func (c *ClusterSpec) NetworkEncryptionEnabled() bool {
+	if c.Network.Connections == nil {
+		return false
+	}
+	if c.Network.Connections.Encryption == nil {
+		return false
+	}
+	return c.Network.Connections.Encryption.Enabled
+}
+
 func (c *ClusterSpec) IsStretchCluster() bool {
 	return c.Mon.StretchCluster != nil && len(c.Mon.StretchCluster.Zones) > 0
 }

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -734,9 +734,7 @@ func (c *cluster) configureMsgr2() error {
 	}
 	monStore := config.GetMonStore(c.context, c.ClusterInfo)
 
-	encryptionEnabled := c.Spec.Network.Connections != nil &&
-		c.Spec.Network.Connections.Encryption != nil &&
-		c.Spec.Network.Connections.Encryption.Enabled
+	encryptionEnabled := c.Spec.NetworkEncryptionEnabled()
 
 	if encryptionEnabled {
 		logger.Infof("setting msgr2 encryption mode to %q", encryptionSetting)

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -168,6 +168,10 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 	if len(clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels) == 0 {
 		clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels = strings.Split(topology.GetDefaultTopologyLabels(), ",")
 	}
+	// if the csi spec does not specify mount options, apply them from the operator env vars
+	if cephClusterSpec.CSI.CephFS.KernelMountOptions == "" {
+		clusterInfo.CSIDriverSpec.CephFS.KernelMountOptions = k8sutil.GetOperatorSetting("CSI_CEPHFS_KERNEL_MOUNT_OPTIONS", "")
+	}
 
 	// If an admin key was provided we don't need to load the other resources
 	// Some people might want to give the admin key

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -163,15 +163,8 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 	// can run on remote executor
 	clusterInfo.NetworkSpec = cephClusterSpec.Network
 
-	// update clusterInfo with cephClusterSpec.CSI.
-	clusterInfo.CSIDriverSpec = cephClusterSpec.CSI
-	if len(clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels) == 0 {
-		clusterInfo.CSIDriverSpec.ReadAffinity.CrushLocationLabels = strings.Split(topology.GetDefaultTopologyLabels(), ",")
-	}
-	// if the csi spec does not specify mount options, apply them from the operator env vars
-	if cephClusterSpec.CSI.CephFS.KernelMountOptions == "" {
-		clusterInfo.CSIDriverSpec.CephFS.KernelMountOptions = k8sutil.GetOperatorSetting("CSI_CEPHFS_KERNEL_MOUNT_OPTIONS", "")
-	}
+	// update clusterInfo with cephClusterSpec.CSI settings
+	clusterInfo.CSIDriverSpec = loadCsiSettings(cephClusterSpec)
 
 	// If an admin key was provided we don't need to load the other resources
 	// Some people might want to give the admin key
@@ -193,6 +186,25 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, context context.
 	}
 
 	return clusterInfo, maxMonID, monMapping, nil
+}
+
+func loadCsiSettings(cephClusterSpec *cephv1.ClusterSpec) cephv1.CSIDriverSpec {
+	settings := cephClusterSpec.CSI
+	if len(settings.ReadAffinity.CrushLocationLabels) == 0 {
+		settings.ReadAffinity.CrushLocationLabels = strings.Split(topology.GetDefaultTopologyLabels(), ",")
+	}
+	// if the csi spec does not specify mount options, apply them from the operator env vars
+	if cephClusterSpec.CSI.CephFS.KernelMountOptions == "" {
+		settings.CephFS.KernelMountOptions = k8sutil.GetOperatorSetting("CSI_CEPHFS_KERNEL_MOUNT_OPTIONS", "")
+		// if the kernel mount options are not set and encryption is enabled, set the default to secure
+		if settings.CephFS.KernelMountOptions == "" {
+			if cephClusterSpec.NetworkEncryptionEnabled() {
+				logger.Info("setting default cephfs kernel mount options to 'ms_mode=secure' since encryption is enabled")
+				settings.CephFS.KernelMountOptions = "ms_mode=secure"
+			}
+		}
+	}
+	return settings
 }
 
 // create new cluster info (FSID, shared keys)

--- a/pkg/operator/ceph/controller/cluster_info_test.go
+++ b/pkg/operator/ceph/controller/cluster_info_test.go
@@ -139,4 +139,25 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "testid", info.CephCred.Username)
 	assert.Equal(t, "testkey", info.CephCred.Secret)
+	assert.Equal(t, "", info.CSIDriverSpec.CephFS.KernelMountOptions)
+
+	// Verify the csi settings are loaded from an env var
+	t.Setenv("CSI_CEPHFS_KERNEL_MOUNT_OPTIONS", "ms_mode=crc")
+	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, cephClusterSpec)
+	assert.NoError(t, err)
+	assert.Equal(t, "ms_mode=crc", info.CSIDriverSpec.CephFS.KernelMountOptions)
+
+	// Verify the csi settings are loaded from the cephClusterSpec if specified and override the env var
+	cephClusterSpec.CSI = cephv1.CSIDriverSpec{
+		ReadAffinity: cephv1.ReadAffinitySpec{
+			Enabled:             true,
+			CrushLocationLabels: []string{"kubernetes.io/hostname"},
+		},
+		CephFS: cephv1.CSICephFSSpec{
+			KernelMountOptions: "ms_mode=secure",
+		},
+	}
+	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, cephClusterSpec)
+	assert.NoError(t, err)
+	assert.Equal(t, "ms_mode=secure", info.CSIDriverSpec.CephFS.KernelMountOptions)
 }

--- a/pkg/operator/ceph/controller/cluster_info_test.go
+++ b/pkg/operator/ceph/controller/cluster_info_test.go
@@ -141,7 +141,20 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.Equal(t, "testkey", info.CephCred.Secret)
 	assert.Equal(t, "", info.CSIDriverSpec.CephFS.KernelMountOptions)
 
+	// Verify the csi settings default to secure if the network is encrypted
+	cephClusterSpec.Network = cephv1.NetworkSpec{
+		Connections: &cephv1.ConnectionsSpec{
+			Encryption: &cephv1.EncryptionSpec{
+				Enabled: true,
+			},
+		},
+	}
+	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, cephClusterSpec)
+	assert.NoError(t, err)
+	assert.Equal(t, "ms_mode=secure", info.CSIDriverSpec.CephFS.KernelMountOptions)
+
 	// Verify the csi settings are loaded from an env var
+	cephClusterSpec.Network = cephv1.NetworkSpec{}
 	t.Setenv("CSI_CEPHFS_KERNEL_MOUNT_OPTIONS", "ms_mode=crc")
 	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, cephClusterSpec)
 	assert.NoError(t, err)


### PR DESCRIPTION
The behavior of the cephfs kernel mount options now has the following precedence:
1. If CephCluster CR setting: `spec.csi.cephfs.kernelMountOptions`
2. Else Operator env var `CSI_CEPHFS_KERNEL_MOUNT_OPTIONS`
3. Else if the CephCluster CR setting `spec.network.connections.encrypted.enabled: true`, then set the kernel mount options to `ms_mode: secure`

There was also a bug causing the ClientProfile CR to never be updated (new with the csi operator), which is now fixed.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  6. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  7. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  8. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13227 #16369

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
