### PR TITLE
osd: rotate lockbox keys for encrypted osd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -64,12 +64,6 @@ func (c *Cluster) getOSDLabels(osd OSDInfo, failureDomainValue string, portable 
 		labels[deviceType] = osd.DeviceType
 	}
 
-	encryptedOSD := "false"
-	if osd.Encrypted {
-		encryptedOSD = "true"
-	}
-	labels[encrypted] = encryptedOSD
-
 	for k, v := range getOSDTopologyLocationLabels(osd.Location) {
 		labels[k] = v
 	}


### PR DESCRIPTION
ceph-volume creates osd-lockbox keys for the encryted osds. This PR rotates those keys along with the OSD keys. Lockbox keys are rotated right after the osd key rotation. No separate status is maintained for these keys. 


Tested on both OSDs on PVs and OSDs on disk.

```
**Before rotation:** 

client.osd-lockbox.070c0bf3-5e90-4a4c-ab13-ec10cd4a6903
        key: AQBmdLFo02zlFxAA+VW+fHjpS+1ohZVIndL4Mw==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/070c0bf3-5e90-4a4c-ab13-ec10cd4a6903/luks"
client.osd-lockbox.3ccbc60c-9019-4f49-b80e-c0fe31229d95
        key: AQCJdLFooQpHMhAATTNULhcLY7tkgEQDC+CVFQ==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/3ccbc60c-9019-4f49-b80e-c0fe31229d95/luks"
client.osd-lockbox.e7f04984-1367-4b8d-b173-29b317df0aa2
        key: AQChdLFoilJJJhAA9qjrO42jEg+Cu7LX12mIZQ==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/e7f04984-1367-4b8d-b173-29b317df0aa2/luks"
client.rbd-mirror-peer



**After Rotation:** 

client.osd-lockbox.070c0bf3-5e90-4a4c-ab13-ec10cd4a6903
        key: AQAbdrFoL2C1DxAAJ5plWMWdQW3KIK8qGlfp0A==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/070c0bf3-5e90-4a4c-ab13-ec10cd4a6903/luks"
client.osd-lockbox.3ccbc60c-9019-4f49-b80e-c0fe31229d95
        key: AQBSdrFoOB76JhAAGrdmrVl8BsXaSbIey3tQpA==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/3ccbc60c-9019-4f49-b80e-c0fe31229d95/luks"
client.osd-lockbox.e7f04984-1367-4b8d-b173-29b317df0aa2
        key: AQB9drFob125CRAAHwTWtMXVibGyrYF6FSPkPg==
        caps: [mon] allow command "config-key get" with key="dm-crypt/osd/e7f04984-1367-4b8d-b173-29b317df0aa2/luks"


**Rook logs:** 

❯ kr1 logs rook-ceph-operator-bd686989d-fb456  --follow | grep "rotat"
2025-08-29 09:40:02.553571 I | ceph-cluster-controller: beginning admin cephx key rotation for cluster in namespace "rook-ceph"
2025-08-29 09:40:02.553638 I | cephclient: getting or creating ceph auth key "client.admin-rotator"
2025-08-29 09:40:03.832544 I | ceph-cluster-controller: temporarily storing admin rotator keyring at "/var/lib/rook/rook-ceph/admin-rotate/client.admin-rotator.keyring" for cluster in namespace "rook-ceph"
2025-08-29 09:40:05.160366 I | ceph-cluster-controller: admin cephx key will be rotated for cluster in namespace "rook-ceph". rook will restart afterwards. some reconciles and health checks may fail in between - this is normal
2025-08-29 09:40:05.160404 I | cephclient: rotating ceph auth key "client.admin"
2025-08-29 09:40:06.508430 I | ceph-cluster-controller: temporarily storing rotated admin cephx keyring at "/var/lib/rook/rook-ceph/admin-rotate/client.admin.keyring" for cluster in namespace "rook-ceph"
2025-08-29 09:40:07.583148 I | cephclient: deleting ceph auth "client.admin-rotator"
2025-08-29 09:40:09.188042 I | ceph-spec: object "rook-ceph-admin-rotator-keyring" matched on delete, reconciling
2025-08-29 09:40:09.229126 I | ceph-cluster-controller: restarting rook operator after successful admin cephx key rotation for cluster in namespace "rook-ceph"
2025-08-29 09:41:09.906771 I | op-mon: cephx keys for mon daemons in the namespace "rook-ceph" will be rotated
2025-08-29 09:41:09.906812 I | cephclient: rotating ceph auth key "mon."
2025-08-29 09:41:10.881080 I | op-mon: successfully rotated cephx keys for mon daemons in the namespace "rook-ceph"
2025-08-29 09:41:10.991062 E | ceph-spec: failed to update cluster condition to {Type:Progressing Status:False Reason:ClusterProgressing Message:failed to create cluster: failed to execute post actions after all the ceph monitors started: triggering a new reconcile to restart the mon daemons after mon cephx key rotation LastHeartbeatTime:2025-08-29 09:41:10.963601959 +0000 UTC m=+470.268302680 LastTransitionTime:2025-08-29 09:41:10.963601678 +0000 UTC m=+470.268302424}. failed to update object "rook-ceph/my-cluster" status: Operation cannot be fulfilled on cephclusters.ceph.rook.io "my-cluster": the object has been modified; please apply your changes to the latest version and try again
2025-08-29 09:41:58.920295 I | ceph-nodedaemon-controller: rotating cephx key for crash collector "client.crash"
2025-08-29 09:41:58.920409 I | cephclient: rotating ceph auth key "client.crash"
2025-08-29 09:42:03.101938 I | ceph-nodedaemon-controller: rotating cephx key for ceph exporter "client.ceph-exporter"
2025-08-29 09:42:03.101976 I | cephclient: rotating ceph auth key "client.ceph-exporter"
2025-08-29 09:42:08.936301 I | op-mgr: cephx keys for mgr daemons in the namespace "rook-ceph" will be rotated
2025-08-29 09:42:10.251380 I | op-mgr: rotating cephx key for mgr daemon "rook-ceph-mgr-a" in the namespace "rook-ceph"
2025-08-29 09:42:10.251463 I | cephclient: rotating ceph auth key "mgr.a"
2025-08-29 09:42:44.599870 I | op-osd: rotating cephx key of OSD 0 for CephCluster in namespace "rook-ceph"
2025-08-29 09:42:44.599922 I | cephclient: rotating ceph auth key "osd.0"
2025-08-29 09:42:46.999938 I | op-osd: rotating osd-lockbox cephx key of encrypted OSD 0 for CephCluster in namespace "rook-ceph"
2025-08-29 09:42:46.999952 I | cephclient: rotating ceph auth key "client.osd-lockbox.070c0bf3-5e90-4a4c-ab13-ec10cd4a6903"
2025-08-29 09:43:41.855014 I | op-osd: rotating cephx key of OSD 1 for CephCluster in namespace "rook-ceph"
2025-08-29 09:43:41.855052 I | cephclient: rotating ceph auth key "osd.1"
2025-08-29 09:43:44.630832 I | op-osd: rotating osd-lockbox cephx key of encrypted OSD 1 for CephCluster in namespace "rook-ceph"
2025-08-29 09:43:44.630848 I | cephclient: rotating ceph auth key "client.osd-lockbox.3ccbc60c-9019-4f49-b80e-c0fe31229d95"
2025-08-29 09:44:25.629743 I | op-osd: rotating cephx key of OSD 2 for CephCluster in namespace "rook-ceph"
2025-08-29 09:44:25.638185 I | cephclient: rotating ceph auth key "osd.2"
2025-08-29 09:44:27.417035 I | op-osd: rotating osd-lockbox cephx key of encrypted OSD 2 for CephCluster in namespace "rook-ceph"
2025-08-29 09:44:27.417051 I | cephclient: rotating ceph auth key "client.osd-lockbox.e7f04984-1367-4b8d-b173-29b317df0aa2"



**OSD activate container logs for OSDs on disks**


❯ kr1 logs rook-ceph-osd-0-7cc9bcf849-rtm84  -c activate
+ OSD_ID=0
+ OSD_UUID=91d54eb8-b17a-4b01-baa0-486dae5439b4
+ OSD_STORE_FLAG=--bluestore
+ OSD_DATA_DIR=/var/lib/ceph/osd/ceph-0
+ KEYRING_FILE=/var/lib/ceph/osd/ceph-0/keyring
+ CV_MODE=lvm
+ DEVICE=/dev/ceph-3df181f5-e4e6-45a8-9fab-4235baa7efc2/osd-block-91d54eb8-b17a-4b01-baa0-486dae5439b4
+ ENCRYPTED=true
+ '[' true == true ']'
+ LOCKBOX_KEYRING_FILE=/var/lib/ceph/osd/ceph-0/lockbox.keyring
+ LOCKBOX_USER=client.osd-lockbox.91d54eb8-b17a-4b01-baa0-486dae5439b4
+ ceph --name client.admin auth get-or-create client.osd-lockbox.91d54eb8-b17a-4b01-baa0-486dae5439b4 mon 'allow command "config-key get" with key="dm-crypt/osd/91d54eb8-b17a-4b01-baa0-486dae5439b4/luks"' --keyring /etc/ceph/admin-keyring-store/keyring
+ [[ lvm == \l\v\m ]]
++ mktemp -d
+ TMP_DIR=/tmp/tmp.MHweQvElpz
+ echo 'devices { filter = ["r|/dev/rbd.*|"] }'
+ ceph-volume lvm activate --no-systemd --bluestore 0 91d54eb8-b17a-4b01-baa0-486dae5439b4
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
--> Running ceph config-key get dm-crypt/osd/91d54eb8-b17a-4b01-baa0-486dae5439b4/luks
Running command: /usr/bin/ceph --cluster ceph --name client.osd-lockbox.91d54eb8-b17a-4b01-baa0-486dae5439b4 --keyring /var/lib/ceph/osd/ceph-0/lockbox.keyring config-key get dm-crypt/osd/91d54eb8-b17a-4b01-baa0-486dae5439b4/luks
Running command: /usr/sbin/cryptsetup --key-size 512 --key-file - --allow-discards luksOpen /dev/ceph-3df181f5-e4e6-45a8-9fab-4235baa7efc2/osd-block-91d54eb8-b17a-4b01-baa0-486dae5439b4 nsgzGN-xTAA-KK66-x1mh-FsHJ-c2el-3VLk5a
 stderr: Device nsgzGN-xTAA-KK66-x1mh-FsHJ-c2el-3VLk5a already exists.
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-0
Running command: /usr/bin/ceph-bluestore-tool --cluster=ceph prime-osd-dir --dev /dev/mapper/nsgzGN-xTAA-KK66-x1mh-FsHJ-c2el-3VLk5a --path /var/lib/ceph/osd/ceph-0 --no-mon-config
Running command: /usr/bin/ln -snf /dev/mapper/nsgzGN-xTAA-KK66-x1mh-FsHJ-c2el-3VLk5a /var/lib/ceph/osd/ceph-0/block
Running command: /usr/bin/chown -h ceph:ceph /var/lib/ceph/osd/ceph-0/block
Running command: /usr/bin/chown -R ceph:ceph /dev/mapper/nsgzGN-xTAA-KK66-x1mh-FsHJ-c2el-3VLk5a
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-0
--> ceph-volume lvm activate successful for osd ID: 0

```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
