### PR TITLE
osd: remove the osd bootstrap keyring

### DIFF
--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -56,16 +56,6 @@ func CephKeyring(cred CephCred) string {
 // CreateKeyring creates a keyring for access to the cluster with the desired set of privileges
 // and writes it to disk at the keyring path
 func CreateKeyring(context *clusterd.Context, clusterInfo *ClusterInfo, username, keyringPath string, access []string, generateContents func(string) string) error {
-	_, err := os.Stat(keyringPath)
-	if err == nil {
-		// no error, the file exists, bail out with no error
-		logger.Debugf("keyring already exists at %s", keyringPath)
-		return nil
-	} else if !os.IsNotExist(err) {
-		// some other error besides "does not exist", bail out with error
-		return errors.Wrapf(err, "failed to stat %s", keyringPath)
-	}
-
 	// get-or-create-key for the user account
 	key, err := AuthGetOrCreateKey(context, clusterInfo, username, access)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -350,8 +350,20 @@ func (c *Cluster) Start() error {
 		return errors.Wrapf(err, "failed to update ceph storage status")
 	}
 
+	// remove the osdBootstrapKey as the osds are running
+	c.deleteOsdBootstrapKeyring()
+
 	logger.Infof("finished running OSDs in namespace %q", namespace)
 	return nil
+}
+
+func (c *Cluster) deleteOsdBootstrapKeyring() {
+	err := cephclient.AuthDelete(c.context, c.clusterInfo, "client.bootstrap-osd")
+	if err != nil {
+		logger.Debugf("failed to delete client.bootstrap-osd bootstrap key in the namespace %q. Error: %v", c.clusterInfo.Namespace, err)
+	} else {
+		logger.Debugf("successfully deleted client.bootstrap-osd bootstrap key in the namespace %q", c.clusterInfo.Namespace)
+	}
 }
 
 func (c *Cluster) startOSDMigration() (*migrationConfig, error) {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -343,7 +344,11 @@ func TestAddRemoveNode(t *testing.T) {
 				return `{}`, nil
 			}
 			if args[0] == "auth" && args[1] == "del" {
-				assert.Equal(t, "osd.1", args[2])
+				if strings.HasPrefix(args[2], "osd.") {
+					assert.Equal(t, "osd.1", args[2])
+				} else if strings.HasPrefix(args[2], "client.") {
+					assert.Equal(t, "client.bootstrap-osd", args[2])
+				}
 				return "", nil
 			}
 			return "", errors.Errorf("unexpected ceph command %q", args)


### PR DESCRIPTION
when the osd is created there is no need for
osd bootstrap keyring, so remove the keyring
and keyring file,

New keyring will be created if
new osd need to be provisoned

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
