### PR TITLE
test: fix create-dev-cluster.sh hanging since v1.18

### DIFF
--- a/tests/scripts/create-dev-cluster.sh
+++ b/tests/scripts/create-dev-cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DEFAULT_NS="rook-ceph"
-CLUSTER_FILES="common.yaml operator.yaml cluster-test.yaml cluster-on-pvc-minikube.yaml dashboard-external-http.yaml toolbox.yaml"
+CLUSTER_FILES="common.yaml operator.yaml cluster-test.yaml cluster-on-pvc-minikube.yaml dashboard-external-http.yaml toolbox.yaml csi-operator.yaml"
 MONITORING_FILES="monitoring/prometheus.yaml monitoring/service-monitor.yaml monitoring/exporter-service-monitor.yaml monitoring/prometheus-service.yaml monitoring/rbac.yaml"
 SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
@@ -122,7 +122,7 @@ create_rook_cluster() {
     if ! kubectl get namespace "$ROOK_OPERATOR_NS" &> /dev/null; then
 	kubectl create namespace "$ROOK_OPERATOR_NS"
     fi
-    $KUBECTL apply -f crds.yaml -f common.yaml -f operator.yaml
+    $KUBECTL apply -f crds.yaml -f common.yaml -f operator.yaml -f csi-operator.yaml
     $KUBECTL apply -f "$ROOK_CLUSTER_SPEC_FILE" -f toolbox.yaml
     $KUBECTL apply -f dashboard-external-http.yaml
 }


### PR DESCRIPTION
Currently create-dev-cluster.sh will hang as the rook operator gets stuck like so:
```
2025-09-08 20:29:58.093909 E | ceph-cluster-controller: failed to reconcile CephCluster "rook-ceph/my-cluster". failed to reconcile cluster "my-cluster": failed to configure local ceph cluster: failed to create cluster: failed to start ceph monitors: failed to initialize ceph cluster info: failed to save mons: failed to create/update cephConnection: failed to get ceph connection CR: no matches for kind "CephConnection" in version "csi.ceph.io/v1"
```

Reconciling the mons is blocked until the new CephConnection CRD is available, and that CRD is new as of v1.18.

The simple fix is to simply install those CRDs in create-dev-cluster.sh. After doing this, the dev cluster bootstraps fine.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
