### PR TITLE
helm: refactoring of rook-ceph's configmap to be easier to read and maintain

### DIFF
--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -269,10 +269,10 @@ data:
   CSI_CEPHFS_ATTACH_REQUIRED: {{ .cephFSAttachRequired | quote }}
   CSI_RBD_ATTACH_REQUIRED: {{ .rbdAttachRequired | quote }}
   CSI_NFS_ATTACH_REQUIRED: {{ .nfsAttachRequired | quote }}
+  {{- if .kubeApiBurst }}
+  CSI_KUBE_API_BURST: {{ .kubeApiBurst | quote }}
   {{- end }}
-  {{- if .Values.csi.kubeApiBurst }}
-  CSI_KUBE_API_BURST: {{ .Values.csi.kubeApiBurst | quote }}
+  {{- if .kubeApiQPS }}
+  CSI_KUBE_API_QPS: {{ .kubeApiQPS | quote }}
   {{- end }}
-  {{- if .Values.csi.kubeApiQPS }}
-  CSI_KUBE_API_QPS: {{ .Values.csi.kubeApiQPS | quote }}
   {{- end }}

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -137,7 +137,7 @@ data:
   {{- with .topology }}
   CSI_ENABLE_TOPOLOGY: {{ .enabled | quote }}
   {{- with .domainLabels }}
-  CSI_TOPOLOGY_DOMAIN_LABELS: {{ . | join "," }}
+  CSI_TOPOLOGY_DOMAIN_LABELS: {{ . | join "," | quote }}
   {{- end }}
   {{- end }}
   {{- with .nfs }}
@@ -156,49 +156,49 @@ data:
   CSI_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .provisionerNodeAffinity }}
-  CSI_PROVISIONER_NODE_AFFINITY: {{ . }}
+  CSI_PROVISIONER_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .rbdProvisionerTolerations }}
   CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .rbdProvisionerNodeAffinity }}
-  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ . }}
+  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .cephFSProvisionerTolerations }}
   CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .cephFSProvisionerNodeAffinity }}
-  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ . }}
+  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .nfsProvisionerTolerations }}
   CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .nfsProvisionerNodeAffinity }}
-  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ . }}
+  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .pluginTolerations }}
   CSI_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .pluginNodeAffinity }}
-  CSI_PLUGIN_NODE_AFFINITY: {{ . }}
+  CSI_PLUGIN_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .rbdPluginTolerations }}
   CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .rbdPluginNodeAffinity }}
-  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ . }}
+  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .cephFSPluginTolerations }}
   CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .cephFSPluginNodeAffinity }}
-  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ . }}
+  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .nfsPluginTolerations }}
   CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
   {{- with .nfsPluginNodeAffinity }}
-  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ . }}
+  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ . | quote }}
   {{- end }}
   {{- with .cephfsLivenessMetricsPort }}
   CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ . | quote }}

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -9,25 +9,25 @@ data:
   ROOK_LOG_LEVEL: {{ .Values.logLevel | quote }}
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: {{ .Values.cephCommandsTimeoutSeconds | quote }}
   ROOK_OBC_WATCH_OPERATOR_NAMESPACE: {{ .Values.enableOBCWatchOperatorNamespace | quote }}
-  {{- if .Values.operatorMetricsBindAddress }}
-  ROOK_OPERATOR_METRICS_BIND_ADDRESS: {{ .Values.operatorMetricsBindAddress | quote }}
+  {{- with .Values.operatorMetricsBindAddress }}
+  ROOK_OPERATOR_METRICS_BIND_ADDRESS: {{ . | quote }}
   {{- end }}
-  {{- if .Values.obcProvisionerNamePrefix }}
-  ROOK_OBC_PROVISIONER_NAME_PREFIX: {{ .Values.obcProvisionerNamePrefix | quote }}
+  {{- with .Values.obcProvisionerNamePrefix }}
+  ROOK_OBC_PROVISIONER_NAME_PREFIX: {{ . | quote }}
   {{- end }}
-  {{- if .Values.obcAllowAdditionalConfigFields }}
-  ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: {{ .Values.obcAllowAdditionalConfigFields | quote }}
+  {{- with .Values.obcAllowAdditionalConfigFields }}
+  ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: {{ . | quote }}
   {{- end }}
   ROOK_CEPH_ALLOW_LOOP_DEVICES: {{ .Values.allowLoopDevices | quote }}
   ROOK_ENABLE_DISCOVERY_DAEMON: {{ .Values.enableDiscoveryDaemon | quote }}
-  {{- if .Values.discoverDaemonUdev }}
-  DISCOVER_DAEMON_UDEV_BLACKLIST: {{ .Values.discoverDaemonUdev | quote }}
+  {{- with .Values.discoverDaemonUdev }}
+  DISCOVER_DAEMON_UDEV_BLACKLIST: {{ . | quote }}
   {{- end }}
-  {{- if .Values.revisionHistoryLimit }}
-  ROOK_REVISION_HISTORY_LIMIT: {{ .Values.revisionHistoryLimit | quote }}
+  {{- with .Values.revisionHistoryLimit }}
+  ROOK_REVISION_HISTORY_LIMIT: {{ . | quote }}
   {{- end }}
-  {{- if .Values.enforceHostNetwork }}
-  ROOK_ENFORCE_HOST_NETWORK: {{ .Values.enforceHostNetwork | quote }}
+  {{- with .Values.enforceHostNetwork }}
+  ROOK_ENFORCE_HOST_NETWORK: {{ . | quote }}
   {{- end }}
 
   {{- with .Values.csi }}
@@ -44,235 +44,235 @@ data:
   CSI_ENABLE_HOST_NETWORK: {{ .enableCSIHostNetwork | quote }}
   CSI_ENABLE_METADATA: {{ .enableMetadata | quote }}
   CSI_ENABLE_VOLUME_GROUP_SNAPSHOT: {{ .enableVolumeGroupSnapshot | quote }}
-  {{- if .csiDriverNamePrefix }}
-  CSI_DRIVER_NAME_PREFIX: {{ .csiDriverNamePrefix | quote }}
+  {{- with .csiDriverNamePrefix }}
+  CSI_DRIVER_NAME_PREFIX: {{ . | quote }}
   {{- end }}
-  {{- if .pluginPriorityClassName }}
-  CSI_PLUGIN_PRIORITY_CLASSNAME: {{ .pluginPriorityClassName | quote }}
+  {{- with .pluginPriorityClassName }}
+  CSI_PLUGIN_PRIORITY_CLASSNAME: {{ . | quote }}
   {{- end }}
-  {{- if .provisionerPriorityClassName }}
-  CSI_PROVISIONER_PRIORITY_CLASSNAME: {{ .provisionerPriorityClassName | quote }}
+  {{- with .provisionerPriorityClassName }}
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: {{ . | quote }}
   {{- end }}
-  {{- if .cephFSPluginUpdateStrategy }}
-  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: {{ .cephFSPluginUpdateStrategy | quote }}
+  {{- with .cephFSPluginUpdateStrategy }}
+  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: {{ . | quote }}
   {{- end }}
-  {{- if .cephFSPluginUpdateStrategyMaxUnavailable }}
-  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .cephFSPluginUpdateStrategyMaxUnavailable | quote }}
+  {{- with .cephFSPluginUpdateStrategyMaxUnavailable }}
+  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ . | quote }}
   {{- end }}
-  {{- if .nfsPluginUpdateStrategy }}
-  CSI_NFS_PLUGIN_UPDATE_STRATEGY: {{ .nfsPluginUpdateStrategy | quote }}
+  {{- with .nfsPluginUpdateStrategy }}
+  CSI_NFS_PLUGIN_UPDATE_STRATEGY: {{ . | quote }}
   {{- end }}
-  {{- if .rbdFSGroupPolicy }}
-  CSI_RBD_FSGROUPPOLICY: {{ .rbdFSGroupPolicy | quote }}
+  {{- with .rbdFSGroupPolicy }}
+  CSI_RBD_FSGROUPPOLICY: {{ . | quote }}
   {{- end }}
-  {{- if .cephFSFSGroupPolicy }}
-  CSI_CEPHFS_FSGROUPPOLICY: {{ .cephFSFSGroupPolicy | quote }}
+  {{- with .cephFSFSGroupPolicy }}
+  CSI_CEPHFS_FSGROUPPOLICY: {{ . | quote }}
   {{- end }}
-  {{- if .nfsFSGroupPolicy }}
-  CSI_NFS_FSGROUPPOLICY: {{ .nfsFSGroupPolicy | quote }}
+  {{- with .nfsFSGroupPolicy }}
+  CSI_NFS_FSGROUPPOLICY: {{ . | quote }}
   {{- end }}
-  {{- if .rbdPluginUpdateStrategy }}
-  CSI_RBD_PLUGIN_UPDATE_STRATEGY: {{ .rbdPluginUpdateStrategy | quote }}
+  {{- with .rbdPluginUpdateStrategy }}
+  CSI_RBD_PLUGIN_UPDATE_STRATEGY: {{ . | quote }}
   {{- end }}
-  {{- if .cephFSKernelMountOptions }}
-  CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: {{ .cephFSKernelMountOptions | quote }}
+  {{- with .cephFSKernelMountOptions }}
+  CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: {{ . | quote }}
   {{- end }}
-  {{- if .rbdPluginUpdateStrategyMaxUnavailable }}
-  CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .rbdPluginUpdateStrategyMaxUnavailable | quote }}
+  {{- with .rbdPluginUpdateStrategyMaxUnavailable }}
+  CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ . | quote }}
   {{- end }}
-  {{- if .kubeletDirPath }}
-  ROOK_CSI_KUBELET_DIR_PATH: {{ .kubeletDirPath | quote }}
+  {{- with .kubeletDirPath }}
+  ROOK_CSI_KUBELET_DIR_PATH: {{ . | quote }}
   {{- end }}
-  {{- if .csiLeaderElectionLeaseDuration }}
-  CSI_LEADER_ELECTION_LEASE_DURATION: {{ .csiLeaderElectionLeaseDuration | quote }}
+  {{- with .csiLeaderElectionLeaseDuration }}
+  CSI_LEADER_ELECTION_LEASE_DURATION: {{ . | quote }}
   {{- end }}
-  {{- if .csiLeaderElectionRenewDeadline }}
-  CSI_LEADER_ELECTION_RENEW_DEADLINE: {{ .csiLeaderElectionRenewDeadline | quote }}
+  {{- with .csiLeaderElectionRenewDeadline }}
+  CSI_LEADER_ELECTION_RENEW_DEADLINE: {{ . | quote }}
   {{- end }}
-  {{- if .csiLeaderElectionRetryPeriod }}
-  CSI_LEADER_ELECTION_RETRY_PERIOD: {{ .csiLeaderElectionRetryPeriod | quote }}
+  {{- with .csiLeaderElectionRetryPeriod }}
+  CSI_LEADER_ELECTION_RETRY_PERIOD: {{ . | quote }}
   {{- end }}
-  {{- if .cephcsi }}
-  {{- if and .cephcsi.repository .cephcsi.tag }}
-  ROOK_CSI_CEPH_IMAGE: "{{ .cephcsi.repository }}:{{ .cephcsi.tag }}"
+  {{- with .cephcsi }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_CEPH_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .registrar }}
-  {{- if and .registrar.repository .registrar.tag }}
-  ROOK_CSI_REGISTRAR_IMAGE: "{{ .registrar.repository }}:{{ .registrar.tag }}"
+  {{- with .registrar }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_REGISTRAR_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .provisioner }}
-  {{- if and .provisioner.repository .provisioner.tag }}
-  ROOK_CSI_PROVISIONER_IMAGE: "{{ .provisioner.repository }}:{{ .provisioner.tag }}"
+  {{- with .provisioner }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_PROVISIONER_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .snapshotter }}
-  {{- if and .snapshotter.repository .snapshotter.tag }}
-  ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .snapshotter.repository }}:{{ .snapshotter.tag }}"
+  {{- with .snapshotter }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .attacher }}
-  {{- if and .attacher.repository .attacher.tag }}
-  ROOK_CSI_ATTACHER_IMAGE: "{{ .attacher.repository }}:{{ .attacher.tag }}"
+  {{- with .attacher }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_ATTACHER_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .resizer }}
-  {{- if and .resizer.repository .resizer.tag }}
-  ROOK_CSI_RESIZER_IMAGE: "{{ .resizer.repository }}:{{ .resizer.tag }}"
+  {{- with .resizer }}
+  {{- if and .repository .tag }}
+  ROOK_CSI_RESIZER_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .imagePullPolicy }}
-  ROOK_CSI_IMAGE_PULL_POLICY: {{ .imagePullPolicy | quote }}
+  {{- with .imagePullPolicy }}
+  ROOK_CSI_IMAGE_PULL_POLICY: {{ . | quote }}
   {{- end }}
-  {{- if .csiAddons }}
-  CSI_ENABLE_CSIADDONS: {{ .csiAddons.enabled | quote }}
-  {{- if and .csiAddons.repository .csiAddons.tag }}
-  ROOK_CSIADDONS_IMAGE: "{{ .csiAddons.repository }}:{{ .csiAddons.tag }}"
+  {{- with .csiAddons }}
+  CSI_ENABLE_CSIADDONS: {{ .enabled | quote }}
+  {{- if and .repository .tag }}
+  ROOK_CSIADDONS_IMAGE: "{{ .repository }}:{{ .tag }}"
   {{- end }}
   {{- end }}
-  {{- if .crossNamespaceVolumeDataSource }}
-  CSI_ENABLE_CROSS_NAMESPACE_VOLUME_DATA_SOURCE: {{ .crossNamespaceVolumeDataSource.enabled | quote }}
+  {{- with .crossNamespaceVolumeDataSource }}
+  CSI_ENABLE_CROSS_NAMESPACE_VOLUME_DATA_SOURCE: {{ .enabled | quote }}
   {{- end }}
-  {{- if .topology }}
-  CSI_ENABLE_TOPOLOGY: {{ .topology.enabled | quote }}
-  {{- if .topology.domainLabels }}
-  CSI_TOPOLOGY_DOMAIN_LABELS: {{ .topology.domainLabels | join "," }}
+  {{- with .topology }}
+  CSI_ENABLE_TOPOLOGY: {{ .enabled | quote }}
+  {{- with .domainLabels }}
+  CSI_TOPOLOGY_DOMAIN_LABELS: {{ . | join "," }}
   {{- end }}
   {{- end }}
-  {{- if .nfs }}
-  ROOK_CSI_ENABLE_NFS: {{ .nfs.enabled | quote }}
+  {{- with .nfs }}
+  ROOK_CSI_ENABLE_NFS: {{ .enabled | quote }}
   {{- end }}
-  {{- if .cephfsPodLabels }}
-  ROOK_CSI_CEPHFS_POD_LABELS: {{ .cephfsPodLabels | quote }}
+  {{- with .cephfsPodLabels }}
+  ROOK_CSI_CEPHFS_POD_LABELS: {{ . | quote }}
   {{- end }}
-  {{- if .nfsPodLabels }}
-  ROOK_CSI_NFS_POD_LABELS: {{ .nfsPodLabels | quote }}
+  {{- with .nfsPodLabels }}
+  ROOK_CSI_NFS_POD_LABELS: {{ . | quote }}
   {{- end }}
-  {{- if .rbdPodLabels }}
-  ROOK_CSI_RBD_POD_LABELS: {{ .rbdPodLabels | quote }}
+  {{- with .rbdPodLabels }}
+  ROOK_CSI_RBD_POD_LABELS: {{ . | quote }}
   {{- end }}
-  {{- if .provisionerTolerations }}
-  CSI_PROVISIONER_TOLERATIONS: {{ toYaml .provisionerTolerations | quote }}
+  {{- with .provisionerTolerations }}
+  CSI_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .provisionerNodeAffinity }}
-  CSI_PROVISIONER_NODE_AFFINITY: {{ .provisionerNodeAffinity }}
+  {{- with .provisionerNodeAffinity }}
+  CSI_PROVISIONER_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .rbdProvisionerTolerations }}
-  CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml .rbdProvisionerTolerations | quote }}
+  {{- with .rbdProvisionerTolerations }}
+  CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .rbdProvisionerNodeAffinity }}
-  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ .rbdProvisionerNodeAffinity }}
+  {{- with .rbdProvisionerNodeAffinity }}
+  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .cephFSProvisionerTolerations }}
-  CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml .cephFSProvisionerTolerations | quote }}
+  {{- with .cephFSProvisionerTolerations }}
+  CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .cephFSProvisionerNodeAffinity }}
-  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ .cephFSProvisionerNodeAffinity }}
+  {{- with .cephFSProvisionerNodeAffinity }}
+  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .nfsProvisionerTolerations }}
-  CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml .nfsProvisionerTolerations | quote }}
+  {{- with .nfsProvisionerTolerations }}
+  CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .nfsProvisionerNodeAffinity }}
-  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ .nfsProvisionerNodeAffinity }}
+  {{- with .nfsProvisionerNodeAffinity }}
+  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .pluginTolerations }}
-  CSI_PLUGIN_TOLERATIONS: {{ toYaml .pluginTolerations | quote }}
+  {{- with .pluginTolerations }}
+  CSI_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .pluginNodeAffinity }}
-  CSI_PLUGIN_NODE_AFFINITY: {{ .pluginNodeAffinity }}
+  {{- with .pluginNodeAffinity }}
+  CSI_PLUGIN_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .rbdPluginTolerations }}
-  CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml .rbdPluginTolerations | quote }}
+  {{- with .rbdPluginTolerations }}
+  CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .rbdPluginNodeAffinity }}
-  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ .rbdPluginNodeAffinity }}
+  {{- with .rbdPluginNodeAffinity }}
+  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .cephFSPluginTolerations }}
-  CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml .cephFSPluginTolerations | quote }}
+  {{- with .cephFSPluginTolerations }}
+  CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .cephFSPluginNodeAffinity }}
-  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ .cephFSPluginNodeAffinity }}
+  {{- with .cephFSPluginNodeAffinity }}
+  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .nfsPluginTolerations }}
-  CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml .nfsPluginTolerations | quote }}
+  {{- with .nfsPluginTolerations }}
+  CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .nfsPluginNodeAffinity }}
-  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ .nfsPluginNodeAffinity }}
+  {{- with .nfsPluginNodeAffinity }}
+  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ . }}
   {{- end }}
-  {{- if .cephfsLivenessMetricsPort }}
-  CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ .cephfsLivenessMetricsPort | quote }}
+  {{- with .cephfsLivenessMetricsPort }}
+  CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ . | quote }}
   {{- end }}
-  {{- if .enableLiveness }}
-  CSI_ENABLE_LIVENESS: {{ .enableLiveness | quote }}
+  {{- with .enableLiveness }}
+  CSI_ENABLE_LIVENESS: {{ . | quote }}
   {{- end }}
-  {{- if .rbdLivenessMetricsPort }}
-  CSI_RBD_LIVENESS_METRICS_PORT: {{ .rbdLivenessMetricsPort | quote }}
+  {{- with .rbdLivenessMetricsPort }}
+  CSI_RBD_LIVENESS_METRICS_PORT: {{ . | quote }}
   {{- end }}
-  {{- if .csiAddonsPort }}
-  CSIADDONS_PORT: {{ .csiAddonsPort | quote }}
+  {{- with .csiAddonsPort }}
+  CSIADDONS_PORT: {{ . | quote }}
   {{- end }}
-  {{- if .csiAddonsRBDProvisionerPort }}
-  CSIADDONS_RBD_PROVISIONER_PORT: {{ .csiAddonsRBDProvisionerPort | quote }}
+  {{- with .csiAddonsRBDProvisionerPort }}
+  CSIADDONS_RBD_PROVISIONER_PORT: {{ . | quote }}
   {{- end }}
-  {{- if .csiAddonsCephFSProvisionerPort }}
-  CSIADDONS_CEPHFS_PROVISIONER_PORT: {{ .csiAddonsCephFSProvisionerPort | quote }}
+  {{- with .csiAddonsCephFSProvisionerPort }}
+  CSIADDONS_CEPHFS_PROVISIONER_PORT: {{ . | quote }}
   {{- end }}
-  {{- if .forceCephFSKernelClient }}
-  CSI_FORCE_CEPHFS_KERNEL_CLIENT: {{ .forceCephFSKernelClient | quote }}
+  {{- with .forceCephFSKernelClient }}
+  CSI_FORCE_CEPHFS_KERNEL_CLIENT: {{ . | quote }}
   {{- end }}
-  {{- if .logLevel }}
-  CSI_LOG_LEVEL: {{ .logLevel | quote }}
+  {{- with .logLevel }}
+  CSI_LOG_LEVEL: {{ . | quote }}
   {{- end }}
-  {{- if .sidecarLogLevel }}
-  CSI_SIDECAR_LOG_LEVEL: {{ .sidecarLogLevel | quote }}
+  {{- with .sidecarLogLevel }}
+  CSI_SIDECAR_LOG_LEVEL: {{ . | quote }}
   {{- end }}
-  {{- if .clusterName }}
-  CSI_CLUSTER_NAME: {{ .clusterName | quote }}
+  {{- with .clusterName }}
+  CSI_CLUSTER_NAME: {{ . | quote }}
   {{- end }}
-  {{- if .grpcTimeoutInSeconds }}
-  CSI_GRPC_TIMEOUT_SECONDS: {{ .grpcTimeoutInSeconds | quote }}
+  {{- with .grpcTimeoutInSeconds }}
+  CSI_GRPC_TIMEOUT_SECONDS: {{ . | quote }}
   {{- end }}
-  {{- if .provisionerReplicas }}
-  CSI_PROVISIONER_REPLICAS: {{ .provisionerReplicas | quote }}
+  {{- with .provisionerReplicas }}
+  CSI_PROVISIONER_REPLICAS: {{ . | quote }}
   {{- end }}
-  {{- if .csiRBDProvisionerResource }}
-  CSI_RBD_PROVISIONER_RESOURCE: {{ .csiRBDProvisionerResource | quote }}
+  {{- with .csiRBDProvisionerResource }}
+  CSI_RBD_PROVISIONER_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiRBDPluginResource }}
-  CSI_RBD_PLUGIN_RESOURCE: {{ .csiRBDPluginResource | quote }}
+  {{- with .csiRBDPluginResource }}
+  CSI_RBD_PLUGIN_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiCephFSProvisionerResource }}
-  CSI_CEPHFS_PROVISIONER_RESOURCE: {{ .csiCephFSProvisionerResource | quote }}
+  {{- with .csiCephFSProvisionerResource }}
+  CSI_CEPHFS_PROVISIONER_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiCephFSPluginResource }}
-  CSI_CEPHFS_PLUGIN_RESOURCE: {{ .csiCephFSPluginResource | quote }}
+  {{- with .csiCephFSPluginResource }}
+  CSI_CEPHFS_PLUGIN_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiNFSProvisionerResource }}
-  CSI_NFS_PROVISIONER_RESOURCE: {{ .csiNFSProvisionerResource | quote }}
+  {{- with .csiNFSProvisionerResource }}
+  CSI_NFS_PROVISIONER_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiNFSPluginResource }}
-  CSI_NFS_PLUGIN_RESOURCE: {{ .csiNFSPluginResource | quote }}
+  {{- with .csiNFSPluginResource }}
+  CSI_NFS_PLUGIN_RESOURCE: {{ . | quote }}
   {{- end }}
-  {{- if .csiRBDPluginVolume }}
-  CSI_RBD_PLUGIN_VOLUME: {{ toYaml .csiRBDPluginVolume | quote }}
+  {{- with .csiRBDPluginVolume }}
+  CSI_RBD_PLUGIN_VOLUME: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .csiRBDPluginVolumeMount }}
-  CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml .csiRBDPluginVolumeMount | quote }}
+  {{- with .csiRBDPluginVolumeMount }}
+  CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .csiCephFSPluginVolume }}
-  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .csiCephFSPluginVolume | quote }}
+  {{- with .csiCephFSPluginVolume }}
+  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml . | quote }}
   {{- end }}
-  {{- if .csiCephFSPluginVolumeMount }}
-  CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml .csiCephFSPluginVolumeMount | quote }}
+  {{- with .csiCephFSPluginVolumeMount }}
+  CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml . | quote }}
   {{- end }}
   CSI_CEPHFS_ATTACH_REQUIRED: {{ .cephFSAttachRequired | quote }}
   CSI_RBD_ATTACH_REQUIRED: {{ .rbdAttachRequired | quote }}
   CSI_NFS_ATTACH_REQUIRED: {{ .nfsAttachRequired | quote }}
-  {{- if .kubeApiBurst }}
-  CSI_KUBE_API_BURST: {{ .kubeApiBurst | quote }}
+  {{- with .kubeApiBurst }}
+  CSI_KUBE_API_BURST: {{ . | quote }}
   {{- end }}
-  {{- if .kubeApiQPS }}
-  CSI_KUBE_API_QPS: {{ .kubeApiQPS | quote }}
+  {{- with .kubeApiQPS }}
+  CSI_KUBE_API_QPS: {{ . | quote }}
   {{- end }}
   {{- end }}

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -31,244 +31,244 @@ data:
   {{- end }}
 
   {{- with .Values.csi }}
-  ROOK_USE_CSI_OPERATOR: {{ .Values.csi.rookUseCsiOperator | quote }}
-  ROOK_CSI_ENABLE_RBD: {{ .Values.csi.enableRbdDriver | quote }}
-  ROOK_CSI_ENABLE_CEPHFS: {{ .Values.csi.enableCephfsDriver | quote }}
-  ROOK_CSI_DISABLE_DRIVER: {{ .Values.csi.disableCsiDriver | quote }}
-  CSI_ENABLE_CEPHFS_SNAPSHOTTER: {{ .Values.csi.enableCephfsSnapshotter | quote }}
-  CSI_ENABLE_NFS_SNAPSHOTTER: {{ .Values.csi.enableNFSSnapshotter | quote }}
-  CSI_ENABLE_RBD_SNAPSHOTTER: {{ .Values.csi.enableRBDSnapshotter | quote }}
-  CSI_PLUGIN_ENABLE_SELINUX_HOST_MOUNT: {{ .Values.csi.enablePluginSelinuxHostMount | quote }}
-  CSI_ENABLE_ENCRYPTION: {{ .Values.csi.enableCSIEncryption | quote }}
-  CSI_ENABLE_OMAP_GENERATOR: {{ .Values.csi.enableOMAPGenerator | quote }}
-  CSI_ENABLE_HOST_NETWORK: {{ .Values.csi.enableCSIHostNetwork | quote }}
-  CSI_ENABLE_METADATA: {{ .Values.csi.enableMetadata | quote }}
-  CSI_ENABLE_VOLUME_GROUP_SNAPSHOT: {{ .Values.csi.enableVolumeGroupSnapshot | quote }}
-  {{- if .Values.csi.csiDriverNamePrefix }}
-  CSI_DRIVER_NAME_PREFIX: {{ .Values.csi.csiDriverNamePrefix | quote }}
+  ROOK_USE_CSI_OPERATOR: {{ .rookUseCsiOperator | quote }}
+  ROOK_CSI_ENABLE_RBD: {{ .enableRbdDriver | quote }}
+  ROOK_CSI_ENABLE_CEPHFS: {{ .enableCephfsDriver | quote }}
+  ROOK_CSI_DISABLE_DRIVER: {{ .disableCsiDriver | quote }}
+  CSI_ENABLE_CEPHFS_SNAPSHOTTER: {{ .enableCephfsSnapshotter | quote }}
+  CSI_ENABLE_NFS_SNAPSHOTTER: {{ .enableNFSSnapshotter | quote }}
+  CSI_ENABLE_RBD_SNAPSHOTTER: {{ .enableRBDSnapshotter | quote }}
+  CSI_PLUGIN_ENABLE_SELINUX_HOST_MOUNT: {{ .enablePluginSelinuxHostMount | quote }}
+  CSI_ENABLE_ENCRYPTION: {{ .enableCSIEncryption | quote }}
+  CSI_ENABLE_OMAP_GENERATOR: {{ .enableOMAPGenerator | quote }}
+  CSI_ENABLE_HOST_NETWORK: {{ .enableCSIHostNetwork | quote }}
+  CSI_ENABLE_METADATA: {{ .enableMetadata | quote }}
+  CSI_ENABLE_VOLUME_GROUP_SNAPSHOT: {{ .enableVolumeGroupSnapshot | quote }}
+  {{- if .csiDriverNamePrefix }}
+  CSI_DRIVER_NAME_PREFIX: {{ .csiDriverNamePrefix | quote }}
   {{- end }}
-  {{- if .Values.csi.pluginPriorityClassName }}
-  CSI_PLUGIN_PRIORITY_CLASSNAME: {{ .Values.csi.pluginPriorityClassName | quote }}
+  {{- if .pluginPriorityClassName }}
+  CSI_PLUGIN_PRIORITY_CLASSNAME: {{ .pluginPriorityClassName | quote }}
   {{- end }}
-  {{- if .Values.csi.provisionerPriorityClassName }}
-  CSI_PROVISIONER_PRIORITY_CLASSNAME: {{ .Values.csi.provisionerPriorityClassName | quote }}
+  {{- if .provisionerPriorityClassName }}
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: {{ .provisionerPriorityClassName | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSPluginUpdateStrategy }}
-  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.cephFSPluginUpdateStrategy | quote }}
+  {{- if .cephFSPluginUpdateStrategy }}
+  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: {{ .cephFSPluginUpdateStrategy | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSPluginUpdateStrategyMaxUnavailable }}
-  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .Values.csi.cephFSPluginUpdateStrategyMaxUnavailable | quote }}
+  {{- if .cephFSPluginUpdateStrategyMaxUnavailable }}
+  CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .cephFSPluginUpdateStrategyMaxUnavailable | quote }}
   {{- end }}
-  {{- if .Values.csi.nfsPluginUpdateStrategy }}
-  CSI_NFS_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.nfsPluginUpdateStrategy | quote }}
+  {{- if .nfsPluginUpdateStrategy }}
+  CSI_NFS_PLUGIN_UPDATE_STRATEGY: {{ .nfsPluginUpdateStrategy | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdFSGroupPolicy }}
-  CSI_RBD_FSGROUPPOLICY: {{ .Values.csi.rbdFSGroupPolicy | quote }}
+  {{- if .rbdFSGroupPolicy }}
+  CSI_RBD_FSGROUPPOLICY: {{ .rbdFSGroupPolicy | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSFSGroupPolicy }}
-  CSI_CEPHFS_FSGROUPPOLICY: {{ .Values.csi.cephFSFSGroupPolicy | quote }}
+  {{- if .cephFSFSGroupPolicy }}
+  CSI_CEPHFS_FSGROUPPOLICY: {{ .cephFSFSGroupPolicy | quote }}
   {{- end }}
-  {{- if .Values.csi.nfsFSGroupPolicy }}
-  CSI_NFS_FSGROUPPOLICY: {{ .Values.csi.nfsFSGroupPolicy | quote }}
+  {{- if .nfsFSGroupPolicy }}
+  CSI_NFS_FSGROUPPOLICY: {{ .nfsFSGroupPolicy | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdPluginUpdateStrategy }}
-  CSI_RBD_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.rbdPluginUpdateStrategy | quote }}
+  {{- if .rbdPluginUpdateStrategy }}
+  CSI_RBD_PLUGIN_UPDATE_STRATEGY: {{ .rbdPluginUpdateStrategy | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSKernelMountOptions }}
-  CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: {{ .Values.csi.cephFSKernelMountOptions | quote }}
+  {{- if .cephFSKernelMountOptions }}
+  CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: {{ .cephFSKernelMountOptions | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdPluginUpdateStrategyMaxUnavailable }}
-  CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .Values.csi.rbdPluginUpdateStrategyMaxUnavailable | quote }}
+  {{- if .rbdPluginUpdateStrategyMaxUnavailable }}
+  CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .rbdPluginUpdateStrategyMaxUnavailable | quote }}
   {{- end }}
-  {{- if .Values.csi.kubeletDirPath }}
-  ROOK_CSI_KUBELET_DIR_PATH: {{ .Values.csi.kubeletDirPath | quote }}
+  {{- if .kubeletDirPath }}
+  ROOK_CSI_KUBELET_DIR_PATH: {{ .kubeletDirPath | quote }}
   {{- end }}
-  {{- if .Values.csi.csiLeaderElectionLeaseDuration }}
-  CSI_LEADER_ELECTION_LEASE_DURATION: {{ .Values.csi.csiLeaderElectionLeaseDuration | quote }}
+  {{- if .csiLeaderElectionLeaseDuration }}
+  CSI_LEADER_ELECTION_LEASE_DURATION: {{ .csiLeaderElectionLeaseDuration | quote }}
   {{- end }}
-  {{- if .Values.csi.csiLeaderElectionRenewDeadline }}
-  CSI_LEADER_ELECTION_RENEW_DEADLINE: {{ .Values.csi.csiLeaderElectionRenewDeadline | quote }}
+  {{- if .csiLeaderElectionRenewDeadline }}
+  CSI_LEADER_ELECTION_RENEW_DEADLINE: {{ .csiLeaderElectionRenewDeadline | quote }}
   {{- end }}
-  {{- if .Values.csi.csiLeaderElectionRetryPeriod }}
-  CSI_LEADER_ELECTION_RETRY_PERIOD: {{ .Values.csi.csiLeaderElectionRetryPeriod | quote }}
+  {{- if .csiLeaderElectionRetryPeriod }}
+  CSI_LEADER_ELECTION_RETRY_PERIOD: {{ .csiLeaderElectionRetryPeriod | quote }}
   {{- end }}
-  {{- if .Values.csi.cephcsi }}
-  {{- if and .Values.csi.cephcsi.repository .Values.csi.cephcsi.tag }}
-  ROOK_CSI_CEPH_IMAGE: "{{ .Values.csi.cephcsi.repository }}:{{ .Values.csi.cephcsi.tag }}"
+  {{- if .cephcsi }}
+  {{- if and .cephcsi.repository .cephcsi.tag }}
+  ROOK_CSI_CEPH_IMAGE: "{{ .cephcsi.repository }}:{{ .cephcsi.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.registrar }}
-  {{- if and .Values.csi.registrar.repository .Values.csi.registrar.tag }}
-  ROOK_CSI_REGISTRAR_IMAGE: "{{ .Values.csi.registrar.repository }}:{{ .Values.csi.registrar.tag }}"
+  {{- if .registrar }}
+  {{- if and .registrar.repository .registrar.tag }}
+  ROOK_CSI_REGISTRAR_IMAGE: "{{ .registrar.repository }}:{{ .registrar.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.provisioner }}
-  {{- if and .Values.csi.provisioner.repository .Values.csi.provisioner.tag }}
-  ROOK_CSI_PROVISIONER_IMAGE: "{{ .Values.csi.provisioner.repository }}:{{ .Values.csi.provisioner.tag }}"
+  {{- if .provisioner }}
+  {{- if and .provisioner.repository .provisioner.tag }}
+  ROOK_CSI_PROVISIONER_IMAGE: "{{ .provisioner.repository }}:{{ .provisioner.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.snapshotter }}
-  {{- if and .Values.csi.snapshotter.repository .Values.csi.snapshotter.tag }}
-  ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .Values.csi.snapshotter.repository }}:{{ .Values.csi.snapshotter.tag }}"
+  {{- if .snapshotter }}
+  {{- if and .snapshotter.repository .snapshotter.tag }}
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .snapshotter.repository }}:{{ .snapshotter.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.attacher }}
-  {{- if and .Values.csi.attacher.repository .Values.csi.attacher.tag }}
-  ROOK_CSI_ATTACHER_IMAGE: "{{ .Values.csi.attacher.repository }}:{{ .Values.csi.attacher.tag }}"
+  {{- if .attacher }}
+  {{- if and .attacher.repository .attacher.tag }}
+  ROOK_CSI_ATTACHER_IMAGE: "{{ .attacher.repository }}:{{ .attacher.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.resizer }}
-  {{- if and .Values.csi.resizer.repository .Values.csi.resizer.tag }}
-  ROOK_CSI_RESIZER_IMAGE: "{{ .Values.csi.resizer.repository }}:{{ .Values.csi.resizer.tag }}"
+  {{- if .resizer }}
+  {{- if and .resizer.repository .resizer.tag }}
+  ROOK_CSI_RESIZER_IMAGE: "{{ .resizer.repository }}:{{ .resizer.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.imagePullPolicy }}
-  ROOK_CSI_IMAGE_PULL_POLICY: {{ .Values.csi.imagePullPolicy | quote }}
+  {{- if .imagePullPolicy }}
+  ROOK_CSI_IMAGE_PULL_POLICY: {{ .imagePullPolicy | quote }}
   {{- end }}
-  {{- if .Values.csi.csiAddons }}
-  CSI_ENABLE_CSIADDONS: {{ .Values.csi.csiAddons.enabled | quote }}
-  {{- if and .Values.csi.csiAddons.repository .Values.csi.csiAddons.tag }}
-  ROOK_CSIADDONS_IMAGE: "{{ .Values.csi.csiAddons.repository }}:{{ .Values.csi.csiAddons.tag }}"
+  {{- if .csiAddons }}
+  CSI_ENABLE_CSIADDONS: {{ .csiAddons.enabled | quote }}
+  {{- if and .csiAddons.repository .csiAddons.tag }}
+  ROOK_CSIADDONS_IMAGE: "{{ .csiAddons.repository }}:{{ .csiAddons.tag }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.crossNamespaceVolumeDataSource }}
-  CSI_ENABLE_CROSS_NAMESPACE_VOLUME_DATA_SOURCE: {{ .Values.csi.crossNamespaceVolumeDataSource.enabled | quote }}
+  {{- if .crossNamespaceVolumeDataSource }}
+  CSI_ENABLE_CROSS_NAMESPACE_VOLUME_DATA_SOURCE: {{ .crossNamespaceVolumeDataSource.enabled | quote }}
   {{- end }}
-  {{- if .Values.csi.topology }}
-  CSI_ENABLE_TOPOLOGY: {{ .Values.csi.topology.enabled | quote }}
-  {{- if .Values.csi.topology.domainLabels }}
-  CSI_TOPOLOGY_DOMAIN_LABELS: {{ .Values.csi.topology.domainLabels | join "," }}
+  {{- if .topology }}
+  CSI_ENABLE_TOPOLOGY: {{ .topology.enabled | quote }}
+  {{- if .topology.domainLabels }}
+  CSI_TOPOLOGY_DOMAIN_LABELS: {{ .topology.domainLabels | join "," }}
   {{- end }}
   {{- end }}
-  {{- if .Values.csi.nfs }}
-  ROOK_CSI_ENABLE_NFS: {{ .Values.csi.nfs.enabled | quote }}
+  {{- if .nfs }}
+  ROOK_CSI_ENABLE_NFS: {{ .nfs.enabled | quote }}
   {{- end }}
-  {{- if .Values.csi.cephfsPodLabels }}
-  ROOK_CSI_CEPHFS_POD_LABELS: {{ .Values.csi.cephfsPodLabels | quote }}
+  {{- if .cephfsPodLabels }}
+  ROOK_CSI_CEPHFS_POD_LABELS: {{ .cephfsPodLabels | quote }}
   {{- end }}
-  {{- if .Values.csi.nfsPodLabels }}
-  ROOK_CSI_NFS_POD_LABELS: {{ .Values.csi.nfsPodLabels | quote }}
+  {{- if .nfsPodLabels }}
+  ROOK_CSI_NFS_POD_LABELS: {{ .nfsPodLabels | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdPodLabels }}
-  ROOK_CSI_RBD_POD_LABELS: {{ .Values.csi.rbdPodLabels | quote }}
+  {{- if .rbdPodLabels }}
+  ROOK_CSI_RBD_POD_LABELS: {{ .rbdPodLabels | quote }}
   {{- end }}
-  {{- if .Values.csi.provisionerTolerations }}
-  CSI_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.provisionerTolerations | quote }}
+  {{- if .provisionerTolerations }}
+  CSI_PROVISIONER_TOLERATIONS: {{ toYaml .provisionerTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.provisionerNodeAffinity }}
-  CSI_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.provisionerNodeAffinity }}
+  {{- if .provisionerNodeAffinity }}
+  CSI_PROVISIONER_NODE_AFFINITY: {{ .provisionerNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.rbdProvisionerTolerations }}
-  CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.rbdProvisionerTolerations | quote }}
+  {{- if .rbdProvisionerTolerations }}
+  CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml .rbdProvisionerTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdProvisionerNodeAffinity }}
-  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.rbdProvisionerNodeAffinity }}
+  {{- if .rbdProvisionerNodeAffinity }}
+  CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ .rbdProvisionerNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.cephFSProvisionerTolerations }}
-  CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.cephFSProvisionerTolerations | quote }}
+  {{- if .cephFSProvisionerTolerations }}
+  CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml .cephFSProvisionerTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSProvisionerNodeAffinity }}
-  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.cephFSProvisionerNodeAffinity }}
+  {{- if .cephFSProvisionerNodeAffinity }}
+  CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ .cephFSProvisionerNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.nfsProvisionerTolerations }}
-  CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.nfsProvisionerTolerations | quote }}
+  {{- if .nfsProvisionerTolerations }}
+  CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml .nfsProvisionerTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.nfsProvisionerNodeAffinity }}
-  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.nfsProvisionerNodeAffinity }}
+  {{- if .nfsProvisionerNodeAffinity }}
+  CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ .nfsProvisionerNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.pluginTolerations }}
-  CSI_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.pluginTolerations | quote }}
+  {{- if .pluginTolerations }}
+  CSI_PLUGIN_TOLERATIONS: {{ toYaml .pluginTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.pluginNodeAffinity }}
-  CSI_PLUGIN_NODE_AFFINITY: {{ .Values.csi.pluginNodeAffinity }}
+  {{- if .pluginNodeAffinity }}
+  CSI_PLUGIN_NODE_AFFINITY: {{ .pluginNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.rbdPluginTolerations }}
-  CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.rbdPluginTolerations | quote }}
+  {{- if .rbdPluginTolerations }}
+  CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml .rbdPluginTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdPluginNodeAffinity }}
-  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ .Values.csi.rbdPluginNodeAffinity }}
+  {{- if .rbdPluginNodeAffinity }}
+  CSI_RBD_PLUGIN_NODE_AFFINITY: {{ .rbdPluginNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.cephFSPluginTolerations }}
-  CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.cephFSPluginTolerations | quote }}
+  {{- if .cephFSPluginTolerations }}
+  CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml .cephFSPluginTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.cephFSPluginNodeAffinity }}
-  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ .Values.csi.cephFSPluginNodeAffinity }}
+  {{- if .cephFSPluginNodeAffinity }}
+  CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ .cephFSPluginNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.nfsPluginTolerations }}
-  CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.nfsPluginTolerations | quote }}
+  {{- if .nfsPluginTolerations }}
+  CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml .nfsPluginTolerations | quote }}
   {{- end }}
-  {{- if .Values.csi.nfsPluginNodeAffinity }}
-  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ .Values.csi.nfsPluginNodeAffinity }}
+  {{- if .nfsPluginNodeAffinity }}
+  CSI_NFS_PLUGIN_NODE_AFFINITY: {{ .nfsPluginNodeAffinity }}
   {{- end }}
-  {{- if .Values.csi.cephfsLivenessMetricsPort }}
-  CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ .Values.csi.cephfsLivenessMetricsPort | quote }}
+  {{- if .cephfsLivenessMetricsPort }}
+  CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ .cephfsLivenessMetricsPort | quote }}
   {{- end }}
-  {{- if .Values.csi.enableLiveness }}
-  CSI_ENABLE_LIVENESS: {{ .Values.csi.enableLiveness | quote }}
+  {{- if .enableLiveness }}
+  CSI_ENABLE_LIVENESS: {{ .enableLiveness | quote }}
   {{- end }}
-  {{- if .Values.csi.rbdLivenessMetricsPort }}
-  CSI_RBD_LIVENESS_METRICS_PORT: {{ .Values.csi.rbdLivenessMetricsPort | quote }}
+  {{- if .rbdLivenessMetricsPort }}
+  CSI_RBD_LIVENESS_METRICS_PORT: {{ .rbdLivenessMetricsPort | quote }}
   {{- end }}
-  {{- if .Values.csi.csiAddonsPort }}
-  CSIADDONS_PORT: {{ .Values.csi.csiAddonsPort | quote }}
+  {{- if .csiAddonsPort }}
+  CSIADDONS_PORT: {{ .csiAddonsPort | quote }}
   {{- end }}
-  {{- if .Values.csi.csiAddonsRBDProvisionerPort }}
-  CSIADDONS_RBD_PROVISIONER_PORT: {{ .Values.csi.csiAddonsRBDProvisionerPort | quote }}
+  {{- if .csiAddonsRBDProvisionerPort }}
+  CSIADDONS_RBD_PROVISIONER_PORT: {{ .csiAddonsRBDProvisionerPort | quote }}
   {{- end }}
-  {{- if .Values.csi.csiAddonsCephFSProvisionerPort }}
-  CSIADDONS_CEPHFS_PROVISIONER_PORT: {{ .Values.csi.csiAddonsCephFSProvisionerPort | quote }}
+  {{- if .csiAddonsCephFSProvisionerPort }}
+  CSIADDONS_CEPHFS_PROVISIONER_PORT: {{ .csiAddonsCephFSProvisionerPort | quote }}
   {{- end }}
-  {{- if .Values.csi.forceCephFSKernelClient }}
-  CSI_FORCE_CEPHFS_KERNEL_CLIENT: {{ .Values.csi.forceCephFSKernelClient | quote }}
+  {{- if .forceCephFSKernelClient }}
+  CSI_FORCE_CEPHFS_KERNEL_CLIENT: {{ .forceCephFSKernelClient | quote }}
   {{- end }}
-  {{- if .Values.csi.logLevel }}
-  CSI_LOG_LEVEL: {{ .Values.csi.logLevel | quote }}
+  {{- if .logLevel }}
+  CSI_LOG_LEVEL: {{ .logLevel | quote }}
   {{- end }}
-  {{- if .Values.csi.sidecarLogLevel }}
-  CSI_SIDECAR_LOG_LEVEL: {{ .Values.csi.sidecarLogLevel | quote }}
+  {{- if .sidecarLogLevel }}
+  CSI_SIDECAR_LOG_LEVEL: {{ .sidecarLogLevel | quote }}
   {{- end }}
-  {{- if .Values.csi.clusterName }}
-  CSI_CLUSTER_NAME: {{ .Values.csi.clusterName | quote }}
+  {{- if .clusterName }}
+  CSI_CLUSTER_NAME: {{ .clusterName | quote }}
   {{- end }}
-  {{- if .Values.csi.grpcTimeoutInSeconds }}
-  CSI_GRPC_TIMEOUT_SECONDS: {{ .Values.csi.grpcTimeoutInSeconds | quote }}
+  {{- if .grpcTimeoutInSeconds }}
+  CSI_GRPC_TIMEOUT_SECONDS: {{ .grpcTimeoutInSeconds | quote }}
   {{- end }}
-  {{- if .Values.csi.provisionerReplicas }}
-  CSI_PROVISIONER_REPLICAS: {{ .Values.csi.provisionerReplicas | quote }}
+  {{- if .provisionerReplicas }}
+  CSI_PROVISIONER_REPLICAS: {{ .provisionerReplicas | quote }}
   {{- end }}
-  {{- if .Values.csi.csiRBDProvisionerResource }}
-  CSI_RBD_PROVISIONER_RESOURCE: {{ .Values.csi.csiRBDProvisionerResource | quote }}
+  {{- if .csiRBDProvisionerResource }}
+  CSI_RBD_PROVISIONER_RESOURCE: {{ .csiRBDProvisionerResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiRBDPluginResource }}
-  CSI_RBD_PLUGIN_RESOURCE: {{ .Values.csi.csiRBDPluginResource | quote }}
+  {{- if .csiRBDPluginResource }}
+  CSI_RBD_PLUGIN_RESOURCE: {{ .csiRBDPluginResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiCephFSProvisionerResource }}
-  CSI_CEPHFS_PROVISIONER_RESOURCE: {{ .Values.csi.csiCephFSProvisionerResource | quote }}
+  {{- if .csiCephFSProvisionerResource }}
+  CSI_CEPHFS_PROVISIONER_RESOURCE: {{ .csiCephFSProvisionerResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiCephFSPluginResource }}
-  CSI_CEPHFS_PLUGIN_RESOURCE: {{ .Values.csi.csiCephFSPluginResource | quote }}
+  {{- if .csiCephFSPluginResource }}
+  CSI_CEPHFS_PLUGIN_RESOURCE: {{ .csiCephFSPluginResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiNFSProvisionerResource }}
-  CSI_NFS_PROVISIONER_RESOURCE: {{ .Values.csi.csiNFSProvisionerResource | quote }}
+  {{- if .csiNFSProvisionerResource }}
+  CSI_NFS_PROVISIONER_RESOURCE: {{ .csiNFSProvisionerResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiNFSPluginResource }}
-  CSI_NFS_PLUGIN_RESOURCE: {{ .Values.csi.csiNFSPluginResource | quote }}
+  {{- if .csiNFSPluginResource }}
+  CSI_NFS_PLUGIN_RESOURCE: {{ .csiNFSPluginResource | quote }}
   {{- end }}
-  {{- if .Values.csi.csiRBDPluginVolume }}
-  CSI_RBD_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiRBDPluginVolume | quote }}
+  {{- if .csiRBDPluginVolume }}
+  CSI_RBD_PLUGIN_VOLUME: {{ toYaml .csiRBDPluginVolume | quote }}
   {{- end }}
-  {{- if .Values.csi.csiRBDPluginVolumeMount }}
-  CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiRBDPluginVolumeMount | quote }}
+  {{- if .csiRBDPluginVolumeMount }}
+  CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml .csiRBDPluginVolumeMount | quote }}
   {{- end }}
-  {{- if .Values.csi.csiCephFSPluginVolume }}
-  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiCephFSPluginVolume | quote }}
+  {{- if .csiCephFSPluginVolume }}
+  CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .csiCephFSPluginVolume | quote }}
   {{- end }}
-  {{- if .Values.csi.csiCephFSPluginVolumeMount }}
-  CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiCephFSPluginVolumeMount | quote }}
+  {{- if .csiCephFSPluginVolumeMount }}
+  CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml .csiCephFSPluginVolumeMount | quote }}
   {{- end }}
-  CSI_CEPHFS_ATTACH_REQUIRED: {{ .Values.csi.cephFSAttachRequired | quote }}
-  CSI_RBD_ATTACH_REQUIRED: {{ .Values.csi.rbdAttachRequired | quote }}
-  CSI_NFS_ATTACH_REQUIRED: {{ .Values.csi.nfsAttachRequired | quote }}
+  CSI_CEPHFS_ATTACH_REQUIRED: {{ .cephFSAttachRequired | quote }}
+  CSI_RBD_ATTACH_REQUIRED: {{ .rbdAttachRequired | quote }}
+  CSI_NFS_ATTACH_REQUIRED: {{ .nfsAttachRequired | quote }}
   {{- end }}
   {{- if .Values.csi.kubeApiBurst }}
   CSI_KUBE_API_BURST: {{ .Values.csi.kubeApiBurst | quote }}

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -9,28 +9,28 @@ data:
   ROOK_LOG_LEVEL: {{ .Values.logLevel | quote }}
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: {{ .Values.cephCommandsTimeoutSeconds | quote }}
   ROOK_OBC_WATCH_OPERATOR_NAMESPACE: {{ .Values.enableOBCWatchOperatorNamespace | quote }}
-{{- if .Values.operatorMetricsBindAddress }}
+  {{- if .Values.operatorMetricsBindAddress }}
   ROOK_OPERATOR_METRICS_BIND_ADDRESS: {{ .Values.operatorMetricsBindAddress | quote }}
-{{- end }}
-{{- if .Values.obcProvisionerNamePrefix }}
+  {{- end }}
+  {{- if .Values.obcProvisionerNamePrefix }}
   ROOK_OBC_PROVISIONER_NAME_PREFIX: {{ .Values.obcProvisionerNamePrefix | quote }}
-{{- end }}
-{{- if .Values.obcAllowAdditionalConfigFields }}
+  {{- end }}
+  {{- if .Values.obcAllowAdditionalConfigFields }}
   ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: {{ .Values.obcAllowAdditionalConfigFields | quote }}
-{{- end }}
+  {{- end }}
   ROOK_CEPH_ALLOW_LOOP_DEVICES: {{ .Values.allowLoopDevices | quote }}
   ROOK_ENABLE_DISCOVERY_DAEMON: {{ .Values.enableDiscoveryDaemon | quote }}
-{{- if .Values.discoverDaemonUdev }}
+  {{- if .Values.discoverDaemonUdev }}
   DISCOVER_DAEMON_UDEV_BLACKLIST: {{ .Values.discoverDaemonUdev | quote }}
-{{- end }}
-{{- if .Values.revisionHistoryLimit }}
+  {{- end }}
+  {{- if .Values.revisionHistoryLimit }}
   ROOK_REVISION_HISTORY_LIMIT: {{ .Values.revisionHistoryLimit | quote }}
-{{- end }}
-{{- if .Values.enforceHostNetwork }}
+  {{- end }}
+  {{- if .Values.enforceHostNetwork }}
   ROOK_ENFORCE_HOST_NETWORK: {{ .Values.enforceHostNetwork | quote }}
-{{- end }}
+  {{- end }}
 
-{{- if .Values.csi }}
+  {{- with .Values.csi }}
   ROOK_USE_CSI_OPERATOR: {{ .Values.csi.rookUseCsiOperator | quote }}
   ROOK_CSI_ENABLE_RBD: {{ .Values.csi.enableRbdDriver | quote }}
   ROOK_CSI_ENABLE_CEPHFS: {{ .Values.csi.enableCephfsDriver | quote }}
@@ -44,235 +44,235 @@ data:
   CSI_ENABLE_HOST_NETWORK: {{ .Values.csi.enableCSIHostNetwork | quote }}
   CSI_ENABLE_METADATA: {{ .Values.csi.enableMetadata | quote }}
   CSI_ENABLE_VOLUME_GROUP_SNAPSHOT: {{ .Values.csi.enableVolumeGroupSnapshot | quote }}
-{{- if .Values.csi.csiDriverNamePrefix }}
+  {{- if .Values.csi.csiDriverNamePrefix }}
   CSI_DRIVER_NAME_PREFIX: {{ .Values.csi.csiDriverNamePrefix | quote }}
-{{- end }}
-{{- if .Values.csi.pluginPriorityClassName }}
+  {{- end }}
+  {{- if .Values.csi.pluginPriorityClassName }}
   CSI_PLUGIN_PRIORITY_CLASSNAME: {{ .Values.csi.pluginPriorityClassName | quote }}
-{{- end }}
-{{- if .Values.csi.provisionerPriorityClassName }}
+  {{- end }}
+  {{- if .Values.csi.provisionerPriorityClassName }}
   CSI_PROVISIONER_PRIORITY_CLASSNAME: {{ .Values.csi.provisionerPriorityClassName | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSPluginUpdateStrategy }}
+  {{- end }}
+  {{- if .Values.csi.cephFSPluginUpdateStrategy }}
   CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.cephFSPluginUpdateStrategy | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSPluginUpdateStrategyMaxUnavailable }}
+  {{- end }}
+  {{- if .Values.csi.cephFSPluginUpdateStrategyMaxUnavailable }}
   CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .Values.csi.cephFSPluginUpdateStrategyMaxUnavailable | quote }}
-{{- end }}
-{{- if .Values.csi.nfsPluginUpdateStrategy }}
+  {{- end }}
+  {{- if .Values.csi.nfsPluginUpdateStrategy }}
   CSI_NFS_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.nfsPluginUpdateStrategy | quote }}
-{{- end }}
-{{- if .Values.csi.rbdFSGroupPolicy }}
+  {{- end }}
+  {{- if .Values.csi.rbdFSGroupPolicy }}
   CSI_RBD_FSGROUPPOLICY: {{ .Values.csi.rbdFSGroupPolicy | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSFSGroupPolicy }}
+  {{- end }}
+  {{- if .Values.csi.cephFSFSGroupPolicy }}
   CSI_CEPHFS_FSGROUPPOLICY: {{ .Values.csi.cephFSFSGroupPolicy | quote }}
-{{- end }}
-{{- if .Values.csi.nfsFSGroupPolicy }}
+  {{- end }}
+  {{- if .Values.csi.nfsFSGroupPolicy }}
   CSI_NFS_FSGROUPPOLICY: {{ .Values.csi.nfsFSGroupPolicy | quote }}
-{{- end }}
-{{- if .Values.csi.rbdPluginUpdateStrategy }}
+  {{- end }}
+  {{- if .Values.csi.rbdPluginUpdateStrategy }}
   CSI_RBD_PLUGIN_UPDATE_STRATEGY: {{ .Values.csi.rbdPluginUpdateStrategy | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSKernelMountOptions }}
+  {{- end }}
+  {{- if .Values.csi.cephFSKernelMountOptions }}
   CSI_CEPHFS_KERNEL_MOUNT_OPTIONS: {{ .Values.csi.cephFSKernelMountOptions | quote }}
-{{- end }}
-{{- if .Values.csi.rbdPluginUpdateStrategyMaxUnavailable }}
+  {{- end }}
+  {{- if .Values.csi.rbdPluginUpdateStrategyMaxUnavailable }}
   CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE: {{ .Values.csi.rbdPluginUpdateStrategyMaxUnavailable | quote }}
-{{- end }}
-{{- if .Values.csi.kubeletDirPath }}
+  {{- end }}
+  {{- if .Values.csi.kubeletDirPath }}
   ROOK_CSI_KUBELET_DIR_PATH: {{ .Values.csi.kubeletDirPath | quote }}
-{{- end }}
-{{- if .Values.csi.csiLeaderElectionLeaseDuration }}
+  {{- end }}
+  {{- if .Values.csi.csiLeaderElectionLeaseDuration }}
   CSI_LEADER_ELECTION_LEASE_DURATION: {{ .Values.csi.csiLeaderElectionLeaseDuration | quote }}
-{{- end }}
-{{- if .Values.csi.csiLeaderElectionRenewDeadline }}
+  {{- end }}
+  {{- if .Values.csi.csiLeaderElectionRenewDeadline }}
   CSI_LEADER_ELECTION_RENEW_DEADLINE: {{ .Values.csi.csiLeaderElectionRenewDeadline | quote }}
-{{- end }}
-{{- if .Values.csi.csiLeaderElectionRetryPeriod }}
+  {{- end }}
+  {{- if .Values.csi.csiLeaderElectionRetryPeriod }}
   CSI_LEADER_ELECTION_RETRY_PERIOD: {{ .Values.csi.csiLeaderElectionRetryPeriod | quote }}
-{{- end }}
-{{- if .Values.csi.cephcsi }}
-{{- if and .Values.csi.cephcsi.repository .Values.csi.cephcsi.tag }}
+  {{- end }}
+  {{- if .Values.csi.cephcsi }}
+  {{- if and .Values.csi.cephcsi.repository .Values.csi.cephcsi.tag }}
   ROOK_CSI_CEPH_IMAGE: "{{ .Values.csi.cephcsi.repository }}:{{ .Values.csi.cephcsi.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.registrar }}
-{{- if and .Values.csi.registrar.repository .Values.csi.registrar.tag }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.registrar }}
+  {{- if and .Values.csi.registrar.repository .Values.csi.registrar.tag }}
   ROOK_CSI_REGISTRAR_IMAGE: "{{ .Values.csi.registrar.repository }}:{{ .Values.csi.registrar.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.provisioner }}
-{{- if and .Values.csi.provisioner.repository .Values.csi.provisioner.tag }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.provisioner }}
+  {{- if and .Values.csi.provisioner.repository .Values.csi.provisioner.tag }}
   ROOK_CSI_PROVISIONER_IMAGE: "{{ .Values.csi.provisioner.repository }}:{{ .Values.csi.provisioner.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.snapshotter }}
-{{- if and .Values.csi.snapshotter.repository .Values.csi.snapshotter.tag }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.snapshotter }}
+  {{- if and .Values.csi.snapshotter.repository .Values.csi.snapshotter.tag }}
   ROOK_CSI_SNAPSHOTTER_IMAGE: "{{ .Values.csi.snapshotter.repository }}:{{ .Values.csi.snapshotter.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.attacher }}
-{{- if and .Values.csi.attacher.repository .Values.csi.attacher.tag }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.attacher }}
+  {{- if and .Values.csi.attacher.repository .Values.csi.attacher.tag }}
   ROOK_CSI_ATTACHER_IMAGE: "{{ .Values.csi.attacher.repository }}:{{ .Values.csi.attacher.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.resizer }}
-{{- if and .Values.csi.resizer.repository .Values.csi.resizer.tag }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.resizer }}
+  {{- if and .Values.csi.resizer.repository .Values.csi.resizer.tag }}
   ROOK_CSI_RESIZER_IMAGE: "{{ .Values.csi.resizer.repository }}:{{ .Values.csi.resizer.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.imagePullPolicy }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.imagePullPolicy }}
   ROOK_CSI_IMAGE_PULL_POLICY: {{ .Values.csi.imagePullPolicy | quote }}
-{{- end }}
-{{- if .Values.csi.csiAddons }}
+  {{- end }}
+  {{- if .Values.csi.csiAddons }}
   CSI_ENABLE_CSIADDONS: {{ .Values.csi.csiAddons.enabled | quote }}
-{{- if and .Values.csi.csiAddons.repository .Values.csi.csiAddons.tag }}
+  {{- if and .Values.csi.csiAddons.repository .Values.csi.csiAddons.tag }}
   ROOK_CSIADDONS_IMAGE: "{{ .Values.csi.csiAddons.repository }}:{{ .Values.csi.csiAddons.tag }}"
-{{- end }}
-{{- end }}
-{{- if .Values.csi.crossNamespaceVolumeDataSource }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.crossNamespaceVolumeDataSource }}
   CSI_ENABLE_CROSS_NAMESPACE_VOLUME_DATA_SOURCE: {{ .Values.csi.crossNamespaceVolumeDataSource.enabled | quote }}
-{{- end }}
-{{- if .Values.csi.topology }}
+  {{- end }}
+  {{- if .Values.csi.topology }}
   CSI_ENABLE_TOPOLOGY: {{ .Values.csi.topology.enabled | quote }}
-{{- if .Values.csi.topology.domainLabels }}
+  {{- if .Values.csi.topology.domainLabels }}
   CSI_TOPOLOGY_DOMAIN_LABELS: {{ .Values.csi.topology.domainLabels | join "," }}
-{{- end }}
-{{- end }}
-{{- if .Values.csi.nfs }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.csi.nfs }}
   ROOK_CSI_ENABLE_NFS: {{ .Values.csi.nfs.enabled | quote }}
-{{- end }}
-{{- if .Values.csi.cephfsPodLabels }}
+  {{- end }}
+  {{- if .Values.csi.cephfsPodLabels }}
   ROOK_CSI_CEPHFS_POD_LABELS: {{ .Values.csi.cephfsPodLabels | quote }}
-{{- end }}
-{{- if .Values.csi.nfsPodLabels }}
+  {{- end }}
+  {{- if .Values.csi.nfsPodLabels }}
   ROOK_CSI_NFS_POD_LABELS: {{ .Values.csi.nfsPodLabels | quote }}
-{{- end }}
-{{- if .Values.csi.rbdPodLabels }}
+  {{- end }}
+  {{- if .Values.csi.rbdPodLabels }}
   ROOK_CSI_RBD_POD_LABELS: {{ .Values.csi.rbdPodLabels | quote }}
-{{- end }}
-{{- if .Values.csi.provisionerTolerations }}
+  {{- end }}
+  {{- if .Values.csi.provisionerTolerations }}
   CSI_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.provisionerTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.provisionerNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.provisionerNodeAffinity }}
   CSI_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.provisionerNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.rbdProvisionerTolerations }}
+  {{- end }}
+  {{- if .Values.csi.rbdProvisionerTolerations }}
   CSI_RBD_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.rbdProvisionerTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.rbdProvisionerNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.rbdProvisionerNodeAffinity }}
   CSI_RBD_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.rbdProvisionerNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.cephFSProvisionerTolerations }}
+  {{- end }}
+  {{- if .Values.csi.cephFSProvisionerTolerations }}
   CSI_CEPHFS_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.cephFSProvisionerTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSProvisionerNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.cephFSProvisionerNodeAffinity }}
   CSI_CEPHFS_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.cephFSProvisionerNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.nfsProvisionerTolerations }}
+  {{- end }}
+  {{- if .Values.csi.nfsProvisionerTolerations }}
   CSI_NFS_PROVISIONER_TOLERATIONS: {{ toYaml .Values.csi.nfsProvisionerTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.nfsProvisionerNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.nfsProvisionerNodeAffinity }}
   CSI_NFS_PROVISIONER_NODE_AFFINITY: {{ .Values.csi.nfsProvisionerNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.pluginTolerations }}
+  {{- end }}
+  {{- if .Values.csi.pluginTolerations }}
   CSI_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.pluginTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.pluginNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.pluginNodeAffinity }}
   CSI_PLUGIN_NODE_AFFINITY: {{ .Values.csi.pluginNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.rbdPluginTolerations }}
+  {{- end }}
+  {{- if .Values.csi.rbdPluginTolerations }}
   CSI_RBD_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.rbdPluginTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.rbdPluginNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.rbdPluginNodeAffinity }}
   CSI_RBD_PLUGIN_NODE_AFFINITY: {{ .Values.csi.rbdPluginNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.cephFSPluginTolerations }}
+  {{- end }}
+  {{- if .Values.csi.cephFSPluginTolerations }}
   CSI_CEPHFS_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.cephFSPluginTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.cephFSPluginNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.cephFSPluginNodeAffinity }}
   CSI_CEPHFS_PLUGIN_NODE_AFFINITY: {{ .Values.csi.cephFSPluginNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.nfsPluginTolerations }}
+  {{- end }}
+  {{- if .Values.csi.nfsPluginTolerations }}
   CSI_NFS_PLUGIN_TOLERATIONS: {{ toYaml .Values.csi.nfsPluginTolerations | quote }}
-{{- end }}
-{{- if .Values.csi.nfsPluginNodeAffinity }}
+  {{- end }}
+  {{- if .Values.csi.nfsPluginNodeAffinity }}
   CSI_NFS_PLUGIN_NODE_AFFINITY: {{ .Values.csi.nfsPluginNodeAffinity }}
-{{- end }}
-{{- if .Values.csi.cephfsLivenessMetricsPort }}
+  {{- end }}
+  {{- if .Values.csi.cephfsLivenessMetricsPort }}
   CSI_CEPHFS_LIVENESS_METRICS_PORT: {{ .Values.csi.cephfsLivenessMetricsPort | quote }}
-{{- end }}
-{{- if .Values.csi.enableLiveness }}
+  {{- end }}
+  {{- if .Values.csi.enableLiveness }}
   CSI_ENABLE_LIVENESS: {{ .Values.csi.enableLiveness | quote }}
-{{- end }}
-{{- if .Values.csi.rbdLivenessMetricsPort }}
+  {{- end }}
+  {{- if .Values.csi.rbdLivenessMetricsPort }}
   CSI_RBD_LIVENESS_METRICS_PORT: {{ .Values.csi.rbdLivenessMetricsPort | quote }}
-{{- end }}
-{{- if .Values.csi.csiAddonsPort }}
+  {{- end }}
+  {{- if .Values.csi.csiAddonsPort }}
   CSIADDONS_PORT: {{ .Values.csi.csiAddonsPort | quote }}
-{{- end }}
-{{- if .Values.csi.csiAddonsRBDProvisionerPort }}
+  {{- end }}
+  {{- if .Values.csi.csiAddonsRBDProvisionerPort }}
   CSIADDONS_RBD_PROVISIONER_PORT: {{ .Values.csi.csiAddonsRBDProvisionerPort | quote }}
-{{- end }}
-{{- if .Values.csi.csiAddonsCephFSProvisionerPort }}
+  {{- end }}
+  {{- if .Values.csi.csiAddonsCephFSProvisionerPort }}
   CSIADDONS_CEPHFS_PROVISIONER_PORT: {{ .Values.csi.csiAddonsCephFSProvisionerPort | quote }}
-{{- end }}
-{{- if .Values.csi.forceCephFSKernelClient }}
+  {{- end }}
+  {{- if .Values.csi.forceCephFSKernelClient }}
   CSI_FORCE_CEPHFS_KERNEL_CLIENT: {{ .Values.csi.forceCephFSKernelClient | quote }}
-{{- end }}
-{{- if .Values.csi.logLevel }}
+  {{- end }}
+  {{- if .Values.csi.logLevel }}
   CSI_LOG_LEVEL: {{ .Values.csi.logLevel | quote }}
-{{- end }}
-{{- if .Values.csi.sidecarLogLevel }}
+  {{- end }}
+  {{- if .Values.csi.sidecarLogLevel }}
   CSI_SIDECAR_LOG_LEVEL: {{ .Values.csi.sidecarLogLevel | quote }}
-{{- end }}
-{{- if .Values.csi.clusterName }}
+  {{- end }}
+  {{- if .Values.csi.clusterName }}
   CSI_CLUSTER_NAME: {{ .Values.csi.clusterName | quote }}
-{{- end }}
-{{- if .Values.csi.grpcTimeoutInSeconds }}
+  {{- end }}
+  {{- if .Values.csi.grpcTimeoutInSeconds }}
   CSI_GRPC_TIMEOUT_SECONDS: {{ .Values.csi.grpcTimeoutInSeconds | quote }}
-{{- end }}
-{{- if .Values.csi.provisionerReplicas }}
+  {{- end }}
+  {{- if .Values.csi.provisionerReplicas }}
   CSI_PROVISIONER_REPLICAS: {{ .Values.csi.provisionerReplicas | quote }}
-{{- end }}
-{{- if .Values.csi.csiRBDProvisionerResource }}
+  {{- end }}
+  {{- if .Values.csi.csiRBDProvisionerResource }}
   CSI_RBD_PROVISIONER_RESOURCE: {{ .Values.csi.csiRBDProvisionerResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiRBDPluginResource }}
+  {{- end }}
+  {{- if .Values.csi.csiRBDPluginResource }}
   CSI_RBD_PLUGIN_RESOURCE: {{ .Values.csi.csiRBDPluginResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiCephFSProvisionerResource }}
+  {{- end }}
+  {{- if .Values.csi.csiCephFSProvisionerResource }}
   CSI_CEPHFS_PROVISIONER_RESOURCE: {{ .Values.csi.csiCephFSProvisionerResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiCephFSPluginResource }}
+  {{- end }}
+  {{- if .Values.csi.csiCephFSPluginResource }}
   CSI_CEPHFS_PLUGIN_RESOURCE: {{ .Values.csi.csiCephFSPluginResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiNFSProvisionerResource }}
+  {{- end }}
+  {{- if .Values.csi.csiNFSProvisionerResource }}
   CSI_NFS_PROVISIONER_RESOURCE: {{ .Values.csi.csiNFSProvisionerResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiNFSPluginResource }}
+  {{- end }}
+  {{- if .Values.csi.csiNFSPluginResource }}
   CSI_NFS_PLUGIN_RESOURCE: {{ .Values.csi.csiNFSPluginResource | quote }}
-{{- end }}
-{{- if .Values.csi.csiRBDPluginVolume }}
+  {{- end }}
+  {{- if .Values.csi.csiRBDPluginVolume }}
   CSI_RBD_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiRBDPluginVolume | quote }}
-{{- end }}
-{{- if .Values.csi.csiRBDPluginVolumeMount }}
+  {{- end }}
+  {{- if .Values.csi.csiRBDPluginVolumeMount }}
   CSI_RBD_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiRBDPluginVolumeMount | quote }}
-{{- end }}
-{{- if .Values.csi.csiCephFSPluginVolume }}
+  {{- end }}
+  {{- if .Values.csi.csiCephFSPluginVolume }}
   CSI_CEPHFS_PLUGIN_VOLUME: {{ toYaml .Values.csi.csiCephFSPluginVolume | quote }}
-{{- end }}
-{{- if .Values.csi.csiCephFSPluginVolumeMount }}
+  {{- end }}
+  {{- if .Values.csi.csiCephFSPluginVolumeMount }}
   CSI_CEPHFS_PLUGIN_VOLUME_MOUNT: {{ toYaml .Values.csi.csiCephFSPluginVolumeMount | quote }}
-{{- end }}
+  {{- end }}
   CSI_CEPHFS_ATTACH_REQUIRED: {{ .Values.csi.cephFSAttachRequired | quote }}
   CSI_RBD_ATTACH_REQUIRED: {{ .Values.csi.rbdAttachRequired | quote }}
   CSI_NFS_ATTACH_REQUIRED: {{ .Values.csi.nfsAttachRequired | quote }}
-{{- end }}
-{{- if .Values.csi.kubeApiBurst }}
+  {{- end }}
+  {{- if .Values.csi.kubeApiBurst }}
   CSI_KUBE_API_BURST: {{ .Values.csi.kubeApiBurst | quote }}
-{{- end }}
-{{- if .Values.csi.kubeApiQPS }}
+  {{- end }}
+  {{- if .Values.csi.kubeApiQPS }}
   CSI_KUBE_API_QPS: {{ .Values.csi.kubeApiQPS | quote }}
-{{- end }}
+  {{- end }}


### PR DESCRIPTION
I made a few refactoring commits of a ConfigMap in the rook-ceph chart to make it easier to read and maintain long term -- based on my subjective experience as a maintainer of Helm charts since 2018.

I made very fine grained commits with messages to help review efforts.

If you appreciate this kind of Helm chart refactoring, I'd be happy to look further in the Helm chart's but I figured this was a suitable starting point as a new contributor to the project.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  This is nothing noteworty, just refactoring.
- [x] Documentation has been updated, if necessary.
  No documentation to update.
- [x] Unit tests have been added, if necessary.
  No test change deemed relevant.
- [x] Integration tests have been added, if necessary.
  No test change deemed relevant.
