### PR TITLE
csi: Set host networking on the csi controller pod if host networking is enforced

### DIFF
--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -253,6 +254,7 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 		return csiopv1.DriverSpec{}, errors.Wrapf(err, "failed to create ceph-CSI operator config ImageSetConfigmap for CR %s", opConfigCRName)
 	}
 
+	controllerPluginHostNetwork := opcontroller.EnforceHostNetwork()
 	driverSpec := csiopv1.DriverSpec{
 		Log: &csiopv1.LogSpec{
 			Verbosity: int(CSIParam.LogLevel),
@@ -277,6 +279,7 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 			EnableSeLinuxHostMount: &CSIParam.EnablePluginSelinuxHostMount,
 		},
 		ControllerPlugin: &csiopv1.ControllerPluginSpec{
+			HostNetwork: &controllerPluginHostNetwork,
 			PodCommonSpec: csiopv1.PodCommonSpec{
 				PrioritylClassName: &CSIParam.PluginPriorityClassName,
 				Affinity: &corev1.Affinity{

--- a/pkg/operator/ceph/csi/operator_driver_test.go
+++ b/pkg/operator/ceph/csi/operator_driver_test.go
@@ -118,13 +118,15 @@ func TestReconcileCSI_createOrUpdateDriverResources(t *testing.T) {
 			c.SetName("testcluster")
 			c.NamespacedName()
 
+			cephv1.SetEnforceHostNetwork(true)
+			defer cephv1.SetEnforceHostNetwork(false)
 			err := r.createOrUpdateDriverResources(*cluster, c)
 			assert.NoError(t, err)
 
 			// Test RBD driver
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s.rbd.csi.ceph.com", c.Namespace), Namespace: ns}, driver)
 			assert.NoError(t, err)
-
+			assert.True(t, *driver.Spec.ControllerPlugin.HostNetwork)
 			if tt.expectMultusAnnots {
 				// Verify that both NodePlugin and ControllerPlugin have Multus annotations
 				assert.Nil(t, driver.Spec.NodePlugin.PodCommonSpec.Annotations)


### PR DESCRIPTION
The ceph csi controller plugin did not have the capability to set host networking, in case the host networking is being enforced with ROOK_ENFORCE_HOST_NETWORK: true.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16431 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
