### PR TITLE
osd: clean encrypted disks from other clusters

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -870,7 +870,12 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 	}
 
 	if len(existingOSDs) == 0 {
-		logger.Info("no existing OSDs were found. No disks to be wiped")
+		// ceph-volume raw list didn't return any existing OSDs. Its possible that /dev/mapper entry of the encrypted disks were removed.
+		// Check for cephFSID in the luks header of the disk and clean the disk if does not match the cephFSID of the current cluster.
+		err := wipeEncryptedDevicesFromOtherClusters(context, a.clusterInfo.FSID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to clean up encrypted disks from other clusters")
+		}
 		return nil
 	}
 
@@ -905,6 +910,39 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 				osdDisk.Filesystem = ""
 			} else {
 				logger.Infof("skip wiping OSD %d device %q belonging to a different ceph cluster %q since not a desired device", osdID, deviceToWipe, existingOSD.CephFsid)
+			}
+		}
+	}
+
+	return nil
+}
+
+func wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context, currentClusterFSID string) error {
+	for _, disk := range context.Devices {
+		if disk.Filesystem == "crypto_LUKS" {
+			metadata, err := dumpLUKS(context, disk.Name)
+			if err != nil {
+				logger.Debugf("failed to determine if the encrypted block %q is from our cluster. %v", disk.Name, err)
+				return nil
+			}
+
+			ceph_fsid := luksLabelCephFSID.FindString(metadata)
+			if ceph_fsid == "" {
+				logger.Error("ceph_fsid not found in the LUKS header, the encrypted disk is not from a ceph cluster")
+				return nil
+			}
+
+			// is it an OSD from our cluster?
+			currentDiskCephFSID := strings.SplitAfter(ceph_fsid, "=")[1]
+			if currentDiskCephFSID != currentClusterFSID {
+				logger.Errorf("cleaning encrypted disk %q (%q) that is part of a different ceph cluster %q", disk.Name, disk.RealPath, currentDiskCephFSID)
+				output, err := context.Executor.ExecuteCommandWithCombinedOutput("stdbuf", "-oL", cephVolumeCmd, "lvm", "zap", disk.RealPath)
+				if err != nil {
+					return errors.Wrapf(err, "failed to zap encryted disk with differetn ceph cluster %q. %s.", disk.RealPath, output)
+				}
+				logger.Infof("completed wiping device %q belonging to a different ceph cluster", disk.RealPath)
+				// Since the device is wiped clean, clear the stale filesystem reference on the disk so that the wiped disk is not filtered out for filesystem check.
+				disk.Filesystem = ""
 			}
 		}
 	}


### PR DESCRIPTION
Clean encrypted disks from other clusters by checking the cephFSID in the luks header.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
