### PR TITLE
core: use latest operator context in the preClusterStartValidation function

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -264,6 +264,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster) error {
 }
 
 func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
+	cluster.ClusterInfo.Context = c.OpManagerCtx
 	// Cluster Spec validation
 	err := preClusterStartValidation(cluster)
 	if err != nil {
@@ -287,8 +288,6 @@ func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
 	}
 
 	controller.UpdateCondition(c.OpManagerCtx, c.context, c.namespacedName, k8sutil.ObservedGenerationNotAvailable, cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, "Configuring the Ceph cluster")
-
-	cluster.ClusterInfo.Context = c.OpManagerCtx
 	// Run the orchestration
 	err = cluster.reconcileCephDaemons(c.rookImage, *cephVersion)
 	if err != nil {


### PR DESCRIPTION
If the CephCluster spec is updated before the [prevalidation check](https://github.com/red-hat-storage/rook/blob/6f3f2430a4d1711bc13c17a71abb550067c97761/pkg/operator/ceph/cluster/cluster.go#L251), then Cluster.context still refers to the cancelled context of the operator. As a result, any namespaced K8s API fails with error message: 

```
2025-09-15 12:59:40.494664 E | ceph-csi: failed to reconcile failed to stop csi Drivers: failed to remove CSI CephFS driver: failed to delete the "csi-cephfsplugin-metrics": client rate limiter Wait returned an error: context canceled
....

2025-09-15 12:59:41.871989 E | ceph-cluster-controller: failed to reconcile CephCluster "openshift-storage/ocs-storagecluster-cephcluster". failed to reconcile cluster "ocs-storagecluster-cephcluster": failed to configure local ceph cluster: failed to perform validation before cluster creation: failed to validate kms connection details: failed to fetch kms token secret "ocs-kms-token": client rate limiter Wait returned an error: context canceled

```

This PR just updates the cluster context to use the latest operator context.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
