### PR TITLE
osd: updated blocking pdbs if drained node is back

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -547,12 +547,29 @@ func TestSetPDBConfig(t *testing.T) {
 			expecteNoOutSetting:           "true",
 		},
 		{
-			name:                          "case 3: failure domain with drained nodes should get higher precedence",
+			name:                          "case 4: failure domain with drained nodes should get higher precedence",
 			pdbConfig:                     fakePDBConfigMap(""),
 			osdDownFailureDomains:         []string{"zone-1", "zone-2", "zone-3"},
 			drainingFailureDomains:        []string{"zone-3"},
 			expectedFailureDomainKeyValue: "zone-3",
 			expecteNoOutSetting:           "true",
+		},
+		{
+			name:                          "case 5: pdb configmap should be updated with new drainingFailureDomain, if previously drained failure domain is up",
+			pdbConfig:                     fakePDBConfigMap("zone-1"),
+			osdDownFailureDomains:         []string{"zone-2"},
+			drainingFailureDomains:        []string{"zone-3"},
+			expectedFailureDomainKeyValue: "zone-3",
+			expecteNoOutSetting:           "true",
+		},
+
+		{
+			name:                          "case 6: pdb configmap should be updated with new osdDownFailureDomains, if previously drained failure domain is up",
+			pdbConfig:                     fakePDBConfigMap("zone-1"),
+			osdDownFailureDomains:         []string{"zone-2"},
+			drainingFailureDomains:        []string{},
+			expectedFailureDomainKeyValue: "zone-2",
+			expecteNoOutSetting:           "",
 		},
 	}
 


### PR DESCRIPTION
If the drained node is added back and one or more others nodes are down, then update the blocking pdbs, that is, add blocking pdb to node that was just added back.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #15840


Testing: 

```
1. Current PDB state. 
 kr get pdb
NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb   N/A             1                 0                     71m
rook-ceph-mon-pdb   N/A             1                 1                     72m
rook-ceph-osd       N/A             1                 1                     2m20s

2. Drain `minikube` 
kubectl drain --ignore-daemonsets --force  --delete-emptydir-data -v=8 minikube

3. Current PDB state: 
❯ kr get pdb
NAME                              MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb                 N/A             1                 1                     74m
rook-ceph-mon-pdb                 N/A             1                 0                     75m
rook-ceph-osd-host-minikube-m02   N/A             0                 0                     6s
rook-ceph-osd-host-minikube-m03   N/A             0                 0                     6s

4. Stop minikube-03. 
 kr get nodes
NAME           STATUS                     ROLES           AGE     VERSION
minikube       Ready,SchedulingDisabled   control-plane   97m     v1.30.0
minikube-m02   Ready                      <none>          96m     v1.30.0
minikube-m03   NotReady                   <none>          7m59s   v1.30.0

5. Uncordon minikube
❯ kr get nodes
NAME           STATUS     ROLES           AGE     VERSION
minikube       Ready      control-plane   97m     v1.30.0
minikube-m02   Ready      <none>          96m     v1.30.0
minikube-m03   NotReady   <none>          8m48s   v1.30.0

6. Current PDB state 
❯ kr get pdb
NAME                              MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb                 N/A             1                 1                     78m
rook-ceph-mon-pdb                 N/A             1                 0                     79m
rook-ceph-osd-host-minikube       N/A             0                 0                     24s
rook-ceph-osd-host-minikube-m02   N/A             0                 0                     4m8s

7. Start minikube-03 
kr get nodes
NAME           STATUS   ROLES           AGE    VERSION
minikube       Ready    control-plane   101m   v1.30.0
minikube-m02   Ready    <none>          100m   v1.30.0
minikube-m03   Ready    <none>          17s    v1.30.0


8. Current PDB state:
❯ kr get pdb
NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
rook-ceph-mgr-pdb   N/A             1                 1                     81m
rook-ceph-mon-pdb   N/A             1                 1                     82m
rook-ceph-osd       N/A             1                 1                     7s

```



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
