### PR TITLE
helm: Allow specifying the image tag and repository separately

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -63,6 +63,9 @@ The following table lists the configurable parameters of the rook-operator chart
 | `cephClusterSpec` | Cluster configuration. | See [below](#ceph-cluster-spec) |
 | `cephFileSystemVolumeSnapshotClass` | Settings for the filesystem snapshot class | See [CephFS Snapshots](../Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md#cephfs-snapshots) |
 | `cephFileSystems` | A list of CephFileSystem configurations to deploy | See [below](#ceph-file-systems) |
+| `cephImage.allowUnsupported` |  | `false` |
+| `cephImage.repository` |  | `"quay.io/ceph/ceph"` |
+| `cephImage.tag` |  | `"v19.2.3"` |
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |

--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -19,4 +19,11 @@ spec:
     interval: {{ . }}
     {{- end }}
   {{- end }}
+  {{- with .Values.cephImage }}
+  cephVersion:
+    image: "{{ .repository }}:{{ .tag }}"
+    allowUnsupported: {{ .allowUnsupported }}
+    imagePullPolicy: {{ .imagePullPolicy }}
+  {{- end }}
+
   {{- .Values.cephClusterSpec | toYaml | nindent 2 }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -89,6 +89,22 @@ pspEnable: false
 # imagePullSecrets:
 # - name: my-registry-secret
 
+# Specify these values to override the Ceph image in the cephClusterSpec below.
+# If specifying these values, do not include the cephVersion section in the cephClusterSpec.
+cephImage:
+  # The repository from which to pull the ceph image
+  repository: quay.io/ceph/ceph
+  # In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
+  # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
+  # To be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v19.2.3-20250717
+  tag: v19.2.3
+  # Whether to allow unsupported versions of Ceph. Currently Reef and Squid are supported.
+  # Future versions such as Tentacle (v20) would require this to be set to `true`.
+  # Do not set to true in production.
+  allowUnsupported: false
+  # The image pull policy for pulling the ceph image in the ceph daemon pods, defaults to IfNotPresent
+  # imagePullPolicy: IfNotPresent
+
 # All values below are taken from the CephCluster CRD
 # -- Cluster configuration.
 # @default -- See [below](#ceph-cluster-spec)
@@ -98,20 +114,7 @@ cephClusterSpec:
   # PVC-based cluster (cluster-on-pvc.yaml), external cluster (cluster-external.yaml),
   # or stretch cluster (cluster-stretched.yaml), replace this entire `cephClusterSpec`
   # with the specs from those examples.
-
   # For more details, check https://rook.io/docs/rook/v1.10/CRDs/Cluster/ceph-cluster-crd/
-  cephVersion:
-    # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
-    # v18 is Reef, v19 is Squid
-    # RECOMMENDATION: In production, use a specific version tag instead of the general v18 flag, which pulls the latest release and could result in different
-    # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v19.2.3-20250717
-    # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: quay.io/ceph/ceph:v19.2.3
-    # Whether to allow unsupported versions of Ceph. Currently Reef and Squid are supported.
-    # Future versions such as Tentacle (v20) would require this to be set to `true`.
-    # Do not set to true in production.
-    allowUnsupported: false
 
   # The path on the host where configuration files will be persisted. Must be specified. If there are multiple clusters, the directory must be unique for each cluster.
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.


### PR DESCRIPTION
The image repo and tag conveniently can be specified separately so the release tag can be picked from the official chart, and the repo can be customized in the values.yaml.

In my testing, the ceph image properties are overridden as expected. It's awkward how we import the entire cephClusterSpec (which includes the `cephVersion` section, while also defining the image outside the cephClusterSpec so we can customize it. This is consistent with the `monitoring` section, but I still wonder if there is a better way. 

@KKonak @consideRatio Does this look reasonable, or any more suggestions?

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16504

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
