### PR TITLE
csi: add labels to the csi-operator driver pod

### DIFF
--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -83,6 +83,8 @@ func (r *ReconcileCSI) createOrUpdateRBDDriverResource(cluster cephv1.CephCluste
 		return err
 	}
 
+	spec.NodePlugin.Labels = CSIParam.CSIRBDPodLabels
+	spec.ControllerPlugin.Labels = CSIParam.CSIRBDPodLabels
 	rbdDriver := &csiopv1.Driver{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -128,6 +130,9 @@ func (r *ReconcileCSI) createOrUpdateCephFSDriverResource(cluster cephv1.CephClu
 	if err != nil {
 		return err
 	}
+
+	spec.NodePlugin.Labels = CSIParam.CSICephFSPodLabels
+	spec.ControllerPlugin.Labels = CSIParam.CSICephFSPodLabels
 
 	cephFsDriver := &csiopv1.Driver{
 		TypeMeta: metav1.TypeMeta{},
@@ -179,6 +184,8 @@ func (r *ReconcileCSI) createOrUpdateNFSDriverResource(cluster cephv1.CephCluste
 	if err != nil {
 		return err
 	}
+	spec.NodePlugin.Labels = CSIParam.CSINFSPodLabels
+	spec.ControllerPlugin.Labels = CSIParam.CSINFSPodLabels
 
 	NFSDriver := &csiopv1.Driver{
 		TypeMeta: metav1.TypeMeta{},


### PR DESCRIPTION
currently, labels are not passed to csi-operator but for csi-driver lables works as expected. This commit add changes to add labels on csi-operator driver pod as well.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16472 

Pending Items"

- [x] Testing


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
