### PR TITLE
ci: fix typo in canary integration test workflow

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -353,7 +353,7 @@ jobs:
             exit 1
           fi
 
-      - name: test key rotation with --cephx-key-rotate in multi tentat case, where --restricted-auth-permission is set
+      - name: test key rotation with --cephx-key-rotate in multi tenant case, where --restricted-auth-permission is set
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # create tenant1 and verify


### PR DESCRIPTION

Thus fixes a typo in the canary integration test workflow file.



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
