### PR TITLE
Monitoring: fix alert CephPoolGrowthWarning

### DIFF
--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -537,7 +537,7 @@ spec:
           annotations:
             description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
             summary: "Pool growth rate may soon exceed capacity"
-          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
+          expr: "(max(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) by (pool_id, instance, pod) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
             severity: "warning"


### PR DESCRIPTION
fix CephPoolGrowthWarning prometheus alert which is broken in case of switch to a different MGR 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Checklist:**

- [ x ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ x ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ x ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ x ] Documentation has been updated, if necessary.
- [ x ] Unit tests have been added, if necessary.
- [ x ] Integration tests have been added, if necessary.
