### PR TITLE
helm: fix failure to cleanup psp fully

### DIFF
--- a/build/rbac/keep-rbac-yaml.sh
+++ b/build/rbac/keep-rbac-yaml.sh
@@ -20,7 +20,6 @@ pushd "${temp_dir}" &>/dev/stderr
 # just read in the files, sorted by the fs for final output.
 
 $YQ eval '
-    select(.kind == "PodSecurityPolicy"),
     select(.kind == "ServiceAccount"),
     select(.kind == "ClusterRole"),
     select(.kind == "ClusterRoleBinding"),


### PR DESCRIPTION
I failed to save a file before making the commit becoming PR #16558. This small change should also have been part of it.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
