### PR TITLE
build: Add csi operator image to images.txt

### DIFF
--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -2,6 +2,7 @@
  gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255
  quay.io/ceph/ceph:v19.2.3
  quay.io/ceph/cosi:v0.1.2
+ quay.io/cephcsi/ceph-csi-operator:v0.4.1
  quay.io/cephcsi/cephcsi:v3.15.0
  quay.io/csiaddons/k8s-sidecar:v0.13.0
  registry.k8s.io/sig-storage/csi-attacher:v4.8.1

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -96,12 +96,12 @@ IMAGE_TMP="/tmp/rook-ceph-image-list"
 list-image: ## Create a list of images for offline installation
 	@echo "producing list of images for offline installation"
 	rm -f $(IMAGE_TMP)
-	awk '/image:/ {print $2}' $(MANIFESTS_DIR)/operator.yaml $(MANIFESTS_DIR)/cluster.yaml | \
+	awk '/image:/ {print $2}' $(MANIFESTS_DIR)/operator.yaml $(MANIFESTS_DIR)/cluster.yaml $(MANIFESTS_DIR)/csi-operator.yaml | \
 		cut -d: -f2- | tee $(IMAGE_TMP)
 	awk '/quay.io/ || /registry.k8s.io/ {print $3}' ../../pkg/operator/ceph/csi/spec.go | \
 		cut -d= -f2- | tr -d '"' | tee -a $(IMAGE_TMP)
 	awk '/quay.io/ || /gcr.io/ {print $4}' ../../pkg/operator/ceph/object/cosi/spec.go | \
 		cut -d= -f2- | tr -d '"' | tee -a $(IMAGE_TMP)
 	rm -f $(MANIFESTS_DIR)/images.txt
-	cat $(IMAGE_TMP) | sort -h | uniq | tee $(MANIFESTS_DIR)/images.txt
+	cat $(IMAGE_TMP) | sort -h | uniq | grep -v '^[[:space:]]*$$' | tee $(MANIFESTS_DIR)/images.txt
 	rm -f $(IMAGE_TMP)


### PR DESCRIPTION
With the addition of the csi operator, the csi operator image is added to the list of images that are required for deploying rook.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16536

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
