### PR TITLE
helm: fix toolbox image fallback

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       containers:
         - name: rook-ceph-tools
-          image: {{ .Values.toolbox.image | default .Values.cephClusterSpec.cephVersion.image }}
+          image: {{ .Values.toolbox.image | default (printf "%s:%s" .Values.cephImage.repository .Values.cephImage.tag) }}
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
This fixes a regression from 51cb22c791d621de4746423a1e743c50260801c9 resulting in upgrade failure by adapting the toolbox deployment.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16567

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.

Only tested with `helm template` so far.