### PR TITLE
exporter: add log collector for ceph exporter pod

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -145,6 +145,14 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 				ServiceAccountName:            k8sutil.DefaultServiceAccount,
 			},
 		}
+
+		// If the log collector is enabled we add the side-car container
+		if cephCluster.Spec.LogCollector.Enabled {
+			shareProcessNamespace := true
+			deploy.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
+			deploy.Spec.Template.Spec.Containers = append(deploy.Spec.Template.Spec.Containers, *controller.LogCollectorContainer(fmt.Sprintf("ceph-exporter.%s", nodeHostnameLabel), cephCluster.GetNamespace(), cephCluster.Spec, nil))
+		}
+
 		cephv1.GetCephExporterAnnotations(cephCluster.Spec.Annotations).ApplyToObjectMeta(&deploy.Spec.Template.ObjectMeta)
 		applyPrometheusAnnotations(cephCluster, &deploy.Spec.Template.ObjectMeta)
 

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -146,6 +146,64 @@ func TestCreateOrUpdateCephExporter(t *testing.T) {
 	})
 }
 
+func TestCephExporterLogrotateContainer(t *testing.T) {
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+		},
+		Spec: cephv1.ClusterSpec{
+			LogCollector: cephv1.LogCollectorSpec{
+				Enabled: true,
+			},
+		},
+	}
+
+	node := corev1.Node{}
+	nodeSelector := map[string]string{corev1.LabelHostname: "testnode"}
+	node.SetLabels(nodeSelector)
+
+	cephVersion := &cephver.CephVersion{Major: 18, Minor: 0, Extra: 0}
+
+	s := scheme.Scheme
+	err := appsv1.AddToScheme(s)
+	assert.NoError(t, err)
+
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+	reconciler := &ReconcileNode{
+		client:           cl,
+		scheme:           s,
+		context:          &clusterd.Context{},
+		opManagerContext: context.TODO(),
+	}
+
+	result, err := reconciler.createOrUpdateCephExporter(node, []corev1.Toleration{}, *cephCluster, cephVersion)
+	assert.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultCreated, result)
+
+	deployment := &appsv1.Deployment{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      "rook-ceph-exporter-testnode",
+		Namespace: "test-namespace",
+	}, deployment)
+	assert.NoError(t, err)
+
+	// Check logrotate container is added
+	assert.Len(t, deployment.Spec.Template.Spec.Containers, 2)
+
+	var logrotateContainer *corev1.Container
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "log-collector" {
+			logrotateContainer = &container
+			break
+		}
+	}
+	// Verify logrotate container configuration
+	assert.NotNil(t, logrotateContainer)
+	assert.Contains(t, logrotateContainer.Command[5], "ceph-exporter")
+}
+
 func TestCephExporterBindAddress(t *testing.T) {
 	prioLimit, statsPeriod := defaultPrioLimit, defaultStatsPeriod
 	prioLimitString, err := strconv.ParseInt(prioLimit, 10, 64)


### PR DESCRIPTION
similar to other ceph pods like osd,mon,mgr,mirror pod this commit add log collector container to the main exporter pod to rotate the logs of exporter pod.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #14434


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
