### PR TITLE
docs: discourage freezing default values in user values.yaml

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -40,6 +40,9 @@ The `release` channel is the most recent release of Rook that is considered stab
 The example install assumes you have first installed the [Rook Operator Helm Chart](operator-chart.md)
 and created your customized values.yaml.
 
+!!! tip
+   Instead of copying the entire default `values.yaml`, create a new `values.yaml` file that only includes the settings you want to override.
+
 ```console
 helm repo add rook-release https://charts.rook.io/release
 helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -43,6 +43,9 @@ The `release` channel is the most recent release of Rook that is considered stab
 The example install assumes you have first installed the [Rook Operator Helm Chart](operator-chart.md)
 and created your customized values.yaml.
 
+!!! tip
+   Instead of copying the entire default `values.yaml`, create a new `values.yaml` file that only includes the settings you want to override.
+
 ```console
 helm repo add rook-release https://charts.rook.io/release
 helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \


### PR DESCRIPTION
Discourage freezing default values in user values.yaml (fix #16523)

Users sometimes copy‑paste the entire default `values.yaml` into their own configs, which “freezes” all defaults and prevents them from inheriting new defaults in future chart versions.

This change enhances the Helm chart documentation (README / values docs) to emphasize that:
- Only *overridden* fields should be declared by users.
- Avoid duplicating all default values.
- Leaving fields unset allows users to benefit from upstream default updates.

These adjustments help maintain upgrade compatibility, reduce config bloat, and make it easier to adopt new defaults.

Closes: #16523

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
