### PR TITLE
doc: add recovery steps for topology based pools

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster/topology-for-external-mode.md
+++ b/Documentation/CRDs/Cluster/external-cluster/topology-for-external-mode.md
@@ -3,6 +3,10 @@
 ## Scenario
 Applications like Kafka will have a deployment with multiple running instances. Each service instance will create a new claim and is expected to be located in a different zone. Since the application has its own redundant instances, there is no requirement for redundancy at the data layer. A storage class is created that will provision storage from replica 1 Ceph pools that are located in each of the separate zones.
 
+!!! warning
+    Configuring Ceph replica 1 pools means that the loss of any OSD in a zone will result in the loss of all data in the replica 1 pool and requires manual intervention to re-create the Ceph pool.
+    See the section on [Recovery](#recovery) below.
+
 ## Configuration Flags
 
 Add the required flags to the script: `create-external-cluster-resources.py`:
@@ -123,3 +127,10 @@ Set two values in the [rook-ceph-operator-config configmap](https://github.com/r
 #### Create a Topology-Based PVC
 
 The topology-based storage class is ready to be consumed! Create a PVC from the `ceph-rbd-topology` storage class above, and watch the OSD usage to see how the data is spread only among the topology-based CRUSH buckets.
+
+## Recovery
+
+In a Ceph replica-1 pool, if any single OSDs in the pool is lost, the pool is unusable and all data in the pool is lost.
+
+To recover, the replica-1 pool must be deleted and re-created.
+Any applications that have provisioned volumes from a storage class referencing this replica-1 pool will need to request a new PVC.


### PR DESCRIPTION

Added a recovery steps for replica-1 pool
if the osd went down
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves # https://github.com/rook/rook/issues/16572

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
