### PR TITLE
pool: Skip setting the target size ratio to 0 by default

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -340,7 +340,7 @@ func setCommonPoolProperties(context *clusterd.Context, clusterInfo *ClusterInfo
 		pool.Parameters = make(map[string]string)
 	}
 
-	if _, ok := pool.Parameters[targetSizeRatioProperty]; !ok {
+	if _, ok := pool.Parameters[targetSizeRatioProperty]; !ok && pool.Replicated.TargetSizeRatio != 0 {
 		pool.Parameters[targetSizeRatioProperty] = strconv.FormatFloat(pool.Replicated.TargetSizeRatio, 'f', -1, 32)
 	}
 

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -310,22 +310,6 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 				return "", nil
 			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-data1", "size", "1"}) {
 				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-metadata", "target_size_ratio", "0"}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-data0", "target_size_ratio", "0"}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-data1", "target_size_ratio", "0"}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-named-pool", "target_size_ratio", "0"}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-metadata", "compression_mode", ""}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-data0", "compression_mode", ""}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-data1", "compression_mode", ""}) {
-				return "", nil
-			} else if reflect.DeepEqual(args[0:6], []string{"osd", "pool", "set", fsName + "-named-pool", "compression_mode", ""}) {
-				return "", nil
 			} else if reflect.DeepEqual(args[0:4], []string{"fs", "add_data_pool", fsName, fsName + "-data1"}) {
 				*addDataPoolCount++
 				return "", nil


### PR DESCRIPTION
The target size ratio is currently always being set to 0, when neither the legacy targetSizeRatio nor the parameter for target_size_ratio are set. In this case, we should not set it to 0, but rather should skip the command to set the target size ratio. We may have discussed this change originally with #15951, but didn't realize it was needed until now.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16592

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
