### PR TITLE
osd: Set osd resources for specific device class

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -77,6 +77,16 @@ func GetOSDResources(p ResourceSpec, deviceClass string) v1.ResourceRequirements
 	return p[ResourcesKeyOSD]
 }
 
+// GetOSDResourcesForDeviceClass returns the resources for a device class, if specified
+func GetOSDResourcesForDeviceClass(resourceSpec ResourceSpec, deviceClass string) (v1.ResourceRequirements, bool) {
+	// if the device class requests specific resources, return them here
+	if resources, ok := resourceSpec[getOSDResourceKeyForDeviceClass(deviceClass)]; ok {
+		return resources, true
+	}
+	// no resources requested specific to the device class
+	return v1.ResourceRequirements{}, false
+}
+
 // getOSDResourceKeyForDeviceClass returns key name for device class in resources spec
 func getOSDResourceKeyForDeviceClass(deviceClass string) string {
 	return ResourcesKeyOSD + "-" + deviceClass

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -354,6 +354,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 		logger.Infof("The device class for osd %d is changing from %q to %q", osd.ID, osd.DeviceClass, osdProps.storeConfig.DeviceClass)
 		osd.DeviceClass = osdProps.storeConfig.DeviceClass
 	}
+	// Assign the resources specific to this device class
+	if resources, ok := cephv1.GetOSDResourcesForDeviceClass(c.spec.Resources, osd.DeviceClass); ok {
+		logger.Debugf("assigning resources for device class %q to osd %d: %+v", osd.DeviceClass, osd.ID, resources)
+		osdProps.resources = resources
+	}
 
 	dataDir := k8sutil.DataDir
 	// Create volume config for /dev so the pod can access devices on the host


### PR DESCRIPTION
The OSDs may require different resources based on their device class. The overall osd resources were only being used, rather than properly looking up the specific device class resources. Now the expected resources will take affect per device class.

This is the resolution of discussion in previous PR #15427.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
