### PR TITLE
mon: wait for the canary pods to be terminated

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -893,13 +893,10 @@ func (c *Cluster) removeCanaryDeployments(labelSelector string) {
 		return
 	}
 
-	// Delete the canary mons, but don't wait for them to exit
+	// Delete the canary mons
 	for _, canary := range canaryDeployments.Items {
 		logger.Infof("cleaning up canary monitor deployment %q", canary.Name)
-		var gracePeriod int64
-		propagation := metav1.DeletePropagationForeground
-		options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-		if err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Delete(c.ClusterInfo.Context, canary.Name, *options); err != nil {
+		if err := k8sutil.DeleteDeployment(c.ClusterInfo.Context, c.context.Clientset, c.Namespace, canary.Name); err != nil {
 			logger.Warningf("failed to delete canary monitor deployment %q. %v", canary.Name, err)
 		}
 	}


### PR DESCRIPTION
Wait for the mon-canary pods to be terminated before starting the actual mons. When topology spread constraints are added to evenly spread the mons, then pod-anti affinity does not allow mons to be created on the same node where other mons are running, this also includes the mon-canary pods. We delete the mon-canary pods and then start the actual mon pods. Sometimes the termination of the canary pods might take more time, so schedular won't schedular mon pods on that node. For example: 


Logs from k8s scheduler 
```
I1017 08:49:34.472016       1 schedule_one.go:314] "Successfully bound pod to node" pod="openshift-storage/rook-ceph-mon-f-canary-f974fcffb-47smk" node="worker-2" evaluatedNodes=6 feasibleNodes=1
I1017 08:49:43.778001       1 preemption.go:264] "No preemption candidate is found; preemption is not helpful for scheduling" pod="openshift-storage/rook-ceph-mon-f-7fb7c6f7d6-mtwqn"
I1017 08:49:43.778076       1 schedule_one.go:1044] "Unable to schedule pod; no fit; waiting" pod="openshift-storage/rook-ceph-mon-f-7fb7c6f7d6-mtwqn" err="0/6 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 2 node(s) didn't match Pod's node affinity/selector, 3 node(s) had untolerated taint {node-role.kubernetes.io/master: }. preemption: 0/6 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 5 Preemption is not helpful for scheduling."
```

Notice that at `08:49:43.778076`, there is a failure to schedule `mon-f` due to the pod's anti affinity rules.  Around the same time, rook  attempted to delete `mon-f-canary` pod.  So the scheduler is not retrying to schedule mon-f after `mon-f-canary` deleted. 

Logs from the Rook operator pod. 

```
2025-10-17 08:49:43.660196 I | op-mon: cleaning up canary monitor deployment "rook-ceph-mon-f-canary"
```


----------------------

One of the downsides of this change is that operator takes a significant time to wait for the canary pods to be terminated and then start new mon pods. Even though this delay will only happen during the cluster creation, its still significant. While testing this PR on minikube, I observed that it took **3 minutes** to terminate all the canary pods before the actual mons could start. Logs: 

```
2025-10-17 08:16:24.988154 I | op-mon: cleaning up canary monitor deployment "rook-ceph-mon-a-canary"
2025-10-17 08:16:24.988197 I | op-k8sutil: removing deployment rook-ceph-mon-a-canary if it exists
2025-10-17 08:16:25.002320 I | op-k8sutil: Removed deployment rook-ceph-mon-a-canary
2025-10-17 08:16:25.016192 I | op-k8sutil: "rook-ceph-mon-a-canary" still found. waiting...
2025-10-17 08:16:29.984184 I | ceph-spec: parsing mon endpoints:
2025-10-17 08:16:29.984216 W | ceph-spec: ignoring invalid monitor
2025-10-17 08:16:29.984941 I | op-bucket-prov: ceph bucket provisioner launched watching for provisioner "rook-ceph.ceph.rook.io/bucket"
2025-10-17 08:16:29.999070 I | op-bucket-prov: successfully reconciled bucket provisioner
I1017 08:16:30.003741       1 manager.go:135] "msg"="starting provisioner" "logger"="objectbucket.io/provisioner-manager" "name"="rook-ceph.ceph.rook.io/bucket"
2025-10-17 08:16:30.358399 I | ceph-spec: parsing mon endpoints:
2025-10-17 08:16:30.358433 W | ceph-spec: ignoring invalid monitor
2025-10-17 08:16:30.358481 I | ceph-csi: disabling csi-driver since EnableCSIOperator is true
2025-10-17 08:16:30.358632 I | op-k8sutil: removing daemonset csi-rbdplugin if it exists
2025-10-17 08:16:30.375040 I | op-k8sutil: removing deployment csi-rbdplugin-provisioner if it exists
2025-10-17 08:16:30.391197 I | ceph-csi: successfully removed CSI Ceph RBD driver
2025-10-17 08:16:30.391314 I | op-k8sutil: removing daemonset csi-cephfsplugin if it exists
2025-10-17 08:16:30.398767 I | op-k8sutil: removing deployment csi-cephfsplugin-provisioner if it exists
2025-10-17 08:16:30.409353 I | ceph-csi: successfully removed CSI CephFS driver
2025-10-17 08:16:30.409432 I | op-k8sutil: removing daemonset csi-nfsplugin if it exists
2025-10-17 08:16:30.415102 I | op-k8sutil: removing deployment csi-nfsplugin-provisioner if it exists
2025-10-17 08:16:30.435826 I | ceph-csi: successfully removed CSI NFS driver
2025-10-17 08:16:30.449183 I | ceph-csi: successfully deleted configmap "rook-ceph-csi-config" in namespace "rook-ceph"
2025-10-17 08:16:30.602150 I | ceph-csi: Creating ceph-CSI operator config CR
2025-10-17 08:16:30.627425 I | ceph-csi: Successfully create imageSet cm rook-csi-operator-image-set-configmap for ceph-CSI operator-config CR "ceph-csi-operator-config"
2025-10-17 08:16:30.752377 I | ceph-csi: Successfully created ceph-CSI operator config CR "ceph-csi-operator-config"
2025-10-17 08:16:30.752477 I | ceph-csi: Creating RBD driver resources
2025-10-17 08:16:30.752707 I | ceph-csi: adding annotation to CSIDriver resource for csi-operator to own it
2025-10-17 08:16:30.790923 I | ceph-csi: Successfully updated imageSet cm rook-csi-operator-image-set-configmap for ceph-CSI operator-config CR "ceph-csi-operator-config"
2025-10-17 08:16:30.924629 I | ceph-csi: successfully created CSI driver cr "rook-ceph.rbd.csi.ceph.com"
2025-10-17 08:16:30.924808 I | ceph-csi: Creating CephFS driver resources
2025-10-17 08:16:30.924996 I | ceph-csi: adding annotation to CSIDriver resource for csi-operator to own it
2025-10-17 08:16:30.970449 I | ceph-csi: Successfully updated imageSet cm rook-csi-operator-image-set-configmap for ceph-CSI operator-config CR "ceph-csi-operator-config"
2025-10-17 08:16:31.000712 I | ceph-csi: successfully created CSI driver cr "rook-ceph.cephfs.csi.ceph.com"
2025-10-17 08:16:35.137686 I | op-k8sutil: "rook-ceph-mon-a-canary" still found. waiting...
2025-10-17 08:16:45.041917 E | clusterdisruption-controller: failed to get OSD status: failed to get osd metadata: exit status 1
2025-10-17 08:16:45.179614 I | op-k8sutil: "rook-ceph-mon-a-canary" still found. waiting...
2025-10-17 08:16:55.295215 I | op-k8sutil: "rook-ceph-mon-a-canary" still found. waiting...
2025-10-17 08:16:59.307582 I | op-k8sutil: confirmed rook-ceph-mon-a-canary does not exist
2025-10-17 08:16:59.307686 I | op-mon: cleaning up canary monitor deployment "rook-ceph-mon-b-canary"
2025-10-17 08:16:59.307772 I | op-k8sutil: removing deployment rook-ceph-mon-b-canary if it exists
2025-10-17 08:16:59.321565 I | op-k8sutil: Removed deployment rook-ceph-mon-b-canary
2025-10-17 08:16:59.345446 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:09.376672 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:19.451930 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:29.488309 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:39.542946 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:49.636123 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:17:59.779318 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:18:07.314555 E | clusterdisruption-controller: failed to get OSD status: failed to get osd metadata: exit status 1
2025-10-17 08:18:09.823053 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:18:19.865543 I | op-k8sutil: "rook-ceph-mon-b-canary" still found. waiting...
2025-10-17 08:18:29.948615 W | op-mon: failed to delete canary monitor deployment "rook-ceph-mon-b-canary". gave up waiting for rook-ceph-mon-b-canary pods to be terminated
2025-10-17 08:18:29.948752 I | op-mon: cleaning up canary monitor deployment "rook-ceph-mon-c-canary"
2025-10-17 08:18:29.948927 I | op-k8sutil: removing deployment rook-ceph-mon-c-canary if it exists
2025-10-17 08:18:30.007549 I | op-k8sutil: Removed deployment rook-ceph-mon-c-canary
2025-10-17 08:18:30.021222 I | op-k8sutil: "rook-ceph-mon-c-canary" still found. waiting...
2025-10-17 08:18:40.058404 I | op-k8sutil: "rook-ceph-mon-c-canary" still found. waiting...
2025-10-17 08:18:50.098332 I | op-k8sutil: "rook-ceph-mon-c-canary" still found. waiting...
2025-10-17 08:19:00.136337 I | op-k8sutil: "rook-ceph-mon-c-canary" still found. waiting...
2025-10-17 08:19:04.178995 I | op-k8sutil: confirmed rook-ceph-mon-c-canary does not exist
2025-10-17 08:19:04.181210 I | op-mon: creating mon a
2025-10-17 08:19:04.265504 I | op-mon: mon "a" cluster IP is 10.111.44.45
```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
