### PR TITLE
WIP: pool: add --debug_ms=0 to ceph config get/set/rm for rbd_stats_pools

### DIFF
--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -109,6 +109,25 @@ func (m *MonStore) Set(who, option, value string) error {
 	return nil
 }
 
+// Set sets a config in the centralized mon configuration database.
+// https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
+func (m *MonStore) SetTest(who, option1, value, option2 string) error {
+	logger.Infof("setting option %q (user %q) to the mon configuration database", option1, who)
+	logger.Tracef("setting option %q = %q (user %q) to the mon configuration database", option1, value, who)
+
+	args := []string{"config", "set", who, option1, value, option2}
+	cephCmd := client.NewCephCommand(m.context, m.clusterInfo, args)
+	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set ceph config in the centralized mon configuration database; "+
+			"you may need to use the rook-config-override ConfigMap. output: %s", string(out))
+	}
+
+	logger.Tracef("successfully set option %q = %q (user %q) to the mon configuration database", option1, value, who)
+	logger.Infof("successfully set option %q (user %q) to the mon configuration database", option1, who)
+	return nil
+}
+
 // Delete a config in the centralized mon configuration database.
 func (m *MonStore) Delete(who, option string) error {
 	logger.Infof("deleting %q %q option from the mon configuration database", who, option)
@@ -124,6 +143,21 @@ func (m *MonStore) Delete(who, option string) error {
 	return nil
 }
 
+// Delete a config in the centralized mon configuration database.
+func (m *MonStore) DeleteTest(who, option1, option2 string) error {
+	logger.Infof("deleting %q %q option from the mon configuration database", who, option1)
+	args := []string{"config", "rm", who, option1, option2}
+	cephCmd := client.NewCephCommand(m.context, m.clusterInfo, args)
+	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete ceph config in the centralized mon configuration database. output: %s",
+			string(out))
+	}
+
+	logger.Infof("successfully deleted %q option from the mon configuration database", option1)
+	return nil
+}
+
 // Get retrieves a config in the centralized mon configuration database.
 // https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
 func (m *MonStore) Get(who, option string) (string, error) {
@@ -132,6 +166,18 @@ func (m *MonStore) Get(who, option string) (string, error) {
 	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option, who)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Get retrieves a config in the centralized mon configuration database.
+// https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
+func (m *MonStore) GetTest(who, option1 string, option2 string) (string, error) {
+	args := []string{"config", "get", who, option1, option2}
+	cephCmd := client.NewCephCommand(m.context, m.clusterInfo, args)
+	out, err := cephCmd.RunWithTimeout(exec.CephCommandsTimeout)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option1, who)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -633,7 +633,8 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 	}
 	monStore := config.GetMonStore(clusterContext, clusterInfo)
 	// Check for existing rbd stats pools
-	existingStatsPools, e := monStore.Get("mgr", "mgr/prometheus/rbd_stats_pools")
+	existingStatsPools, e := monStore.GetTest("mgr", "mgr/prometheus/rbd_stats_pools", "--debug_ms=0")
+	logger.Debugf("existing rbd_stats_pools: %q", existingStatsPools)
 	if e != nil {
 		return errors.Wrapf(e, "failed to get rbd_stats_pools")
 	}
@@ -641,10 +642,10 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 	enableStatsForPools := generateStatsPoolList(existingStatsPoolsList, rookStatsPools, removePools)
 	logger.Debugf("RBD per-image IO statistics will be collected for pools: %v", enableStatsForPools)
 	if len(enableStatsForPools) == 0 {
-		err = monStore.Delete("mgr", "mgr/prometheus/rbd_stats_pools")
+		err = monStore.DeleteTest("mgr", "mgr/prometheus/rbd_stats_pools", "--debug_ms=0")
 	} else {
 		// appending existing rbd stats pools if any
-		err = monStore.Set("mgr", "mgr/prometheus/rbd_stats_pools", enableStatsForPools)
+		err = monStore.SetTest("mgr", "mgr/prometheus/rbd_stats_pools", enableStatsForPools, "--debug_ms=0")
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to enable rbd_stats_pools")


### PR DESCRIPTION
When the Ceph cluster is configured with `debug_ms > 0`, the `ceph config get/set/rm` commands used by Rook to manage `mgr/prometheus/rbd_stats_pools` may hang and never return. This causes the `configureRBDStats()` logic in the `CephBlockPool` controller to fail to update the list of pools with `enableRBDStats: true`.

During testing I reproduced the issue by setting:
```
kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
ceph config set global debug_ms 10
```

With this setting, calls like the following do not work reliably:
```
ceph config get mgr mgr/prometheus/rbd_stats_pools
ceph config set mgr mgr/prometheus/rbd_stats_pools pool1
ceph config rm mgr mgr/prometheus/rbd_stats_pools
```
However, when adding `--debug_ms=0` to the same commands, everything works as expected:
```
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: pool12345
  namespace: rook-ceph # namespace:cluster
spec:
  enableRBDStats: true
  failureDomain: osd
  replicated:
    size: 1
```
```
$ kubectl -n rook-ceph logs rook-ceph-operator-7b8b5d4bd-b4bfn | grep "existing rbd_stats_pools:"
2025-10-20 12:39:45.012031 D | ceph-block-pool-controller: existing rbd_stats_pools: ""
2025-10-20 12:40:42.061552 D | ceph-block-pool-controller: existing rbd_stats_pools: ""
2025-10-20 12:42:20.038074 D | ceph-block-pool-controller: existing rbd_stats_pools: "pool1112"
2025-10-20 12:43:08.014873 D | ceph-block-pool-controller: existing rbd_stats_pools: "pool1112,pool1234"
2025-10-20 12:43:48.040821 D | ceph-block-pool-controller: existing rbd_stats_pools: "pool1112,pool1234,pool12345"
2025-10-20 12:50:13.078718 D | ceph-block-pool-controller: existing rbd_stats_pools: "pool1112,pool1234,pool12345,pool123456"
2025-10-20 12:52:00.126868 D | ceph-block-pool-controller: existing rbd_stats_pools: "pool1112,pool1234,pool12345"
```

Without add `--debug_ms=0`
```
$ kubectl -n rook-ceph logs rook-ceph-operator-9c5c46cb9-l9vhn | grep "existing rbd_stats_pools:"
2025-10-20 13:28:55.707509 D | ceph-block-pool-controller: existing rbd_stats_pools: ""
2025-10-20 13:31:15.444569 D | ceph-block-pool-controller: existing rbd_stats_pools: "2025-10-20T13:31:15.289+0000 7f0c348c8640  1 -- 10.244.0.4:0/359662367 >> [v2:10.97.43.132:3300/0,v1:10.97.43.132:6789/0] conn(0x7f0c30110230 msgr2=0x7f0c30110610 secure :-1 s=STATE_CONNECTION_ESTABLISHED l=1).mark_down\n2025-10-20T13:31:15.289+0000 7f0c348c8640  1 --2- 10.244.0.4:0/359662367 >> [v2:10.97.43.132:3300/0,v1:10.97.43.132:6789/0] conn(0x7f0c30110230 0x7f0c30110610 secure :-1 s=READY pgs=299 cs=0 l=1 rev1=1 crypto rx=0x7f0c240099b0 tx=0x7f0c2402f2b0 comp rx=0 tx=0).stop\n2025-10-20T13:31:15.289+0000 7f0c348c8640  5 --2- 10.244.0.4:0/359662367 >> [v2:10.97.43.132:3300/0,v1:10.97.43.132:6789/0] conn(0x7f0c30110230 0x7f0c30110610 secure :-1 s=READY pgs=299 cs=0 l=1 rev1=1 crypto rx=0x7f0c240099b0 tx=0x7f0c2402f2b0 comp rx=0 tx=0).reset_recv_state\n2025-10-20T13:31:15.289+0000 7f0c348c8640 10 --2- 10.244.0.4:0/359662367 >> [v2:10.97.43.132:3300/0,v1:10.97.43.132:6789/0] conn(0x7f0c30110230 0x7f0c30110610 secure :-1 s=READY pgs=299 cs=0 l=1 re
```
**Note**
This code is not a solution.
It is added only to demonstrate and validate the behavior when using --debug_ms=0.
A proper solution will be implemented after further discussion with maintainers.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
