### PR TITLE
ci: add kustomize to helm.lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,11 @@ yamllint:
 
 helm.lint: ## Check the helm charts
 	ct lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false
+	helm -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
+	helm -n rook-ceph template deploy/charts/rook-ceph-cluster >> templated.yaml
+	echo 'resources: [templated.yaml]' > kustomization.yaml
+	kustomize build >/dev/null
+	rm templated.yaml kustomization.yaml
 
 .PHONY: lint
 lint: yamllint pylint shellcheck checkmake vet markdownlint golangci-lint helm.lint  ## Run various linters


### PR DESCRIPTION
This catches duplicate keys in maps.

The produced files are ignored by Git but can be inspected if a local `helm.lint` fails.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16639 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
