### PR TITLE
core: use sync.Map for cluster.monitoringRoutines

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -82,25 +83,32 @@ func newCephStatusChecker(context *clusterd.Context, clusterInfo *cephclient.Clu
 }
 
 // checkCephStatus periodically checks the health of the cluster
-func (c *cephStatusChecker) checkCephStatus(monitoringRoutines map[string]*opcontroller.ClusterHealth, daemon string) {
+func (c *cephStatusChecker) checkCephStatus(monitoringRoutines *sync.Map, daemon string) {
 	// check the status immediately before starting the loop
-	c.checkStatus(monitoringRoutines[daemon].InternalCtx)
+	v, ok := monitoringRoutines.Load(daemon)
+	if !ok {
+		logger.Infof("ceph cluster %q has been deleted. stopping ceph status check", c.clusterInfo.Namespace)
+		return
+	}
+	c.checkStatus(v.(*opcontroller.ClusterHealth).InternalCtx)
 
 	for {
 		// We must perform this check otherwise the case will check an index that does not exist anymore and
 		// we will get an invalid pointer error and the go routine will panic
-		if _, ok := monitoringRoutines[daemon]; !ok {
+		v, ok := monitoringRoutines.Load(daemon)
+		if !ok {
 			logger.Infof("ceph cluster %q has been deleted. stopping ceph status check", c.clusterInfo.Namespace)
 			return
 		}
+		health := v.(*opcontroller.ClusterHealth)
 		select {
-		case <-monitoringRoutines[daemon].InternalCtx.Done():
+		case <-health.InternalCtx.Done():
 			logger.Infof("stopping monitoring of ceph status")
-			delete(monitoringRoutines, daemon)
+			monitoringRoutines.Delete(daemon)
 			return
 
 		case <-time.After(*c.interval):
-			c.checkStatus(monitoringRoutines[daemon].InternalCtx)
+			c.checkStatus(health.InternalCtx)
 		}
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -65,22 +66,24 @@ func NewOSDHealthMonitor(context *clusterd.Context, clusterInfo *client.ClusterI
 }
 
 // Start runs monitoring logic for osds status at set intervals
-func (m *OSDHealthMonitor) Start(monitoringRoutines map[string]*opcontroller.ClusterHealth, daemon string) {
+func (m *OSDHealthMonitor) Start(monitoringRoutines *sync.Map, daemon string) {
 	for {
 		// We must perform this check otherwise the case will check an index that does not exist anymore and
 		// we will get an invalid pointer error and the go routine will panic
-		if _, ok := monitoringRoutines[daemon]; !ok {
+		v, ok := monitoringRoutines.Load(daemon)
+		if !ok {
 			logger.Infof("ceph cluster %q has been deleted. stopping monitoring of OSDs", m.clusterInfo.Namespace)
 			return
 		}
+		health := v.(*opcontroller.ClusterHealth)
 		select {
 		case <-time.After(*m.interval):
 			logger.Debug("checking osd processes status.")
 			m.checkOSDHealth()
 
-		case <-monitoringRoutines[daemon].InternalCtx.Done():
+		case <-health.InternalCtx.Done():
 			logger.Infof("stopping monitoring of OSDs in namespace %q", m.clusterInfo.Namespace)
-			delete(monitoringRoutines, daemon)
+			monitoringRoutines.Delete(daemon)
 			return
 		}
 	}

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,15 +101,15 @@ func TestOSDHealthCheck(t *testing.T) {
 
 func TestMonitorStart(t *testing.T) {
 	context, cancel := context.WithCancel(context.TODO())
-	monitoringRoutines := make(map[string]*opcontroller.ClusterHealth)
-	monitoringRoutines["osd"] = &opcontroller.ClusterHealth{
+	var monitoringRoutines sync.Map
+	monitoringRoutines.Store("osd", &opcontroller.ClusterHealth{
 		InternalCtx:    context,
 		InternalCancel: cancel,
-	}
+	})
 
 	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, client.AdminTestClusterInfo("ns"), true, cephv1.CephClusterHealthCheckSpec{})
 	logger.Infof("starting osd monitor")
-	go osdMon.Start(monitoringRoutines, "osd")
+	go osdMon.Start(&monitoringRoutines, "osd")
 	cancel()
 }
 


### PR DESCRIPTION
`cluster.monitoringRoutines` stores three types of daemon health: "mon", "osd", and "status". These are used by three goroutines respectively, resulting in: error: concurrent map reads and map writes.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
