### PR TITLE
object: fix user quotas being overwritten when obc bucketOwner is set

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -208,7 +208,8 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{})
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -227,7 +228,8 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{})
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -247,9 +249,10 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			maxSize: aws.Int64(2),
-		})
+		}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -270,9 +273,10 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			maxObjects: aws.Int64(2),
-		})
+		}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -293,10 +297,11 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			maxObjects: aws.Int64(2),
 			maxSize:    aws.Int64(3),
-		})
+		}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -318,10 +323,11 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setUserQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			maxObjects: aws.Int64(12),
 			maxSize:    aws.Int64(13),
-		})
+		}}
+		err := p.setUserQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[userPath], 1)
@@ -394,7 +400,8 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setBucketQuota(&additionalConfigSpec{})
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{}}
+		err := p.setBucketQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[bucketPath], 1)
@@ -413,7 +420,8 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setBucketQuota(&additionalConfigSpec{})
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{}}
+		err := p.setBucketQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[bucketPath], 1)
@@ -433,9 +441,10 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setBucketQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			bucketMaxObjects: aws.Int64(4),
-		})
+		}}
+		err := p.setBucketQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[bucketPath], 1)
@@ -456,9 +465,10 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setBucketQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			bucketMaxSize: aws.Int64(5),
-		})
+		}}
+		err := p.setBucketQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[bucketPath], 1)
@@ -479,10 +489,11 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		p := newProvisioner(t, &getResult, &getSeen, &putSeen)
 		p.setBucketName("bob")
 
-		err := p.setBucketQuota(&additionalConfigSpec{
+		bucket := &bucket{additionalConfig: &additionalConfigSpec{
 			bucketMaxObjects: aws.Int64(14),
 			bucketMaxSize:    aws.Int64(15),
-		})
+		}}
+		err := p.setBucketQuota(bucket)
 		assert.NoError(t, err)
 
 		assert.Len(t, getSeen[bucketPath], 1)


### PR DESCRIPTION
When linking an obc to an existing ceph user with the `bucketOwner` field, obc should not manage quotas configured on the user as obc is **explicitly** not managing the user.

Resolves https://github.com/rook/rook/issues/16417

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
