### PR TITLE
pool: allow configuring pool for a specific failure domain

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -12495,6 +12495,30 @@ string
 </tr>
 <tr>
 <td>
+<code>specificFailureDomain</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The specific failure domain name of the chosen failure domain</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subFailureDomain</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The failure domain for the chosen specific failure domain</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>crushRoot</code><br/>
 <em>
 string

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -595,6 +595,9 @@ spec:
                   required:
                     - size
                   type: object
+                specificFailureDomain:
+                  description: The specific failure domain name of the chosen failure domain
+                  type: string
                 statusCheck:
                   description: The mirroring statusCheck
                   properties:
@@ -612,6 +615,9 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                subFailureDomain:
+                  description: The failure domain for the chosen specific failure domain
+                  type: string
               type: object
             status:
               description: CephBlockPoolStatus represents the mirroring status of Ceph Storage Pool
@@ -7816,6 +7822,9 @@ spec:
                         required:
                           - size
                         type: object
+                      specificFailureDomain:
+                        description: The specific failure domain name of the chosen failure domain
+                        type: string
                       statusCheck:
                         description: The mirroring statusCheck
                         properties:
@@ -7833,6 +7842,9 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      subFailureDomain:
+                        description: The failure domain for the chosen specific failure domain
+                        type: string
                     type: object
                   nullable: true
                   type: array
@@ -8011,6 +8023,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -8028,6 +8043,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 metadataServer:
                   description: The mds pod info
@@ -11837,6 +11855,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -11854,6 +11875,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 defaultRealm:
                   description: |-
@@ -13470,6 +13494,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -13487,6 +13514,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
@@ -14439,6 +14469,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -14456,6 +14489,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 metadataPool:
                   description: The metadata pool settings
@@ -14629,6 +14665,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -14646,6 +14685,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 preservePoolsOnDelete:
                   default: true

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -597,6 +597,9 @@ spec:
                   required:
                     - size
                   type: object
+                specificFailureDomain:
+                  description: The specific failure domain name of the chosen failure domain
+                  type: string
                 statusCheck:
                   description: The mirroring statusCheck
                   properties:
@@ -614,6 +617,9 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                subFailureDomain:
+                  description: The failure domain for the chosen specific failure domain
+                  type: string
               type: object
             status:
               description: CephBlockPoolStatus represents the mirroring status of Ceph Storage Pool
@@ -7811,6 +7817,9 @@ spec:
                         required:
                           - size
                         type: object
+                      specificFailureDomain:
+                        description: The specific failure domain name of the chosen failure domain
+                        type: string
                       statusCheck:
                         description: The mirroring statusCheck
                         properties:
@@ -7828,6 +7837,9 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      subFailureDomain:
+                        description: The failure domain for the chosen specific failure domain
+                        type: string
                     type: object
                   nullable: true
                   type: array
@@ -8006,6 +8018,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -8023,6 +8038,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 metadataServer:
                   description: The mds pod info
@@ -11828,6 +11846,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -11845,6 +11866,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 defaultRealm:
                   description: |-
@@ -13461,6 +13485,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -13478,6 +13505,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
@@ -14427,6 +14457,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -14444,6 +14477,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 metadataPool:
                   description: The metadata pool settings
@@ -14617,6 +14653,9 @@ spec:
                       required:
                         - size
                       type: object
+                    specificFailureDomain:
+                      description: The specific failure domain name of the chosen failure domain
+                      type: string
                     statusCheck:
                       description: The mirroring statusCheck
                       properties:
@@ -14634,6 +14673,9 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    subFailureDomain:
+                      description: The failure domain for the chosen specific failure domain
+                      type: string
                   type: object
                 preservePoolsOnDelete:
                   default: true

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -937,6 +937,14 @@ type PoolSpec struct {
 	// +optional
 	FailureDomain string `json:"failureDomain,omitempty"`
 
+	// The specific failure domain name of the chosen failure domain
+	// +optional
+	SpecificFailureDomain string `json:"specificFailureDomain,omitempty"`
+
+	// The failure domain for the chosen specific failure domain
+	// +optional
+	SubFailureDomain string `json:"subFailureDomain,omitempty"`
+
 	// The root of the crush hierarchy utilized by the pool
 	// +optional
 	// +nullable


### PR DESCRIPTION
currently we cant create a pool to select a specific domain from the available failure domains

add a new api spec to support choosing the speific domain among the failure domains avaialble for creating the pool

closes: https://github.com/rook/rook/issues/16181

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
