### PR TITLE
osd: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -224,7 +224,7 @@ func GetInternalOrExternalClient() kubernetes.Interface {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig != "" {
 		logger.Debugf("attempting to create kube client interface from KUBCONFIG environment variable: %s", kubeconfig)
-		for _, kConf := range strings.Split(kubeconfig, ":") {
+		for kConf := range strings.SplitSeq(kubeconfig, ":") {
 			restConfig, err = clientcmd.BuildConfigFromFlags("", kConf)
 			if err == nil {
 				logger.Debugf("attempting to create kube clientset from kube config file %q", kConf)

--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -117,7 +117,7 @@ func verifyConfig(t *testing.T, cephConfig *CephConfig, cluster *ClusterInfo, lo
 	for _, expectedMon := range cluster.InternalMonitors {
 		contained := false
 		monMembers[i] = expectedMon.Name
-		for _, actualMon := range strings.Split(cephConfig.MonMembers, " ") {
+		for actualMon := range strings.SplitSeq(cephConfig.MonMembers, " ") {
 			if expectedMon.Name == actualMon {
 				contained = true
 				break
@@ -131,9 +131,9 @@ func verifyConfig(t *testing.T, cephConfig *CephConfig, cluster *ClusterInfo, lo
 
 	expectedMons := "[v2:10.0.0.1:3300,v1:10.0.0.1:6789],[v2:10.0.0.2:3300,v1:10.0.0.2:6789]"
 
-	for _, expectedMon := range strings.Split(expectedMons, ",") {
+	for expectedMon := range strings.SplitSeq(expectedMons, ",") {
 		contained := false
-		for _, actualMon := range strings.Split(cephConfig.MonHost, ",") {
+		for actualMon := range strings.SplitSeq(cephConfig.MonHost, ",") {
 			if expectedMon == actualMon {
 				contained = true
 				break

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -76,8 +76,8 @@ type OSDDump struct {
 
 // IsFlagSet checks if an OSD flag is set
 func (dump *OSDDump) IsFlagSet(checkFlag string) bool {
-	flags := strings.Split(dump.Flags, ",")
-	for _, flag := range flags {
+	flags := strings.SplitSeq(dump.Flags, ",")
+	for flag := range flags {
 		if flag == checkFlag {
 			return true
 		}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -283,7 +283,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 }
 
 func matchDevLinks(devLinks, deviceName string) bool {
-	for _, link := range strings.Split(devLinks, " ") {
+	for link := range strings.SplitSeq(devLinks, " ") {
 		if link == deviceName {
 			logger.Infof("%q found in the desired devices (matched by link: %q)", deviceName, link)
 			return true

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -364,8 +364,8 @@ func getEncryptedBlockPath(op, blockType string) string {
 	matches := re.FindAllString(op, -1)
 
 	for _, line := range matches {
-		lineSlice := strings.Fields(line)
-		for _, word := range lineSlice {
+		lineSlice := strings.FieldsSeq(line)
+		for word := range lineSlice {
 			if strings.Contains(word, blockType) {
 				return fmt.Sprintf("/dev/mapper/%s", word)
 			}
@@ -1410,8 +1410,8 @@ func GetBackingDeviceForEncryptedBlock(context *clusterd.Context, disk string) (
 	}
 
 	// Example output line: "device:  /dev/sdb1"
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(output, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "device:") {
 			parts := strings.Fields(line)

--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -72,8 +72,8 @@ func (c *Cluster) getOSDLabels(osd OSDInfo, failureDomainValue string, portable 
 
 func getOSDTopologyLocationLabels(topologyLocation string) map[string]string {
 	labels := map[string]string{}
-	locations := strings.Split(topologyLocation, " ")
-	for _, location := range locations {
+	locations := strings.SplitSeq(topologyLocation, " ")
+	for location := range locations {
 		loc := strings.Split(location, "=")
 		if len(loc) == 2 {
 			labels[fmt.Sprintf(TopologyLocationLabel, loc[0])] = loc[1]

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -324,8 +324,8 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (extMons ma
 
 	// Parse the mons that were detected out of quorum
 	if outOfQuorum, ok := cm.Data[OutOfQuorumKey]; ok && len(outOfQuorum) > 0 {
-		monNames := strings.Split(outOfQuorum, ",")
-		for _, monName := range monNames {
+		monNames := strings.SplitSeq(outOfQuorum, ",")
+		for monName := range monNames {
 			if monInfo, ok := internalMons[monName]; ok {
 				monInfo.OutOfQuorum = true
 			} else {
@@ -441,8 +441,8 @@ func UpdateClusterAccessSecret(clientset kubernetes.Interface, clusterInfo *ceph
 func ParseMonEndpoints(input string) map[string]*cephclient.MonInfo {
 	logger.Infof("parsing mon endpoints: %s", input)
 	mons := map[string]*cephclient.MonInfo{}
-	rawMons := strings.Split(input, ",")
-	for _, rawMon := range rawMons {
+	rawMons := strings.SplitSeq(input, ",")
+	for rawMon := range rawMons {
 		parts := strings.Split(rawMon, "=")
 		if len(parts) != 2 {
 			logger.Warningf("ignoring invalid monitor %s", rawMon)

--- a/pkg/operator/ceph/csi/ceph_connection_test.go
+++ b/pkg/operator/ceph/csi/ceph_connection_test.go
@@ -145,7 +145,7 @@ func TestCephConnectionDefaultTopology(t *testing.T) {
 	for _, label := range csiCephConnection.Spec.ReadAffinity.CrushLocationLabels {
 		labels[label] = true
 	}
-	for _, defaultLabel := range strings.Split(topology.GetDefaultTopologyLabels(), ",") {
+	for defaultLabel := range strings.SplitSeq(topology.GetDefaultTopologyLabels(), ",") {
 		assert.True(t, labels[defaultLabel], "expected label %q not found", defaultLabel)
 	}
 }

--- a/pkg/operator/k8sutil/labels.go
+++ b/pkg/operator/k8sutil/labels.go
@@ -31,7 +31,7 @@ func ParseStringToLabels(in string) map[string]string {
 		return labels
 	}
 
-	for _, v := range strings.Split(in, ",") {
+	for v := range strings.SplitSeq(in, ",") {
 		labelSplit := strings.Split(v, "=")
 
 		// When a value is set for a label k/v pair

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -363,11 +363,11 @@ func GenerateNodeAffinity(nodeAffinity string) (*v1.NodeAffinity, error) {
 			},
 		},
 	}
-	nodeLabels := strings.Split(nodeAffinity, ";")
+	nodeLabels := strings.SplitSeq(nodeAffinity, ";")
 	// For each label in 'nodeLabels', retrieve (key,value) pair and create nodeAffinity
 	// '=' separates key from values
 	// ',' separates values
-	for _, nodeLabel := range nodeLabels {
+	for nodeLabel := range nodeLabels {
 		// If tmpNodeLabel is an array of length > 1
 		// [0] is Key and [1] is comma separated values
 		tmpNodeLabel := strings.Split(nodeLabel, "=")

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -339,16 +339,16 @@ func GetLVName(executor exec.Executor, devicePath string) (string, error) {
 // finds the disk uuid in the output of sgdisk
 func parseUUID(device, output string) (string, error) {
 	// find the line with the uuid
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(output, "\n")
+	for line := range lines {
 		// If GPT is not found in a disk, sgdisk creates a new GPT in memory and reports its UUID.
 		// This ID changes each call and is not appropriate to identify the device.
 		if strings.Contains(line, "Creating new GPT entries in memory.") {
 			break
 		}
 		if strings.Contains(line, "Disk identifier (GUID)") {
-			words := strings.Split(line, " ")
-			for _, word := range words {
+			words := strings.SplitSeq(line, " ")
+			for word := range words {
 				// we expect most words in the line not to be a uuid, but will return the first one that is
 				result, err := uuid.Parse(word)
 				if err == nil {

--- a/pkg/util/sys/parse.go
+++ b/pkg/util/sys/parse.go
@@ -25,7 +25,7 @@ func Grep(input, searchFor string) string {
 	if input == "" || searchFor == "" {
 		return ""
 	}
-	for _, line := range strings.Split(input, "\n") {
+	for line := range strings.SplitSeq(input, "\n") {
 		if matched, _ := regexp.MatchString(searchFor, line); matched {
 			return line
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


Optimize code using a more modern writing style which can make the code more efficient and cleaner.
More info: https://github.com/golang/go/issues/61901


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
