### PR TITLE
osd: support snaptrimp and snaptrip_wait pgs

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -37,10 +37,7 @@ const (
 )
 
 const (
-	activeClean              = "active+clean"
-	activeCleanScrubbing     = "active+clean+scrubbing"
-	activeCleanScrubbingDeep = "active+clean+scrubbing+deep"
-	defaultPgHealthyRegex    = `^(active\+clean|active\+clean\+scrubbing|active\+clean\+scrubbing\+deep)$`
+	defaultPgHealthyRegex = `^active(\+(clean|deep|scrubbing|snaptrim|snaptrim_wait))+$`
 )
 
 var defaultPgHealthyRegexCompiled = regexp.MustCompile(defaultPgHealthyRegex)

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -24,6 +24,12 @@ import (
 )
 
 const (
+	activeClean              = "active+clean"
+	activeCleanScrubbing     = "active+clean+scrubbing"
+	activeCleanScrubbingDeep = "active+clean+scrubbing+deep"
+	activeCleanSnaptrim      = "active+clean+snaptrim"
+	activeCleanSnaptrimWait  = "active+clean+snaptrim_wait"
+
 	// this JSON was generated from `ceph status -f json`, using Ceph Luminous 12.1.3
 	CephStatusResponseRaw = `{"fsid":"613975f3-3025-4802-9de1-a2280b950e75","health":{"checks":{"OSD_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 osds down"}},"OSD_HOST_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 host (1 osds) down"}},"PG_AVAILABILITY":{"severity":"HEALTH_WARN","summary":{"message":"Reduced data availability: 101 pgs stale"}},"POOL_APP_NOT_ENABLED":{"severity":"HEALTH_WARN","summary":{"message":"application not enabled on 1 pool(s)"}}},"status":"HEALTH_WARN","overall_status":"HEALTH_WARN"},"election_epoch":12,"quorum":[0,1,2],"quorum_names":["rook-ceph-mon0","rook-ceph-mon2","rook-ceph-mon1"],"monmap":{"epoch":3,"fsid":"613975f3-3025-4802-9de1-a2280b950e75","modified":"2017-08-11 20:13:02.075679","created":"2017-08-11 20:12:35.314510","features":{"persistent":["kraken","luminous"],"optional":[]},"mons":[{"rank":0,"name":"rook-ceph-mon0","addr":"10.3.0.45:6789/0","public_addr":"10.3.0.45:6789/0"},{"rank":1,"name":"rook-ceph-mon2","addr":"10.3.0.249:6789/0","public_addr":"10.3.0.249:6789/0"},{"rank":2,"name":"rook-ceph-mon1","addr":"10.3.0.252:6789/0","public_addr":"10.3.0.252:6789/0"}]},"osdmap":{"epoch":17,"num_osds":2,"num_up_osds":1,"num_in_osds":2,"full":false,"nearfull":true,"num_remapped_pgs":0},"pgmap":{"pgs_by_state":[{"state_name":"stale+active+clean","count":101},{"state_name":"active+clean","count":99}],"num_pgs":200,"num_pools":2,"num_objects":243,"data_bytes":976793635,"bytes_used":13611479040,"bytes_avail":19825307648,"bytes_total":33436786688},"fsmap":{"epoch":1,"by_rank":[]},"mgrmap":{"epoch":3,"active_gid":14111,"active_name":"rook-ceph-mgr0","active_addr":"10.2.73.6:6800/9","available":true,"standbys":[],"modules":["restful","status"],"available_modules":["dashboard","prometheus","restful","status","zabbix"]},"servicemap":{"epoch":1,"modified":"0.000000","services":{}}}`
 )
@@ -87,7 +93,7 @@ func TestIsClusterClean(t *testing.T) {
 			PgsByState: []PgStateEntry{
 				{StateName: activeClean, Count: 3},
 			},
-			NumPgs: 10,
+			NumPgs: 14,
 		},
 	}
 
@@ -100,6 +106,10 @@ func TestIsClusterClean(t *testing.T) {
 		PgStateEntry{StateName: activeCleanScrubbing, Count: 5})
 	status.PgMap.PgsByState = append(status.PgMap.PgsByState,
 		PgStateEntry{StateName: activeCleanScrubbingDeep, Count: 2})
+	status.PgMap.PgsByState = append(status.PgMap.PgsByState,
+		PgStateEntry{StateName: activeCleanSnaptrim, Count: 2})
+	status.PgMap.PgsByState = append(status.PgMap.PgsByState,
+		PgStateEntry{StateName: activeCleanSnaptrimWait, Count: 2})
 	_, clean = isClusterClean(status, defaultPgHealthyRegexCompiled)
 	assert.True(t, clean)
 


### PR DESCRIPTION
If the ceph status is "active+lean+snaptrimp" or
"ative+clean+snatrip_wait" , the the PDB controller should treat this ceph staus as healthy and don't block the node drain

Tested only via unit tests. 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16712 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
