### PR TITLE
mds: Remove MDS standby if activeStandby disabled

### DIFF
--- a/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
+++ b/Documentation/CRDs/Shared-Filesystem/ceph-fs-subvolumegroup-crd.md
@@ -29,9 +29,9 @@ spec:
   # by default pinning is set with value: distributed=1
   # for disabling default values set (distributed=0)
   pinning:
-    distributed: 1            # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    distributed: 1 # distributed=<0, 1> (disabled=0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)
   # Quota size of the subvolume group.
   #quota: 10G
   # data pool name for the subvolume group layout instead of the default data pool.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,4 +2,8 @@
 
 ## Breaking Changes
 
+- The behavior of the `activeStandby` property in the `CephFilesystem` CRD has changed.
+    When set to `false`, the standby MDS daemon deployment will be scaled down and removed,
+    rather than only disabling the standby cache while the daemon remains running.
+
 ## Features

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -16,9 +16,9 @@ spec:
   # by default pinning is set with value: distributed=1
   # for disabling default values set (distributed=0)
   pinning:
-    distributed: 1            # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    distributed: 1 # distributed=<0, 1> (disabled=0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)
 ---
 kind: CephFilesystem
 apiVersion: ceph.rook.io/v1

--- a/deploy/examples/filesystem-ec.yaml
+++ b/deploy/examples/filesystem-ec.yaml
@@ -106,5 +106,5 @@ spec:
   # for disabling default values set (distributed=0)
   pinning:
     distributed: 1 # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)

--- a/deploy/examples/filesystem-test.yaml
+++ b/deploy/examples/filesystem-test.yaml
@@ -22,7 +22,7 @@ spec:
   preserveFilesystemOnDelete: false
   metadataServer:
     activeCount: 1
-    activeStandby: true
+    activeStandby: false
 ---
 # create default csi subvolume group
 apiVersion: ceph.rook.io/v1
@@ -40,6 +40,6 @@ spec:
   # by default pinning is set with value: distributed=1
   # for disabling default values set (distributed=0)
   pinning:
-    distributed: 1            # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    distributed: 1 # distributed=<0, 1> (disabled=0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)

--- a/deploy/examples/filesystem.yaml
+++ b/deploy/examples/filesystem.yaml
@@ -48,7 +48,7 @@ spec:
     # The number of active MDS instances
     activeCount: 1
     # Whether each active MDS instance will have an active standby with a warm metadata cache for faster failover.
-    # If false, standbys will be available, but will not have a warm cache.
+    # If true, double the number of mds daemons will be created.
     activeStandby: true
     # The affinity rules to apply to the mds deployment
     placement:
@@ -160,5 +160,5 @@ spec:
   # for disabling default values set (distributed=0)
   pinning:
     distributed: 1 # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)

--- a/deploy/examples/subvolumegroup.yaml
+++ b/deploy/examples/subvolumegroup.yaml
@@ -15,8 +15,8 @@ spec:
   # for disabling default values set (distributed=0)
   pinning:
     distributed: 1 # distributed=<0, 1> (disabled=0)
-    # export:                 # export=<0-256> (disabled=-1)
-    # random:                 # random=[0.0, 1.0](disabled=0.0)
+    # export:      # export=<0-256> (disabled=-1)
+    # random:      # random=[0.0, 1.0](disabled=0.0)
   # Quota size of the subvolume group.
   #quota: 10G
   # data pool name for the subvolume group layout instead of the default data pool.

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -356,7 +356,8 @@ func fsTest(fsName string) cephv1.CephFilesystem {
 				},
 			},
 			MetadataServer: cephv1.MetadataServerSpec{
-				ActiveCount: 1,
+				ActiveCount:   1,
+				ActiveStandby: true,
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
 						v1.ResourceMemory: *resource.NewQuantity(4294967296, resource.BinarySI),
@@ -609,7 +610,8 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "myfs", Namespace: "ns"},
 		Spec: cephv1.FilesystemSpec{
 			MetadataServer: cephv1.MetadataServerSpec{
-				ActiveCount: 1,
+				ActiveCount:   1,
+				ActiveStandby: true,
 			},
 		},
 	}

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -128,8 +128,11 @@ func (c *Cluster) Start() error {
 		}
 	}()
 
-	// Always create double the number of metadata servers to have standby mdses available
-	replicas := c.fs.Spec.MetadataServer.ActiveCount * 2
+	replicas := c.fs.Spec.MetadataServer.ActiveCount
+	// Create double the number of metadata servers if active standby is enabled
+	if c.fs.Spec.MetadataServer.ActiveStandby {
+		replicas = replicas * 2
+	}
 
 	mdsToSkipReconcile, err := controller.GetDaemonsToSkipReconcile(c.clusterInfo.Context, c.context, c.clusterInfo.Namespace, config.MdsType, AppName)
 	if err != nil {


### PR DESCRIPTION
The `activeStandby` property was being ignored when deciding how many mds daemons to start. 2x the active count of mds daemons were always being created. If the standby is not desired, the standby can be removed, and it was unexpected that it was not removed.

Creating as a draft to review if there was some need for 2x MDS daemons always that I'm forgetting... @BlaineEXE?

From the comments around that property, active standby was intended:
```
# If false, standbys will be available, but will not have a warm cache.
```

But this is causing confusion described in #12576. It would be more intuitive to only start standby daemons when true. This would be a change in semantics of that property, so we need to be clear about the intention.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #12576 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
