### PR TITLE
core: Include namespace more consistently in cluster logging

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -89,7 +90,7 @@ func (c *Cluster) generateKeyring(m *mgrConfig) (string, error) {
 	}
 
 	if c.shouldRotateCephxKeys {
-		logger.Infof("rotating cephx key for mgr daemon %q in the namespace %q", m.ResourceName, c.clusterInfo.Namespace)
+		log.NamespacedInfo(c.clusterInfo.Namespace, logger, "rotating cephx key for mgr daemon %q in the namespace %q", m.ResourceName, c.clusterInfo.Namespace)
 		newKey, err := s.RotateKey(user)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to rotate cephx key for mgr daemon %q", m.ResourceName)
@@ -101,9 +102,9 @@ func (c *Cluster) generateKeyring(m *mgrConfig) (string, error) {
 	err = c.context.Clientset.CoreV1().Secrets(c.clusterInfo.Namespace).Delete(c.clusterInfo.Context, m.ResourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Debugf("legacy mgr key %q is already removed", m.ResourceName)
+			log.NamespacedDebug(c.clusterInfo.Namespace, logger, "legacy mgr key %q is already removed", m.ResourceName)
 		} else {
-			logger.Warningf("legacy mgr key %q could not be removed. %v", m.ResourceName, err)
+			log.NamespacedWarning(c.clusterInfo.Namespace, logger, "legacy mgr key %q could not be removed. %v", m.ResourceName, err)
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/mgr/drain.go
+++ b/pkg/operator/ceph/cluster/mgr/drain.go
@@ -19,6 +19,7 @@ package mgr
 import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	policyv1 "k8s.io/api/policy/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,13 +64,13 @@ func (c *Cluster) deleteMgrPDB() {
 	err := c.context.Client.Get(c.clusterInfo.Context, pdbRequest, mgrPDB)
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
-			logger.Errorf("failed to get mgr pdb %q. %v", mgrPDBName, err)
+			log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to get mgr pdb %q. %v", mgrPDBName, err)
 		}
 		return
 	}
-	logger.Debugf("ensuring the mgr pdb %q is deleted", mgrPDBName)
+	log.NamespacedDebug(c.clusterInfo.Namespace, logger, "ensuring the mgr pdb %q is deleted", mgrPDBName)
 	err = c.context.Client.Delete(c.clusterInfo.Context, mgrPDB)
 	if err != nil {
-		logger.Errorf("failed to delete mgr pdb %q. %v", mgrPDBName, err)
+		log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to delete mgr pdb %q. %v", mgrPDBName, err)
 	}
 }

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ const (
 )
 
 func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error) {
-	logger.Debugf("mgrConfig: %+v", mgrConfig)
+	log.NamespacedDebug(c.clusterInfo.Namespace, logger, "mgrConfig: %+v", mgrConfig)
 
 	volumes := controller.DaemonVolumes(mgrConfig.DataPathMap, mgrConfig.ResourceName, c.spec.DataDirHostPath)
 	if c.spec.Network.IsMultus() {

--- a/pkg/operator/ceph/cluster/mon/predicate_test.go
+++ b/pkg/operator/ceph/cluster/mon/predicate_test.go
@@ -37,7 +37,7 @@ func TestWereMonEndpointsUpdated(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := wereMonEndpointsUpdated(tt.args.oldCMData, tt.args.newCMData); got != tt.want {
+			if got := wereMonEndpointsUpdated("ns", tt.args.oldCMData, tt.args.newCMData); got != tt.want {
 				t.Errorf("whereMonEndpointsUpdated() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/log"
 
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -57,11 +58,11 @@ func (r *ReconcileNode) createOrUpdateCephExporter(node corev1.Node, tolerations
 	// CephVersion change is done temporarily, as some regression was detected in Ceph version 17.2.6 which is summarised here https://github.com/ceph/ceph/pull/50718#issuecomment-1505608312.
 	// Thus, disabling ceph-exporter for now until all the regression are fixed.
 	if !cephVersion.IsAtLeast(MinVersionForCephExporter) {
-		logger.Infof("Skipping exporter reconcile on ceph version %q", cephVersion.String())
+		log.NamespacedInfo(cephCluster.Namespace, logger, "Skipping exporter reconcile on ceph version %q", cephVersion.String())
 		return controllerutil.OperationResultNone, nil
 	}
 	if cephCluster.Spec.Monitoring.MetricsDisabled {
-		logger.Info("Skipping exporter reconcile since monitoring.metricsDisabled is true")
+		log.NamespacedInfo(cephCluster.Namespace, logger, "Skipping exporter reconcile since monitoring.metricsDisabled is true")
 		return controllerutil.OperationResultNone, nil
 	}
 
@@ -283,10 +284,10 @@ func applyCephExporterLabels(cephCluster cephv1.CephCluster, serviceMonitor *mon
 				serviceMonitor.Spec.Endpoints[0].RelabelConfigs = append(
 					serviceMonitor.Spec.Endpoints[0].RelabelConfigs, relabelConfig)
 			} else {
-				logger.Info("rook.io/managedBy not specified in ceph-exporter labels")
+				log.NamespacedInfo(cephCluster.Namespace, logger, "rook.io/managedBy not specified in ceph-exporter labels")
 			}
 		} else {
-			logger.Debug("ceph-exporter labels not specified")
+			log.NamespacedDebug(cephCluster.Namespace, logger, "ceph-exporter labels not specified")
 		}
 	}
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -96,7 +97,7 @@ func createCrashCollectorKeyring(s *keyring.SecretStore, context *clusterd.Conte
 	}
 
 	if shouldRotateCephxKeys {
-		logger.Infof("rotating cephx key for crash collector %q", crashCollectorKeyringUsername)
+		log.NamespacedInfo(clusterInfo.Namespace, logger, "rotating cephx key for crash collector %q", crashCollectorKeyringUsername)
 		newKey, err := s.RotateKey(crashCollectorKeyringUsername)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to rotate cephx key for crash collector %q", crashCollectorKeyringUsername)
@@ -124,7 +125,7 @@ func updateCrashCollectorCephxStatus(context *clusterd.Context, clusterInfo *cli
 		if err := reporting.UpdateStatus(context.Client, cluster); err != nil {
 			return errors.Wrap(err, "failed to update cluster cephx status for crash collector daemon")
 		}
-		logger.Debugf("successfully updated the crash collector cephx status for cluster in namespace %q to %+v", cluster.Namespace, cluster.Status.Cephx.CrashCollector)
+		log.NamespacedDebug(clusterInfo.Namespace, logger, "successfully updated the crash collector cephx status for cluster in namespace %q to %+v", cluster.Namespace, cluster.Status.Cephx.CrashCollector)
 
 		return nil
 	})
@@ -161,7 +162,7 @@ func createOrUpdateCrashCollectorSecret(clusterInfo *client.ClusterInfo, crashCo
 		return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", s.Name, clusterInfo.Namespace)
 	}
 
-	logger.Infof("created kubernetes crash collector secret for cluster %q", clusterInfo.Namespace)
+	log.NamespacedInfo(clusterInfo.Namespace, logger, "created kubernetes crash collector secret")
 	return nil
 }
 
@@ -212,7 +213,7 @@ func createExporterKeyring(s *keyring.SecretStore, context *clusterd.Context, cl
 	}
 
 	if shouldRotateCephxKeys {
-		logger.Infof("rotating cephx key for ceph exporter %q", exporterKeyringUsername)
+		log.NamespacedInfo(clusterInfo.Namespace, logger, "rotating cephx key for ceph exporter %q", exporterKeyringUsername)
 		newKey, err := s.RotateKey(exporterKeyringUsername)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to rotate cephx key for ceph exporter %q", exporterKeyringUsername)
@@ -239,7 +240,7 @@ func updateCephExporterCephxStatus(context *clusterd.Context, clusterInfo *clien
 		if err := reporting.UpdateStatus(context.Client, cluster); err != nil {
 			return errors.Wrap(err, "failed to update cluster cephx status for ceph exporter daemon")
 		}
-		logger.Debugf("successfully updated the ceph exporter cephx status for cluster in namespace %q to %+v", cluster.Namespace, cluster.Status.Cephx.CephExporter)
+		log.NamespacedDebug(clusterInfo.Namespace, logger, "successfully updated the ceph exporter cephx status for cluster in namespace %q to %+v", cluster.Namespace, cluster.Status.Cephx.CephExporter)
 
 		return nil
 	})
@@ -276,6 +277,6 @@ func createOrUpdateExporterSecret(clusterInfo *client.ClusterInfo, exporterSecre
 		return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", s.Name, clusterInfo.Namespace)
 	}
 
-	logger.Infof("created kubernetes exporter secret for cluster %q", clusterInfo.Namespace)
+	log.NamespacedInfo(clusterInfo.Namespace, logger, "created kubernetes exporter secret for cluster %q", clusterInfo.Namespace)
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/key_rotation.go
+++ b/pkg/operator/ceph/cluster/osd/key_rotation.go
@@ -25,6 +25,7 @@ import (
 	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,7 +248,7 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 			}
 			return nil
 		}
-		logger.Debugf("successfully deleted key rotation cron jobs")
+		log.NamespacedDebug(c.clusterInfo.Namespace, logger, "successfully deleted key rotation cron jobs")
 
 		return nil
 	}
@@ -259,7 +260,7 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 		return errors.Wrap(err, "failed to query existing OSD deployments")
 	}
 
-	logger.Debugf("found %d osd deployments", len(deployments.Items))
+	log.NamespacedDebug(c.clusterInfo.Namespace, logger, "found %d osd deployments", len(deployments.Items))
 	for i := range deployments.Items {
 		osdDep := deployments.Items[i]
 		osd, err := c.getOSDInfo(&osdDep)
@@ -279,7 +280,7 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 			continue
 		}
 
-		logger.Infof("starting OSD key rotation cron job for osd %d", osd.ID)
+		log.NamespacedInfo(c.clusterInfo.Namespace, logger, "starting OSD key rotation cron job for osd %d", osd.ID)
 		cj, err := c.makeKeyRotationCronJob(pvcName, osd, osdProps)
 		if err != nil {
 			return errors.Wrap(err, "failed to make key rotation cron job")
@@ -294,9 +295,9 @@ func (c *Cluster) reconcileKeyRotationCronJob() error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to create or update key rotation cron job %q", cj.Name)
 		}
-		logger.Infof("started OSD key rotation cron job %q", cj.Name)
+		log.NamespacedInfo(c.clusterInfo.Namespace, logger, "started OSD key rotation cron job %q", cj.Name)
 	}
-	logger.Infof("successfully started OSD key rotation cron jobs")
+	log.NamespacedInfo(c.clusterInfo.Namespace, logger, "successfully started OSD key rotation cron jobs")
 
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -365,13 +366,13 @@ func (c *Cluster) deleteAllOrphanedPrepareJobs() {
 	}
 	jobs, err := c.context.Clientset.BatchV1().Jobs(c.clusterInfo.Namespace).List(c.clusterInfo.Context, listOpts)
 	if err != nil {
-		logger.Warningf("failed to clean up any orphaned OSD prepare jobs. failed to list OSD prepare jobs. %v", err)
+		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to clean up any orphaned OSD prepare jobs. failed to list OSD prepare jobs. %v", err)
 		return
 	}
 
 	nodes, err := c.context.Clientset.CoreV1().Nodes().List(c.clusterInfo.Context, metav1.ListOptions{})
 	if err != nil {
-		logger.Warningf("failed to clean up any orphaned OSD prepare jobs. failed to list nodes. %v", err)
+		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to clean up any orphaned OSD prepare jobs. failed to list nodes. %v", err)
 		return
 	}
 
@@ -387,9 +388,9 @@ func (c *Cluster) deleteAllOrphanedPrepareJobs() {
 		nodeSelector := job.Spec.Template.Spec.NodeSelector
 		if jobHostName, ok := nodeSelector[k8sutil.LabelHostname()]; ok {
 			if !hostNames.Has(jobHostName) {
-				logger.Infof("cleaning up orphaned OSD prepare job %q.", job.Name)
+				log.NamespacedInfo(c.clusterInfo.Namespace, logger, "cleaning up orphaned OSD prepare job %q.", job.Name)
 				if err := c.context.Clientset.BatchV1().Jobs(c.clusterInfo.Namespace).Delete(c.clusterInfo.Context, job.Name, metav1.DeleteOptions{}); err != nil {
-					logger.Warningf("failed to clean up OSD prepare job %q. %v", job.Name, err)
+					log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to clean up OSD prepare job %q. %v", job.Name, err)
 				}
 			}
 		}

--- a/pkg/operator/ceph/cluster/osd/volumes.go
+++ b/pkg/operator/ceph/cluster/osd/volumes.go
@@ -23,6 +23,7 @@ import (
 
 	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -169,7 +170,7 @@ func getPVCOSDVolumes(osdProps *osdProperties, configDir string, namespace strin
 		volumes = append(volumes, walPVCVolume...)
 	}
 
-	logger.Debugf("volumes are %+v", volumes)
+	log.NamespacedDebug(namespace, logger, "volumes are %+v", volumes)
 
 	return volumes
 }

--- a/pkg/operator/ceph/cluster/telemetry/telemetry.go
+++ b/pkg/operator/ceph/cluster/telemetry/telemetry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/util/log"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "telemetry")
@@ -53,8 +54,8 @@ var CSIVersion string
 func ReportKeyValue(context *clusterd.Context, clusterInfo *client.ClusterInfo, key, value string) {
 	ms := config.GetMonStore(context, clusterInfo)
 	if err := ms.SetKeyValue(key, value); err != nil {
-		logger.Warningf("failed to set telemetry key %q. %v", key, err)
+		log.NamespacedWarning(clusterInfo.Namespace, logger, "failed to set telemetry key %q. %v", key, err)
 		return
 	}
-	logger.Debugf("set telemetry key: %s=%s", key, value)
+	log.NamespacedDebug(clusterInfo.Namespace, logger, "set telemetry key: %s=%s", key, value)
 }

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -44,7 +44,8 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err := json.Unmarshal(fakeRunningVersions, &dummyRunningVersions)
 	assert.NoError(t, err)
 
-	m, err := diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions)
+	c := testSpec(t)
+	m, err := c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions)
 	assert.Error(t, err) // Overall is absent
 	assert.False(t, m)
 
@@ -60,7 +61,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal(fakeRunningVersions, &dummyRunningVersions2)
 	assert.NoError(t, err)
 
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions2)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions2)
 	assert.NoError(t, err)
 	assert.True(t, m)
 
@@ -76,7 +77,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Allow the downgrade
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions3)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions3)
 	assert.NoError(t, err)
 	assert.True(t, m)
 
@@ -92,7 +93,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal(fakeRunningVersions, &dummyRunningVersions4)
 	assert.NoError(t, err)
 
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions4)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions4)
 	assert.NoError(t, err)
 	assert.True(t, m)
 
@@ -111,7 +112,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal(fakeRunningVersions, &dummyRunningVersions5)
 	assert.NoError(t, err)
 
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions5)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions5)
 	assert.NoError(t, err)
 	assert.False(t, m)
 
@@ -130,7 +131,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal(fakeRunningVersions, &dummyRunningVersions6)
 	assert.NoError(t, err)
 
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions6)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions6)
 	assert.NoError(t, err)
 	assert.True(t, m)
 
@@ -149,7 +150,7 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal(fakeRunningVersions, &dummyRunningVersions7)
 	assert.NoError(t, err)
 
-	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions7)
+	m, err = c.diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions7)
 	assert.NoError(t, err)
 	assert.False(t, m)
 }

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package log
+
+import (
+	"fmt"
+
+	"github.com/coreos/pkg/capnslog"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func NamedInfo(name types.NamespacedName, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	NamespacedInfo(name.String(), logger, message, args...)
+}
+
+func NamedWarning(name types.NamespacedName, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	NamespacedWarning(name.String(), logger, message, args...)
+}
+
+func NamedError(name types.NamespacedName, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	NamespacedError(name.String(), logger, message, args...)
+}
+
+func NamedDebug(name types.NamespacedName, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	NamespacedDebug(name.String(), logger, message, args...)
+}
+
+func NamedTrace(name types.NamespacedName, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	NamespacedTrace(name.String(), logger, message, args...)
+}
+
+func NamespacedInfo(namespace string, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	logger.Infof("[%s] %s", namespace, fmt.Sprintf(message, args...))
+}
+
+func NamespacedWarning(namespace string, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	logger.Warningf("[%s] %s", namespace, fmt.Sprintf(message, args...))
+}
+
+func NamespacedError(namespace string, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	logger.Errorf("[%s] %s", namespace, fmt.Sprintf(message, args...))
+}
+
+func NamespacedDebug(namespace string, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	logger.Debugf("[%s] %s", namespace, fmt.Sprintf(message, args...))
+}
+
+func NamespacedTrace(namespace string, logger *capnslog.PackageLogger, message string, args ...interface{}) {
+	logger.Tracef("[%s] %s", namespace, fmt.Sprintf(message, args...))
+}


### PR DESCRIPTION
We have discussed several approaches to logging, in particular to improve the logging when multiple cephclusters are being reconciled in parallel with #16719. 

This is a prototype of one of the approaches. It's just a simple wrapper around the canpslog package that requires the namespace, and will write the log, warning, error, or debug log. This approach, though tedious, seems like the simplest approach instead of rewriting the logging. 

Other approaches? I'm not convinced yet this is the direction we need to go.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
