### PR TITLE
helm(rook-ceph-cluster): Fix default pathType for HTTPRoute

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-httproute.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-httproute.yaml
@@ -21,7 +21,7 @@ spec:
           port: {{ .route.port | default .spec.gateway.securePort | default .spec.gateway.port }}
       matches:
         - path:
-            type: {{ .route.host.pathType | default "Prefix" }}
+            type: {{ .route.host.pathType | default "PathPrefix" }}
             value: {{ .route.host.path | default "/" }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/httproute.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/httproute.yaml
@@ -30,6 +30,6 @@ spec:
           {{- end }}
       matches:
         - path:
-            type: {{ .Values.route.dashboard.host.pathType | default "Prefix" }}
+            type: {{ .Values.route.dashboard.host.pathType | default "PathPrefix" }}
             value: {{ .Values.route.dashboard.host.path | default "/" }}
 {{- end }}


### PR DESCRIPTION
https://gateway-api.sigs.k8s.io/reference/spec/#pathmatchtype

`Prefix` isn't valid in HTTPRoute. The sample in `values.yaml` is correct but the default value is wrong.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
