### PR TITLE
toolbox: merge rook-config-override ConfigMap into ceph.conf

### DIFF
--- a/deploy/examples/toolbox-job.yaml
+++ b/deploy/examples/toolbox-job.yaml
@@ -27,6 +27,9 @@ spec:
               mountPath: /etc/rook
             - name: ceph-admin-secret
               mountPath: /var/lib/rook-ceph-mon
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
       containers:
         - name: script
           image: docker.io/rook/ceph:master
@@ -57,6 +60,10 @@ spec:
             items:
               - key: data
                 path: mon-endpoints
+        - name: rook-config-override
+          configMap:
+            name: rook-config-override
+            optional: true
         - name: ceph-config
           emptyDir: {}
       restartPolicy: Never

--- a/deploy/examples/toolbox-operator-image.yaml
+++ b/deploy/examples/toolbox-operator-image.yaml
@@ -35,6 +35,7 @@ spec:
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
 
               # create a ceph config file in its default location so ceph/rados tools can be used
               # without specifying any arguments
@@ -55,6 +56,13 @@ spec:
               [client.admin]
               keyring = ${KEYRING_FILE}
               EOF
+
+                # Merge the config override if it exists and is not empty
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
               }
 
               # watch the endpoints config file and update if the mon endpoints ever change
@@ -114,6 +122,9 @@ spec:
             - name: ceph-admin-secret
               mountPath: /var/lib/rook-ceph-mon
               readOnly: true
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
       volumes:
         - name: ceph-admin-secret
           secret:
@@ -128,6 +139,10 @@ spec:
             items:
               - key: data
                 path: mon-endpoints
+        - name: rook-config-override
+          configMap:
+            name: rook-config-override
+            optional: true
         - name: ceph-config
           emptyDir: {}
       tolerations:

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -29,6 +29,7 @@ spec:
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
 
               # create a ceph config file in its default location so ceph/rados tools can be used
               # without specifying any arguments
@@ -49,6 +50,13 @@ spec:
               [client.admin]
               keyring = ${KEYRING_FILE}
               EOF
+
+                # Merge the config override if it exists and is not empty
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
               }
 
               # watch the endpoints config file and update if the mon endpoints ever change
@@ -108,6 +116,9 @@ spec:
             - name: ceph-admin-secret
               mountPath: /var/lib/rook-ceph-mon
               readOnly: true
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
       volumes:
         - name: ceph-admin-secret
           secret:
@@ -122,6 +133,10 @@ spec:
             items:
               - key: data
                 path: mon-endpoints
+        - name: rook-config-override
+          configMap:
+            name: rook-config-override
+            optional: true
         - name: ceph-config
           emptyDir: {}
       tolerations:

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -17,6 +17,7 @@
 CEPH_CONFIG="/etc/ceph/ceph.conf"
 MON_CONFIG="/etc/rook/mon-endpoints"
 KEYRING_FILE="/etc/ceph/keyring"
+CONFIG_OVERRIDE="/etc/rook-config-override/config"
 
 # create a ceph config file in its default location so ceph/rados tools can be used
 # without specifying any arguments
@@ -37,6 +38,13 @@ mon_host = ${mon_endpoints}
 [client.admin]
 keyring = ${KEYRING_FILE}
 EOF
+
+  # Merge the config override if it exists and is not empty
+  if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+    echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+    echo "" >> ${CEPH_CONFIG}
+    cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+  fi
 }
 
 # watch the endpoints config file and update if the mon endpoints ever change


### PR DESCRIPTION
The toolbox was not respecting the rook-config-override ConfigMap, resulting in a minimal ceph.conf with only mon_host and keyring settings. This made it difficult to run diagnostic commands that require custom configuration parameters.

This change mounts the rook-config-override ConfigMap in all toolbox variants and merges its contents into the generated ceph.conf. The merge happens after writing the base config with mon endpoints, and is re-applied whenever mon endpoints change.

The toolbox now has consistent behavior with other Rook-managed Ceph daemons (mon, mgr, osd, mds, rgw) which already respect config overrides.

**Issue resolved by this Pull Request:**
Resolves: https://github.com/rook/rook/issues/16730

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
