### PR TITLE
helm: Include exporter options in CephCluster

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -8,6 +8,10 @@ spec:
   {{- with .Values.monitoring }}
   monitoring:
     enabled: {{ .enabled | default false }}
+    {{- with .exporter }}
+    exporter:
+    {{- . | toYaml | nindent 6 }}
+    {{- end }}
     {{- with .externalMgrEndpoints }}
     externalMgrEndpoints:
     {{- . | toYaml | nindent 6 }}


### PR DESCRIPTION
The operator supports setting options on the node exporter, such as hostNetwork, which were previously omitted from the templated CephCluster resource in the rook-ceph-cluster helm chart.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #16742
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
