### PR TITLE
core: Shorten the logger names

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -55,7 +55,7 @@ const (
 	controllerName = "ceph-client-controller"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "client-controller")
 
 // Sets the type meta for the controller main object
 var controllerTypeMeta = metav1.TypeMeta{

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -67,7 +67,7 @@ const (
 )
 
 var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "cluster-controller")
 	// disallowedHostDirectories directories which are not allowed to be used
 	disallowedHostDirectories = []string{"/etc/ceph", "/rook", "/var/log/ceph"}
 )

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -52,7 +52,7 @@ import (
 )
 
 var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "nodedaemon")
 	// Implement reconcile.Reconciler so the controller can reconcile objects
 	_ reconcile.Reconciler = &ReconcileNode{}
 

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -52,7 +52,7 @@ const (
 	controllerName = "ceph-rbd-mirror-controller"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "rbd-mirror-controller")
 
 // List of object resources to watch by the controller
 var objectsToWatch = []client.Object{

--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -687,11 +687,11 @@ func (c *clientCluster) getCephCluster() *cephv1.CephCluster {
 
 	err := c.client.List(context.TODO(), clusterList, client.InNamespace(c.namespace))
 	if err != nil {
-		logger.Debugf("%q: failed to fetch CephCluster %v", controllerName, err)
+		logger.Debugf("failed to fetch CephCluster %v", err)
 		return &cephv1.CephCluster{}
 	}
 	if len(clusterList.Items) == 0 {
-		logger.Debugf("%q: no CephCluster resource found in namespace %q", controllerName, c.namespace)
+		logger.Debugf("no CephCluster resource found in namespace %q", c.namespace)
 		return &cephv1.CephCluster{}
 	}
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "disruption")
 
 	// Implement reconcile.Reconciler so the controller can reconcile objects
 	_ reconcile.Reconciler = &ReconcileClusterDisruption{}

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -53,7 +53,7 @@ const (
 	controllerName = "ceph-file-controller"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "file-controller")
 
 // List of object resources to watch by the controller
 var objectsToWatch = []client.Object{

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -51,7 +51,7 @@ const (
 	controllerName = "ceph-filesystem-mirror-controller"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephfs-mirror-controller")
 
 // List of object resources to watch by the controller
 var objectsToWatch = []client.Object{

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -53,7 +53,7 @@ const (
 	controllerName = "ceph-nfs-controller"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "nfs-controller")
 
 // List of object resources to watch by the controller
 var objectsToWatch = []client.Object{

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -62,7 +62,7 @@ const (
 
 var waitForRequeueIfObjectStoreNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "object-controller")
 
 // List of object resources to watch by the controller
 var objectsToWatch = []client.Object{

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -61,7 +61,7 @@ const (
 // newMultisiteAdminOpsCtxFunc help us mocking the admin ops API client in unit test
 var newMultisiteAdminOpsCtxFunc = object.NewMultisiteAdminOpsContext
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "object-user-controller")
 
 // Sets the type meta for the controller main object
 var controllerTypeMeta = metav1.TypeMeta{

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -67,7 +67,7 @@ var createObjectStorePoolsFunc = object.CreateObjectStorePools
 // allow this to be overridden for unit tests
 var commitConfigChangesFunc = object.CommitConfigChanges
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "zone-controller")
 
 // Sets the type meta for the controller main object
 var controllerTypeMeta = metav1.TypeMeta{

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -53,7 +53,7 @@ const (
 
 var waitForRequeueIfObjectRealmNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "zonegroup-controller")
 
 // Sets the type meta for the controller main object
 var controllerTypeMeta = metav1.TypeMeta{


### PR DESCRIPTION
The logger names are seen on each line of logging. As long as they are unique, they really don't need to be long and descriptive, so let's make them a bit more concise. In particular, the `ceph` prefix isn't really necessary since everything in Rook is for ceph these days.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
