### PR TITLE
RGW: Update scaledObject resource

### DIFF
--- a/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+++ b/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
@@ -321,17 +321,18 @@ metadata:
  namespace: rook-ceph
 spec:
  scaleTargetRef:
-   kind: Deployment
-   name: rook-ceph-rgw-my-store-a # deployment for the autoscaling
+   apiVersion: ceph.rook.io/v1
+   kind: CephObjectStore
+   name: my-store # name of the cephObjectStore resource
  minReplicaCount: 1
  maxReplicaCount: 5
  triggers:
  - type: prometheus
    metadata:
      serverAddress: http://rook-prometheus.rook-ceph.svc:9090
-     metricName: collecting_ceph_rgw_put
+     metricName: ceph_rgw_put_collector
      query: |
-       sum(rate(ceph_rgw_put[2m])) # prometheus query used for autoscaling
+       sum(rate(ceph_rgw_op_put_obj_ops[2m])) # prometheus query used for autoscaling
      threshold: "90"
 ```
 

--- a/deploy/examples/monitoring/keda-rgw.yaml
+++ b/deploy/examples/monitoring/keda-rgw.yaml
@@ -16,5 +16,5 @@ spec:
         serverAddress: http://rook-prometheus.rook-ceph.svc:9090
         metricName: ceph_rgw_put_collector
         query: |
-          sum(rate(ceph_rgw_put[2m]))
+          sum(rate(ceph_rgw_op_put_obj_ops[2m]))
         threshold: "90"


### PR DESCRIPTION
Update ScaledObject Resource to use correct metric. `ceph_rgw_put` is not availabe. Using `ceph_rgw_op_put_obj_ops` instead.

Need to check when this name got modified and confirm if we need to backport or not. 

<img width="1909" height="357" alt="Screenshot 2025-12-02 at 12 11 33 PM" src="https://github.com/user-attachments/assets/2919e13e-fa27-4144-b4ec-157d108dc536" />



<img width="1912" height="833" alt="Screenshot 2025-12-02 at 12 04 29 PM" src="https://github.com/user-attachments/assets/47b92822-7e8a-42f1-a551-921e95431efa" />



<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
