### PR TITLE
ci: run daily nightly job in with gh arm runner

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   canary-arm64:
-    runs-on: [self-hosted, ubuntu-20.04-arm64, ARM64]
+    runs-on: [ubuntu-22.04-arm]
     if: github.repository == 'rook/rook'
 
     steps:
@@ -28,48 +28,16 @@ jobs:
         with:
           use-tmate: ${{ secrets.USE_TMATE }}
 
-      - name: setup golang
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version: "1.25"
-
-      - name: Install Docker
-        run: |
-          sudo apt-get update
-          sudo apt-get install docker.io -y
-
-      - name: Start Docker service
-        run: sudo service docker start
-
-      - name: Check Docker version
-        run: docker version
-
-      - name: setup minikube
-        run: |
-          sudo apt-get install build-essential -y
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm64
-          sudo install minikube-linux-arm64 /usr/local/bin/minikube
-          sudo rm -f minikube-linux-arm64
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          minikube start --memory 28g --cpus=12 --driver=docker
-
-      - name: install yq
-        run: |
-          sudo curl -JL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_arm64  --output /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-
-      - name: print k8s cluster status
-        run: tests/scripts/github-action-helper.sh print_k8s_cluster_status
-
-      - name: use local disk and create partitions for osds
-        run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          tests/scripts/github-action-helper.sh use_local_disk
-          tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 1
+      - name: setup cluster resources
+        uses: ./.github/workflows/canary-test-config
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
+
+      - name: use local disk and create partitions for osds
+        run: |
+          tests/scripts/github-action-helper.sh use_local_disk
+          tests/scripts/github-action-helper.sh create_partitions_for_osds
 
       - name: deploy cluster
         run: |
@@ -81,35 +49,18 @@ jobs:
           yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.osd.disabled" true
           tests/scripts/github-action-helper.sh deploy_cluster
           tests/scripts/github-action-helper.sh deploy_all_additional_resources_on_cluster
-          # there are no package for arm64 nfs-ganesha
-          kubectl delete -f deploy/examples/nfs-test.yaml
 
       - name: wait for prepare pod
-        run: timeout 900 sh -c 'until kubectl -n rook-ceph logs -f $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'); do sleep 5; done' || kubectl -n rook-ceph get all && kubectl logs -n rook-ceph deploy/rook-ceph-operator
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
-        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready "mon,mgr,osd,mds,rgw,rbd_mirror,fs_mirror" 1
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
 
       - name: collect common logs
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
           name: canary-arm64
-
-      - name: teardown minikube, docker and kubectl
-        if: always()
-        run: |
-          uptime
-          minikube delete
-          docker system prune --all --force
-          sudo service docker stop
-          sudo rm -rf  /usr/local/bin/minikube
-          sudo rm -rf /usr/local/bin/kubectl
-          sudo modprobe -r nbd
-
-      - name: remove /usr/bin/yq
-        if: always()
-        run: sudo rm -rf /usr/bin/yq
 
   smoke-suite-reef-devel:
     if: github.repository == 'rook/rook'

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -26,6 +26,14 @@ SERVICE_UNAVAILABLE_ERROR="Service Unavailable"
 INTERNAL_ERROR="INTERNAL_ERROR"
 INTERNAL_SERVER_ERROR="500 Internal Server Error"
 
+# Architecture detection
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+  ARCH_SUFFIX="arm64"
+else
+  ARCH_SUFFIX="amd64"
+fi
+
 #############
 # FUNCTIONS #
 #############
@@ -60,7 +68,7 @@ function block_dev_basename() {
 }
 
 function install_deps() {
-  sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/local/bin/yq
+  sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${ARCH_SUFFIX} -O /usr/local/bin/yq
   sudo chmod +x /usr/local/bin/yq
 }
 
@@ -719,24 +727,24 @@ function install_minikube_with_none_driver() {
 
   sudo apt update
   sudo apt install -y conntrack socat
-  curl -LO https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_amd64.deb
-  sudo dpkg -i minikube_latest_amd64.deb
-  rm -f minikube_latest_amd64.deb
+  curl -LO https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube_latest_${ARCH_SUFFIX}.deb
+  sudo dpkg -i minikube_latest_${ARCH_SUFFIX}.deb
+  rm -f minikube_latest_${ARCH_SUFFIX}.deb
   # The dpkg install does not install the minikube binary to the needed location, so
   # move the minikube binary to the expected location
   sudo mv /usr/bin/minikube /usr/local/bin/minikube
 
-  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.4.0/cri-dockerd_0.4.0.3-0.ubuntu-focal_amd64.deb
-  sudo dpkg -i cri-dockerd_0.4.0.3-0.ubuntu-focal_amd64.deb
-  rm -f cri-dockerd_0.4.0.3-0.ubuntu-focal_amd64.deb
+  curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH_SUFFIX}.deb
+  sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH_SUFFIX}.deb
+  rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH_SUFFIX}.deb
 
-  wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
-  sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-  rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+  wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-${ARCH_SUFFIX}.tar.gz
+  sudo tar zxvf crictl-$CRICTL_VERSION-linux-${ARCH_SUFFIX}.tar.gz -C /usr/local/bin
+  rm -f crictl-$CRICTL_VERSION-linux-${ARCH_SUFFIX}.tar.gz
   sudo sysctl fs.protected_regular=0
 
   CNI_PLUGIN_VERSION="v1.7.1"
-  CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz" # change arch if not on amd64
+  CNI_PLUGIN_TAR="cni-plugins-linux-${ARCH_SUFFIX}-$CNI_PLUGIN_VERSION.tgz"
   CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
 
   curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"


### PR DESCRIPTION
let's run daily nightly canary job with github action arm runner as self-hosted runners is shutting down which was provided by upstream user.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16776


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
