### PR TITLE
operator: watch cephConfigFromSecret changes

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -144,7 +144,19 @@ func watchOwnedCoreObject[T client.Object](c controller.Controller, mgr manager.
 	)
 }
 
-func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reconciler, context *clusterd.Context, opConfig opcontroller.OperatorConfig) error {
+// isSecretRefFromCluster checks if the secret name is referenced in the CephCluster cephConfigFromSecret field.
+func isSecretRefFromCluster(secretName string, clusterSpec cephv1.ClusterSpec) bool {
+	for _, secretKeyMap := range clusterSpec.CephConfigFromSecret {
+		for _, keySelector := range secretKeyMap {
+			if secretName == keySelector.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reconciler, clusterdContext *clusterd.Context, opConfig opcontroller.OperatorConfig) error {
 	concurrentClusters := os.Getenv("ROOK_RECONCILE_CONCURRENT_CLUSTERS")
 	concurrentReconciles := 1
 	if i, err := strconv.Atoi(concurrentClusters); err == nil && i > 1 {
@@ -208,7 +220,43 @@ func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reco
 			mgr.GetCache(),
 			&corev1.Node{TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: corev1.SchemeGroupVersion.String()}},
 			handler.TypedEnqueueRequestsFromMapFunc(nodeHandler),
-			predicateForNodeWatcher(opManagerContext, mgr.GetClient(), context, opConfig.OperatorNamespace),
+			predicateForNodeWatcher(opManagerContext, mgr.GetClient(), clusterdContext, opConfig.OperatorNamespace),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to secrets referenced in ClusterSpec.CephConfigFromSecret
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: corev1.SchemeGroupVersion.String()}},
+			handler.TypedEnqueueRequestsFromMapFunc(
+				func(ctx context.Context, secret *corev1.Secret) []reconcile.Request {
+					clusterList := cephv1.CephClusterList{}
+					err := mgr.GetClient().List(ctx, &clusterList)
+					if err != nil {
+						return nil
+					}
+					requests := []reconcile.Request{}
+					for _, clusterResource := range clusterList.Items {
+						// No more than 1 cluster can exist in a namespace, and all secrets referenced by a
+						// CephConfigFromSecret must be in the same namespace as the cluster. We only need to
+						// trigger a reconcile once, so we only need to find one match per cluster.
+						if secret.GetNamespace() == clusterResource.GetNamespace() && isSecretRefFromCluster(secret.GetName(), clusterResource.Spec) {
+							requests = append(requests, reconcile.Request{
+								NamespacedName: client.ObjectKey{
+									Namespace: clusterResource.GetNamespace(),
+									Name:      clusterResource.GetName(),
+								},
+							})
+						}
+					}
+					return requests
+				},
+			),
+			changedOrDeleted,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
Add a resource watch to reconcile clusters when any referenced Secrets in cephConfigFromSecret are updated. This matches the behaviour of reconciling clusters when cephConfig changes. Without this change, if a Secret that is referenced by cephConfigFromSecret is updated, then the cluster is not immediately updated, so the cluster state will not match the configuration until something else triggers a reconcile.

I had to rename one of the function arguments (`context` becomes `clusterdContext`) to prevent a name collision with the imported `context` that is needed for in-line function typing.

`changedOrDeleted` is now identically defined in three different places in the repo, but it doesn't make sense to import it from any of the existing locations. I added it to `predicate.go` because it has all of the applicable imports already and `controller.go` did not. This is a little different to the other two occurrences of `changedOrDeleted` but seems in-pattern with the existing code in the `cluster` directory.

I'm not sure if `reconcileQueued` is strictly needed or if duplicate `reconcile.Request`s are implicitly handled elsewhere.

Resolves #16371
Updated from #16483

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.

Tested with minikube and triggers a reconcile as expected on secret updates and deletes.