### PR TITLE
core: Enhance logging in more controllers with namespaced names

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,3 +12,5 @@
   being managed by the same Rook operator. Concurrency is enabled by increasing
   the operator setting `ROOK_RECONCILE_CONCURRENT_CLUSTERS` to a value greater
   than `1`.
+- Improved logging with namespaced names for the controllers for more consistency in
+  troubleshooting the rook operator log.

--- a/pkg/operator/ceph/controller/conditions.go
+++ b/pkg/operator/ceph/controller/conditions.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,7 +36,7 @@ func UpdateCondition(ctx context.Context, c *clusterd.Context, namespaceName typ
 	// use client.Client unit test this more easily with updating statuses which must use the client
 	cluster := &cephv1.CephCluster{}
 	if err := c.Client.Get(ctx, namespaceName, cluster); err != nil {
-		logger.Errorf("failed to get cluster %v to update the conditions. %v", namespaceName, err)
+		log.NamedError(namespaceName, logger, "failed to get cluster %v to update the conditions. %v", namespaceName, err)
 		return
 	}
 
@@ -101,11 +102,11 @@ func UpdateClusterCondition(c *clusterd.Context, cluster *cephv1.CephCluster, na
 			cluster.Status.State = state
 		}
 		cluster.Status.Message = currentCondition.Message
-		logger.Debugf("CephCluster %q status: %q. %q", namespaceName.Namespace, cluster.Status.Phase, cluster.Status.Message)
+		log.NamedDebug(namespaceName, logger, "CephCluster status: %q. %q", cluster.Status.Phase, cluster.Status.Message)
 	}
 
 	if err := reporting.UpdateStatus(c.Client, cluster); err != nil {
-		logger.Errorf("failed to update cluster condition to %+v. %v", *currentCondition, err)
+		log.NamedError(namespaceName, logger, "failed to update cluster condition to %+v. %v", *currentCondition, err)
 	}
 }
 

--- a/pkg/operator/ceph/controller/finalizer.go
+++ b/pkg/operator/ceph/controller/finalizer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/util/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ func AddFinalizerIfNotPresent(ctx context.Context, client client.Client, obj cli
 	}
 
 	if !contains(accessor.GetFinalizers(), objectFinalizer) {
-		logger.Infof("adding finalizer %q on %q", objectFinalizer, accessor.GetName())
+		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "adding finalizer %q", objectFinalizer)
 		accessor.SetFinalizers(append(accessor.GetFinalizers(), objectFinalizer))
 		originalGeneration := obj.GetGeneration()
 
@@ -69,7 +70,7 @@ func AddFinalizerIfNotPresent(ctx context.Context, client client.Client, obj cli
 			return false, errors.Wrapf(err, "failed to add finalizer %q on %q", objectFinalizer, accessor.GetName())
 		}
 		newGeneration := obj.GetGeneration()
-		logger.Debugf("when adding finalizer on %q, original generation %d, new generation %d", accessor.GetName(), originalGeneration, newGeneration)
+		log.NamedDebug(NsName(obj.GetNamespace(), obj.GetName()), logger, "when adding finalizer, original generation %d, new generation %d", originalGeneration, newGeneration)
 		return originalGeneration != newGeneration, nil
 	}
 
@@ -94,7 +95,7 @@ func RemoveFinalizerWithName(ctx context.Context, client client.Client, obj clie
 	}
 
 	if contains(accessor.GetFinalizers(), finalizerName) {
-		logger.Infof("removing finalizer %q on %q", finalizerName, accessor.GetName())
+		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "removing finalizer %q", finalizerName)
 		accessor.SetFinalizers(remove(accessor.GetFinalizers(), finalizerName))
 		if err := client.Update(ctx, obj); err != nil {
 			return errors.Wrapf(err, "failed to remove finalizer %q on %q", finalizerName, accessor.GetName())

--- a/pkg/operator/ceph/controller/mirror_peer.go
+++ b/pkg/operator/ceph/controller/mirror_peer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,7 +123,7 @@ func CreateBootstrapPeerSecret(ctx *clusterd.Context, clusterInfo *cephclient.Cl
 	}
 
 	// Create Secret
-	logger.Debugf("store %s-mirror bootstrap token in a Kubernetes Secret %q in namespace %q", daemonType, s.Name, ns)
+	log.NamedDebug(NsName(ns, s.Name), logger, "store %s-mirror bootstrap token in a Kubernetes Secret", daemonType)
 	_, err = k8sutil.CreateOrUpdateSecret(clusterInfo.Context, ctx.Clientset, s)
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return ImmediateRetryResult, errors.Wrapf(err, "failed to create %s-mirror bootstrap peer %q secret", daemonType, s.Name)
@@ -266,7 +267,7 @@ func updateCephClusterCephxRbdMirrorStatus(c *clusterd.Context, clusterInfo *cep
 		}
 		updatedStatus := keyring.UpdatedCephxStatus(didRotate, cluster.Spec.Security.CephX.RBDMirrorPeer, clusterInfo.CephVersion, cluster.Status.Cephx.RBDMirrorPeer)
 		cluster.Status.Cephx.RBDMirrorPeer = updatedStatus
-		logger.Debugf("updating rbd-mirror cephx status to %+v", cluster.Status.Cephx.RBDMirrorPeer)
+		log.NamespacedDebug(clusterInfo.Namespace, logger, "updating rbd-mirror cephx status to %+v", cluster.Status.Cephx.RBDMirrorPeer)
 		if err := reporting.UpdateStatus(c.Client, cluster); err != nil {
 			return errors.Wrap(err, "failed to update cluster cephx status for rbd-mirror")
 		}
@@ -275,6 +276,6 @@ func updateCephClusterCephxRbdMirrorStatus(c *clusterd.Context, clusterInfo *cep
 	if err != nil {
 		return err
 	}
-	logger.Debugf("successfully updated rbd-mirror cephx status on the cluster %q", clusterInfo.NamespacedName())
+	log.NamespacedDebug(clusterInfo.Namespace, logger, "successfully updated rbd-mirror cephx status")
 	return nil
 }

--- a/pkg/operator/ceph/controller/object_operations.go
+++ b/pkg/operator/ceph/controller/object_operations.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -46,12 +47,12 @@ func CreateOrUpdateObject(ctx context.Context, client client.Client, obj client.
 				return errors.Wrapf(err, "failed to update ceph %q object %q", objType, objName)
 			}
 
-			logger.Infof("updated ceph %q object %q", objType, objName)
+			log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "updated ceph %q object %q", objType, objName)
 			return nil
 		}
 		return errors.Wrapf(err, "failed to create ceph %v object %q", objType, objName)
 	}
 
-	logger.Infof("created ceph %v object %q", objType, objName)
+	log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "created ceph %v object %q", objType, objName)
 	return nil
 }

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -55,10 +55,7 @@ func objectInfo(scheme *runtime.Scheme, obj client.Object) (string, types.Namesp
 		logger.Debugf("Unable to get GVK for object %+v", obj)
 	}
 
-	nsName := types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	}
+	nsName := NsName(obj.GetNamespace(), obj.GetName())
 
 	return gvk.Kind, nsName
 }

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -23,6 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,7 +52,7 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 	}
 
 	if c.shouldRotateCephxKeys {
-		logger.Infof("rotating cephx key for CephFileSystem %q", m.ResourceName)
+		log.NamedInfo(opcontroller.NsName(c.fs.Namespace, c.fs.Name), logger, "rotating cephx key for CephFileSystem")
 		newKey, err := s.RotateKey(user)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to rotate cephx key for CephFileSystem %q", m.ResourceName)
@@ -63,9 +65,9 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 	err = c.context.Clientset.CoreV1().Secrets(c.fs.Namespace).Delete(c.clusterInfo.Context, m.ResourceName, metav1.DeleteOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Debugf("legacy mds key %s is already removed", m.ResourceName)
+			log.NamedDebug(opcontroller.NsName(c.fs.Namespace, c.fs.Name), logger, "legacy mds key %s is already removed", m.ResourceName)
 		} else {
-			logger.Warningf("legacy mds key %q could not be removed. %v", m.ResourceName, err)
+			log.NamedWarning(opcontroller.NsName(c.fs.Namespace, c.fs.Name), logger, "legacy mds key %q could not be removed. %v", m.ResourceName, err)
 		}
 	}
 

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -179,7 +180,7 @@ func getMdsDeployments(ctx context.Context, context *clusterd.Context, namespace
 
 func deleteMdsDeployment(ctx context.Context, clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment) error {
 	// Delete the mds deployment
-	logger.Infof("deleting mds deployment %s", deployment.Name)
+	log.NamedInfo(controller.NsName(namespace, deployment.Name), logger, "deleting mds deployment")
 	var gracePeriod int64
 	propagation := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
@@ -191,7 +192,7 @@ func deleteMdsDeployment(ctx context.Context, clusterdContext *clusterd.Context,
 
 func scaleMdsDeployment(ctx context.Context, clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment, replicas int32) error {
 	// scale mds deployment
-	logger.Infof("scaling mds deployment %q to %d replicas", deployment.Name, replicas)
+	log.NamedInfo(controller.NsName(namespace, deployment.Name), logger, "scaling mds deployment to %d replicas", replicas)
 	d, err := clusterdContext.Clientset.AppsV1().Deployments(namespace).Get(ctx, deployment.GetName(), metav1.GetOptions{})
 	if err != nil {
 		if replicas != 0 && kerrors.IsNotFound(err) {

--- a/pkg/operator/ceph/file/mirror/config.go
+++ b/pkg/operator/ceph/file/mirror/config.go
@@ -22,7 +22,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 )
 
 const (
@@ -60,7 +62,7 @@ func (r *ReconcileFilesystemMirror) generateKeyring(daemonConfig *daemonConfig) 
 	}
 
 	if r.shouldRotateCephxKeys {
-		logger.Infof("rotating CephX key for CephFileSystemMirror %q in the namespace %q", daemonConfig.ResourceName, r.clusterInfo.Namespace)
+		log.NamedInfo(opcontroller.NsName(r.clusterInfo.Namespace, daemonConfig.ResourceName), logger, "rotating CephX key for CephFileSystemMirror")
 		newKey, err := s.RotateKey(user)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to rotate CephX key for CephFileSystemMirror %q in the namespace %q", daemonConfig.ResourceName, r.clusterInfo.Namespace)

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,6 +83,7 @@ func (r *ReconcileCephNFS) generateCephNFSService(nfs *cephv1.CephNFS, cfg daemo
 
 func (r *ReconcileCephNFS) createCephNFSService(nfs *cephv1.CephNFS, cfg daemonConfig) error {
 	s := r.generateCephNFSService(nfs, cfg)
+	nsName := controller.NsName(nfs.Namespace, nfs.Name)
 
 	// Set owner ref to the parent object
 	err := controllerutil.SetControllerReference(nfs, s, r.scheme)
@@ -94,11 +96,11 @@ func (r *ReconcileCephNFS) createCephNFSService(nfs *cephv1.CephNFS, cfg daemonC
 		if !kerrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "failed to create ganesha service")
 		}
-		logger.Infof("ceph nfs service already created")
+		log.NamedInfo(nsName, logger, "ceph nfs service already created")
 		return nil
 	}
 
-	logger.Infof("ceph nfs service running at %s:%d", svc.Spec.ClusterIP, nfsPort)
+	log.NamedInfo(nsName, logger, "ceph nfs service running at %s:%d", svc.Spec.ClusterIP, nfsPort)
 	return nil
 }
 

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -187,12 +187,14 @@ func TestProvisioner_setUserQuota(t *testing.T) {
 		adminClient, err := admin.New("rgw.test", "accesskey", "secretkey", mockClient)
 		assert.NoError(t, err)
 
+		clusterInfo := &client.ClusterInfo{
+			Context: context.Background(),
+		}
 		p := &Provisioner{
-			clusterInfo: &client.ClusterInfo{
-				Context: context.Background(),
-			},
+			clusterInfo:    clusterInfo,
 			cephUserName:   "bob",
 			adminOpsClient: adminClient,
+			objectContext:  object.NewContext(&clusterd.Context{}, clusterInfo, "store"),
 		}
 
 		return p
@@ -379,12 +381,14 @@ func TestProvisioner_setBucketQuota(t *testing.T) {
 		adminClient, err := admin.New("rgw.test", "accesskey", "secretkey", mockClient)
 		assert.NoError(t, err)
 
+		clusterInfo := &client.ClusterInfo{
+			Context: context.Background(),
+		}
 		p := &Provisioner{
-			clusterInfo: &client.ClusterInfo{
-				Context: context.Background(),
-			},
+			clusterInfo:    clusterInfo,
 			cephUserName:   "bob",
 			adminOpsClient: adminClient,
+			objectContext:  object.NewContext(&clusterd.Context{}, clusterInfo, "store"),
 		}
 
 		return p

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -26,6 +26,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	cephObject "github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/pkg/util/log"
 	storagev1 "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -172,7 +173,7 @@ func GetObjectStoreNameFromBucket(ob *bktv1alpha1.ObjectBucket) (types.Namespace
 	// TODO: remove after Rook v1.12
 	// Older OBCs don't have the additional state labels, but they will always be configured to use
 	// the legacy CephObjectStore Service which has a deterministic domain structure.
-	logger.Debugf("falling back to legacy method for determining OBC \"%s/%s\"'s CephObjectStore from endpoint %q",
+	log.NamedDebug(nsName, logger, "falling back to legacy method for determining OBC \"%s/%s\"'s CephObjectStore from endpoint %q",
 		ob.Namespace, ob.Name, ob.Spec.Connection.Endpoint.BucketHost)
 	nsName, err = cephObject.ParseDomainName(ob.Spec.Connection.Endpoint.BucketHost)
 	if err != nil {

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -176,7 +176,8 @@ func Test_clusterConfig_generateMonConfigOptions(t *testing.T) {
 			}
 
 			c := &clusterConfig{
-				store: cos,
+				store:       cos,
+				clusterInfo: &cephclient.ClusterInfo{Namespace: "ns"},
 			}
 
 			got, err := c.generateMonConfigOptions(rgwConfig)

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -21,7 +21,9 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -45,9 +47,10 @@ func mimeTypesMountPath() string {
 
 // store mime.types file in a config map
 func (c *clusterConfig) generateMimeTypes() error {
+	nsName := opcontroller.NsName(c.store.Namespace, c.store.Name)
 	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, c.ownerInfo)
 	if _, err := k.GetValue(c.clusterInfo.Context, c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
-		logger.Infof("config map %q for object store %q already exists, not overwriting", c.mimeTypesConfigMapName(), c.store.Name)
+		log.NamedInfo(nsName, logger, "config map %q for object store %q already exists, not overwriting", c.mimeTypesConfigMapName(), c.store.Name)
 		return nil
 	}
 	// is not found

--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -30,6 +30,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
+	"github.com/rook/rook/pkg/util/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -158,7 +159,7 @@ var createNotification = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, t
 		return errors.Wrapf(err, "failed to provisioning CephBucketNotification %q for bucket %q", bnName, bucketName)
 	}
 
-	logger.Infof("CephBucketNotification %q was created for bucket %q", bnName, bucketName)
+	log.NamedInfo(bnName, logger, "CephBucketNotification was created for bucket %q", bucketName)
 
 	return nil
 }

--- a/pkg/operator/ceph/object/shared_pools.go
+++ b/pkg/operator/ceph/object/shared_pools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -413,7 +414,7 @@ func getZoneJSON(objContext *Context) (map[string]interface{}, error) {
 	}
 	zoneArg := fmt.Sprintf("--rgw-zone=%s", objContext.Zone)
 
-	logger.Debugf("get zone: rgw-realm=%s, rgw-zone=%s", objContext.Realm, objContext.Zone)
+	log.NamedDebug(objContext.NsName(), logger, "get zone: rgw-realm=%s, rgw-zone=%s", objContext.Realm, objContext.Zone)
 
 	jsonStr, err := RunAdminCommandNoMultisite(objContext, true, "zone", "get", realmArg, zoneArg)
 	if err != nil {
@@ -424,7 +425,7 @@ func getZoneJSON(objContext *Context) (map[string]interface{}, error) {
 		}
 		return nil, errors.Wrap(err, "failed to get rgw zone group")
 	}
-	logger.Debugf("get zone success: rgw-realm=%s, rgw-zone=%s, res=%s", objContext.Realm, objContext.Zone, jsonStr)
+	log.NamedDebug(objContext.NsName(), logger, "get zone success: rgw-realm=%s, rgw-zone=%s, res=%s", objContext.Realm, objContext.Zone, jsonStr)
 	res := map[string]interface{}{}
 	return res, json.Unmarshal([]byte(jsonStr), &res)
 }
@@ -445,7 +446,7 @@ func getZoneGroupJSON(objContext *Context) (map[string]interface{}, error) {
 	}
 	zoneGroupArg := fmt.Sprintf("--rgw-zonegroup=%s", objContext.ZoneGroup)
 
-	logger.Debugf("get zonegroup: rgw-realm=%s, rgw-zone=%s, rgw-zonegroup=%s", objContext.Realm, objContext.Zone, objContext.ZoneGroup)
+	log.NamedDebug(objContext.NsName(), logger, "get zonegroup: rgw-realm=%s, rgw-zone=%s, rgw-zonegroup=%s", objContext.Realm, objContext.Zone, objContext.ZoneGroup)
 	jsonStr, err := RunAdminCommandNoMultisite(objContext, true, "zonegroup", "get", realmArg, zoneGroupArg, zoneArg)
 	if err != nil {
 		// This handles the case where the pod we use to exec command (act as a proxy) is not found/ready yet
@@ -455,7 +456,7 @@ func getZoneGroupJSON(objContext *Context) (map[string]interface{}, error) {
 		}
 		return nil, errors.Wrap(err, "failed to get rgw zone group")
 	}
-	logger.Debugf("get zonegroup success: rgw-realm=%s, rgw-zone=%s, rgw-zonegroup=%s, res=%s", objContext.Realm, objContext.Zone, objContext.ZoneGroup, jsonStr)
+	log.NamedDebug(objContext.NsName(), logger, "get zonegroup success: rgw-realm=%s, rgw-zone=%s, rgw-zonegroup=%s, res=%s", objContext.Realm, objContext.Zone, objContext.ZoneGroup, jsonStr)
 	res := map[string]interface{}{}
 	return res, json.Unmarshal([]byte(jsonStr), &res)
 }
@@ -486,7 +487,7 @@ func updateZoneJSON(objContext *Context, zone map[string]interface{}) (map[strin
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set zone config")
 	}
-	logger.Debugf("update zone: %s json config updated value from %q to %q", objContext.Zone, string(configBytes), string(updatedBytes))
+	log.NamedDebug(objContext.NsName(), logger, "update zone: %s json config updated value from %q to %q", objContext.Zone, string(configBytes), string(updatedBytes))
 	updated := map[string]interface{}{}
 	err = json.Unmarshal([]byte(updatedBytes), &updated)
 	return updated, err

--- a/pkg/operator/ceph/object/shared_pools_test.go
+++ b/pkg/operator/ceph/object/shared_pools_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1144,7 +1145,8 @@ func Test_adjustZoneDefaultPools(t *testing.T) {
 			srcZone := map[string]interface{}{}
 			err := json.Unmarshal([]byte(tt.args.beforeJSON), &srcZone)
 			assert.NoError(t, err)
-			changedZone, err := adjustZoneDefaultPools(srcZone, tt.args.spec)
+			objContext := &Context{clusterInfo: &cephclient.ClusterInfo{Namespace: "test"}}
+			changedZone, err := adjustZoneDefaultPools(objContext, srcZone, tt.args.spec)
 
 			// check that source was not modified
 			orig := map[string]interface{}{}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/util/exec"
+	"github.com/rook/rook/pkg/util/log"
 )
 
 const (
@@ -86,7 +87,7 @@ func decodeUser(data string) (*ObjectUser, int, error) {
 // The function is used **ONCE** only to provision so the RGW Admin Ops User
 // Subsequent interaction with the API will be done with the created user
 func GetUser(c *Context, id string) (*ObjectUser, int, error) {
-	logger.Debugf("getting s3 user %q", id)
+	log.NamedDebug(c.NsName(), logger, "getting s3 user %q", id)
 	// note: err is set for non-existent user but result output is also empty
 	result, err := runAdminCommand(c, false, "user", "info", "--uid", id)
 	if strings.Contains(result, "no user info saved") {
@@ -106,7 +107,7 @@ func GetUser(c *Context, id string) (*ObjectUser, int, error) {
 // The function is used **ONCE** only to provision so the RGW Admin Ops User
 // Subsequent interaction with the API will be done with the created user
 func CreateUser(c *Context, user ObjectUser, force bool) (*ObjectUser, int, error) {
-	logger.Debugf("creating s3 user %q", user.UserID)
+	log.NamedDebug(c.NsName(), logger, "creating s3 user %q", user.UserID)
 	timeout := exec.CephCommandsTimeout
 	if user.UserID == RGWAdminOpsUserSecretName {
 		// Setting a really long timeout for the command that creates the admin user

--- a/pkg/operator/ceph/object/zone/dependents.go
+++ b/pkg/operator/ceph/object/zone/dependents.go
@@ -23,8 +23,10 @@ import (
 	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/util/dependents"
+	"github.com/rook/rook/pkg/util/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,7 +36,7 @@ func CephObjectZoneDependentStores(
 	zone *v1.CephObjectZone,
 	objContext *object.Context,
 ) (*dependents.DependentList, error) {
-	nsName := fmt.Sprintf("%s/%s", zone.Namespace, zone.Name)
+	nsName := controller.NsName(zone.Namespace, zone.Name)
 	baseErrMsg := fmt.Sprintf("failed to get dependents of CephObjectZone %q", nsName)
 
 	deps := dependents.NewDependentList()
@@ -46,10 +48,10 @@ func CephObjectZoneDependentStores(
 	for _, store := range stores.Items {
 		if store.Spec.Zone.Name == zone.Name {
 			deps.Add("CephObjectStore", store.Name)
-			logger.Debugf("found CephObjectStore %q that depends on CephObjectZone %q", store.Name, nsName)
+			log.NamedDebug(nsName, logger, "found CephObjectStore %q that depends on CephObjectZone %q", store.Name, nsName)
 
 		} else {
-			logger.Debugf("found CephObjectStore %q that does not depend on CephObjectZone %q", store.Name, nsName)
+			log.NamedDebug(nsName, logger, "found CephObjectStore %q that does not depend on CephObjectZone %q", store.Name, nsName)
 		}
 	}
 

--- a/pkg/operator/ceph/pool/dependents.go
+++ b/pkg/operator/ceph/pool/dependents.go
@@ -23,7 +23,9 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/util/dependents"
+	"github.com/rook/rook/pkg/util/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,7 +34,7 @@ const radosNamespacesKeyName = "CephBlockPoolRadosNamespaces"
 // cephBlockPoolDependents returns the rbd namespaces (s) which exist in the rbd pool that should block
 // deletion.
 func cephBlockPoolDependents(clusterdCtx *clusterd.Context, clusterInfo *client.ClusterInfo, blockpool *cephv1.CephBlockPool) (*dependents.DependentList, error) {
-	nsName := fmt.Sprintf("%s/%s", blockpool.Namespace, blockpool.Name)
+	nsName := controller.NsName(blockpool.Namespace, blockpool.Name)
 	baseErrMsg := fmt.Sprintf("failed to get dependents of CephBlockPool %q", nsName)
 
 	deps := dependents.NewDependentList()
@@ -46,7 +48,7 @@ func cephBlockPoolDependents(clusterdCtx *clusterd.Context, clusterInfo *client.
 		if namespace.Spec.BlockPoolName == blockpool.Name {
 			deps.Add(radosNamespacesKeyName, cephv1.GetRadosNamespaceName(&namespaces.Items[i]))
 		}
-		logger.Debugf("found CephBlockPoolRadosNamespace %q that does not depend on CephBlockPool %q", namespace.Name, nsName)
+		log.NamedDebug(nsName, logger, "found CephBlockPoolRadosNamespace %q that does not depend on CephBlockPool %q", namespace.Name, blockpool.Name)
 	}
 
 	return deps, nil

--- a/pkg/operator/ceph/pool/peers.go
+++ b/pkg/operator/ceph/pool/peers.go
@@ -21,6 +21,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,7 +37,7 @@ func (r *ReconcileCephBlockPool) reconcileAddBootstrapPeer(pool *cephv1.CephBloc
 	// List all the peers secret, we can have more than one peer we might want to configure
 	// For each, get the Kubernetes Secret and import the "peer token" so that we can configure the mirroring
 	for _, peerSecret := range pool.Spec.Mirroring.Peers.SecretNames {
-		logger.Debugf("fetching bootstrap peer kubernetes secret %q", peerSecret)
+		log.NamedDebug(namespacedName, logger, "fetching bootstrap peer kubernetes secret %q", peerSecret)
 		s, err := r.context.Clientset.CoreV1().Secrets(r.clusterInfo.Namespace).Get(r.opManagerContext, peerSecret, metav1.GetOptions{})
 		// We don't care about IsNotFound here, we still need to fail
 		if err != nil {

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -22,6 +22,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/util/log"
 )
 
 // validatePool Validate the pool arguments
@@ -142,7 +143,7 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 
 	// validate pool compression mode if specified
 	if p.CompressionMode != "" {
-		logger.Warning("compressionMode is DEPRECATED, use Parameters instead")
+		log.NamespacedWarning(clusterInfo.Namespace, logger, "compressionMode is DEPRECATED, use Parameters instead")
 	}
 
 	// Test the same for Parameters
@@ -177,7 +178,7 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 	}
 
 	if !p.Mirroring.Enabled && p.Mirroring.SnapshotSchedulesEnabled() {
-		logger.Warning("mirroring must be enabled to configure snapshot scheduling")
+		log.NamespacedWarning(clusterInfo.Namespace, logger, "mirroring must be enabled to configure snapshot scheduling")
 	}
 
 	return nil


### PR DESCRIPTION
For majority of the controllers, the logging now includes the namespaced name of the resource that is being reconciled. This will help with log troubleshooting to help analyze logs consistently for the resource being reconciled.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
