### PR TITLE
external: fix endpoint slice type for ipv6 clusters

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -871,13 +871,18 @@ func createExternalMetricsEndpoints(namespace string, monitoringSpec cephv1.Moni
 		addresses[i] = endpoint.IP
 	}
 
+	addressType, err := k8sutil.GetIpAddressType(addresses)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get the addressType")
+	}
+
 	endpoints := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ExternalMgrAppName,
 			Namespace: namespace,
 			Labels:    labels,
 		},
-		AddressType: discoveryv1.AddressTypeIPv4,
+		AddressType: addressType,
 		Endpoints: []discoveryv1.Endpoint{
 			{
 				Addresses: addresses,
@@ -895,7 +900,7 @@ func createExternalMetricsEndpoints(namespace string, monitoringSpec cephv1.Moni
 		},
 	}
 
-	err := ownerInfo.SetControllerReference(endpoints)
+	err = ownerInfo.SetControllerReference(endpoints)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to set owner reference to metric endpoints %q", endpoints.Name)
 	}

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -727,7 +727,7 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 	return svc
 }
 
-func (c *clusterConfig) generateEndpoint(cephObjectStore *cephv1.CephObjectStore) *discoveryv1.EndpointSlice {
+func (c *clusterConfig) generateEndpoint(cephObjectStore *cephv1.CephObjectStore) (*discoveryv1.EndpointSlice, error) {
 	labels := getLabels(cephObjectStore.Name, cephObjectStore.Namespace, true)
 
 	// Convert to string addresses
@@ -736,13 +736,18 @@ func (c *clusterConfig) generateEndpoint(cephObjectStore *cephv1.CephObjectStore
 		k8sEndpointAddrs = append(k8sEndpointAddrs, rookEndpoint.IP)
 	}
 
+	addressType, err := k8sutil.GetIpAddressType(k8sEndpointAddrs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get the addressType")
+	}
+
 	endpoints := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instanceName(cephObjectStore.Name),
 			Namespace: cephObjectStore.Namespace,
 			Labels:    labels,
 		},
-		AddressType: discoveryv1.AddressTypeIPv4,
+		AddressType: addressType,
 		Endpoints: []discoveryv1.Endpoint{
 			{
 				Addresses: k8sEndpointAddrs,
@@ -757,15 +762,18 @@ func (c *clusterConfig) generateEndpoint(cephObjectStore *cephv1.CephObjectStore
 	addPortToEndpoint(endpoints, "http", cephObjectStore.Spec.Gateway.Port)
 	addPortToEndpoint(endpoints, "https", cephObjectStore.Spec.Gateway.SecurePort)
 
-	return endpoints
+	return endpoints, nil
 }
 
 func (c *clusterConfig) reconcileExternalEndpoint(cephObjectStore *cephv1.CephObjectStore) error {
 	logger.Info("reconciling external object store service")
 
-	endpoint := c.generateEndpoint(cephObjectStore)
+	endpoint, err := c.generateEndpoint(cephObjectStore)
+	if err != nil {
+		return errors.Wrapf(err, "failed to generate the endpoint %q", endpoint.Name)
+	}
 	// Set owner ref to the parent object
-	err := c.ownerInfo.SetControllerReference(endpoint)
+	err = c.ownerInfo.SetControllerReference(endpoint)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set owner reference to ceph object store endpoint %q", endpoint.Name)
 	}


### PR DESCRIPTION
in endpoint slice for the mgr and rgw service
it was harcoded to use the ipv4,
now dynamically assign the type based on the endpoint ip adrress type

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
