### PR TITLE
mon: mute the mon netsplit warning

### DIFF
--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -164,3 +164,10 @@ func SetNewTiebreaker(context *clusterd.Context, clusterInfo *ClusterInfo, monNa
 	logger.Infof("successfully set new mon tiebreaker %q in arbiter zone", monName)
 	return nil
 }
+
+// MuteMonNetSplitWarning mutes the MON_NETSPLIT warning
+func MuteMonNetSplitWarning(context *clusterd.Context, clusterInfo *ClusterInfo) error {
+	args := []string{"health", "mute", "MON_NETSPLIT"}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	return err
+}

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -553,6 +553,15 @@ func (c *cluster) postMonStartupActions() error {
 	// client.bootstrap-osd is used by Rook and is not removed here.
 	c.deleteBootstrapKeys()
 
+	// Mute the NetSplit warning for the stretch bases clusters
+	// we have ceph fix https://github.com/ceph/ceph/pull/64122 in master
+	// it will be backported to Tentacles and Squid releases
+	if c.Spec.IsStretchCluster() {
+		err := client.MuteMonNetSplitWarning(c.context, c.ClusterInfo)
+		if err != nil {
+			return errors.Wrap(err, "failed to mute NetSplit warning for stretch cluster")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
during post mon startup mute the
netsplit warning,
HEALTH_WARN 6 network partitions detected
It has to be fixed by the ceph team

Once the fix is there, we need to unmute the
warning

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
