### PR TITLE
ci: Run canary tests against tentacle

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ceph_images:
         description: "JSON list of Ceph images for creating Ceph cluster"
-        default: '["quay.io/ceph/ceph:v19"]'
+        default: '["quay.io/ceph/ceph:v20"]'
         type: string
       kubernetes-version:
         description: kubernetes version to use for the workflow


### PR DESCRIPTION
The [daily CI](https://github.com/rook/rook/actions/workflows/daily-nightly-jobs.yml) canary tests are unstable, but it's not easy to see if tentacle is the cause. Let's see how stable the canary tests specifically are against tentacle... 

We have been seeing a lot of instability in the `osd-with-metadata-partition-device` canary test because it was always running against tentacle. (See #16822)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
