### PR TITLE
build: use ceph tentacle v20 as default version

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -70,7 +70,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `cephFileSystems` | A list of CephFileSystem configurations to deploy | See [below](#ceph-file-systems) |
 | `cephImage.allowUnsupported` |  | `false` |
 | `cephImage.repository` |  | `"quay.io/ceph/ceph"` |
-| `cephImage.tag` |  | `"v19.2.3"` |
+| `cephImage.tag` |  | `"v20.2.1"` |
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |

--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -27,10 +27,11 @@ until all the daemons have been updated.
 The following Ceph versions are supported in this release of Rook:
 
 * Ceph Squid v19.2.0 or newer
-* Ceph Tentacle v20.2.0 or newer
+* Ceph Tentacle v20.2.1 or newer
+* Ceph Tentacle v20.2.0: Not recommended
     * IMPORTANT: **There is a known data corruption issue in v20.2.0**, if the "read affinity" feature is enabled.
     Read affinity is disabled by default, and is enabled by the CephCluster setting `csi.readAffinity.enabled: true`.
-    If you have enabled read affinity, we recommend waiting for v20.2.1 before upgrading to Ceph Tentacle v20.
+    If read affinity is enabled in your cluster, upgrade to v20.2.1+.
     If read affinity is enabled with v20.2.0, Rook automatically disables read affinity internally to help avoid this corruption.
     After the upgrade, existing applications must be restarted to fully disable the read affinity in existing volumes.
     See [this issue](https://github.com/rook/rook/issues/16839) for more details.

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -98,7 +98,7 @@ cephImage:
   # In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
   # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
   # To be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v19.2.3-20250717
-  tag: v19.2.3
+  tag: v20.2.1
   # Whether to allow unsupported versions of Ceph. Currently Squid and Tentacle are supported.
   # Future versions such as Tentacle (v20) would require this to be set to `true`.
   # Do not set to true in production.

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -19,9 +19,9 @@ spec:
     # v19 is Squid, v20 is Tentacle
     # RECOMMENDATION: In production, use a specific version tag instead of the general v20 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v20.2.0-20251104
+    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v20.2.1-20260402
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: quay.io/ceph/ceph:v19.2.3
+    image: quay.io/ceph/ceph:v20.2.1
     # Whether to allow unsupported versions of Ceph. Currently Squid and Tentacle are supported.
     # Future versions such as Umbrella (v21) would require this to be set to `true`.
     # Do not set to true in production.

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,6 +1,6 @@
  docker.io/rook/ceph:master
  gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
- quay.io/ceph/ceph:v19.2.3
+ quay.io/ceph/ceph:v20.2.1
  quay.io/ceph/cosi:v0.1.4
  quay.io/cephcsi/ceph-csi-operator:v0.6.0
  quay.io/cephcsi/cephcsi:v3.16.2

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -16,7 +16,7 @@ include ../image.mk
 
 # ====================================================================================
 # Image Build Options
-CEPH_VERSION ?= v20.2.0-20251104
+CEPH_VERSION ?= v20.2.1-20260402
 
 REGISTRY_NAME = quay.io
 BASEIMAGE = $(REGISTRY_NAME)/ceph/ceph:$(CEPH_VERSION)


### PR DESCRIPTION
let's use ceph tentacle as default version in deployment

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
