### PR TITLE
csi: add fix to support multiple fs mount option

### DIFF
--- a/pkg/operator/ceph/csi/config_test.go
+++ b/pkg/operator/ceph/csi/config_test.go
@@ -81,3 +81,34 @@ func TestCreateUpdateClientProfile(t *testing.T) {
 	assert.Equal(t, csiOpClientProfile.Spec.CephFs.SubVolumeGroup, cephSubVolGrpNamespacedName.Name)
 	assert.Equal(t, csiOpClientProfile.Spec.CephFs.KernelMountOptions["ms_mode"], kernelMountKeyVal[1])
 }
+
+func TestParseMountOptions(t *testing.T) {
+	t.Run("single mount option", func(t *testing.T) {
+		options := "ms_mode=crc"
+		result := parseMountOptions(options)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, "crc", result["ms_mode"])
+	})
+
+	t.Run("multiple mount options", func(t *testing.T) {
+		options := "ms_mode=prefer-secure,recover_session=clean"
+		result := parseMountOptions(options)
+		assert.Equal(t, 2, len(result))
+		assert.Equal(t, "prefer-secure", result["ms_mode"])
+		assert.Equal(t, "clean", result["recover_session"])
+	})
+
+	t.Run("multiple mount options with spaces", func(t *testing.T) {
+		options := "ms_mode=prefer-secure, recover_session=clean"
+		result := parseMountOptions(options)
+		assert.Equal(t, 2, len(result))
+		assert.Equal(t, "prefer-secure", result["ms_mode"])
+		assert.Equal(t, "clean", result["recover_session"])
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		options := ""
+		result := parseMountOptions(options)
+		assert.Equal(t, 0, len(result))
+	})
+}


### PR DESCRIPTION
previously, if multiple mount option was passed it was handing it wrong. For example,
```
ms_mode=prefer-secure,recover_session=clean
```
 was treated as
```
ms_mode: prefer-secure,recover_session
```

With current fix it handles it correctly. Example,
```
ms_mode: prefer-secure,
recover_session=clean,
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16772


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
