### PR TITLE
build: remove obsolete operator-sdk from makefile

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -77,8 +77,6 @@ roleRef:
   name: cephfs-external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
 ---
-# This is required by operator-sdk to map the cluster/clusterrolebindings with SA
-# otherwise operator-sdk will create a individual file for these.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -671,8 +671,6 @@ rules:
     resources: ["drivers"]
     verbs: ["create", "delete", "get", "list", "update", "watch"]
 ---
-# This is required by operator-sdk to map the cluster/clusterrolebindings with SA
-# otherwise operator-sdk will create a individual file for these.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -21,7 +21,6 @@ CEPH_VERSION ?= v19.2.3-20250717
 REGISTRY_NAME = quay.io
 BASEIMAGE = $(REGISTRY_NAME)/ceph/ceph:$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
-OPERATOR_SDK_VERSION = v1.25.0
 # TODO: update to yq v4 - v3 end of life in Aug 2021 ; v4 removes the 'yq delete' cmd and changes syntax
 YQv3_VERSION = 3.4.1
 GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go
@@ -41,12 +40,8 @@ endif
 # s5cmd's version
 S5CMD_VERSION = 2.3.0
 
-# Note: as of version 1.3 of operator-sdk, the url format changed to:
-# ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
-# (see: https://sdk.operatorframework.io/docs/installation/)
-OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
 YQv3 := $(TOOLS_HOST_DIR)/yq-$(YQv3_VERSION)
-export OPERATOR_SDK YQv3
+export YQv3
 
 # ====================================================================================
 # Build Rook
@@ -75,21 +70,13 @@ do.build:
 
 # call this before building multiple arches in parallel to prevent parallel build processes from
 # conflicting
-prerequisites: $(OPERATOR_SDK) $(YQv3)
+prerequisites: $(YQv3)
 
 $(YQv3):
 	@echo === installing yq $(YQv3_VERSION) $(REAL_HOST_PLATFORM)
 	@mkdir -p $(TOOLS_HOST_DIR)
 	@curl -JL https://github.com/mikefarah/yq/releases/download/$(YQv3_VERSION)/yq_$(REAL_HOST_PLATFORM) -o $(YQv3)
 	@chmod +x $(YQv3)
-
-$(OPERATOR_SDK):
-	@echo === installing operator-sdk $(REAL_HOST_PLATFORM)
-	@mkdir -p $(TOOLS_HOST_DIR)
-	@curl -JL -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) \
-		https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$(REAL_HOST_PLATFORM)
-	@chmod +x $(OPERATOR_SDK)
-	@$(OPERATOR_SDK) version
 
 # reading from a file and outputting to the same file can have undefined results, so use this intermediate
 IMAGE_TMP="/tmp/rook-ceph-image-list"


### PR DESCRIPTION
Since we removed the csv from rook,we don't need this tool anymore. Let's just remove all traces of the operator SDK from Rook

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16827


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
