### PR TITLE
helm: add cephclusters/finalizers permission for mgr sidecar

### DIFF
--- a/deploy/charts/library/templates/_cluster-role.tpl
+++ b/deploy/charts/library/templates/_cluster-role.tpl
@@ -61,6 +61,7 @@ rules:
     resources:
       - cephclients
       - cephclusters
+      - cephclusters/finalizers
       - cephblockpools
       - cephfilesystems
       - cephnfses

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -998,6 +998,7 @@ rules:
     resources:
       - cephclients
       - cephclusters
+      - cephclusters/finalizers
       - cephblockpools
       - cephfilesystems
       - cephnfses


### PR DESCRIPTION
The `watch-active` sidecar reconciles Services and wants to set `blockOwnerDeletion=true` in the `ownerReference`. On clusters with `OwnerReferencesPermissionEnforcement` admission controller this requires the cephclusters/finalizers permission.

For example, on OpenShift the `watch-active` sidecar is failing to update the `mgr_role` label because of the missing permission:
```
I | cephcmd: Checking mgr_role label value of daemon b (prev active mgr was )
E | cephcmd: failed to reconcile services. failed to set active mgr labels: unable to reconcile services: failed to create mgr metrics service: failed to create service rook-ceph-mgr. services "rook-ceph-mgr" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

Related issue that was fixed a few years ago for the OSD SA: #3567

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
