### PR TITLE
helm: merge rook-config-override ConfigMap into toolbox ceph.conf

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
 
               # create a ceph config file in its default location so ceph/rados tools can be used
               # without specifying any arguments
@@ -66,6 +67,13 @@ spec:
               [client.admin]
               keyring = ${KEYRING_FILE}
               EOF
+
+                # Merge the config override if it exists and is not empty
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
               }
 
               # watch the endpoints config file and update if the mon endpoints ever change
@@ -124,6 +132,9 @@ spec:
               mountPath: /etc/rook
             - name: ceph-admin-secret
               mountPath: /var/lib/rook-ceph-mon
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
       serviceAccountName: rook-ceph-default
       volumes:
         - name: ceph-admin-secret
@@ -139,6 +150,10 @@ spec:
             items:
               - key: data
                 path: mon-endpoints
+        - name: rook-config-override
+          configMap:
+            name: rook-config-override
+            optional: true
         - name: ceph-config
           emptyDir: {}
       tolerations:


### PR DESCRIPTION
This change mounts the rook-config-override ConfigMap in the helm chart toolbox and merges its contents into the generated ceph.conf, matching the behavior from PR https://github.com/rook/rook/pull/16731

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
