### PR TITLE
core: replace custom contains() with slices.Contains()

### DIFF
--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -367,13 +368,13 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "sgdisk" {
 				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
 			}
-			if contains(args, "lvm") && contains(args, "list") {
+			if slices.Contains(args, "lvm") && slices.Contains(args, "list") {
 				return `{}`, nil
 			}
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil
 			}
-			if contains(args, "raw") && contains(args, "list") {
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 				return fmt.Sprintf(`{
 				"0": {
 					"ceph_fsid": "%s",
@@ -393,7 +394,7 @@ func TestConfigureCVDevices(t *testing.T) {
 				args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "prepare" && args[6] == "--bluestore" && args[8] == "/mnt/set1-data-0-rpf2k" {
 				return "", nil
 			}
-			if contains(args, "lvm") && contains(args, "list") {
+			if slices.Contains(args, "lvm") && slices.Contains(args, "list") {
 				return `{}`, nil
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
@@ -2045,15 +2046,6 @@ func TestAllowRawMode(t *testing.T) {
 	}
 }
 
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-	return false
-}
-
 func TestAppendOSDInfo(t *testing.T) {
 	// Set 1: duplicate entries
 	{
@@ -2164,7 +2156,7 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
-		if contains(args, "raw") && contains(args, "list") {
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return cephVolumeRAWTestResult, nil
 		}
 		return "", errors.Errorf("unknown command %s %s", command, args)
@@ -2179,8 +2171,8 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 			return luksDump, nil
 		}
 
-		if contains(args, "zap") {
-			if !contains(args, devicePath) {
+		if slices.Contains(args, "zap") {
+			if !slices.Contains(args, devicePath) {
 				return "", errors.Errorf("device %s should not be zapped", devicePath)
 			}
 			return "", nil
@@ -2197,7 +2189,7 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	// `ceph-volume raw list` returns dmcrypt devices on "vdb" and "vdc" but only "vdb" should be zapped
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
-		if contains(args, "raw") && contains(args, "list") {
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return cephVolumeRAWEncryptedTestResult, nil
 		}
 		if command == cryptsetupBinary && args[0] == "status" && args[1] == "/dev/mapper/set2-data-0jkntr-block-dmcrypt" {
@@ -2223,7 +2215,7 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	// `ceph-volume raw list` returns empty but the expected device still has luks header with cephFSID from another cluster.
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
-		if contains(args, "raw") && contains(args, "list") {
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return `{}`, nil // return empty
 		}
 		return "", errors.Errorf("unknown command %s %s", command, args)

--- a/pkg/operator/ceph/controller/finalizer.go
+++ b/pkg/operator/ceph/controller/finalizer.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,17 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// contains checks if an item exists in a given list.
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
-}
 
 // remove removes any element from a list
 func remove(list []string, s string) []string {
@@ -60,7 +50,7 @@ func AddFinalizerIfNotPresent(ctx context.Context, client client.Client, obj cli
 		return false, errors.Wrap(err, "failed to get meta information of object")
 	}
 
-	if !contains(accessor.GetFinalizers(), objectFinalizer) {
+	if !slices.Contains(accessor.GetFinalizers(), objectFinalizer) {
 		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "adding finalizer %q", objectFinalizer)
 		accessor.SetFinalizers(append(accessor.GetFinalizers(), objectFinalizer))
 		originalGeneration := obj.GetGeneration()
@@ -94,7 +84,7 @@ func RemoveFinalizerWithName(ctx context.Context, client client.Client, obj clie
 		return errors.Wrap(err, "failed to get meta information of object")
 	}
 
-	if contains(accessor.GetFinalizers(), finalizerName) {
+	if slices.Contains(accessor.GetFinalizers(), finalizerName) {
 		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "removing finalizer %q", finalizerName)
 		accessor.SetFinalizers(remove(accessor.GetFinalizers(), finalizerName))
 		if err := client.Update(ctx, obj); err != nil {

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -182,41 +183,41 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 	if multiFS {
 		return &exectest.MockExecutor{
 			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-				if contains(args, "fs") && contains(args, "get") {
+				if slices.Contains(args, "fs") && slices.Contains(args, "get") {
 					if firstGet {
 						firstGet = false
 						return "", errors.New("fs doesn't exist")
 					}
 					return string(createdFsResponse), nil
-				} else if contains(args, "fs") && contains(args, "ls") {
+				} else if slices.Contains(args, "fs") && slices.Contains(args, "ls") {
 					return `[{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":4,"data_pool_ids":[5],"data_pools":["myfs-data0"]},{"name":"myfs2","metadata_pool":"myfs2-metadata","metadata_pool_id":6,"data_pool_ids":[7],"data_pools":["myfs2-data0"]},{"name":"leseb","metadata_pool":"cephfs.leseb.meta","metadata_pool_id":8,"data_pool_ids":[9],"data_pools":["cephfs.leseb.data"]}]`, nil
-				} else if contains(args, "fs") && contains(args, "dump") {
+				} else if slices.Contains(args, "fs") && slices.Contains(args, "dump") {
 					return `{"standbys":[], "filesystems":[]}`, nil
 				} else if reflect.DeepEqual(args[0:5], []string{"fs", "subvolumegroup", "create", fsName, defaultCSISubvolumeGroup}) {
 					return "", nil
-				} else if contains(args, "osd") && contains(args, "lspools") {
+				} else if slices.Contains(args, "osd") && slices.Contains(args, "lspools") {
 					return "[]", nil
-				} else if contains(args, "mds") && contains(args, "fail") {
+				} else if slices.Contains(args, "mds") && slices.Contains(args, "fail") {
 					return "", nil
 				} else if isBasePoolOperation(fsName, command, args) {
 					return "", nil
 				} else if reflect.DeepEqual(args[0:5], []string{"fs", "new", fsName, fsName + "-metadata", fsName + "-data0"}) {
 					return "", nil
-				} else if contains(args, "auth") && contains(args, "get-or-create-key") {
+				} else if slices.Contains(args, "auth") && slices.Contains(args, "get-or-create-key") {
 					return "{\"key\":\"mysecurekey\"}", nil
-				} else if contains(args, "auth") && contains(args, "del") {
+				} else if slices.Contains(args, "auth") && slices.Contains(args, "del") {
 					return "", nil
-				} else if contains(args, "config") && contains(args, "get") {
+				} else if slices.Contains(args, "config") && slices.Contains(args, "get") {
 					return "{}", nil
-				} else if contains(args, "config") && contains(args, "mds_cache_memory_limit") {
+				} else if slices.Contains(args, "config") && slices.Contains(args, "mds_cache_memory_limit") {
 					return "", nil
-				} else if contains(args, "set") && contains(args, "max_mds") {
+				} else if slices.Contains(args, "set") && slices.Contains(args, "max_mds") {
 					return "", nil
-				} else if contains(args, "set") && contains(args, "allow_standby_replay") {
+				} else if slices.Contains(args, "set") && slices.Contains(args, "allow_standby_replay") {
 					return "", nil
-				} else if contains(args, "config") && contains(args, "mds_join_fs") {
+				} else if slices.Contains(args, "config") && slices.Contains(args, "mds_join_fs") {
 					return "", nil
-				} else if contains(args, "flag") && contains(args, "enable_multiple") {
+				} else if slices.Contains(args, "flag") && slices.Contains(args, "enable_multiple") {
 					return "", nil
 				} else if reflect.DeepEqual(args[0:5], []string{"osd", "crush", "rule", "create-replicated", fsName + "-data1"}) {
 					return "", nil
@@ -240,7 +241,7 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 					return "", nil
 				} else if reflect.DeepEqual(args[0:3], []string{"osd", "pool", "get"}) {
 					return "", errors.New("test pool does not exist yet")
-				} else if contains(args, "versions") {
+				} else if slices.Contains(args, "versions") {
 					versionStr, _ := json.Marshal(
 						map[string]map[string]int{
 							"mds": {
@@ -261,45 +262,45 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 
 	return &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-			if contains(args, "fs") && contains(args, "get") {
+			if slices.Contains(args, "fs") && slices.Contains(args, "get") {
 				if firstGet {
 					firstGet = false
 					return "", errors.New("fs doesn't exist")
 				}
 				return string(createdFsResponse), nil
-			} else if contains(args, "fs") && contains(args, "ls") {
+			} else if slices.Contains(args, "fs") && slices.Contains(args, "ls") {
 				return "[]", nil
-			} else if contains(args, "fs") && contains(args, "dump") {
+			} else if slices.Contains(args, "fs") && slices.Contains(args, "dump") {
 				return `{"standbys":[], "filesystems":[]}`, nil
 			} else if reflect.DeepEqual(args[0:5], []string{"fs", "subvolumegroup", "create", fsName, defaultCSISubvolumeGroup}) {
 				return "", nil
 			} else if reflect.DeepEqual(args[0:5], []string{"fs", "subvolumegroup", "info", fsName, defaultCSISubvolumeGroup}) {
 				return "", nil
-			} else if contains(args, "osd") && contains(args, "lspools") {
+			} else if slices.Contains(args, "osd") && slices.Contains(args, "lspools") {
 				return "[]", nil
-			} else if contains(args, "mds") && contains(args, "fail") {
+			} else if slices.Contains(args, "mds") && slices.Contains(args, "fail") {
 				return "", nil
 			} else if isBasePoolOperation(fsName, command, args) {
 				return "", nil
 			} else if reflect.DeepEqual(args[0:5], []string{"fs", "new", fsName, fsName + "-metadata", fsName + "-data0"}) {
 				return "", nil
-			} else if contains(args, "auth") && contains(args, "get-or-create-key") {
+			} else if slices.Contains(args, "auth") && slices.Contains(args, "get-or-create-key") {
 				return "{\"key\":\"mysecurekey\"}", nil
-			} else if contains(args, "auth") && contains(args, "del") {
+			} else if slices.Contains(args, "auth") && slices.Contains(args, "del") {
 				return "", nil
-			} else if contains(args, "auth") && contains(args, "rotate") {
+			} else if slices.Contains(args, "auth") && slices.Contains(args, "rotate") {
 				return `[{"key":"myrotatedkey"}]`, nil
-			} else if contains(args, "config") && contains(args, "mds_cache_memory_limit") {
+			} else if slices.Contains(args, "config") && slices.Contains(args, "mds_cache_memory_limit") {
 				return "", nil
-			} else if contains(args, "set") && contains(args, "max_mds") {
+			} else if slices.Contains(args, "set") && slices.Contains(args, "max_mds") {
 				return "", nil
-			} else if contains(args, "set") && contains(args, "allow_standby_replay") {
+			} else if slices.Contains(args, "set") && slices.Contains(args, "allow_standby_replay") {
 				return "", nil
-			} else if contains(args, "config") && contains(args, "mds_join_fs") {
+			} else if slices.Contains(args, "config") && slices.Contains(args, "mds_join_fs") {
 				return "", nil
-			} else if contains(args, "flag") && contains(args, "enable_multiple") {
+			} else if slices.Contains(args, "flag") && slices.Contains(args, "enable_multiple") {
 				return "", nil
-			} else if contains(args, "config") && contains(args, "get") {
+			} else if slices.Contains(args, "config") && slices.Contains(args, "get") {
 				return "{}", nil
 			} else if reflect.DeepEqual(args[0:5], []string{"osd", "crush", "rule", "create-replicated", fsName + "-data1"}) {
 				return "", nil
@@ -325,7 +326,7 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 			} else if reflect.DeepEqual(args[0:4], []string{"fs", "add_data_pool", fsName, fsName + "-named-pool"}) {
 				*addDataPoolCount++
 				return "", nil
-			} else if contains(args, "versions") {
+			} else if slices.Contains(args, "versions") {
 				versionStr, _ := json.Marshal(
 					map[string]map[string]int{
 						"mds": {
@@ -512,23 +513,23 @@ func TestUpgradeFilesystem(t *testing.T) {
 			},
 		})
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-		if contains(args, "fs") {
-			if contains(args, "get") {
+		if slices.Contains(args, "fs") {
+			if slices.Contains(args, "get") {
 				return string(createdFsResponse), nil
-			} else if contains(args, "ls") {
+			} else if slices.Contains(args, "ls") {
 				return "[]", nil
-			} else if contains(args, "dump") {
+			} else if slices.Contains(args, "dump") {
 				return `{"standbys":[], "filesystems":[]}`, nil
-			} else if contains(args, "subvolumegroup") {
+			} else if slices.Contains(args, "subvolumegroup") {
 				return "[]", nil
 			}
 		}
-		if contains(args, "osd") {
-			if contains(args, "lspools") {
+		if slices.Contains(args, "osd") {
+			if slices.Contains(args, "lspools") {
 				return "[]", nil
 			}
-			if contains(args, "pool") && contains(args, "application") {
-				if contains(args, "get") {
+			if slices.Contains(args, "pool") && slices.Contains(args, "application") {
+				if slices.Contains(args, "get") {
 					return `{"":{}}`, nil
 				}
 				return "[]", nil
@@ -537,7 +538,7 @@ func TestUpgradeFilesystem(t *testing.T) {
 				return "", errors.New("test pool does not exist yet")
 			}
 		}
-		if contains(args, "mds") && contains(args, "fail") {
+		if slices.Contains(args, "mds") && slices.Contains(args, "fail") {
 			return "", errors.New("fail mds failed")
 		}
 		if isBasePoolOperation(fsName, command, args) {
@@ -546,30 +547,30 @@ func TestUpgradeFilesystem(t *testing.T) {
 		if reflect.DeepEqual(args[0:5], []string{"fs", "new", fsName, fsName + "-metadata", fsName + "-data0"}) {
 			return "", nil
 		}
-		if contains(args, "auth") {
-			if contains(args, "get-or-create-key") {
+		if slices.Contains(args, "auth") {
+			if slices.Contains(args, "get-or-create-key") {
 				return "{\"key\":\"mysecurekey\"}", nil
-			} else if contains(args, "auth") && contains(args, "del") {
+			} else if slices.Contains(args, "auth") && slices.Contains(args, "del") {
 				return "", nil
 			}
 		}
-		if contains(args, "config") {
-			if contains(args, "mds_cache_memory_limit") {
+		if slices.Contains(args, "config") {
+			if slices.Contains(args, "mds_cache_memory_limit") {
 				return "", nil
-			} else if contains(args, "mds_join_fs") {
+			} else if slices.Contains(args, "mds_join_fs") {
 				return "", nil
-			} else if contains(args, "get") {
+			} else if slices.Contains(args, "get") {
 				return "{}", nil
 			}
 		}
-		if contains(args, "set") {
-			if contains(args, "max_mds") {
+		if slices.Contains(args, "set") {
+			if slices.Contains(args, "max_mds") {
 				return "", nil
-			} else if contains(args, "allow_standby_replay") {
+			} else if slices.Contains(args, "allow_standby_replay") {
 				return "", nil
 			}
 		}
-		if contains(args, "versions") {
+		if slices.Contains(args, "versions") {
 			return string(mockedVersionStr), nil
 		}
 		assert.Fail(t, fmt.Sprintf("Unexpected command %q %q", command, args))
@@ -627,15 +628,6 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, ownerInfo, "/var/lib/rook/", false)
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
-}
-
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-	return false
 }
 
 func validateStart(ctx context.Context, t *testing.T, context *clusterd.Context, fs cephv1.CephFilesystem) {

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -585,7 +586,7 @@ func generateStatsPoolList(existingStatsPools []string, rookStatsPools []string,
 			return
 		}
 		// Check if the pool should be removed or already exists in poolList
-		if contains(removePools, pool) || contains(poolList, pool) {
+		if slices.Contains(removePools, pool) || slices.Contains(poolList, pool) {
 			return
 		}
 		poolList = append(poolList, pool)
@@ -600,16 +601,6 @@ func generateStatsPoolList(existingStatsPools []string, rookStatsPools []string,
 	sort.Strings(poolList) // Sort the list to ensure deterministic output
 
 	return strings.Join(poolList, ",")
-}
-
-// Helper function to check if a slice contains a string
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }
 
 func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient.ClusterInfo, deletedPool string) error {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Summary:**
This PR removes duplicate `contains()` implementations and uses the standard library `slices.Contains()` function instead.

- Removed `contains()` from `pkg/daemon/ceph/osd/volume_test.go`
- Replaced `contains()` usage in `pkg/daemon/ceph/osd/volume_test.go` with `slices.Contains()`
- Removed `contains()` from `pkg/operator/ceph/controller/finalizer.go`
- Replaced `contains()` usage in `pkg/operator/ceph/controller/finalizer.go` with `slices.Contains()`
- Removed `contains()` from `pkg/operator/ceph/file/filesystem_test.go`
- Replaced `contains()` usage in `pkg/operator/ceph/file/filesystem_test.go` with `slices.Contains()`
- Removed `contains()` from `pkg/operator/ceph/pool/controller.go`
- Replaced `contains()` usage in `pkg/operator/ceph/pool/controller.go` with `slices.Contains()`

**Issue resolved by this Pull Request:**
Resolves #16871

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
