### PR TITLE
core: allow skipping cephcluster reconcile via do-not-reconcile label

### DIFF
--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -210,7 +210,25 @@ func watchControllerPredicate[T *cephv1.CephCluster](ctx context.Context, c clie
 			objNew := (*cephv1.CephCluster)(e.ObjectNew)
 
 			log.NamespacedDebug(objNew.Namespace, logger, "update event on CephCluster CR")
-			// If the labels "do_not_reconcile" is set on the object, let's not reconcile that request
+			// If the user sets the skip-reconcile label, avoid doing anything (including manager reloads)
+			// for this CephCluster.
+			//
+			// However, we still want to trigger a reconcile when the label is added/removed so the
+			// controller can early-exit and record a "ReconcileSkipped" event (when label is added),
+			// and also resume reconciliation immediately when the label is removed.
+			_, oldHasSkipLabel := objOld.GetLabels()[cephv1.SkipReconcileLabelKey]
+			_, newHasSkipLabel := objNew.GetLabels()[cephv1.SkipReconcileLabelKey]
+			if oldHasSkipLabel != newHasSkipLabel {
+				log.NamespacedDebug(objNew.Namespace, logger, "CephCluster %q skip-reconcile label changed (%v -> %v); triggering reconcile", objNew.Name, oldHasSkipLabel, newHasSkipLabel)
+				return true
+			}
+			if newHasSkipLabel {
+				log.NamespacedInfo(objNew.Namespace, logger, "object %q matched on update but %q label is set, doing nothing", objNew.Name, cephv1.SkipReconcileLabelKey)
+				return false
+			}
+
+			// Backwards/alternative label used by some controllers to avoid reconciling an object.
+			// If this label is set on the object, let's not reconcile that request.
 			if opcontroller.IsDoNotReconcile(objNew.GetLabels()) {
 				log.NamespacedDebug(objNew.Namespace, logger, "object %q matched on update but %q label is set, doing nothing", opcontroller.DoNotReconcileLabelName, objNew.Name)
 				return false


### PR DESCRIPTION
add support for `ceph.rook.io/do-not-reconcile` on cephcluster crs skip reconcile early and emit a normal reconcile-skipped event avoid reloadmanager on updates for labeled cephclusters add unit test for skip behavior

#16597

**Test Process:**
```
0) Tested on minikube with 2 cephclusters
$ kubectl get pods -A
NAMESPACE             NAME                                                       READY   STATUS      RESTARTS   AGE
rook-ceph-cluster     rook-ceph-exporter-minikube-dc8d7d9cb-cpdtp                1/1     Running     0          26m
rook-ceph-cluster     rook-ceph-mgr-a-764496c79d-8lgm7                           1/1     Running     0          4h59m
rook-ceph-cluster     rook-ceph-mon-a-5f77c57b8-l9jj6                            1/1     Running     0          4h59m
rook-ceph-cluster     rook-ceph-osd-0-578579947f-6d8wb                           1/1     Running     0          141m
rook-ceph-cluster     rook-ceph-osd-prepare-minikube-sc6xd                       0/1     Completed   0          3m29s
rook-ceph-secondary   rook-ceph-exporter-minikube-7667b6665c-5h797               1/1     Running     0          26m
rook-ceph-secondary   rook-ceph-mgr-a-58ff6b6fdf-8qpgm                           1/1     Running     0          4h57m
rook-ceph-secondary   rook-ceph-mon-a-7dff9548b8-fwklz                           1/1     Running     0          4h58m
rook-ceph-secondary   rook-ceph-osd-0-6885db454-zgrtz                            1/1     Running     0          140m
rook-ceph-secondary   rook-ceph-osd-prepare-minikube-stpws                       0/1     Completed   0          8m19s
rook-ceph             ceph-csi-controller-manager-675cd9dcf5-vjh22               1/1     Running     0          5h1m
rook-ceph             rook-ceph-operator-5c96647fbf-mqjdg                        1/1     Running     0          9m16s
rook-ceph             rook-ceph.cephfs.csi.ceph.com-ctrlplugin-fb4556c6d-9qpjm   5/5     Running     0          4h59m
rook-ceph             rook-ceph.cephfs.csi.ceph.com-nodeplugin-6c455             2/2     Running     0          4h59m
rook-ceph             rook-ceph.rbd.csi.ceph.com-ctrlplugin-85bfc6699d-pfvbv     5/5     Running     0          4h59m
rook-ceph             rook-ceph.rbd.csi.ceph.com-nodeplugin-n5vqh                2/2     Running     0          4h59m

$ kubectl get cephclusters.ceph.rook.io -A
NAMESPACE             NAME           DATADIRHOSTPATH          MONCOUNT   AGE    PHASE   MESSAGE                        HEALTH      EXTERNAL   FSID
rook-ceph-cluster     my-cluster-1   /var/lib/rook/cluster1   1          5h1m   Ready   Cluster created successfully   HEALTH_OK              3acb8e83-91ab-437f-a7ba-4dc28429968c
rook-ceph-secondary   my-cluster-2   /var/lib/rook/cluster2   1          5h1m   Ready   Cluster created successfully   HEALTH_OK              d77a1bc3-a0c6-4a4c-be89-e7fc0da3c138

1) Enable “skip reconcile” for ONLY cluster1
$ kubectl -n rook-ceph-cluster label cephcluster my-cluster-1 ceph.rook.io/do-not-reconcile=true --overwrite
cephcluster.ceph.rook.io/my-cluster-1 labeled

2) Trigger reconcile attempts on BOTH clusters
$ kubectl patch cm rook-ceph-operator-config -n rook-ceph --type merge -p '{"data":{"ROOK_LOG_LEVEL":"DEBUG"}}'
configmap/rook-ceph-operator-config patched

$ kubectl -n rook-ceph-cluster label cephcluster my-cluster-1 \
  test-trigger="$(date +%s)" --overwrite
cephcluster.ceph.rook.io/my-cluster-1 labeled

$ kubectl -n rook-ceph-secondary label cephcluster my-cluster-2 \
  test-trigger="$(date +%s)" --overwrite
cephcluster.ceph.rook.io/my-cluster-2 labeled

3) Verify logs (cluster1 skipped, cluster2 continues)
$ kubectl -n rook-ceph logs deploy/rook-ceph-operator --since=10m | \
  grep -E 'skip-reconcile label changed|skipping reconcile of CephCluster|recorded event "ReconcileSkipped"|reconciling ceph cluster|matched on update but "ceph.rook.io/do-not-reconcile" label is set'
2026-01-01 14:41:56.967132 I | cluster-controller: [rook-ceph-cluster/my-cluster-1] reconciling ceph cluster
2026-01-01 14:42:10.695619 D | cluster-controller: [rook-ceph-cluster] CephCluster "my-cluster-1" skip-reconcile label changed (false -> true); triggering reconcile
2026-01-01 14:42:19.585831 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:42:20.718321 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:42:24.631114 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:42:29.106857 I | cluster-controller: [rook-ceph-cluster] done reconciling ceph cluster
2026-01-01 14:42:29.123632 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:42:29.124021 I | cluster-controller: [rook-ceph-secondary/my-cluster-2] reconciling ceph cluster
2026-01-01 14:42:38.339843 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:42:56.781671 I | cluster-controller: [rook-ceph-secondary] done reconciling ceph cluster
2026-01-01 14:42:56.794408 I | cluster-controller: [rook-ceph-cluster] skipping reconcile of CephCluster "my-cluster-1" since label "ceph.rook.io/do-not-reconcile" is set
2026-01-01 14:42:56.794416 I | cluster-controller: [rook-ceph-cluster] recorded event "ReconcileSkipped" for CephCluster "my-cluster-1" (label "ceph.rook.io/do-not-reconcile" is set)
2026-01-01 14:42:58.284184 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing
2026-01-01 14:43:59.011464 D | cluster-controller: [rook-ceph-cluster] object "my-cluster-1" matched on update but "ceph.rook.io/do-not-reconcile" label is set, doing nothing

4) Verify events for cluster1 (ReconcileSkipped should appear)
$ kubectl -n rook-ceph-cluster get events --sort-by=.lastTimestamp | \
  grep -E 'my-cluster-1|ReconcileSkipped|ReconcileSucceeded' || true
21m         Normal   ReconcileSkipped     cephcluster/my-cluster-1                            Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster
19m         Normal   ReconcileSucceeded   cephblockpool/builtin-mgr                           successfully configured CephBlockPool "rook-ceph-cluster/builtin-mgr"
19m         Normal   ReconcileSucceeded   cephblockpool/replicapool                           successfully configured CephBlockPool "rook-ceph-cluster/replicapool"
18m         Normal   ReconcileSucceeded   cephcluster/my-cluster-1                            successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
3m42s       Normal   ReconcileSucceeded   cephblockpool/builtin-mgr                           successfully configured CephBlockPool "rook-ceph-cluster/builtin-mgr"
3m39s       Normal   ReconcileSucceeded   cephblockpool/replicapool                           successfully configured CephBlockPool "rook-ceph-cluster/replicapool"
2m54s       Normal   ReconcileSucceeded   cephcluster/my-cluster-1                            successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
2m54s       Normal   ReconcileSkipped     cephcluster/my-cluster-1                            Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster

$ kubectl -n rook-ceph-cluster describe cephcluster my-cluster-1 | sed -n '/Events:/,$p'
Events:
  Type    Reason              Age                    From                          Message
  ----    ------              ----                   ----                          -------
  Normal  ReconcileSkipped    21m                    rook-ceph-cluster-controller  Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster
  Normal  ReconcileSucceeded  19m (x2 over 21m)      rook-ceph-cluster-controller  successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
  Normal  ReconcileSucceeded  3m24s (x2 over 3m51s)  rook-ceph-cluster-controller  successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
  Normal  ReconcileSkipped    3m24s                  rook-ceph-cluster-controller  Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster
  
5) Re-enable reconcile (remove the label)
$ kubectl -n rook-ceph-cluster label cephcluster my-cluster-1  ceph.rook.io/do-not-reconcile-
cephcluster.ceph.rook.io/my-cluster-1 unlabeled

6) Trigger reconcile again for cluster1
$ kubectl -n rook-ceph-cluster label cephcluster my-cluster-1 test-trigger="$(date +%s)" --overwrite
cephcluster.ceph.rook.io/my-cluster-1 labeled

7) Verify reconcile resumed (look at newest events; don't rely on "Age")
$ kubectl -n rook-ceph-cluster describe cephcluster my-cluster-1 | sed -n '/Events:/,$p'
Events:
  Type    Reason              Age                  From                          Message
  ----    ------              ----                 ----                          -------
  Normal  ReconcileSkipped    24m                  rook-ceph-cluster-controller  Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster
  Normal  ReconcileSucceeded  22m (x2 over 24m)    rook-ceph-cluster-controller  successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
  Normal  ReconcileSkipped    6m19s                rook-ceph-cluster-controller  Skipping reconcile because label "ceph.rook.io/do-not-reconcile" is set on the CephCluster
  Normal  ReconcileSucceeded  90s (x3 over 6m46s)  rook-ceph-cluster-controller  successfully configured CephCluster "rook-ceph-cluster/my-cluster-1"
```

**Script to create two CephClusters managed by a single Rook operator**
```
#!/usr/bin/env bash
set -euo pipefail

# Usage:
#   ./deploy-multi-ceph.sh
#   ./deploy-multi-ceph.sh <TAG>
#
# Behavior:
# - If TAG is NOT provided: uses the stock operator image from deploy/examples/operator.yaml
# - If TAG IS provided: generates a custom operator YAML in a random directory and sets the operator image to a private image

TAG="${1:-}"

REPO_ROOT="/home/oviner/go/src/github.com/rook/rook"
EXAMPLES_DIR="${REPO_ROOT}/deploy/examples"

ROOK_OPERATOR_NAMESPACE="rook-ceph"
CLUSTER1_NS="rook-ceph-cluster"
CLUSTER2_NS="rook-ceph-secondary"

# Private operator image repo to use when TAG is provided
# Override if desired:
#   ROOK_PRIVATE_IMAGE_REPO=quay.io/<you>/rook ./deploy-multi-ceph.sh <TAG>
ROOK_PRIVATE_IMAGE_REPO="${ROOK_PRIVATE_IMAGE_REPO:-quay.io/oviner/rook}"

OUT_DIR="$(mktemp -d -p /tmp rook-multi-ceph-XXXXXXXX)"
echo "Generated manifests dir: ${OUT_DIR}"

echo "Deleting minikube..."
minikube delete --all --purge || true

echo "Starting minikube..."
minikube start --disk-size=20g --extra-disks=2 --driver=qemu2

echo "Waiting for Kubernetes API..."
until kubectl get nodes >/dev/null 2>&1; do
  sleep 2
done

echo "Creating operator namespace: ${ROOK_OPERATOR_NAMESPACE}"
kubectl create namespace "${ROOK_OPERATOR_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -

echo "Copying base manifests..."
cp -a "${EXAMPLES_DIR}/crds.yaml" "${OUT_DIR}/crds.yaml"
cp -a "${EXAMPLES_DIR}/common.yaml" "${OUT_DIR}/common-${CLUSTER1_NS}.yaml"
cp -a "${EXAMPLES_DIR}/common-second-cluster.yaml" "${OUT_DIR}/common-${CLUSTER2_NS}.yaml"
cp -a "${EXAMPLES_DIR}/operator.yaml" "${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
cp -a "${EXAMPLES_DIR}/csi-operator.yaml" "${OUT_DIR}/csi-operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
cp -a "${EXAMPLES_DIR}/cluster-test.yaml" "${OUT_DIR}/cluster1.yaml"
cp -a "${EXAMPLES_DIR}/cluster-test.yaml" "${OUT_DIR}/cluster2.yaml"

echo "Patching namespaces (operator + cluster1)..."
sed -i.bak \
  -e "s/\(.*\):.*# namespace:operator/\1: ${ROOK_OPERATOR_NAMESPACE} # namespace:operator/g" \
  -e "s/\(.*\):.*# namespace:cluster/\1: ${CLUSTER1_NS} # namespace:cluster/g" \
  -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:operator/\1:${ROOK_OPERATOR_NAMESPACE}:\2 # serviceaccount:namespace:operator/g" \
  -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:cluster/\1:${CLUSTER1_NS}:\2 # serviceaccount:namespace:cluster/g" \
  "${OUT_DIR}/common-${CLUSTER1_NS}.yaml" \
  "${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml" \
  "${OUT_DIR}/cluster1.yaml"

echo "Patching namespaces (cluster2 RBAC + cluster2)..."
sed -i.bak \
  -e "s/\(.*\):.*# namespace:operator/\1: ${ROOK_OPERATOR_NAMESPACE} # namespace:operator/g" \
  -e "s/\(.*\):.*# namespace:cluster/\1: ${CLUSTER2_NS} # namespace:cluster/g" \
  "${OUT_DIR}/common-${CLUSTER2_NS}.yaml" \
  "${OUT_DIR}/cluster2.yaml"

echo "Customizing CephCluster names + disks..."

# Replace the storage devices section in a YAML-safe way (real newlines, correct indentation).
# Requires: awk (gawk on Fedora).
set_cluster_device() {
  local file="$1"
  local dev="$2"
  local tmp="${file}.tmp"

  awk -v dev="${dev}" '
    {
      # Replace the first occurrence only
      if (!done && $0 ~ /^[[:space:]]*useAllDevices:[[:space:]]*true[[:space:]]*$/) {
        match($0, /^([[:space:]]*)useAllDevices:/, m)
        indent = m[1]
        print indent "useAllDevices: false"
        print indent "devices:"
        print indent "  - name: \"" dev "\""
        done = 1
        next
      }
      print
    }
    END {
      if (!done) exit 2
    }
  ' "${file}" > "${tmp}" && mv "${tmp}" "${file}"
}

# cluster1: unique name, separate dataDirHostPath, use vda only
sed -i.bak \
  -e "s/^  name: my-cluster$/  name: my-cluster-1/g" \
  -e "s|^  dataDirHostPath: /var/lib/rook$|  dataDirHostPath: /var/lib/rook/cluster1|g" \
  "${OUT_DIR}/cluster1.yaml"
set_cluster_device "${OUT_DIR}/cluster1.yaml" "vda"

# cluster2: unique name, separate dataDirHostPath, use vdb only
sed -i.bak \
  -e "s/^  name: my-cluster$/  name: my-cluster-2/g" \
  -e "s|^  dataDirHostPath: /var/lib/rook$|  dataDirHostPath: /var/lib/rook/cluster2|g" \
  "${OUT_DIR}/cluster2.yaml"
set_cluster_device "${OUT_DIR}/cluster2.yaml" "vdb"

OPERATOR_TO_APPLY="${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml"

if [[ -n "${TAG}" ]]; then
  echo "Using private operator image: ${ROOK_PRIVATE_IMAGE_REPO}:${TAG}"
  # Replace the operator container image line. Keep the leading indentation.
  sed -i.bak \
    -e "s|^\\(\\s*image:\\s*\\).*rook/ceph:.*$|\\1${ROOK_PRIVATE_IMAGE_REPO}:${TAG}|g" \
    "${OPERATOR_TO_APPLY}"

  # Ensure imagePullPolicy: Always is present under the operator container (indented 10 spaces in the sample).
  if ! grep -q '^[[:space:]]*imagePullPolicy:[[:space:]]*Always[[:space:]]*$' "${OPERATOR_TO_APPLY}"; then
    sed -i.bak \
      -e "/^[[:space:]]*image:[[:space:]]*${ROOK_PRIVATE_IMAGE_REPO//\//\\/}:${TAG}$/a\\
\\          imagePullPolicy: Always" \
      "${OPERATOR_TO_APPLY}"
  fi
else
  echo "No TAG provided; using stock operator image from examples."
fi

echo "Generating per-cluster pool + StorageClass manifests..."
cat > "${OUT_DIR}/storageclass-rbd-${CLUSTER1_NS}.yaml" <<EOF
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: replicapool
  namespace: ${CLUSTER1_NS}
spec:
  failureDomain: host
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: rook-ceph-block-cluster1
provisioner: ${ROOK_OPERATOR_NAMESPACE}.rbd.csi.ceph.com
parameters:
  clusterID: ${CLUSTER1_NS}
  pool: replicapool
  imageFormat: "2"
  imageFeatures: layering
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-publish-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/fstype: ext4
allowVolumeExpansion: true
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOF

cat > "${OUT_DIR}/storageclass-rbd-${CLUSTER2_NS}.yaml" <<EOF
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: replicapool
  namespace: ${CLUSTER2_NS}
spec:
  failureDomain: host
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: rook-ceph-block-cluster2
provisioner: ${ROOK_OPERATOR_NAMESPACE}.rbd.csi.ceph.com
parameters:
  clusterID: ${CLUSTER2_NS}
  pool: replicapool
  imageFormat: "2"
  imageFeatures: layering
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-publish-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/fstype: ext4
allowVolumeExpansion: true
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOF

echo "Applying manifests..."
kubectl apply -f "${OUT_DIR}/crds.yaml"
kubectl apply -f "${OUT_DIR}/common-${CLUSTER1_NS}.yaml"
kubectl apply -f "${OUT_DIR}/csi-operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
kubectl apply -f "${OPERATOR_TO_APPLY}"

kubectl -n "${ROOK_OPERATOR_NAMESPACE}" wait --for=condition=available deployment/rook-ceph-operator --timeout=300s
kubectl -n "${ROOK_OPERATOR_NAMESPACE}" wait --for=condition=available deployment/ceph-csi-controller-manager --timeout=300s

kubectl apply -f "${OUT_DIR}/cluster1.yaml"
kubectl apply -f "${OUT_DIR}/common-${CLUSTER2_NS}.yaml"
kubectl apply -f "${OUT_DIR}/cluster2.yaml"

kubectl apply -f "${OUT_DIR}/storageclass-rbd-${CLUSTER1_NS}.yaml"
kubectl apply -f "${OUT_DIR}/storageclass-rbd-${CLUSTER2_NS}.yaml"

echo "Done."
echo "Generated YAMLs: ${OUT_DIR}"
echo "StorageClasses:"
echo "  - rook-ceph-block-cluster1 (cluster namespace: ${CLUSTER1_NS})"
echo "  - rook-ceph-block-cluster2 (cluster namespace: ${CLUSTER2_NS})"

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
