### PR TITLE
external: if admin creds is provided stop creating csi secret

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,6 +6,10 @@
     When set to `false`, the standby MDS daemon deployment will be scaled down and removed,
     rather than only disabling the standby cache while the daemon remains running.
 
+- Now rook operator won't create the csi user and secrets for external mode when admin keyring is used.
+  There will be a single source of truth. The python script will be responsible for creating the ceph user
+  and the import script will handle creating the kubernetes secrets for ceph user.  [PR](https://github.com/rook/rook/pull/16882)
+
 ## Features
 
 - Experimental: Allow concurrent reconciles of the CephCluster CR when there multiple clusters

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1863,8 +1863,7 @@ class RadosJSON:
                     },
                 }
             )
-
-        # if 'CSI_RBD_NODE_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
+        # if 'CSI_RBD_NODE_SECRET' && 'CSI_RBD_NODE_SECRET_NAME' exists, then only add 'rook-csi-rbd-node' Secret
         if (
             self.out_map["CSI_RBD_NODE_SECRET"]
             and self.out_map["CSI_RBD_NODE_SECRET_NAME"]
@@ -1881,7 +1880,7 @@ class RadosJSON:
                     },
                 }
             )
-        # if 'CSI_RBD_PROVISIONER_SECRET' exists, then only add 'rook-csi-rbd-provisioner' Secret
+        # if 'CSI_RBD_PROVISIONER_SECRET' && 'CSI_RBD_PROVISIONER_SECRET_NAME' exists, then only add 'rook-csi-rbd-provisioner' Secret
         if (
             self.out_map["CSI_RBD_PROVISIONER_SECRET"]
             and self.out_map["CSI_RBD_PROVISIONER_SECRET_NAME"]
@@ -1892,13 +1891,14 @@ class RadosJSON:
                     "kind": "Secret",
                     "data": {
                         "userID": self.get_user_id(
-                            self.out_map["CSI_RBD_PROVISIONER_SECRET_NAME"], generation
+                            self.out_map["CSI_RBD_PROVISIONER_SECRET_NAME"],
+                            generation,
                         ),
                         "userKey": self.out_map["CSI_RBD_PROVISIONER_SECRET"],
                     },
                 }
             )
-        # if 'CSI_CEPHFS_PROVISIONER_SECRET' exists, then only add 'rook-csi-cephfs-provisioner' Secret
+        # if 'CSI_CEPHFS_PROVISIONER_SECRET' && 'CSI_CEPHFS_PROVISIONER_SECRET_NAME' exists, then only add 'rook-csi-cephfs-provisioner' Secret
         if (
             self.out_map["CSI_CEPHFS_PROVISIONER_SECRET"]
             and self.out_map["CSI_CEPHFS_PROVISIONER_SECRET_NAME"]
@@ -1916,7 +1916,7 @@ class RadosJSON:
                     },
                 }
             )
-        # if 'CSI_CEPHFS_NODE_SECRET' exists, then only add 'rook-csi-cephfs-node' Secret
+        # if 'CSI_CEPHFS_NODE_SECRET' && 'CSI_CEPHFS_NODE_SECRET_NAME' exists, then only add 'rook-csi-cephfs-node' Secret
         if (
             self.out_map["CSI_CEPHFS_NODE_SECRET"]
             and self.out_map["CSI_CEPHFS_NODE_SECRET_NAME"]

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -101,14 +101,6 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 	log.NamespacedInfo(cluster.Namespace, logger, "external cluster identity established")
 
-	// Create CSI Secrets only if the user has provided the admin key
-	if cluster.ClusterInfo.CephCred.Username == client.AdminUsername {
-		err = csi.CreateCSISecrets(c.context, cluster.ClusterInfo, cluster.namespacedName)
-		if err != nil {
-			return errors.Wrap(err, "failed to create csi kubernetes secrets")
-		}
-	}
-
 	// update the msgr2 flag
 	for _, m := range cluster.ClusterInfo.InternalMonitors {
 		// m.Endpoint=10.1.115.104:3300


### PR DESCRIPTION
if admin secret is created stop creating csi secret from
the rook operator

the csi creds and secret will still be created by the python and
the import script

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
