### PR TITLE
object: fix duplicate statements in ModifyBucketPolicy

### DIFF
--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -203,6 +203,8 @@ func (bp *BucketPolicy) ModifyBucketPolicy(ps ...PolicyStatement) *BucketPolicy 
 		for j, oldP := range bp.Statement {
 			if newP.Sid == oldP.Sid {
 				bp.Statement[j] = newP
+				match = true
+				break
 			}
 		}
 		if !match {


### PR DESCRIPTION
### Description
Fix `BucketPolicy.ModifyBucketPolicy` to correctly detect existing policy statements by `Sid` and replace them instead of appending duplicates.

Previously, the `match` flag was never set when a matching `Sid` was found, causing the function to both overwrite the existing statement and append a new one. This resulted in duplicate policy statements in the final bucket policy.

This change ensures that:
- Statements with matching `Sid` are replaced in place
- New statements are only appended when no match exists

<!--
**Issue resolved by this Pull Request:**
Resolves #
-->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the developer guide.
- [x] Reviewed the developer guide on Submitting a Pull Request.
- [ ] Pending release notes updated (not required for a bug fix with no user-facing or breaking changes).
- [ ] Documentation updated (not required).
- [ ] Unit tests added (not added; change is a small logic fix verified by manual inspection).
- [ ] Integration tests added (not required).
