### PR TITLE
object: add new caps in tentacle to ceph object store user crd

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -60,3 +60,5 @@ spec:
     * `user-policy`
     * `odic-provider`
     * `ratelimit`
+    * `user-info-without-keys`
+    * `accounts` # minimum ceph version 19.2.3 for supporting this cap

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -13896,6 +13896,16 @@ spec:
                   description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
+                    accounts:
+                      description: |-
+                        Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.3) onwards
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
                     amz-cache:
                       description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api
                       enum:
@@ -13994,6 +14004,14 @@ spec:
                       type: string
                     user:
                       description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
+                    user-info-without-keys:
+                      description: Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
                       enum:
                         - '*'
                         - read

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -13886,6 +13886,16 @@ spec:
                   description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
+                    accounts:
+                      description: |-
+                        Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.3) onwards
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
                     amz-cache:
                       description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api
                       enum:
@@ -13984,6 +13994,14 @@ spec:
                       type: string
                     user:
                       description: Admin capabilities to read/write Ceph object store users. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
+                    user-info-without-keys:
+                      description: Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
                       enum:
                         - '*'
                         - read

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2336,6 +2336,15 @@ type ObjectUserCapSpec struct {
 	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
 	// Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
 	RateLimit string `json:"ratelimit,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
+	// Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+	UserInfoWithoutKeys string `json:"user-info-without-keys,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
+	// Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+	// Note: Only supported from Ceph Squid (v19.2.3) onwards
+	Accounts string `json:"accounts,omitempty"`
 }
 
 // ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -620,6 +620,12 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) *admin.User {
 		if user.Spec.Capabilities.RateLimit != "" {
 			userConfig.UserCaps += fmt.Sprintf("ratelimit=%s;", user.Spec.Capabilities.RateLimit)
 		}
+		if user.Spec.Capabilities.UserInfoWithoutKeys != "" {
+			userConfig.UserCaps += fmt.Sprintf("user-info-without-keys=%s;", user.Spec.Capabilities.UserInfoWithoutKeys)
+		}
+		if user.Spec.Capabilities.Accounts != "" {
+			userConfig.UserCaps += fmt.Sprintf("accounts=%s;", user.Spec.Capabilities.Accounts)
+		}
 	}
 
 	return userConfig


### PR DESCRIPTION
Add missing caps such `user-info-without-key` and `accounts` to cephobjectstoreuser crd

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
