### PR TITLE
csi: Disable read affinity for ceph v20.2.0

### DIFF
--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -28,6 +28,12 @@ The following Ceph versions are supported in this release of Rook:
 
 * Ceph Squid v19.2.0 or newer
 * Ceph Tentacle v20.2.0 or newer
+    * IMPORTANT: **There is a known data corruption issue in v20.2.0**, if the "read affinity" feature is enabled.
+    Read affinity is disabled by default, and is enabled by the CephCluster setting `csi.readAffinity.enabled: true`.
+    If you have enabled read affinity, we recommend waiting for v20.2.1 before upgrading to Ceph Tentacle v20.
+    If read affinity is enabled with v20.2.0, Rook automatically disables read affinity internally to help avoid this corruption.
+    After the upgrade, existing applications must be restarted to fully disable the read affinity in existing volumes.
+    See [this issue](https://github.com/rook/rook/issues/16839)) for more details.
 
 !!! important
     When an update is requested, the operator will check Ceph's status,

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -77,10 +77,21 @@ func TestFilesystemSubvolumeGroupController(t *testing.T) {
 		cephFilesystemSubVolumeGroup,
 	}
 
+	cephDaemonVersions := `{
+	"mon": {
+		"ceph version 20.2.1 (0000000000000000) tentacle (stable)": 3
+	},
+	"osd": {
+		"ceph version 20.2.1 (0000000000000000) tentacle (stable)": 3
+	}
+}`
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+			}
+			if args[0] == "versions" {
+				return cephDaemonVersions, nil
 			}
 
 			return "", nil
@@ -202,6 +213,9 @@ func TestFilesystemSubvolumeGroupController(t *testing.T) {
 					return "", nil
 				} else if args[0] == "fs" && args[1] == "subvolumegroup" && args[2] == "pin" {
 					return "", nil
+				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
 				}
 
 				return "", errors.Errorf("unknown command. %v", args)

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -77,10 +77,22 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 		cephBlockPoolRadosNamespace,
 	}
 
+	cephDaemonVersions := `{
+	"mon": {
+		"ceph version 20.2.1 (0000000000000000) tentacle (stable)": 3
+	},
+	"osd": {
+		"ceph version 20.2.1 (0000000000000000) tentacle (stable)": 3
+	}
+}`
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			logger.Infof("COMMAND: %s %v", command, args)
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+			}
+			if args[0] == "versions" {
+				return cephDaemonVersions, nil
 			}
 
 			return "", nil
@@ -220,6 +232,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				if args[0] == "mirror" && args[1] == "pool" {
 					return `{"mode":"disabled"}`, nil
 				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
+				}
 
 				return "", nil
 			},
@@ -341,6 +356,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				if args[0] == "mirror" && args[1] == "pool" {
 					return `{"mode":""}`, nil
 				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
+				}
 
 				return "", nil
 			},
@@ -387,6 +405,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				}
 				if args[0] == "mirror" && args[1] == "pool" {
 					return `{"mode":""}`, nil
+				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
 				}
 
 				return "", nil
@@ -440,6 +461,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
 					return `{}`, nil
 				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
+				}
 				return "", nil
 			},
 		}
@@ -490,6 +514,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				}
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
 					return `{}`, nil
+				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
 				}
 				return "", nil
 			},
@@ -543,6 +570,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				}
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
 					return `{}`, nil
+				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
 				}
 				return "", nil
 			},
@@ -600,6 +630,9 @@ func TestCephBlockPoolRadosNamespaceController(t *testing.T) {
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "disable" {
 					assert.Equal(t, cephBlockPool.Name+"/"+cephBlockPoolRadosNamespace.Name, args[3])
 					return `{}`, nil
+				}
+				if args[0] == "versions" {
+					return cephDaemonVersions, nil
 				}
 				return "", nil
 			},


### PR DESCRIPTION
Read affinity in Ceph v20.2.0 can cause corruption. Disable this feature for this version of Ceph to
avoid hitting any corruption in this case. When the next patch release is out for tentacle, this issue will be resolved and when upgrading to it, read affinity would automatically be re-enabled if needed.

By disabling the read affinity in Rook, we can remove the risk for data corruption, and unblock waiting on the tentacle patch release.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16839

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
