### PR TITLE
docs: Update cosi controller to new github repo

### DIFF
--- a/Documentation/Storage-Configuration/Object-Storage-RGW/cosi.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/cosi.md
@@ -17,8 +17,14 @@ COSI requires:
 Deploy the COSI controller with these commands:
 
 ```bash
-kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-api
-kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-controller
+kubectl apply -k 'github.com/kubernetes-sigs/container-object-storage-interface//?ref=v0.2.2'
+```
+
+Following pods will be started in the container-object-storage-system namespace:
+
+```console
+NAME                                                   READY   STATUS    RESTARTS   AGE
+container-object-storage-controller-64ff5586fb-jl96b   1/1     Running   0          2d6h
 ```
 
 ## Ceph COSI Driver


### PR DESCRIPTION
I recently started messing with COSI and found some issues with the docs here. The cosi development has moved the controller from [two separate repos to one](https://container-object-storage-interface.sigs.k8s.io/quick-start.html). Using the old github links results in a few conflicts. Also added a note about namespacing.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
