### PR TITLE
helm: Setting for reconciling concurrent clusters

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -167,6 +167,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `priorityClassName` | Set the priority class for the rook operator deployment if desired | `nil` |
 | `rbacAggregate.enableOBCs` | If true, create a ClusterRole aggregated to [user facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) for objectbucketclaims | `false` |
 | `rbacEnable` | If true, create & use RBAC resources | `true` |
+| `reconcileConcurrentClusters` | Number of clusters the operator reconciles concurrently | `1` |
 | `resources` | Pod resource requests & limits | `{"limits":{"memory":"512Mi"},"requests":{"cpu":"200m","memory":"128Mi"}}` |
 | `revisionHistoryLimit` | The revision history limit for all pods created by Rook. If blank, the K8s default is 10. | `nil` |
 | `scaleDownOperator` | If true, scale down the rook operator. This is useful for administrative actions where the rook operator must be scaled down, while using gitops style tooling to deploy your helm charts. | `false` |

--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: ROOK_CURRENT_NAMESPACE_ONLY
               value: {{ .Values.currentNamespaceOnly | quote }}
+            - name: ROOK_RECONCILE_CONCURRENT_CLUSTERS
+              value: {{ .Values.reconcileConcurrentClusters | quote }}
             {{- with .Values.discover }}
             {{- with .toleration }}
             - name: DISCOVER_TOLERATION

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -44,6 +44,9 @@ unreachableNodeTolerationSeconds: 5
 # -- Whether the operator should watch cluster CRD in its own namespace or not
 currentNamespaceOnly: false
 
+# -- Number of clusters the operator reconciles concurrently
+reconcileConcurrentClusters: 1
+
 # -- Custom pod labels for the operator
 operatorPodLabels: {}
 


### PR DESCRIPTION
The setting for concurrent clusters is now available in the helm chart, instead of only as an env var on the operator deployment. reconcileConcurrentClusters will be applied to the env var ROOK_RECONCILE_CONCURRENT_CLUSTERS.

I noticed this missing helm setting while reviewing for the v1.19 release.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
