### PR TITLE
mon: do not reconcile the floating mon

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -26,6 +26,7 @@ import (
 const (
 	// SkipReconcileLabelKey is a label indicating that the pod should not be reconciled
 	SkipReconcileLabelKey = "ceph.rook.io/do-not-reconcile"
+	FloatingMonLabelKey   = "ceph.rook.io/floating-mon"
 )
 
 // LabelsSpec is the main spec label for all daemons

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1546,6 +1546,13 @@ func (c *Cluster) startMon(m *monConfig, schedule *controller.MonScheduleInfo) e
 		return errors.Wrapf(err, "failed to get mon deployment %s", d.Name)
 	}
 
+	// check if its the floating mon
+	_, exists := existingDeployment.Labels[cephv1.FloatingMonLabelKey]
+	if exists {
+		log.NamespacedInfo(c.Namespace, logger, "mon %q is a floating mon, do not update it", m.DaemonName)
+		return nil
+	}
+
 	// persistent storage is not altered after the deployment is created. this
 	// means we need to be careful when updating the deployment to avoid new
 	// changes to the crd to change an existing pod's persistent storage. the


### PR DESCRIPTION
add a new label for flaoting mon,
so we dont reconcile it,
`ceph.rook.io/floating-mon`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
