### PR TITLE
ci: lock minikube version in CI

### DIFF
--- a/.github/workflows/canary-test-config/action.yaml
+++ b/.github/workflows/canary-test-config/action.yaml
@@ -28,6 +28,9 @@ runs:
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:
+        # lock minikube version to ensure release branch CI doesn't fail when latest minikube no
+        # longer supports older k8s version we lock to
+        minikube-version: "1.37.0"
         kubernetes-version: v1.35.0
         driver: none
         container-runtime: docker

--- a/.github/workflows/integration-test-config-latest-k8s/action.yaml
+++ b/.github/workflows/integration-test-config-latest-k8s/action.yaml
@@ -32,6 +32,9 @@ runs:
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:
+        # lock minikube version to ensure release branch CI doesn't fail when latest minikube no
+        # longer supports older k8s version we lock to
+        minikube-version: "1.37.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
         driver: none
         container-runtime: docker


### PR DESCRIPTION
In CI, lock the minikube version. This is important to ensure that when release branches are created from master, the minikube version is locked to a version that will forever support the desired k8s version. If the latest minikube version is used, CI for older releases will eventually break when the latest minikube no longer supports the older k8s version.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
