### PR TITLE
helm: Set default ceph image pull policy

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -27,7 +27,9 @@ spec:
   cephVersion:
     image: "{{ .repository }}:{{ .tag }}"
     allowUnsupported: {{ .allowUnsupported }}
-    imagePullPolicy: {{ .imagePullPolicy }}
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
   {{- end }}
 
   {{- .Values.cephClusterSpec | toYaml | nindent 2 }}


### PR DESCRIPTION
The image pull policy was expected to be set in the cephcluster CR or else the helm deployment would fail. Now we set the expected default to pull if not present.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #16947

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
