### PR TITLE
rgw: update ca bundle mount perms to read-all

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -981,9 +981,8 @@ func (c *clusterConfig) generateVolumeSourceWithTLSSecret() (*v1.SecretVolumeSou
 }
 
 func (c *clusterConfig) generateVolumeSourceWithCaBundleSecret() (*v1.SecretVolumeSource, error) {
-	// Keep the ca-bundle as secure as possible in the container. Give only user read perms.
-	// Same as above for generateVolumeSourceWithTLSSecret function.
-	userReadOnly := int32(0o400)
+	// RGW runs as 'ceph' user and needs access to the CA bundle.
+	readOnly := int32(0o444)
 	caBundleVolSrc := &v1.SecretVolumeSource{
 		SecretName: c.store.Spec.Gateway.CaBundleRef,
 	}
@@ -995,7 +994,7 @@ func (c *clusterConfig) generateVolumeSourceWithCaBundleSecret() (*v1.SecretVolu
 		return nil, errors.New("CaBundle secret should be 'Opaque' type")
 	}
 	caBundleVolSrc.Items = []v1.KeyToPath{
-		{Key: caBundleKeyName, Path: caBundleFileName, Mode: &userReadOnly},
+		{Key: caBundleKeyName, Path: caBundleFileName, Mode: &readOnly},
 	}
 	return caBundleVolSrc, nil
 }


### PR DESCRIPTION
Update the CA bundle volume mount permissions to read-all (o444). RGW runs as 'ceph', but the volume mount defaults to 'root'. o444 ensures the RGW can read the bundle.

resolves #16957 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
