### PR TITLE
csi: run csi controller plugin on host network

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -18,6 +18,7 @@ package csi
 
 import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 
 	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
 	"github.com/pkg/errors"
@@ -30,8 +31,7 @@ import (
 )
 
 const (
-	opConfigCRName    = "ceph-csi-operator-config"
-	imageSetConfigMap = "rook-csi-operator-image-set-configmap"
+	opConfigCRName = "ceph-csi-operator-config"
 )
 
 func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) error {
@@ -74,6 +74,8 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 }
 
 func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opConfig *csiopv1.OperatorConfig, imageSetCmName string) csiopv1.OperatorConfigSpec {
+	controllerPluginHostNetwork := opcontroller.EnforceHostNetwork() || CSIParam.EnableCSIHostNetwork
+
 	cephfsClientType := csiopv1.KernelCephFsClient
 	if CSIParam.ForceCephFSKernelClient == "false" {
 		cephfsClientType = csiopv1.AutoDetectCephFsClient
@@ -107,6 +109,7 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 				DeploymentStrategy: &appsv1.DeploymentStrategy{
 					Type: appsv1.RecreateDeploymentStrategyType,
 				},
+				HostNetwork: &controllerPluginHostNetwork,
 				PodCommonSpec: csiopv1.PodCommonSpec{
 					PrioritylClassName: &CSIParam.PluginPriorityClassName,
 					Affinity: &v1.Affinity{

--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
-	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -261,7 +260,6 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 		return csiopv1.DriverSpec{}, errors.Wrapf(err, "failed to create ceph-CSI operator config ImageSetConfigmap for CR %s", opConfigCRName)
 	}
 
-	controllerPluginHostNetwork := opcontroller.EnforceHostNetwork()
 	driverSpec := csiopv1.DriverSpec{
 		Log: &csiopv1.LogSpec{
 			Verbosity: int(CSIParam.LogLevel),
@@ -286,7 +284,6 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 			EnableSeLinuxHostMount: &CSIParam.EnablePluginSelinuxHostMount,
 		},
 		ControllerPlugin: &csiopv1.ControllerPluginSpec{
-			HostNetwork: &controllerPluginHostNetwork,
 			PodCommonSpec: csiopv1.PodCommonSpec{
 				PrioritylClassName: &CSIParam.PluginPriorityClassName,
 				Affinity: &corev1.Affinity{

--- a/pkg/operator/ceph/csi/operator_driver_test.go
+++ b/pkg/operator/ceph/csi/operator_driver_test.go
@@ -122,15 +122,12 @@ func TestReconcileCSI_createOrUpdateDriverResources(t *testing.T) {
 			c.SetName("testcluster")
 			c.NamespacedName()
 
-			cephv1.SetEnforceHostNetwork(true)
-			defer cephv1.SetEnforceHostNetwork(false)
 			err := r.createOrUpdateDriverResources(*cluster, c)
 			assert.NoError(t, err)
 
 			// Test RBD driver
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s.rbd.csi.ceph.com", c.Namespace), Namespace: ns}, driver)
 			assert.NoError(t, err)
-			assert.True(t, *driver.Spec.ControllerPlugin.HostNetwork)
 			if tt.expectMultusAnnots {
 				// Verify that both NodePlugin and ControllerPlugin have Multus annotations
 				assert.Nil(t, driver.Spec.NodePlugin.PodCommonSpec.Annotations)


### PR DESCRIPTION
When CSI_ENABLE_HOST_NETWORK is set run the csi controller plugin pods on the host network

@travisn i moved the configuration set at each driver level in https://github.com/rook/rook/pull/16462 to the operator level here as this is global configuration.

closes: #16960

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
