### PR TITLE
csi: pass nil affinity to ceph-csi-operator when not configured

### DIFF
--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -276,10 +276,8 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 		NodePlugin: &csiopv1.NodePluginSpec{
 			PodCommonSpec: csiopv1.PodCommonSpec{
 				PrioritylClassName: &CSIParam.ProvisionerPriorityClassName,
-				Affinity: &corev1.Affinity{
-					NodeAffinity: getNodeAffinity(pluginNodeAffinityEnv, &corev1.NodeAffinity{}),
-				},
-				Tolerations: getToleration(pluginTolerationsEnv, []corev1.Toleration{}),
+				Affinity:           getAffinity(pluginNodeAffinityEnv),
+				Tolerations:        getToleration(pluginTolerationsEnv, []corev1.Toleration{}),
 			},
 			Resources:              csiopv1.NodePluginResourcesSpec{},
 			KubeletDirPath:         CSIParam.KubeletDirPath,
@@ -289,10 +287,8 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 			HostNetwork: &controllerPluginHostNetwork,
 			PodCommonSpec: csiopv1.PodCommonSpec{
 				PrioritylClassName: &CSIParam.PluginPriorityClassName,
-				Affinity: &corev1.Affinity{
-					NodeAffinity: getNodeAffinity(provisionerNodeAffinityEnv, &corev1.NodeAffinity{}),
-				},
-				Tolerations: getToleration(provisionerTolerationsEnv, []corev1.Toleration{}),
+				Affinity:           getAffinity(provisionerNodeAffinityEnv),
+				Tolerations:        getToleration(provisionerTolerationsEnv, []corev1.Toleration{}),
 			},
 			Replicas:  &CSIParam.ProvisionerReplicas,
 			Resources: csiopv1.ControllerPluginResourcesSpec{},

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -161,6 +161,19 @@ func getNodeAffinity(nodeAffinityName string, defaultNodeAffinity *corev1.NodeAf
 	return v1NodeAffinity
 }
 
+// getAffinity returns an Affinity struct with NodeAffinity if configured,
+// or nil if no affinity is set. This ensures the ceph-csi-operator can
+// use its defaults from OperatorConfig when no affinity is specified.
+func getAffinity(nodeAffinityEnv string) *corev1.Affinity {
+	nodeAffinity := getNodeAffinity(nodeAffinityEnv, nil)
+	if nodeAffinity == nil {
+		return nil
+	}
+	return &corev1.Affinity{
+		NodeAffinity: nodeAffinity,
+	}
+}
+
 func applyToPodSpec(pod *corev1.PodSpec, n *corev1.NodeAffinity, t []corev1.Toleration) {
 	pod.Tolerations = t
 	pod.Affinity = &corev1.Affinity{


### PR DESCRIPTION
## Description

When no node affinity is configured, Rook passes an empty Affinity struct to the ceph-csi-operator Driver CR. This prevents the operator from using its own defaults from OperatorConfig, since it only checks for nil (not empty structs).

This PR passes `nil` instead of an empty struct when no affinity is configured, allowing the ceph-csi-operator to apply its OperatorConfig defaults.

This is the Rook-side fix as suggested in review of https://github.com/ceph/ceph-csi-operator/pull/388 — rather than having the ceph-csi-operator check for empty structs, Rook should simply pass `nil` when no affinity is configured.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.