### PR TITLE
ci: use latest minikube v1.38.0 in the integration tests

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -34,7 +34,7 @@ runs:
       with:
         # lock minikube version to ensure release branch CI doesn't fail when latest minikube no
         # longer supports older k8s version we lock to
-        minikube-version: "1.37.0"
+        minikube-version: "1.38.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
         driver: none
         container-runtime: docker


### PR DESCRIPTION

**Description:**

minikube v1.38.0 has just been released: https://github.com/kubernetes/minikube/releases/tag/v1.38.0

This changes the CI to use it.





**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
