### PR TITLE
doc: add csi-operator example in configuration doc

### DIFF
--- a/Documentation/Getting-Started/example-configurations.md
+++ b/Documentation/Getting-Started/example-configurations.md
@@ -24,6 +24,8 @@ After the common resources are created, the next step is to create the Operator 
 
 * [`operator.yaml`](https://github.com/rook/rook/blob/master/deploy/examples/operator.yaml): The most common settings for production deployments
     * `kubectl create -f operator.yaml`
+* [`csi-operator.yaml`](https://github.com/rook/rook/blob/master/deploy/examples/csi-operator.yaml): Deploys the CSI operator, CRDs, and RBAC for the CSI driver (block and shared filesystem provisioning). Deploy alongside operator.yaml for CSI-based storage.
+    * `kubectl create -f csi-operator.yaml`
 * [`operator-openshift.yaml`](https://github.com/rook/rook/blob/master/deploy/examples/operator-openshift.yaml): Includes all of the operator settings for running a basic Rook cluster in an OpenShift environment. You will also want to review the [OpenShift Prerequisites](../Getting-Started/ceph-openshift.md) to confirm the settings.
     * `oc create -f operator-openshift.yaml`
 


### PR DESCRIPTION
adding missing doc step for csi-operator deployment in the example configuration step.

Related to #16620 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
