### PR TITLE
test: Multicluster test to use raw device instead of partition

### DIFF
--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -51,7 +51,7 @@ jobs:
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           export BLOCK="/dev/${DEVICE_NAME}"
-          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}1"
+          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}"
           export DEVICE_FILTER="$DEVICE_NAME"
           go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -77,7 +77,7 @@ jobs:
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           export BLOCK="$/dev/${DEVICE_NAME}"
-          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}1"
+          export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}"
           export DEVICE_FILTER="$DEVICE_NAME"
           go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 


### PR DESCRIPTION
With the iscsi device created now for integration tests, the multicluster test can now use the raw device name instead of assuming it is a partition.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
