### PR TITLE
test: resove some canary test failures on v1.18 branch

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -7,6 +7,10 @@ on:
         description: "JSON list of Ceph images for creating Ceph cluster"
         default: '["quay.io/ceph/ceph:v19"]'
         type: string
+      kubernetes-version:
+        description: kubernetes version to use for the workflow
+        default: '["v1.34.0"]'
+        type: string
 
 defaults:
   run:
@@ -23,6 +27,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,7 +41,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -453,6 +460,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -466,7 +474,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -532,6 +542,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -544,7 +555,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -584,6 +597,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -597,7 +611,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
@@ -634,6 +650,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -647,7 +664,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -693,6 +712,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -706,7 +726,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -746,6 +768,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -759,7 +782,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -804,6 +829,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -817,7 +843,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -911,6 +939,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -924,7 +953,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -965,6 +996,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -978,7 +1010,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1030,6 +1064,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1043,7 +1078,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1129,6 +1166,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1142,7 +1180,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1185,6 +1225,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1198,7 +1239,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1251,6 +1294,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1264,7 +1308,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1342,6 +1388,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1355,7 +1402,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1413,6 +1462,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1426,7 +1476,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "tests/manifests/test-cluster-on-pvc-encrypted.yaml" "${{ matrix.ceph-image }}"
@@ -1472,6 +1524,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1485,7 +1538,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -1732,6 +1787,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1745,7 +1801,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
@@ -1830,6 +1888,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -1860,6 +1919,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1873,7 +1933,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image "deploy/examples/cluster-multus-test.yaml" "${{ matrix.ceph-image }}"
@@ -1944,6 +2006,7 @@ jobs:
     strategy:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -1957,7 +2020,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/canary-test-config
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: set Ceph version in CephCluster manifest
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -126,7 +126,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"
@@ -206,7 +206,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"
@@ -246,7 +246,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"
@@ -286,7 +286,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"
@@ -326,7 +326,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"
@@ -367,7 +367,7 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "1.33.1"

--- a/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
+++ b/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
@@ -13,6 +13,9 @@ inputs:
   ceph-image:
     description: the name of ceph image
     required: true
+  kubernetes-version:
+    description: kubernetes version to use for the workflow
+    required: true
 
 runs:
   using: "composite"
@@ -26,7 +29,9 @@ runs:
       run: echo "IBM_KP_SERVICE_INSTANCE_ID and IBM_KP_SERVICE_API_KEY must be set in the environment" && exit 0
 
     - name: setup cluster resources
-      uses: ./.github/workflows/canary-test-config
+      uses: ./.github/workflows/integration-test-setup-cluster-resources
+      with:
+        kubernetes-version: ${{ inputs.kubernetes-version }}
 
     - name: set Ceph version in CephCluster manifest
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -47,10 +47,10 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: remove read permission from kube config file
         run: sudo chmod go-r ~/.kube/config
@@ -73,5 +73,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-helm-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-helm-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-keystone-auth-suite.yaml
+++ b/.github/workflows/integration-test-keystone-auth-suite.yaml
@@ -46,11 +46,11 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephKeystoneAuthSuite
         run: |
@@ -70,5 +70,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-keystone-auth-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-keystone-auth-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -41,9 +41,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephMgrSuite
         run: |
@@ -63,5 +63,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-mgr-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-mgr-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -42,9 +42,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephMultiClusterDeploySuite
         run: |
@@ -67,5 +67,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -41,10 +41,10 @@ jobs:
           use-tmate: ${{ secrets.USE_TMATE }}
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephObjectSuite
         run: |
@@ -64,5 +64,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-object-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-object-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -1,5 +1,5 @@
-name: Cluster Setup
-description: Cluster setup for integration test
+name: setup cluster resources
+description: Setup cluster resources for canary/integration tests
 inputs:
   kubernetes-version:
     description: kubernetes version to use for the workflow
@@ -18,7 +18,7 @@ runs:
         haskell: false # takes a long time to run b/c package mgr
 
     - name: setup golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: "1.24"
 
@@ -26,6 +26,10 @@ runs:
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         tests/scripts/github-action-helper.sh install_minikube_with_none_driver ${{ inputs.kubernetes-version }}
+
+    - name: install deps
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: tests/scripts/github-action-helper.sh install_deps
 
     - name: print k8s cluster status
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -42,9 +42,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephSmokeSuite
         run: |
@@ -64,5 +64,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -42,9 +42,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephUpgradeSuite
         run: |
@@ -64,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestHelmUpgradeSuite:
@@ -92,9 +92,9 @@ jobs:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestHelmUpgradeSuite
         run: |
@@ -116,5 +116,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-upgrade-helm-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-upgrade-helm-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -29,9 +29,9 @@ jobs:
           fetch-depth: 0
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephHelmSuite
         run: |
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-helm-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-helm-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephMultiClusterDeploySuite:
@@ -67,10 +67,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephMultiClusterDeploySuite
         run: |
@@ -93,7 +93,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephSmokeSuite:
@@ -108,10 +108,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephSmokeSuite
         run: |
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephUpgradeSuite:
@@ -146,10 +146,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephUpgradeSuite
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestHelmUpgradeSuite:
@@ -185,9 +185,9 @@ jobs:
           fetch-depth: 0
 
       - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestHelmUpgradeSuite
         run: |
@@ -208,7 +208,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephObjectSuite:
@@ -223,10 +223,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup latest cluster resources
-        uses: ./.github/workflows/integration-test-config-latest-k8s
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: ${{ matrix.kubernetes-versions }}
+          kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephObjectSuite
         run: |
@@ -246,5 +246,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: ceph-object-suite-artifact-${{ matrix.kubernetes-versions }}
+          name: ceph-object-suite-artifact-${{ matrix.kubernetes-version }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/


### PR DESCRIPTION
Cherry picked from commit https://github.com/rook/rook/commit/c5bfe3a8063385f3f01481c3f450e1256f3df3de to resolve some canary test failures.

Change from the original version:
- Keep the test target k8s versions as are.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
