### PR TITLE
osd: fix updateExistingOSDs function for cancelled context

### DIFF
--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -237,6 +237,10 @@ func WaitForDeploymentsToUpdate(
 	waitFunc := func() (done bool, err error) {
 		deployments, err := listFunc()
 		if err != nil {
+			// if the context got cancelled, then no need to wait or retry.
+			if errors.Is(err, context.Canceled) {
+				return true, errors.Wrap(err, "failed to list deployments due to context cancellation")
+			}
 			return false, errors.Wrap(err, "failed to list deployments")
 		}
 		if len(deployments.Items) < len(waitingOn) {


### PR DESCRIPTION
[updateExistingOSDs](https://github.com/rook/rook/blob/69826e8ac062511e792a726234cd38cb7b168d26/pkg/operator/ceph/cluster/osd/status.go#L273) should not wait and retry if the golang context got cancelled. Else it would keep on retrying for 20 minutes before exiting.

logs after fixing the issue. 
[after-fix.txt](https://github.com/user-attachments/files/25088548/after-fix.txt)


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #17023


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
