### PR TITLE
build: set release version to v1.19.1

### DIFF
--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -36,7 +36,7 @@ To configure the Ceph storage cluster, at least one of these local storage optio
 A simple Rook cluster is created for Kubernetes with the following `kubectl` commands and [example manifests](https://github.com/rook/rook/blob/master/deploy/examples).
 
 ```console
-$ git clone --single-branch --branch v1.19.0 https://github.com/rook/rook.git
+$ git clone --single-branch --branch v1.19.1 https://github.com/rook/rook.git
 cd rook/deploy/examples
 kubectl create -f crds.yaml -f common.yaml -f csi-operator.yaml -f operator.yaml
 kubectl create -f cluster.yaml

--- a/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+++ b/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
@@ -48,7 +48,7 @@ There are two sources for metrics collection:
 From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
-$ git clone --single-branch --branch v1.19.0 https://github.com/rook/rook.git
+$ git clone --single-branch --branch v1.19.1 https://github.com/rook/rook.git
 cd rook/deploy/examples/monitoring
 ```
 

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -143,7 +143,7 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
 ## Rook Operator Upgrade
 
 The examples given in this guide upgrade a live Rook cluster running `1.18.9` to
-the version `v1.19.0`. This upgrade should work from any official patch release of Rook v1.18 to any
+the version `v1.19.1`. This upgrade should work from any official patch release of Rook v1.18 to any
 official patch release of v1.19.
 
 Let's get started!
@@ -170,7 +170,7 @@ by the Operator. Also update the Custom Resource Definitions (CRDs).
 Get the latest common resources manifests that contain the latest changes.
 
 ```console
-git clone --single-branch --depth=1 --branch v1.19.0 https://github.com/rook/rook.git
+git clone --single-branch --depth=1 --branch v1.19.1 https://github.com/rook/rook.git
 cd rook/deploy/examples
 ```
 
@@ -209,7 +209,7 @@ The largest portion of the upgrade is triggered when the operator's image is upd
 When the operator is updated, it will proceed to update all of the Ceph daemons.
 
 ```console
-kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.19.0
+kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.19.1
 ```
 
 ### **3. Update Ceph CSI Custom Images **
@@ -233,16 +233,16 @@ watch --exec kubectl -n $ROOK_CLUSTER_NAMESPACE get deployments -l rook_cluster=
 ```
 
 As an example, this cluster is midway through updating the OSDs. When all deployments report `1/1/1`
-availability and `rook-version=v1.19.0`, the Ceph cluster's core components are fully updated.
+availability and `rook-version=v1.19.1`, the Ceph cluster's core components are fully updated.
 
 ```console
 Every 2.0s: kubectl -n rook-ceph get deployment -o j...
 
-rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.19.0
-rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.19.0
-rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.19.0
-rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.19.0
-rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.19.0
+rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.19.1
+rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.19.1
+rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.19.1
+rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.19.1
+rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.19.1
 rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=1.18.9
 rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=1.18.9
 ```
@@ -254,13 +254,13 @@ An easy check to see if the upgrade is totally finished is to check that there i
 # kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
   rook-version=1.18.9
-  rook-version=v1.19.0
+  rook-version=v1.19.1
 This cluster is finished:
-  rook-version=v1.19.0
+  rook-version=v1.19.1
 ```
 
 ### **5. Verify the updated cluster**
 
-At this point, the Rook operator should be running version `rook/ceph:v1.19.0`.
+At this point, the Rook operator should be running version `rook/ceph:v1.19.1`.
 
 Verify the CephCluster health using the [health verification doc](health-verification.md).

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: docker.io/rook/ceph
   # -- Image tag
   # @default -- `master`
-  tag: v1.19.0
+  tag: v1.19.1
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/deploy/examples/direct-mount.yaml
+++ b/deploy/examples/direct-mount.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-direct-mount
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           command: ["/bin/bash"]
           args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,4 +1,4 @@
- docker.io/rook/ceph:v1.19.0
+ docker.io/rook/ceph:v1.19.1
  gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255
  quay.io/ceph/ceph:v19.2.3
  quay.io/ceph/cosi:v0.1.2

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -691,7 +691,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -615,7 +615,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true

--- a/deploy/examples/osd-purge.yaml
+++ b/deploy/examples/osd-purge.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: rook-ceph-purge-osd
       containers:
         - name: osd-removal
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           # TODO: Insert the OSD ID in the last parameter that is to be removed
           # The OSD IDs are a comma-separated list. For example: "0" or "0,2".
           # If you want to preserve the OSD PVCs, set `--preserve-pvc true`.

--- a/deploy/examples/toolbox-job.yaml
+++ b/deploy/examples/toolbox-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
         - name: config-init
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           command: ["/usr/local/bin/toolbox.sh"]
           args: ["--skip-watch"]
           imagePullPolicy: IfNotPresent
@@ -32,7 +32,7 @@ spec:
               readOnly: true
       containers:
         - name: script
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config

--- a/deploy/examples/toolbox-operator-image.yaml
+++ b/deploy/examples/toolbox-operator-image.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-ceph-tools-operator-image
-          image: docker.io/rook/ceph:v1.19.0
+          image: docker.io/rook/ceph:v1.19.1
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
For the patch release update the docs and examples to v1.19.1


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
