### PR TITLE
nvmeof: switch to official csi images

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1998,7 +1998,7 @@ jobs:
       - name: deploy cluster without ceph-csi operator
         run: |
           OPERATOR_MANIFEST="deploy/examples/operator.yaml"
-          sed -i 's|# ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"|ROOK_CSI_CEPH_IMAGE: "quay.io/nixpanic/cephcsi:nvmeof"|' "${OPERATOR_MANIFEST}"
+          sed -i 's|# ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"|ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:canary"|' "${OPERATOR_MANIFEST}"
           sed -i 's|ROOK_USE_CSI_OPERATOR: "true"|ROOK_USE_CSI_OPERATOR: "false"|' "${OPERATOR_MANIFEST}"
 
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "${OPERATOR_MANIFEST}"

--- a/deploy/examples/csi/nvmeof/node-plugin.yaml
+++ b/deploy/examples/csi/nvmeof/node-plugin.yaml
@@ -44,7 +44,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: quay.io/cephcsi/cephcsi:v3.16.1
+          image: quay.io/cephcsi/cephcsi:canary
           imagePullPolicy: Always
           name: csi-nvmeofplugin
           resources: {}

--- a/deploy/examples/csi/nvmeof/provisioner.yaml
+++ b/deploy/examples/csi/nvmeof/provisioner.yaml
@@ -198,7 +198,7 @@ spec:
         - name: csi-nvmeofplugin
           # for stable functionality replace canary with latest release version
           # image: quay.io/gdidi/cephcsi:nvmeof
-          image: quay.io/cephcsi/cephcsi:v3.16.1
+          image: quay.io/cephcsi/cephcsi:canary
           command: ["/usr/local/bin/cephcsi"]
           args:
             - "--nodeid=$(NODE_ID)"
@@ -244,8 +244,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-provisioner
-          #          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-          image: quay.io/nixpanic/csi-provisioner:pr1440
+          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:canary
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -299,8 +298,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: quay.io/nixpanic/csi-resizer:pr544
-          #          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: gcr.io/k8s-staging-sig-storage/csi-resizer:canary
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -763,7 +763,7 @@ function test_csi_nfs_workload {
 function test_csi_nvmeof_workload {
   cd "${REPO_DIR}/deploy/examples/csi/nvmeof"
 
-  local cephcsi_image="${1:-quay.io/nixpanic/cephcsi:nvmeof}"
+  local cephcsi_image="${1:-quay.io/cephcsi/cephcsi:canary}"
   local gateway_svc="rook-ceph-nvmeof-nvmeof-a"
   local gateway_listener_hostname="rook-ceph-nvmeof-nvmeof-a"
   local service_ip


### PR DESCRIPTION
use official csi images instead of private ones.
align nvmeof example with upstream canary images.

#16943


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
