### PR TITLE
Documentation: Fix metadata and data pool names for 'us' region

### DIFF
--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -231,8 +231,8 @@ spec:
     poolPlacements:
     - name: us
       default: true
-      metadataPoolName: "us-data-pool"
-      dataPoolName: "us-meta-pool"
+      metadataPoolName: "us-meta-pool"
+      dataPoolName: "us-data-pool"
       storageClasses:
       - name: REDUCED_REDUNDANCY
         dataPoolName: "us-reduced-pool"


### PR DESCRIPTION
This fixes a small typo in the Object-storage-rg documentation.
metadata and normal datapool names where switched.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
