### PR TITLE
rgw: fix status info when http is disabled

### DIFF
--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -86,10 +86,15 @@ func updateStatus(ctx context.Context, observedGeneration int64, replicaCount in
 		insecurePort := objectStore.Spec.Gateway.Port
 		if insecurePort > 0 {
 			objectStore.Status.Endpoints.Insecure = getAllDNSEndpoints(objectStore, insecurePort, false)
+		} else if insecurePort == 0 {
+			objectStore.Status.Endpoints.Insecure = []string{}
 		}
+
 		securePort := objectStore.Spec.Gateway.SecurePort
 		if securePort > 0 {
 			objectStore.Status.Endpoints.Secure = getAllDNSEndpoints(objectStore, securePort, true)
+		} else if securePort == 0 {
+			objectStore.Status.Endpoints.Secure = []string{}
 		}
 
 		if cephx != nil {


### PR DESCRIPTION
When http is disabled, the spec.status.info.insecure will keep on showing the insecure endpoint. This PR makes sure that the spec.status.info.insecure is empty when http is disabled

Before disabling http: 

RGW service 
```
spec:
  clusterIP: 10.98.85.38
  clusterIPs:
  - 10.98.85.38
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: https
    port: 443
    protocol: TCP
    targetPort: 443
  selector:
    app: rook-ceph-rgw
    ceph_daemon_id: my-store
    rgw: my-store
    rook_cluster: rook-ceph
    rook_object_store: my-store
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

ObjectStore Status: 
```
status:
    cephx:
      daemon:
        keyCephVersion: 20.2.0-0
        keyGeneration: 1
    endpoints:
      insecure:
      - http://rook-ceph-rgw-my-store.rook-ceph.svc:80
      secure:
      - https://rook-ceph-rgw-my-store.rook-ceph.svc:443
    info:
      endpoint: http://rook-ceph-rgw-my-store.rook-ceph.svc:80
      secureEndpoint: https://rook-ceph-rgw-my-store.rook-ceph.svc:443
    observedGeneration: 2
    phase: Ready
    replicas: 1
    selector: app=rook-ceph-rgw,ceph_daemon_id=my-store,rgw=my-store,rook_cluster=rook-ceph,rook_object_store=my-store
kind: List
metadata:
  resourceVersion: ""
```

```
 kubectl get cephobjectstore -n rook-ceph                                                                                                                                                                        ─╯
NAME       PHASE   ENDPOINT                                         SECUREENDPOINT                                     AGE
my-store   Ready   http://rook-ceph-rgw-my-store.rook-ceph.svc:80   https://rook-ceph-rgw-my-store.rook-ceph.svc:443   10m

```

After disabling http: 

RGW service 
```
spec:
  clusterIP: 10.98.85.38
  clusterIPs:
  - 10.98.85.38
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: https
    port: 443
    protocol: TCP
    targetPort: 443
  selector:
    app: rook-ceph-rgw
    ceph_daemon_id: my-store
    rgw: my-store
    rook_cluster: rook-ceph
    rook_object_store: my-store
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}

```

ObjectStore Status: 
```
status:
    cephx:
      daemon:
        keyCephVersion: 20.2.0-0
        keyGeneration: 1
    endpoints:
      insecure: []
      secure:
      - https://rook-ceph-rgw-my-store.rook-ceph.svc:443
    info:
      endpoint: https://rook-ceph-rgw-my-store.rook-ceph.svc:443
    observedGeneration: 3
    phase: Ready
    replicas: 1
    selector: app=rook-ceph-rgw,ceph_daemon_id=my-store,rgw=my-store,rook_cluster=rook-ceph,rook_object_store=my-store
kind: List
metadata:
  resourceVersion: ""
```

````
 kubectl get cephobjectstore -n rook-ceph                                                                                                                                                                        ─╯
NAME       PHASE   ENDPOINT                                           SECUREENDPOINT   AGE
my-store   Ready   https://rook-ceph-rgw-my-store.rook-ceph.svc:443                    13m
````

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
