### PR TITLE
osd: in cephx key init, don't overwrite key on failure

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -1480,11 +1480,16 @@ set -o xtrace
 OSD_ID="` + osdID + `"
 KEYRING_FILE=/var/lib/ceph/osd/ceph-"${OSD_ID}"/keyring
 
+# If this fails, it still writes to redirected file, so use temp file
 if ! ceph --name client.admin auth get-or-create osd."${OSD_ID}" \
 		mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' \
-		--keyring /etc/ceph/admin-keyring-store/keyring > "$KEYRING_FILE"; then
+		--keyring /etc/ceph/admin-keyring-store/keyring > /tmp/keyring; then
 	echo "failed to get latest cephx key for OSD. continuing OSD startup using on-disk key" >/dev/stderr
+	exit 0
 fi
+
+echo "got latest cephx key for OSD successfully. updating on-disk key" >/dev/stderr
+mv /tmp/keyring "$KEYRING_FILE"
 `
 	// ^ (above) Continue on failure here. Getting latest key can fail due to system issues that
 	// blocking here could make worse. Key rotation is rare, so on-disk key is likely good. If not,


### PR DESCRIPTION
Previously, if the OSD cephx-keyring-update init container couldn't contact the mons, the output redirect would overwrite the on-disk keyring file with no text, removing the on-disk keyring.

Modify the init container to only overwrite the keyring file when the ceph command to get the latest key suceeds, to avoid removing the on-disk key.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
