### PR TITLE
nvmeof: add nvmeof minikube canary test without csi operator

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1957,6 +1957,78 @@ jobs:
         with:
           debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
 
+  nvmeof-protocol:
+    runs-on: ubuntu-22.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    strategy:
+      matrix:
+        ceph-image: ["quay.io/ceph/ceph:v20"]
+        kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: consider (pre-job) debugging
+        uses: ./.github/workflows/tmate_debug
+        with:
+          use-tmate: ${{ secrets.USE_TMATE }}
+          debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
+
+      - name: install nvme initiator prerequisites
+        run: tests/scripts/github-action-helper.sh install_nvme_initiator_prerequisites
+
+      - name: set Ceph version in CephCluster manifest
+        run: tests/scripts/github-action-helper.sh replace_ceph_image "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
+
+      - name: validate-yaml
+        run: tests/scripts/github-action-helper.sh validate_yaml
+
+      - name: use local disk and create partitions for osds
+        run: |
+          tests/scripts/github-action-helper.sh use_local_disk
+          tests/scripts/github-action-helper.sh create_partitions_for_osds
+
+      - name: deploy cluster without ceph-csi operator
+        run: |
+          OPERATOR_MANIFEST="deploy/examples/operator.yaml"
+          sed -i 's|# ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"|ROOK_CSI_CEPH_IMAGE: "quay.io/nixpanic/cephcsi:nvmeof"|' "${OPERATOR_MANIFEST}"
+          sed -i 's|ROOK_USE_CSI_OPERATOR: "true"|ROOK_USE_CSI_OPERATOR: "false"|' "${OPERATOR_MANIFEST}"
+
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "${OPERATOR_MANIFEST}"
+
+          export BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          yq w -i -d0 deploy/examples/cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"
+          kubectl create -f deploy/examples/cluster-test.yaml
+          tests/scripts/github-action-helper.sh deploy_toolbox
+
+      - name: wait for prepare pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
+
+      - name: wait for ceph to be ready
+        env:
+          CSI_POD_MIN_COUNT: "6"
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+
+      - name: test ceph-csi-nvmeof plugin restart and data persistence
+        run: tests/scripts/github-action-helper.sh test_csi_nvmeof_workload
+
+      - name: collect common logs
+        if: always()
+        uses: ./.github/workflows/collect-logs
+        with:
+          name: ${{ github.job }}-${{ matrix.ceph-image }}
+      - name: consider (post-job) debugging
+        uses: ./.github/workflows/upterm_debug
+        with:
+          debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
+
   encryption-pvc-kms-ibm-kp:
     runs-on: ubuntu-22.04
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"

--- a/deploy/examples/csi/nvmeof/storageclass.yaml
+++ b/deploy/examples/csi/nvmeof/storageclass.yaml
@@ -14,8 +14,6 @@ parameters:
   listeners: |
     [
       {
-        "address": "10.129.2.36",
-        "port": 4420,
         "hostname": "rook-ceph-nvmeof-nvmeof-a"
       }
     ]

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -102,9 +102,10 @@ function test_demo_pool {
 }
 
 function test_csi {
-  timeout 360 bash -x <<-'EOF'
-    until [[ "$(kubectl -n rook-ceph get pods --field-selector=status.phase=Running|grep -c csi.)" -ge 7 ]]; do
-      echo "waiting for csi pods to be ready"
+  csi_pod_min_count="${CSI_POD_MIN_COUNT:-7}"
+  timeout 360 bash -x <<EOF
+    until [[ "\$(kubectl -n rook-ceph get pods --field-selector=status.phase=Running | grep -c csi.)" -ge "${csi_pod_min_count}" ]]; do
+      echo "waiting for csi pods to be ready (need ${csi_pod_min_count})"
       kubectl -n rook-ceph get pods | grep csi
       sleep 5
     done


### PR DESCRIPTION
adds a new nvmeof minikube canary job for ceph v20. the test deploys rook with csi operator disabled for nvmeof flow. it validates pvc and pod io, gateway restart, and data persistence.

Based on this test:
```
1.Create a minikube v1.38.0

2.Create a Ceph Block Pool
kubectl create -f deploy/examples/csi/nvmeof/nvmeof-pool.yaml

apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: nvmeof
  namespace: rook-ceph # namespace:cluster
spec:
  failureDomain: osd
  replicated:
    size: 1

3.Create the NVMe-oF Gateway
$ kubectl create -f deploy/examples/nvmeof-test.yaml

4.Deploy the NVMe-oF CSI Driver 
ceph-csi image= quay.io/nixpanic/cephcsi:nvmeof
$ kubectl create -f deploy/examples/csi/nvmeof/provisioner.yaml

5.Create the StorageClass
$ kubectl get service -n rook-ceph rook-ceph-nvmeof-nvmeof-a
NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
rook-ceph-nvmeof-nvmeof-a   ClusterIP   10.105.129.118   <none>        4420/TCP,5500/TCP,5499/TCP,8009/TCP   3m13s

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ceph-nvmeof
parameters:
  clusterID: rook-ceph
  pool: nvmeof
  subsystemNQN: nqn.2016-06.io.spdk:cnode1.rook-ceph
  # Management API - talks to gateway to create subsystems/namespaces
  nvmeofGatewayAddress: "10.105.129.118"
  nvmeofGatewayPort: "5500"
  # Data Plane - worker nodes connect here for actual I/O
  # List ALL gateway pods for HA and multipath
  listeners: |
    [
      {
        "address": "10.105.129.118",
        "port": 4420,
        "hostname": "rook-ceph-nvmeof-nvmeof-a"
      }
    ]
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
  csi.storage.k8s.io/node-expand-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-expand-secret-namespace: rook-ceph
  imageFormat: "2"
  imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
provisioner: nvmeof.csi.ceph.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
allowVolumeExpansion: true

$ kubectl create -f deploy/examples/csi/nvmeof/storageclass.yaml

6. Create a PersistentVolumeClaim
kubectl create -f deploy/examples/csi/nvmeof/pvc.yaml

$ kubectl get pvc
NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
nvmeof-external-volume   Bound    pvc-a172f3ad-e179-412c-a890-d973e4b45d8b   128Mi      RWO            ceph-nvmeof    <unset>                 7s

7.Deploy the NVMe-oF CSI Node Plugin
ceph-csi image= quay.io/nixpanic/cephcsi:nvmeof
kubectl create -f deploy/examples/csi/nvmeof/node-plugin.yaml

8. Create pod:
$ kubectl create -f deploy/examples/csi/nvmeof/pod.yaml
$ kubectl get pods 
NAME              READY   STATUS    RESTARTS   AGE
nvmeof-test-pod   1/1     Running   0          22s

9.Login to pod and write data to /mnt/nvmeof path
$ kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # df -h /mnt/nvmeof
Filesystem                Size      Used Available Use% Mounted on
/dev/nvme0n1            103.9M     24.0K    101.3M   0% /mnt/nvmeof
/ # vi /mnt/nvmeof/test.txt
/ # cat /mnt/nvmeof/test.txt
abcd

10.Restart nvmeof-controller [ip address changed]
$ kubectl get pods -n rook-ceph rook-ceph-nvmeof-nvmeof-a-7576b84f67-g8kq8 -o wide
NAME                                         READY   STATUS    RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
rook-ceph-nvmeof-nvmeof-a-7576b84f67-g8kq8   1/1     Running   0          11m   10.244.0.16   minikube   <none>           <none>

$ kubectl delete pod rook-ceph-nvmeof-nvmeof-a-7576b84f67-g8kq8 -n rook-ceph 
pod "rook-ceph-nvmeof-nvmeof-a-7576b84f67-g8kq8" deleted


$  kubectl get pods -n rook-ceph  rook-ceph-nvmeof-nvmeof-a-7576b84f67-lpmzh -o wide
NAME                                         READY   STATUS    RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
rook-ceph-nvmeof-nvmeof-a-7576b84f67-lpmzh   1/1     Running   0          30s   10.244.0.19   minikube   <none>           <none>


11.Check pod and pvc statut and check data content: [working]
$ kubectl get pvc,pod
NAME                                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/nvmeof-external-volume   Bound    pvc-a172f3ad-e179-412c-a890-d973e4b45d8b   128Mi      RWO            ceph-nvmeof    <unset>                 5m15s

NAME                  READY   STATUS    RESTARTS   AGE
pod/nvmeof-test-pod   1/1     Running   0          3m32s

$ kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # cat /mnt/nvmeof/test.txt 
abcd

12.Add data to test.txt file [working as expected]
$ kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # vi /mnt/nvmeof/test.txt 
/ # cat /mnt/nvmeof/test.txt 
abcd efg

13.Delete the pod:
$ kubectl delete pod nvmeof-test-pod --force 
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "nvmeof-test-pod" force deleted


14. Create the pod again on same pvc:
$ kubectl create -f deploy/examples/csi/nvmeof/pod.yaml
pod/nvmeof-test-pod created
$ kubectl get pods
NAME              READY   STATUS    RESTARTS   AGE
nvmeof-test-pod   1/1     Running   0          6s

15.Check contenct in mount /mnt/nvmeof/test.txt
$ kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # cat /mnt/nvmeof/test.txt
abcd efg
/ # vi /mnt/nvmeof/test.txt 
/ # cat /mnt/nvmeof/test.txt
abcd efg hij

```

#17072

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
