### PR TITLE
buid: use buildx instead of manifest-tool

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -72,18 +72,6 @@ S3_SYNC := aws s3 sync --only-show-errors
 S3_SYNC_DEL := aws s3 sync --only-show-errors --delete
 
 # ====================================================================================
-# tools
-
-MANIFEST_TOOL_VERSION=v1.0.2
-MANIFEST_TOOL := $(TOOLS_HOST_DIR)/manifest-tool-$(MANIFEST_TOOL_VERSION)
-
-$(MANIFEST_TOOL):
-	@echo === installing manifest-tool
-	mkdir -p $(TOOLS_HOST_DIR)
-	curl -sL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-$(shell go env GOHOSTOS)-$(GOHOSTARCH) > $@
-	chmod +x $@
-
-# ====================================================================================
 # Targets
 
 build: $(addprefix build.,$(FLAVORS)) ;
@@ -192,10 +180,15 @@ publish.all.images.$(1): publish.image.$(1).$(2)
 endef
 $(foreach r,$(REGISTRIES), $(foreach a,$(IMAGE_ARCHS),$(eval $(call repo.targets,$(r),$(a)))))
 
+# Per-arch image refs for buildx imagetools create (registry + tag)
+define manifest_sources
+$(foreach a,$(IMAGE_ARCHS),$(1)/ceph-$(a):$(2))
+endef
+
 define repo.manifest.targets
-publish.manifest.image.$(1): publish.all.images.$(1) $(MANIFEST_TOOL)
-	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(VERSION) --target $(1)/ceph:$(VERSION)
-	$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS_COMMA) --template $(1)/ceph-ARCH:$(BRANCH_NAME) --target $(1)/ceph:$(BRANCH_NAME)
+publish.manifest.image.$(1): publish.all.images.$(1)
+	$(DOCKERCMD) buildx imagetools create -t $(1)/ceph:$(VERSION) $(call manifest_sources,$(1),$(VERSION))
+	$(DOCKERCMD) buildx imagetools create -t $(1)/ceph:$(BRANCH_NAME) $(call manifest_sources,$(1),$(BRANCH_NAME))
 	cosign sign --yes $(1)/ceph:$(VERSION)
 	cosign sign --yes $(1)/ceph:$(BRANCH_NAME)
 


### PR DESCRIPTION
instead of using of using manifest-tool and updating it's version, we can use docker buildx which works like manifest-tool only and based on manifest-tool working.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #https://github.com/rook/rook/issues/17071


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
