### PR TITLE
csi: update imagePullPolicy in operatorconfig and driver CR

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -99,7 +99,8 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 					Affinity: &v1.Affinity{
 						NodeAffinity: getNodeAffinity(pluginNodeAffinityEnv, &v1.NodeAffinity{}),
 					},
-					Tolerations: getToleration(pluginTolerationsEnv, []v1.Toleration{}),
+					Tolerations:     getToleration(pluginTolerationsEnv, []v1.Toleration{}),
+					ImagePullPolicy: v1.PullPolicy(CSIParam.ImagePullPolicy),
 				},
 				Resources:              csiopv1.NodePluginResourcesSpec{},
 				KubeletDirPath:         CSIParam.KubeletDirPath,
@@ -115,7 +116,8 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 					Affinity: &v1.Affinity{
 						NodeAffinity: getNodeAffinity(provisionerNodeAffinityEnv, &v1.NodeAffinity{}),
 					},
-					Tolerations: getToleration(provisionerTolerationsEnv, []v1.Toleration{}),
+					Tolerations:     getToleration(provisionerTolerationsEnv, []v1.Toleration{}),
+					ImagePullPolicy: v1.PullPolicy(CSIParam.ImagePullPolicy),
 				},
 				Replicas:  &CSIParam.ProvisionerReplicas,
 				Resources: csiopv1.ControllerPluginResourcesSpec{},


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

```
Adds ImagePullPolicy configuration to CSI node plugin and controller
plugin specs in both the operatorconfig CR generation function.
This ensures the CSI driver components use the configured pull policy
from CSIParam.ImagePullPolicy.
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breakin and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
