### PR TITLE
osd: update lockbox key rotation for encrypted OSDs

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -121,9 +121,12 @@ if [ "$ENCRYPTED" == "true" ] ; then
 
 	if ! ceph --name client.admin auth get-or-create "$LOCKBOX_USER" \
 			mon 'allow command "config-key get" with key="dm-crypt/osd/'$OSD_UUID'/luks"' \
-			--keyring /etc/ceph/admin-keyring-store/keyring > "$LOCKBOX_KEYRING_FILE"; then
+			--keyring /etc/ceph/admin-keyring-store/keyring > /tmp/lockbox.keyring; then
 		echo "failed to get latest cephx lockbox key for OSD. continuing OSD startup using on-disk key" >/dev/stderr
 		# allowing OSD to attempt to start could avoid full OSD outage due to mon/system issues
+	else
+		echo "got latest cephx lockbox key for OSD successfully. updating on-disk key" >/dev/stderr
+		mv /tmp/lockbox.keyring "$LOCKBOX_KEYRING_FILE"
 	fi
 fi
 


### PR DESCRIPTION
Update `lockbox.keyring` rotation for encrypted OSDs to ensure the key is not lost if the init container fails but continues assuming (reasonably) that the key is likely still relevant.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
