### PR TITLE
osd: set device-type label on update

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -796,6 +796,7 @@ func (c *Cluster) getOSDInfo(d *appsv1.Deployment) (OSDInfo, error) {
 	}
 
 	osd.Store = d.Labels[osdStore]
+	osd.DeviceType = d.Labels[deviceType]
 	osd.Encrypted = false
 	if d.Labels[encrypted] == "true" {
 		osd.Encrypted = true


### PR DESCRIPTION
We should set OSDInfo.DeviceType if "device-type" label is set on the corresponding Deployment. Otherwise, Rook deletes this label on Update.

**Issue resolved by this Pull Request:**

Nothing.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
