### PR TITLE
exporter: add configurable port for ceph exporter

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -4032,6 +4032,18 @@ int64
 </tr>
 <tr>
 <td>
+<code>port</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Port is the listening port of the ceph-exporter process. Defaults to 9926.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>hostNetwork</code><br/>
 <em>
 bool

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2929,6 +2929,12 @@ spec:
                           description: Only performance counters greater than or equal to this option are fetched
                           format: int64
                           type: integer
+                        port:
+                          description: Port is the listening port of the ceph-exporter process. Defaults to 9926.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         statsPeriodSeconds:
                           default: 5
                           description: Time to wait before sending requests again to exporter server (seconds)

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2927,6 +2927,12 @@ spec:
                           description: Only performance counters greater than or equal to this option are fetched
                           format: int64
                           type: integer
+                        port:
+                          description: Port is the listening port of the ceph-exporter process. Defaults to 9926.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         statsPeriodSeconds:
                           default: 5
                           description: Time to wait before sending requests again to exporter server (seconds)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -508,6 +508,12 @@ type CephExporterSpec struct {
 	// +kubebuilder:default=5
 	StatsPeriodSeconds int64 `json:"statsPeriodSeconds,omitempty"`
 
+	// Port is the listening port of the ceph-exporter process. Defaults to 9926.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port int32 `json:"port,omitempty"`
+
 	// Whether host networking is enabled for CephExporter. If not set, the network settings from CephCluster.spec.networking will be applied.
 	// +nullable
 	// +optional


### PR DESCRIPTION
the ceph exporter port was hardcoded to 9926, preventing co-location of exporters from different ceph clusters on the same node. add a port field to cephexporterspec so users can override it via spec.monitoring.exporter.port. 

fixes #16492



Test the PR on my pc [Fedora 42] with private image `quay.io/oviner/rook:feb25_mon_2`
```
1.Create minikube Cluster
2.Create 2 cephclusters with my private image based on this pr quay.io/oviner/rook:feb25_mon_2
[step 1 and step 2 in script]
3. Configure two CephClusters with:
network.provider: host: Forces the exporter to use the host's physical port.
monitoring.enabled: true: Activates the exporter.

kubectl patch cephcluster my-cluster-1 -n rook-ceph-cluster --type='merge' -p '{"spec":{"network":{"provider":"host"},"monitoring":{"enabled":true}}}'

Wait 20 sec

kubectl patch cephcluster my-cluster-2 -n rook-ceph-secondary --type='merge' -p '{"spec":{"network":{"provider":"host"},"monitoring":{"enabled":true}}}'

4.Check pod status:
$ kubectl get pods -n rook-ceph-cluster rook-ceph-exporter-minikube-66d44dc7ff-lgf86
NAME                                           READY   STATUS    RESTARTS   AGE
rook-ceph-exporter-minikube-66d44dc7ff-lgf86   1/1     Running   0          13m

$ kubectl get pod rook-ceph-exporter-minikube-798c65866-mrlxh -n rook-ceph-secondary 
NAME                                          READY   STATUS    RESTARTS   AGE
rook-ceph-exporter-minikube-798c65866-mrlxh   0/1     Pending   0          8m54s


Containers:
  ceph-exporter:
    Image:      quay.io/ceph/ceph:v20
    Port:       9926/TCP
    Host Port:  9926/TCP
    Command:
      ceph-exporter
    Args:
      --sock-dir
      /run/ceph
      --port
      9926
      --prio-limit
      5
      --stats-period
      5
    Environment:


Events:
  Type     Reason            Age                  From               Message
  ----     ------            ----                 ----               -------
  Warning  FailedScheduling  78s (x2 over 6m31s)  default-scheduler  0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports. no new claims to deallocate, preemption: 0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports.

5.Patch Cephcluster my-cluster-2 to set the exporter port to 9927
kubectl patch cephcluster my-cluster-2 -n rook-ceph-secondary --type merge -p '{"spec":{"monitoring":{"exporter":{"port":9927}}}}'

6.Check ceph exporter pod status:
$ kubectl get pod -n rook-ceph-secondary rook-ceph-exporter-minikube-5f8474cb68-7zgrt 
NAME                                           READY   STATUS    RESTARTS      AGE
rook-ceph-exporter-minikube-5f8474cb68-7zgrt   1/1     Running   3 (16m ago)   16m

Containers:
  ceph-exporter:
    Container ID:  docker://fd10ce889a8a8f3445cc41910df7e84bf3738fbf94fa6a8891bf8dc7c2a5da2b
    Image:         quay.io/ceph/ceph:v20
    Image ID:      docker-pullable://quay.io/ceph/ceph@sha256:1228c3d05e45fbc068a8c33614e4409b6dac688bcc77369b06009b5830fa8d86
    Port:          9927/TCP
    Host Port:     9927/TCP
    Command:
      ceph-exporter
    Args:
      --sock-dir
      /run/ceph
      --port
      9927
      --prio-limit
      5
      --stats-period
      5
    State:          Running
```


Script to create two CephClusters managed by a single Rook operator:
```
#!/usr/bin/env bash
set -euo pipefail

# Usage:
#   ./deploy-multi-ceph.sh
#   ./deploy-multi-ceph.sh <TAG>
#
# Behavior:
# - If TAG is NOT provided: uses the stock operator image from deploy/examples/operator.yaml
# - If TAG IS provided: generates a custom operator YAML in a random directory and sets the operator image to a private image

TAG="${1:-}"

REPO_ROOT="/home/oviner/go/src/github.com/rook/rook"
EXAMPLES_DIR="${REPO_ROOT}/deploy/examples"

ROOK_OPERATOR_NAMESPACE="rook-ceph"
CLUSTER1_NS="rook-ceph-cluster"
CLUSTER2_NS="rook-ceph-secondary"

# Private operator image repo to use when TAG is provided
# Override if desired:
#   ROOK_PRIVATE_IMAGE_REPO=quay.io/<you>/rook ./deploy-multi-ceph.sh <TAG>
ROOK_PRIVATE_IMAGE_REPO="${ROOK_PRIVATE_IMAGE_REPO:-quay.io/oviner/rook}"

OUT_DIR="$(mktemp -d -p /tmp rook-multi-ceph-XXXXXXXX)"
echo "Generated manifests dir: ${OUT_DIR}"

echo "Deleting minikube..."
minikube delete --all --purge || true

echo "Starting minikube..."
minikube start --disk-size=20g --extra-disks=2 --driver=qemu2

echo "Waiting for Kubernetes API..."
until kubectl get nodes >/dev/null 2>&1; do
  sleep 2
done

echo "Creating operator namespace: ${ROOK_OPERATOR_NAMESPACE}"
kubectl create namespace "${ROOK_OPERATOR_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -

echo "Copying base manifests..."
cp -a "${EXAMPLES_DIR}/crds.yaml" "${OUT_DIR}/crds.yaml"
cp -a "${EXAMPLES_DIR}/common.yaml" "${OUT_DIR}/common-${CLUSTER1_NS}.yaml"
cp -a "${EXAMPLES_DIR}/common-second-cluster.yaml" "${OUT_DIR}/common-${CLUSTER2_NS}.yaml"
cp -a "${EXAMPLES_DIR}/operator.yaml" "${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
cp -a "${EXAMPLES_DIR}/csi-operator.yaml" "${OUT_DIR}/csi-operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
cp -a "${EXAMPLES_DIR}/cluster-test.yaml" "${OUT_DIR}/cluster1.yaml"
cp -a "${EXAMPLES_DIR}/cluster-test.yaml" "${OUT_DIR}/cluster2.yaml"

echo "Patching namespaces (operator + cluster1)..."
sed -i.bak \
  -e "s/\(.*\):.*# namespace:operator/\1: ${ROOK_OPERATOR_NAMESPACE} # namespace:operator/g" \
  -e "s/\(.*\):.*# namespace:cluster/\1: ${CLUSTER1_NS} # namespace:cluster/g" \
  -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:operator/\1:${ROOK_OPERATOR_NAMESPACE}:\2 # serviceaccount:namespace:operator/g" \
  -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:cluster/\1:${CLUSTER1_NS}:\2 # serviceaccount:namespace:cluster/g" \
  "${OUT_DIR}/common-${CLUSTER1_NS}.yaml" \
  "${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml" \
  "${OUT_DIR}/cluster1.yaml"

echo "Patching namespaces (cluster2 RBAC + cluster2)..."
sed -i.bak \
  -e "s/\(.*\):.*# namespace:operator/\1: ${ROOK_OPERATOR_NAMESPACE} # namespace:operator/g" \
  -e "s/\(.*\):.*# namespace:cluster/\1: ${CLUSTER2_NS} # namespace:cluster/g" \
  "${OUT_DIR}/common-${CLUSTER2_NS}.yaml" \
  "${OUT_DIR}/cluster2.yaml"

echo "Customizing CephCluster names + disks..."

# Replace the storage devices section in a YAML-safe way (real newlines, correct indentation).
# Requires: awk (gawk on Fedora).
set_cluster_device() {
  local file="$1"
  local dev="$2"
  local tmp="${file}.tmp"

  awk -v dev="${dev}" '
    {
      # Replace the first occurrence only
      if (!done && $0 ~ /^[[:space:]]*useAllDevices:[[:space:]]*true[[:space:]]*$/) {
        match($0, /^([[:space:]]*)useAllDevices:/, m)
        indent = m[1]
        print indent "useAllDevices: false"
        print indent "devices:"
        print indent "  - name: \"" dev "\""
        done = 1
        next
      }
      print
    }
    END {
      if (!done) exit 2
    }
  ' "${file}" > "${tmp}" && mv "${tmp}" "${file}"
}

# cluster1: unique name, separate dataDirHostPath, use vda only
sed -i.bak \
  -e "s/^  name: my-cluster$/  name: my-cluster-1/g" \
  -e "s|^  dataDirHostPath: /var/lib/rook$|  dataDirHostPath: /var/lib/rook/cluster1|g" \
  "${OUT_DIR}/cluster1.yaml"
set_cluster_device "${OUT_DIR}/cluster1.yaml" "vda"

# cluster2: unique name, separate dataDirHostPath, use vdb only
sed -i.bak \
  -e "s/^  name: my-cluster$/  name: my-cluster-2/g" \
  -e "s|^  dataDirHostPath: /var/lib/rook$|  dataDirHostPath: /var/lib/rook/cluster2|g" \
  "${OUT_DIR}/cluster2.yaml"
set_cluster_device "${OUT_DIR}/cluster2.yaml" "vdb"

OPERATOR_TO_APPLY="${OUT_DIR}/operator-${ROOK_OPERATOR_NAMESPACE}.yaml"

if [[ -n "${TAG}" ]]; then
  echo "Using private operator image: ${ROOK_PRIVATE_IMAGE_REPO}:${TAG}"
  # Replace the operator container image line. Keep the leading indentation.
  sed -i.bak \
    -e "s|^\\(\\s*image:\\s*\\).*rook/ceph:.*$|\\1${ROOK_PRIVATE_IMAGE_REPO}:${TAG}|g" \
    "${OPERATOR_TO_APPLY}"

  # Ensure imagePullPolicy: Always is present under the operator container (indented 10 spaces in the sample).
  if ! grep -q '^[[:space:]]*imagePullPolicy:[[:space:]]*Always[[:space:]]*$' "${OPERATOR_TO_APPLY}"; then
    sed -i.bak \
      -e "/^[[:space:]]*image:[[:space:]]*${ROOK_PRIVATE_IMAGE_REPO//\//\\/}:${TAG}$/a\\
\\          imagePullPolicy: Always" \
      "${OPERATOR_TO_APPLY}"
  fi
else
  echo "No TAG provided; using stock operator image from examples."
fi

echo "Generating per-cluster pool + StorageClass manifests..."
cat > "${OUT_DIR}/storageclass-rbd-${CLUSTER1_NS}.yaml" <<EOF
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: replicapool
  namespace: ${CLUSTER1_NS}
spec:
  failureDomain: host
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: rook-ceph-block-cluster1
provisioner: ${ROOK_OPERATOR_NAMESPACE}.rbd.csi.ceph.com
parameters:
  clusterID: ${CLUSTER1_NS}
  pool: replicapool
  imageFormat: "2"
  imageFeatures: layering
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-publish-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: ${CLUSTER1_NS}
  csi.storage.k8s.io/fstype: ext4
allowVolumeExpansion: true
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOF

cat > "${OUT_DIR}/storageclass-rbd-${CLUSTER2_NS}.yaml" <<EOF
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: replicapool
  namespace: ${CLUSTER2_NS}
spec:
  failureDomain: host
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: rook-ceph-block-cluster2
provisioner: ${ROOK_OPERATOR_NAMESPACE}.rbd.csi.ceph.com
parameters:
  clusterID: ${CLUSTER2_NS}
  pool: replicapool
  imageFormat: "2"
  imageFeatures: layering
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-publish-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: ${CLUSTER2_NS}
  csi.storage.k8s.io/fstype: ext4
allowVolumeExpansion: true
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOF

echo "Applying manifests..."
kubectl apply -f "${OUT_DIR}/crds.yaml"
kubectl apply -f "${OUT_DIR}/common-${CLUSTER1_NS}.yaml"
kubectl apply -f "${OUT_DIR}/csi-operator-${ROOK_OPERATOR_NAMESPACE}.yaml"
kubectl apply -f "${OPERATOR_TO_APPLY}"

kubectl -n "${ROOK_OPERATOR_NAMESPACE}" wait --for=condition=available deployment/rook-ceph-operator --timeout=300s
kubectl -n "${ROOK_OPERATOR_NAMESPACE}" wait --for=condition=available deployment/ceph-csi-controller-manager --timeout=300s

kubectl apply -f "${OUT_DIR}/cluster1.yaml"
kubectl apply -f "${OUT_DIR}/common-${CLUSTER2_NS}.yaml"
kubectl apply -f "${OUT_DIR}/cluster2.yaml"

kubectl apply -f "${OUT_DIR}/storageclass-rbd-${CLUSTER1_NS}.yaml"
kubectl apply -f "${OUT_DIR}/storageclass-rbd-${CLUSTER2_NS}.yaml"

echo "Done."
echo "Generated YAMLs: ${OUT_DIR}"
echo "StorageClasses:"
echo "  - rook-ceph-block-cluster1 (cluster namespace: ${CLUSTER1_NS})"
echo "  - rook-ceph-block-cluster2 (cluster namespace: ${CLUSTER2_NS})"

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
