### PR TITLE
ci: deduplicate boot device names

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -60,7 +60,7 @@ function find_extra_block_dev() {
   # NAME="sda15" SIZE="106M" TYPE="part" MOUNTPOINT="/boot/efi" PKNAME="sda"
   # NAME="sdb"   SIZE="75G"  TYPE="disk" MOUNTPOINT=""          PKNAME=""
   # NAME="sdb1"  SIZE="75G"  TYPE="part" MOUNTPOINT="/mnt"      PKNAME="sdb"
-  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
+  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}'| sort -u)"
   echo "  == find_extra_block_dev(): boot_dev='$boot_dev'" >/dev/stderr # debug in case of future errors
   # --nodeps ignores partitions
   extra_dev="$(sudo lsblk --noheading --list --nodeps --output KNAME | egrep -v "($boot_dev|loop|nbd)" | head -1)"


### PR DESCRIPTION
When multiple partitions on the same disk have
boot-related mountpoints (e.g. /boot/efi and /boot), the parent device name appears multiple times in
boot_dev. This causes the egrep -v exclusion pattern to contain duplicates like "sda|sda" which, while
functionally correct, is unnecessary. Add sort -u to produce a clean, deduplicated list.

failed in https://github.com/Rakshith-R/ceph-volsync-plugin/actions/runs/22408064734/job/64873527116

```
++++ find_extra_block_dev
+++++ sudo lsblk
++++ echo 'NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda       8:0    0   75G  0 disk 
├─sda1    8:1    0   74G  0 part /
├─sda14   8:14   0    4M  0 part 
├─sda15   8:15   0  106M  0 part /boot/efi
└─sda16 259:0    0  913M  0 part /boot
sdb       8:16   0   75G  0 disk 
└─sdb1    8:17   0   75G  0 part 
sdc       8:32   0   75G  0 disk '
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda       8:0    0   75G  0 disk 
├─sda1    8:1    0   74G  0 part /
├─sda14   8:14   0    4M  0 part 
├─sda15   8:15   0  106M  0 part /boot/efi
└─sda16 259:0    0  913M  0 part /boot
sdb       8:16   0   75G  0 disk 
└─sdb1    8:17   0   75G  0 part 
sdc       8:32   0   75G  0 disk 
+++++ sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME
+++++ grep boot
+++++ awk '{print $2}'
++++ boot_dev='sda
sda'
++++ echo '  == find_extra_block_dev(): boot_dev='\''sda
sda'\'''
  == find_extra_block_dev(): boot_dev='sda
sda'
+++++ sudo lsblk --noheading --list --nodeps --output KNAME
+++++ egrep -v '(sda
sda|loop|nbd)'
+++++ head -1
grep: Unmatched ( or \(
++++ extra_dev=
++++ '[' -z '' ']'
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
