### PR TITLE
build: silence docs-build

### DIFF
--- a/.docs/macros/includes/main.py
+++ b/.docs/macros/includes/main.py
@@ -30,4 +30,4 @@ def on_post_page_macros(env):
     if target == "master":
         return
 
-    env.raw_markdown = re.sub(regex, subst % target, env.raw_markdown, 0)
+    env.markdown = re.sub(regex, subst % target, env.markdown, 0)


### PR DESCRIPTION
**Description:**
make docs-build in the CI issued a lot of messages about `env.raw_markdown` being removed.

While looking like error messages, these did not result in build failures.

This change silences make docs-build by
using `env.markdown` instead



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
