### PR TITLE
Build: cleanup PHONY  declarations in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ build.version:
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
+.PHONY: build.common
 build.common: export SKIP_GEN_CRD_DOCS=true
 build.common: build.version helm.build mod.check crds gen-rbac
 	@$(MAKE) go.init
@@ -130,10 +131,12 @@ do.build.platform.%:
 .PHONY: do.build.parallel
 do.build.parallel: $(foreach p,$(PLATFORMS_TO_BUILD_FOR), do.build.platform.$(p))
 
+.PHONY: build
 build: build.common ## Only build for linux platform
 	@$(MAKE) go.build PLATFORM=linux_$(GOARCH)
 	@$(MAKE) -C images PLATFORM=linux_$(GOARCH)
 
+.PHONY: build.all
 build.all: build.common ## Build source code for all platforms.
 ifneq ($(GOHOSTARCH),amd64)
 	$(error cross platform image build only supported on amd64 host currently)
@@ -141,6 +144,7 @@ endif
 	@$(MAKE) do.build.parallel
 	@$(MAKE) -C images build.all
 
+.PHONY: install
 install: build.common
 	@$(MAKE) go.install
 
@@ -154,10 +158,12 @@ test: ## Runs unit tests.
 test-integration: ## Runs integration tests.
 	@$(MAKE) go.test.integration
 
+.PHONY: vet
 vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet
 
+.PHONY: fmt
 fmt: $(YQ) ## Check formatting of go sources.
 	@$(MAKE) go.fmt
 
@@ -180,7 +186,6 @@ yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
 
 .PHONY: helm.lint
-
 helm.lint: ## Check the helm charts
 	ct lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false
 	helm -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
@@ -203,7 +208,9 @@ checkmake:
 shellcheck:
 	shellcheck --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
 
+.PHONY: gen.codegen
 gen.codegen: codegen
+.PHONY: codegen
 codegen: ${CODE_GENERATOR} ## Run code generators.
 	@build/codegen/codegen.sh
 
@@ -213,33 +220,42 @@ mod.check: go.mod.check ## Check if any go modules changed.
 .PHONY: mod.update
 mod.update: go.mod.update ## Update all go modules.
 
+.PHONY: clean
 clean: ## Remove all files that are created by building.
 	@$(MAKE) helm.dependency.clean
 	@$(MAKE) go.mod.clean
 	@$(MAKE) -C images clean
 	@rm -fr $(OUTPUT_DIR) $(WORK_DIR)
 
+.PHONY: distclean
 distclean: clean ## Remove all files that are created by building or configuring.
 	@rm -fr $(CACHE_DIR)
 
+.PHONY: prune
 prune: ## Prune cached artifacts.
 	@$(MAKE) -C images prune
 
+.PHONY: gen.crds
 gen.crds: crds
+.PHONY: crds
 crds: $(CONTROLLER_GEN) $(YQ)
 	@echo Updating CRD manifests
 	@build/crds/build-crds.sh $(CONTROLLER_GEN) $(YQ)
 	@GOBIN=$(GOBIN) build/crds/generate-crd-docs.sh
 
+.PHONY: gen.rbac
 gen.rbac: gen-rbac
+.PHONY: gen-rbac
 gen-rbac: $(HELM) $(YQ) helm.dependency.build ## Generate RBAC from Helm charts
 	@# output only stdout to the file; stderr for debugging should keep going to stderr
 	HELM=$(HELM) ./build/rbac/gen-common.sh
 	HELM=$(HELM) ./build/rbac/gen-nfs-rbac.sh
 
+.PHONY: gen.docs
 gen.docs: docs ## generate docs
 .PHONY: docs
 docs: helm-docs ## generate documentation
+.PHONY: gen.helm-docs
 gen.helm-docs: helm-docs
 helm-docs: $(HELM_DOCS) ## Use helm-docs to generate documentation from helm charts
 	$(HELM_DOCS) -c deploy/charts/rook-ceph \
@@ -257,15 +273,15 @@ docs-preview: ## Preview the documentation through mkdocs
 docs-build:  ## Build the documentation to the `site/` directory
 	mkdocs build --strict
 
+.PHONY: gen.crd-docs
 gen.crd-docs: generate-docs-crds
 generate-docs-crds: ## Build the documentation for CRD
 	@GOBIN=$(GOBIN) build/crds/generate-crd-docs.sh
 
+.PHONY: generate
 generate: gen.codegen gen.crds gen.rbac gen.docs gen.crd-docs ## Update all generated files (code, manifests, charts, and docs).
 
 
-.PHONY: all build.common
-.PHONY: build build.all install test check vet fmt codegen gen.codegen gen.rbac gen.crds gen.crd-docs gen.docs gen.helm-docs generate mod.check clean distclean prune
 
 # ====================================================================================
 # Help


### PR DESCRIPTION
** Description:**

Most phony targets in the Makefile were declared phony
    by grouping multiple targets in  long combined `.PHONY`
    statements which obfuscates the phony nature of a target to some extent.
    
This change makes the phony target declarations a bit more obvious and explicit by prepending each phony target by a corresponding
    individual `.PHONY` statement and removing the confusing combined `.PHONY`lines.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
