### PR TITLE
object: call generateUserCaps after AdminOpsClient calls

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -427,6 +427,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		logCreateOrUpdate = fmt.Sprintf("updated ceph object user %q", u.Name)
 	}
 
+	liveUser.UserCaps = generateUserCaps(&liveUser)
 	// Update caps, if necessary
 	log.NamedTrace(nsName, logger, "user capabilities(id: %s, caps: %#v, user caps: %s, op mask: %s)",
 		liveUser.ID, liveUser.Caps, liveUser.UserCaps, liveUser.OpMask)
@@ -646,7 +647,6 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) (*admin.User, error) {
 	}
 
 	userConfig.OpMask = opMask
-	userConfig.UserCaps = generateUserCaps(userConfig)
 
 	return userConfig, nil
 }


### PR DESCRIPTION
This prevents overwriting the user-specified capabilities and correctly copies the Capabilities into UserCapabilities after the AdminOpsClient calls, which returns the User object with only the Capabilities field. This will fix the issue where the user capabilities were not propagated from the CephObjectStoreUser to the RGW user.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17148 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
