### PR TITLE
test: Increase osd reconcile wait timeout

### DIFF
--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -335,7 +335,7 @@ func testOSDIntegration(t *testing.T) {
 			updateStatusConfigmap(clientset, statusMapWatcher, cpy)
 			if i == 2 {
 				t.Log("canceling orchestration")
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				// after the second status map is made ready, cancel the orchestration. wait a short
 				// while to make sure the watcher picks up the updated change
 				cancel()


### PR DESCRIPTION
The osd unit tests periodically fail with a timing issue when canceling an orchestration. Attempt to stabilize the test with a longer timeout before canceling the test.

I was not able to repro the failure when testing in a loop, so it seems there is a race condition that only hits when the test is running cold. 

The failure seen in the test is as follows. It seems the osd counts just aren't updated as expected when this hits, since the reconcile was canceled.
```
    integration_test.go:350: c.Start() error: context canceled
        failed to update/create OSDs
        github.com/rook/rook/pkg/operator/ceph/cluster/osd.(*Cluster).Start
        	/home/runner/work/rook/rook/pkg/operator/ceph/cluster/osd/osd.go:330
        github.com/rook/rook/pkg/operator/ceph/cluster/osd.testOSDIntegration.func4
        	/home/runner/work/rook/rook/pkg/operator/ceph/cluster/osd/integration_test.go:253
        runtime.goexit
        	/opt/hostedtoolcache/go/1.25.7/x64/src/runtime/asm_amd64.s:1693
    integration_test.go:352: 
        	Error Trace:	/home/runner/work/rook/rook/pkg/operator/ceph/cluster/osd/integration_test.go:352
        	Error:      	"[rook-ceph-osd-23]" should have 2 item(s), but has 1
        	Test:       	TestOSDIntegration/mixed_create_and_update,_cancel_reconcile,_and_continue_reconcile
    integration_test.go:355: deployments updated: 1

=== NAME  TestOSDIntegration/mixed_create_and_update,_cancel_reconcile,_and_continue_reconcile
    integration_test.go:366: 
        	Error Trace:	/home/runner/work/rook/rook/pkg/operator/ceph/cluster/osd/integration_test.go:366
        	Error:      	"[rook-ceph-osd-25 rook-ceph-osd-26 rook-ceph-osd-24 rook-ceph-osd-27]" should have 3 item(s), but has 4
        	Test:       	TestOSDIntegration/mixed_create_and_update,_cancel_reconcile,_and_continue_reconcile
    integration_test.go:367: 
        	Error Trace:	/home/runner/work/rook/rook/pkg/operator/ceph/cluster/osd/integration_test.go:367
        	Error:      	"[rook-ceph-osd-0 rook-ceph-osd-1 rook-ceph-osd-10 rook-ceph-osd-11 rook-ceph-osd-12 rook-ceph-osd-13 rook-ceph-osd-14 rook-ceph-osd-15 rook-ceph-osd-16 rook-ceph-osd-17 rook-ceph-osd-18 rook-ceph-osd-19 rook-ceph-osd-2 rook-ceph-osd-20 rook-ceph-osd-21 rook-ceph-osd-22 rook-ceph-osd-23 rook-ceph-osd-3 rook-ceph-osd-4 rook-ceph-osd-5 rook-ceph-osd-6 rook-ceph-osd-7 rook-ceph-osd-8 rook-ceph-osd-9]" should have 25 item(s), but has 24
        	Test:       	TestOSDIntegration/mixed_create_and_update,_cancel_reconcile,_and_continue_reconcile
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
