### PR TITLE
nvmeof: add csi operator support for nvmeof canary test

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -2019,13 +2019,17 @@ jobs:
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/github-action-helper.sh create_partitions_for_osds
 
-      - name: deploy cluster without ceph-csi operator
+      - name: deploy cluster with ceph-csi operator
         run: |
           OPERATOR_MANIFEST="deploy/examples/operator.yaml"
-          sed -i 's|# ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"|ROOK_CSI_CEPH_IMAGE: "quay.io/nixpanic/cephcsi:nvmeof"|' "${OPERATOR_MANIFEST}"
-          sed -i 's|ROOK_USE_CSI_OPERATOR: "true"|ROOK_USE_CSI_OPERATOR: "false"|' "${OPERATOR_MANIFEST}"
+          CSI_OPERATOR_MANIFEST="deploy/examples/csi-operator.yaml"
+
+          sed -i 's|# ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"|ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:canary"|' "${OPERATOR_MANIFEST}"
+          sed -i 's|image: quay.io/cephcsi/ceph-csi-operator:v0.5.0|image: quay.io/cephcsi/ceph-csi-operator:latest|' "${CSI_OPERATOR_MANIFEST}"
+          sed -i 's#(rbd|cephfs|nfs)#(rbd|cephfs|nfs|nvmeof)#g' "${CSI_OPERATOR_MANIFEST}"
 
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "${OPERATOR_MANIFEST}"
+          tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "${CSI_OPERATOR_MANIFEST}"
 
           export BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           yq w -i -d0 deploy/examples/cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"
@@ -2041,7 +2045,7 @@ jobs:
         run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
 
       - name: test ceph-csi-nvmeof plugin restart and data persistence
-        run: tests/scripts/github-action-helper.sh test_csi_nvmeof_workload
+        run: tests/scripts/github-action-helper.sh test_csi_nvmeof_workload_with_operator
 
       - name: collect common logs
         if: always()

--- a/Documentation/Storage-Configuration/Block-Storage-RBD/nvme-of.md
+++ b/Documentation/Storage-Configuration/Block-Storage-RBD/nvme-of.md
@@ -27,7 +27,11 @@ This guide assumes a Rook cluster as explained in the [Quickstart Guide](../../G
 ### Requirements
 
 - **Ceph Version**: Ceph v20 (Tentacle) or later
-- **Disable the Ceph CSI operator**: We are still updating the Ceph CSI operator with NVMe-oF support. Currently, it is required to disable the CSI operator to test NVMe-oF. In operator.yaml, set `ROOK_USE_CSI_OPERATOR: "false"`.
+- **Ceph CSI operator**: The CSI operator must be enabled (`ROOK_USE_CSI_OPERATOR: "true"` in `operator.yaml`). The Driver CRD must allow `nvmeof` in its name validation. If the CRD does not yet include `nvmeof`, patch it before deploying:
+
+    ```console
+    kubectl get crd drivers.csi.ceph.io -o json | sed 's#(rbd|cephfs|nfs)#(rbd|cephfs|nfs|nvmeof)#g' | kubectl apply -f -
+    ```
 
 ## Step 1: Create a Ceph Block Pool
 
@@ -97,81 +101,37 @@ NAME                                         READY   STATUS    RESTARTS   AGE
 rook-ceph-nvmeof-nvmeof-a-85844ff6b8-4r8gj   1/1     Running   0          91s
 ```
 
-## Step 4: Deploy the NVMe-oF CSI Driver
+## Step 3: Deploy the NVMe-oF CSI Driver via CSI Operator
 
-The NVMe-oF CSI driver handles dynamic provisioning of volumes. Deploy the CSI provisioner with the NVMe-oF driver.
-
-Deploy the NVMe-oF CSI provisioner from the example manifest:
+The NVMe-oF CSI driver is deployed via the ceph-csi operator.
+Apply the manifest that creates the RBAC resources and
+the `Driver` CR for NVMe-oF:
 
 ```console
-kubectl create -f deploy/examples/csi/nvmeof/provisioner.yaml
+kubectl create -f deploy/examples/csi/nvmeof/csi-operator-nvmeof.yaml
 ```
 
-Verify the CSI provisioner pod is running:
+Verify the CSI operator created the controller and node plugins:
 
 ```console
-kubectl get pods -n rook-ceph -l app=csi-nvmeofplugin-provisioner
+kubectl get pods -n rook-ceph | grep nvmeof
 ```
 
 **Example Output**
 
 ```console
-NAME                                           READY   STATUS    RESTARTS   AGE
-csi-nvmeofplugin-provisioner-65b4fbbc8-jjsqj   4/4     Running   0          75s
+rook-ceph.nvmeof.csi.ceph.com-ctrlplugin-d9d77fb7c-kkl28   5/5     Running   0          60s
+rook-ceph.nvmeof.csi.ceph.com-nodeplugin-xvt5g              2/2     Running   0          60s
 ```
 
-## Step 5: Create the StorageClass
+## Step 4: Create the StorageClass
 
-Create a StorageClass that uses the NVMe-oF CSI driver. You'll need to gather the following information from the gateway:
+Create a StorageClass that uses the NVMe-oF CSI driver.
 
-1. **nvmeofGatewayAddress**: A stable address for the gateway management API
-2. **nvmeofGatewayPort**: The gateway port (default: 5500)
-3. **listeners**: A JSON array containing listener information for each gateway instance
-
-Discover the values to use in the StorageClass:
-
-1. **nvmeofGatewayAddress**: Use the Service `CLUSTER-IP`.
-
-    ```console
-    kubectl get service -n rook-ceph rook-ceph-nvmeof-nvmeof-a
-    ```
-
-    **Example Output**
-
-    ```console
-    NAME                        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                               AGE
-    rook-ceph-nvmeof-nvmeof-a   ClusterIP   10.106.98.71   <none>        4420/TCP,5500/TCP,5499/TCP,8009/TCP   24m
-    ```
-
-2. **listeners.address**: Use the gateway pod IP.
-
-    ```console
-    kubectl get pods -n rook-ceph -l app=rook-ceph-nvmeof -o wide
-
-    ```
-
-    **Example Output**
-
-    ```console
-    NAME                                         READY   STATUS    RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
-    rook-ceph-nvmeof-nvmeof-a-5fd6cd4d46-mrbwk   1/1     Running   0          26m   10.244.0.16   minikube   <none>           <none>
-    ```
-
-3. **listeners.hostname**: Use the gateway deployment name.
-
-    ```console
-    kubectl get deployments.apps -n rook-ceph -l app=rook-ceph-nvmeof
-    ```
-
-    **Example Output**
-
-    ```console
-    NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
-    rook-ceph-nvmeof-nvmeof-a   1/1     1            1           27m
-    ```
-
-Create the StorageClass:
-
+The `nvmeofGatewayAddress` and `listeners` fields use the gateway
+deployment hostname (e.g. `rook-ceph-nvmeof-nvmeof-a`) rather than
+IP addresses, so the StorageClass does not need to be updated when
+pods restart.
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -182,16 +142,11 @@ parameters:
   clusterID: rook-ceph
   pool: nvmeof
   subsystemNQN: nqn.2016-06.io.spdk:cnode1.rook-ceph
-  # Management API - talks to gateway to create subsystems/namespaces
-  nvmeofGatewayAddress: "10.106.98.71"
+  nvmeofGatewayAddress: "rook-ceph-nvmeof-nvmeof-a"
   nvmeofGatewayPort: "5500"
-  # Data Plane - worker nodes connect here for actual I/O
-  # List ALL gateway pods for HA and multipath
   listeners: |
     [
       {
-        "address": "10.244.0.16",
-        "port": 4420,
         "hostname": "rook-ceph-nvmeof-nvmeof-a"
       }
     ]
@@ -205,19 +160,21 @@ parameters:
   csi.storage.k8s.io/node-expand-secret-namespace: rook-ceph
   imageFormat: "2"
   imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
-provisioner: nvmeof.csi.ceph.com
+provisioner: rook-ceph.nvmeof.csi.ceph.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 ```
 
-Create the StorageClass:
+!!! note
+    The provisioner name `rook-ceph.nvmeof.csi.ceph.com` is prefixed
+    with the operator namespace when using the CSI operator.
 
 ```console
 kubectl create -f deploy/examples/csi/nvmeof/storageclass.yaml
 ```
 
-## Step 6: Create a PersistentVolumeClaim
+## Step 5: Create a PersistentVolumeClaim
 
 Create a PVC using the NVMe-oF storage class:
 
@@ -258,36 +215,9 @@ NAME                     STATUS   VOLUME                                     CAP
 nvmeof-external-volume   Bound    pvc-b4108580-5cfa-46d3-beff-320088a5bf3c   128Mi      RWO            ceph-nvmeof    20m
 ```
 
-## Step 7: Deploy the NVMe-oF CSI Node Plugin
+## Step 6: Create a Pod
 
-Deploy the NVMe-oF CSI node plugin:
-
-```console
-kubectl create -f deploy/examples/csi/nvmeof/node-plugin.yaml
-```
-
-Verify the node plugin pod is running:
-
-```console
-kubectl get pods -n rook-ceph -l app=nvmeof.csi.ceph.com-nodeplugin
-```
-
-**Example Output**
-
-```console
-NAME                               READY   STATUS    RESTARTS   AGE
-nvmeof.csi.ceph.com-nodeplugin-xnm82   2/2     Running   0          31h
-```
-
-## Step 8: Accessing Volumes via NVMe-oF
-
-Once the PVC is created and bound, the volume is available via NVMe-oF. The volume can be accessed by both Kubernetes pods within the cluster and external clients outside the cluster.
-
-### Access from Kubernetes Pods
-
-Kubernetes pods can consume NVMe-oF volumes by mounting the PVC directly. The CSI driver handles the NVMe-oF connection automatically when the pod mounts the volume.
-
-Create a sample pod that mounts the PVC:
+Create a pod that consumes the NVMe-oF volume:
 
 ```console
 kubectl create -f deploy/examples/csi/nvmeof/pod.yaml
@@ -296,15 +226,21 @@ kubectl create -f deploy/examples/csi/nvmeof/pod.yaml
 Verify the pod is running:
 
 ```console
-kubectl get pods -n default
+kubectl get pods -n default nvmeof-test-pod
 ```
 
 **Example Output**
 
 ```console
 NAME              READY   STATUS    RESTARTS   AGE
-nvmeof-test-pod   1/1     Running   0          29h
+nvmeof-test-pod   1/1     Running   0          60s
 ```
+
+## Step 7: Accessing Volumes via NVMe-oF
+
+Once the PVC is created and bound, the volume is available via
+NVMe-oF. The volume can be accessed by both Kubernetes pods within
+the cluster and external clients outside the cluster.
 
 ### Access from External Clients
 
@@ -366,7 +302,7 @@ sudo mount /dev/nvmeXnY /mnt/nvmeof
 For production deployments, configure multiple gateway instances for high availability:
 
 1. **Increase Gateway Instances**: Set `instances: 2` or higher in the `CephNVMeOFGateway` spec
-2. **Update StorageClass Listeners**: Add all gateway instance addresses and instance names to the `listeners` array
+2. **Update StorageClass Listeners**: Add all gateway deployment hostnames to the `listeners` array
 3. **Load Balancing**: Each gateway instance has its own Service; list all of them to support multipath/HA
 
 Example with multiple instances:
@@ -377,19 +313,16 @@ spec:
   # ... other settings
 ```
 
-Then update the StorageClass `listeners` to include all gateway instances/services:
+Then update the StorageClass `listeners` to include all gateway
+hostnames:
 
 ```yaml
 listeners: |
   [
     {
-      "address": "10.99.212.218",
-      "port": 4420,
       "hostname": "rook-ceph-nvmeof-nvmeof-a"
     },
     {
-      "address": "10.99.212.219",
-      "port": 4420,
       "hostname": "rook-ceph-nvmeof-nvmeof-b"
     }
   ]
@@ -403,16 +336,16 @@ listeners: |
 kubectl logs -n rook-ceph -l app=rook-ceph-nvmeof --tail=100
 ```
 
-### Check CSI Provisioner Logs
+### Check CSI Controller Plugin Logs
 
 ```console
-kubectl logs -n rook-ceph -l app=csi-nvmeofplugin-provisioner --tail=100
+kubectl logs -n rook-ceph deploy/rook-ceph.nvmeof.csi.ceph.com-ctrlplugin --tail=100
 ```
 
 ### Verify Gateway Service
 
 ```console
-kubectl describe service -n rook-ceph rook-ceph-nvmeof-my-nvmeof-0
+kubectl describe service -n rook-ceph rook-ceph-nvmeof-nvmeof-a
 ```
 
 ### Check PVC Events
@@ -446,17 +379,14 @@ kubectl delete pvc nvmeof-external-volume
 # Delete the StorageClass
 kubectl delete storageclass ceph-nvmeof
 
-# Delete the NVMe-oF CSI node plugin
-kubectl delete -f deploy/examples/csi/nvmeof/node-plugin.yaml
-
-# Delete the NVMe-oF CSI provisioner (includes ServiceAccount/RBAC)
-kubectl delete -f deploy/examples/csi/nvmeof/provisioner.yaml
+# Delete the NVMe-oF CSI operator resources
+kubectl delete -f deploy/examples/csi/nvmeof/csi-operator-nvmeof.yaml
 
 # Delete the NVMe-oF gateway
-kubectl delete -n rook-ceph cephnvmeofgateway.ceph.rook.io my-nvmeof
+kubectl delete -f deploy/examples/nvmeof-test.yaml
 
 # Delete the block pool (optional)
-kubectl delete -n rook-ceph cephblockpool.ceph.rook.io nvmeof
+kubectl delete -f deploy/examples/csi/nvmeof/nvmeof-pool.yaml
 ```
 
 ## References

--- a/deploy/examples/csi/nvmeof/csi-operator-nvmeof.yaml
+++ b/deploy/examples/csi/nvmeof/csi-operator-nvmeof.yaml
@@ -1,0 +1,283 @@
+# NVMe-oF CSI driver resources for the ceph-csi-operator.
+#
+# When ROOK_USE_CSI_OPERATOR is "true", apply this manifest to deploy
+# the NVMe-oF provisioner and nodeplugin via the CSI operator.
+#
+# Prerequisites:
+#   1. The Driver CRD must allow "nvmeof" in the name validation.
+#      If using csi-operator.yaml from before ceph-csi-operator PR #375,
+#      patch the CRD first (see patch-crd-nvmeof.sh or do it manually).
+#   2. The ceph-csi-operator image must be quay.io/cephcsi/ceph-csi-operator:latest
+#      (or any version that includes NVMe-oF support).
+#
+# Usage:
+#   kubectl apply -f csi-operator-nvmeof.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-nvmeof-ctrlplugin-sa
+  namespace: rook-ceph # namespace:operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-nvmeof-nodeplugin-sa
+  namespace: rook-ceph # namespace:operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ceph-csi-nvmeof-ctrlplugin-cr
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.openshift.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.openshift.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.openshift.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationcontents"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: ["cbt.storage.k8s.io"]
+    resources: ["snapshotmetadataservices"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ceph-csi-nvmeof-nodeplugin-cr
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ceph-csi-nvmeof-ctrlplugin-crb
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-nvmeof-ctrlplugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: ClusterRole
+  name: ceph-csi-nvmeof-ctrlplugin-cr
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ceph-csi-nvmeof-nodeplugin-crb
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-nvmeof-nodeplugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: ClusterRole
+  name: ceph-csi-nvmeof-nodeplugin-cr
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ceph-csi-nvmeof-ctrlplugin-r
+  namespace: rook-ceph # namespace:operator
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ceph-csi-nvmeof-nodeplugin-r
+  namespace: rook-ceph # namespace:operator
+rules:
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-nvmeof-ctrlplugin-rb
+  namespace: rook-ceph # namespace:operator
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-nvmeof-ctrlplugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: Role
+  name: ceph-csi-nvmeof-ctrlplugin-r
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-nvmeof-nodeplugin-rb
+  namespace: rook-ceph # namespace:operator
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-nvmeof-nodeplugin-sa
+    namespace: rook-ceph # namespace:operator
+roleRef:
+  kind: Role
+  name: ceph-csi-nvmeof-nodeplugin-r
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: csi.ceph.io/v1
+kind: Driver
+metadata:
+  name: rook-ceph.nvmeof.csi.ceph.com
+  namespace: rook-ceph # namespace:operator
+spec:
+  clusterName: my-cluster
+  controllerPlugin:
+    affinity:
+      nodeAffinity: {}
+    imagePullPolicy: ""
+    priorityClassName: system-cluster-critical
+    replicas: 1
+    resources: {}
+  deployCsiAddons: false
+  enableMetadata: true
+  fsGroupPolicy: File
+  generateOMapInfo: false
+  imageSet:
+    name: rook-csi-operator-image-set-configmap
+  log:
+    verbosity: 5
+  nodePlugin:
+    affinity:
+      nodeAffinity: {}
+    enableSeLinuxHostMount: false
+    imagePullPolicy: ""
+    kubeletDirPath: /var/lib/kubelet
+    priorityClassName: system-node-critical
+    resources: {}
+    updateStrategy:
+      type: RollingUpdate

--- a/deploy/examples/csi/nvmeof/storageclass.yaml
+++ b/deploy/examples/csi/nvmeof/storageclass.yaml
@@ -7,7 +7,7 @@ parameters:
   pool: nvmeof
   subsystemNQN: nqn.2016-06.io.spdk:cnode1.rook-ceph
   # Management API - talks to gateway to create subsystems/namespaces
-  nvmeofGatewayAddress: "172.30.47.120"
+  nvmeofGatewayAddress: "rook-ceph-nvmeof-nvmeof-a"
   nvmeofGatewayPort: "5500"
   # Data Plane - worker nodes connect here for actual I/O
   # List ALL gateway pods for HA and multipath
@@ -27,7 +27,10 @@ parameters:
   csi.storage.k8s.io/node-expand-secret-namespace: rook-ceph
   imageFormat: "2"
   imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
-provisioner: nvmeof.csi.ceph.com
+# When using the CSI operator (ROOK_USE_CSI_OPERATOR=true), the driver name
+# is prefixed with the operator namespace: rook-ceph.nvmeof.csi.ceph.com
+# Without the CSI operator, use: nvmeof.csi.ceph.com
+provisioner: rook-ceph.nvmeof.csi.ceph.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -106,6 +106,8 @@ users:
   - system:serviceaccount:rook-ceph:ceph-csi-nfs-nodeplugin-sa # serviceaccount:namespace:operator
   - system:serviceaccount:rook-ceph:ceph-csi-rbd-ctrlplugin-sa # serviceaccount:namespace:operator
   - system:serviceaccount:rook-ceph:ceph-csi-rbd-nodeplugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:ceph-csi-nvmeof-ctrlplugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:ceph-csi-nvmeof-nodeplugin-sa # serviceaccount:namespace:operator
 ---
 # Rook Ceph Operator Config
 # Use this ConfigMap to override operator configurations
@@ -202,7 +204,7 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.1"
+  ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:canary"
   # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"
   # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
   # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v6.1.1"

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -764,13 +764,9 @@ function test_csi_nfs_workload {
   kubectl exec -t pod/csinfs-demo-pod -- ls -alh /var/lib/www/html/
 }
 
-function test_csi_nvmeof_workload {
+function test_csi_nvmeof_workload_with_operator {
   cd "${REPO_DIR}/deploy/examples/csi/nvmeof"
 
-  local cephcsi_image="${1:-quay.io/nixpanic/cephcsi:nvmeof}"
-  local gateway_svc="rook-ceph-nvmeof-nvmeof-a"
-  local gateway_listener_hostname="rook-ceph-nvmeof-nvmeof-a"
-  local service_ip
   local old_gateway_pod
 
   sed -i 's/failureDomain: .*/failureDomain: osd/' nvmeof-pool.yaml
@@ -781,28 +777,39 @@ function test_csi_nvmeof_workload {
   kubectl create -f "${REPO_DIR}/deploy/examples/nvmeof-test.yaml"
   wait_for cephnvmeofgateway nvmeof rook-ceph 600
   timeout 300 bash <<EOF
-until kubectl -n rook-ceph get pod --no-headers | awk '/rook-ceph-nvmeof-nvmeof-a-/ {print \$3}' | grep -q "^Running$"; do
+until kubectl -n rook-ceph get pod --no-headers 2>/dev/null | awk '/rook-ceph-nvmeof-nvmeof-a-/ && \$3 == "Running" {f=1} END {exit !f}'; do
   echo "waiting for NVMe-oF gateway pod to be running"
   sleep 5
 done
 EOF
 
-  service_ip="$(kubectl -n rook-ceph get svc "${gateway_svc}" -o jsonpath='{.spec.clusterIP}')"
-  if [[ -z "${service_ip}" ]]; then
-    echo "failed to discover gateway service IP for ${gateway_svc}"
-    exit 1
+  kubectl create -f csi-operator-nvmeof.yaml
+
+  timeout 300 bash <<EOF
+until kubectl -n rook-ceph get deployment --no-headers 2>/dev/null | grep -q "nvmeof"; do
+  echo "waiting for CSI operator to create NVMe-oF controller plugin deployment"
+  sleep 5
+done
+EOF
+
+  kubectl -n rook-ceph wait --for=condition=available \
+    deployment/rook-ceph.nvmeof.csi.ceph.com-ctrlplugin --timeout=300s
+
+  timeout 300 bash <<EOF
+until kubectl -n rook-ceph get daemonset --no-headers 2>/dev/null | grep -q "nvmeof"; do
+  echo "waiting for CSI operator to create NVMe-oF node plugin daemonset"
+  sleep 5
+done
+EOF
+
+  kubectl -n rook-ceph rollout status \
+    daemonset/rook-ceph.nvmeof.csi.ceph.com-nodeplugin --timeout=300s
+
+  lsmod | grep -E 'nvme(_|-)(tcp|fabrics)' || true
+  if [[ ! -d /sys/module/nvme_tcp ]]; then
+    echo "nvme_tcp kernel module is required but unavailable on kernel $(uname -r)"
+    return 1
   fi
-
-  sed -i "s|nvmeofGatewayAddress: \".*\"|nvmeofGatewayAddress: \"${service_ip}\"|g" storageclass.yaml
-  # ceph-csi PR 6061 expects listeners to include hostname only.
-  sed -i '/"address":/d' storageclass.yaml
-  sed -i '/"port":/d' storageclass.yaml
-  sed -i "s|\"hostname\": \".*\"|\"hostname\": \"${gateway_listener_hostname}\"|g" storageclass.yaml
-  sed -i "s|image: quay.io/cephcsi/cephcsi:.*|image: ${cephcsi_image}|g" provisioner.yaml
-  sed -i "s|image: quay.io/cephcsi/cephcsi:.*|image: ${cephcsi_image}|g" node-plugin.yaml
-
-  kubectl create -f provisioner.yaml
-  kubectl -n rook-ceph wait --for=condition=available deployment/csi-nvmeofplugin-provisioner --timeout=300s
 
   kubectl create -f storageclass.yaml
   kubectl create -f pvc.yaml
@@ -810,23 +817,7 @@ EOF
     echo "PVC nvmeof-external-volume did not reach Bound; collecting diagnostics..."
     kubectl describe pvc nvmeof-external-volume || true
     kubectl get events -n default --sort-by=.metadata.creationTimestamp | tail -n 50 || true
-    kubectl -n rook-ceph logs deploy/csi-nvmeofplugin-provisioner -c csi-provisioner --tail=200 || true
-    kubectl -n rook-ceph logs deploy/csi-nvmeofplugin-provisioner -c csi-nvmeofplugin --tail=200 || true
-    return 1
-  fi
-
-  # Sanity check module availability; prerequisites are installed earlier in CI setup.
-  lsmod | grep -E 'nvme(_|-)(tcp|fabrics)' || true
-  if [[ ! -d /sys/module/nvme_tcp ]]; then
-    echo "nvme_tcp kernel module is required but unavailable on kernel $(uname -r)"
-    return 1
-  fi
-
-  kubectl create -f node-plugin.yaml
-  if ! kubectl -n rook-ceph rollout status daemonset/nvmeof.csi.ceph.com-nodeplugin --timeout=300s; then
-    kubectl -n rook-ceph get pods -l app=nvmeof.csi.ceph.com-nodeplugin -o wide || true
-    kubectl -n rook-ceph describe daemonset nvmeof.csi.ceph.com-nodeplugin || true
-    echo "nvmeof nodeplugin daemonset failed to become ready"
+    kubectl -n rook-ceph logs -l "app.kubernetes.io/part-of=rook-ceph.nvmeof.csi.ceph.com" --tail=200 || true
     return 1
   fi
 
@@ -836,10 +827,10 @@ EOF
   kubectl -n default exec pod/nvmeof-test-pod -- sh -c "echo 'abcd' > /mnt/nvmeof/test.txt && cat /mnt/nvmeof/test.txt"
   kubectl -n default exec pod/nvmeof-test-pod -- sh -c "grep -qx 'abcd' /mnt/nvmeof/test.txt"
 
-  old_gateway_pod="$(kubectl -n rook-ceph get pod --no-headers | awk '/rook-ceph-nvmeof-nvmeof-a-/ {print $1; exit}')"
+  old_gateway_pod="$(kubectl -n rook-ceph get pod --no-headers | awk '/rook-ceph-nvmeof-nvmeof-a-/ {if (!f) f=$1} END {print f}')"
   kubectl -n rook-ceph delete pod "${old_gateway_pod}"
   timeout 300 bash <<EOF
-until new_gateway_pod=\$(kubectl -n rook-ceph get pod --no-headers | awk '/rook-ceph-nvmeof-nvmeof-a-/ && \$3 == "Running" {print \$1; exit}') && [[ -n "\${new_gateway_pod}" && "\${new_gateway_pod}" != "${old_gateway_pod}" ]]; do
+until new_gateway_pod=\$(kubectl -n rook-ceph get pod --no-headers | awk '/rook-ceph-nvmeof-nvmeof-a-/ && \$3 == "Running" {if (!f) f=\$1} END {print f}') && [[ -n "\${new_gateway_pod}" && "\${new_gateway_pod}" != "${old_gateway_pod}" ]]; do
   echo "waiting for NVMe-oF gateway pod restart"
   sleep 5
 done


### PR DESCRIPTION
update the nvmeof minikube canary test to use the
ceph-csi operator instead of manually deploying
the provisioner and node-plugin.

changes:
- add csi-operator-nvmeof.yaml with rbac and driver cr
- update storageclass to use operator-prefixed provisioner
- override ceph-csi and csi-operator images in ci
- replace test_csi_nvmeof_workload with operator variant

tested with:
- `ceph-csi: quay.io/cephcsi/cephcsi:canary`
- `ceph-csi-operator: quay.io/cephcsi/ceph-csi-operator:latest`

Tested manually on my Machine [fedora42]
```
1.Create a minikube version 1.38
minikube start --disk-size=10g --extra-disks=1 --driver=qemu2

2.Create a Ceph Block Pool
kubectl create -f deploy/examples/csi/nvmeof/nvmeof-pool.yaml

apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: nvmeof
  namespace: rook-ceph # namespace:cluster
spec:
  failureDomain: osd
  replicated:
    size: 1
    
3.Create the NVMe-oF Gateway
$ kubectl create -f deploy/examples/nvmeof-test.yaml

4. Add csi operator nvmeof
$ kubectl create -f deploy/examples/csi/nvmeof/csi-operator-nvmeof.yaml

5.Create the StorageClass
$ kubectl create -f deploy/examples/csi/nvmeof/storageclass.yaml

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ceph-nvmeof
parameters:
  clusterID: rook-ceph
  pool: nvmeof
  subsystemNQN: nqn.2016-06.io.spdk:cnode1.rook-ceph
  # Management API - talks to gateway to create subsystems/namespaces
  nvmeofGatewayAddress: "rook-ceph-nvmeof-nvmeof-a"
  nvmeofGatewayPort: "5500"
  # Data Plane - worker nodes connect here for actual I/O
  # List ALL gateway pods for HA and multipath
  listeners: |
    [
      {
        "hostname": "rook-ceph-nvmeof-nvmeof-a"
      }
    ]
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
  csi.storage.k8s.io/node-expand-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-expand-secret-namespace: rook-ceph
  imageFormat: "2"
  imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
# When using the CSI operator (ROOK_USE_CSI_OPERATOR=true), the driver name
# is prefixed with the operator namespace: rook-ceph.nvmeof.csi.ceph.com
# Without the CSI operator, use: nvmeof.csi.ceph.com
provisioner: rook-ceph.nvmeof.csi.ceph.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
allowVolumeExpansion: true


6. Create a PersistentVolumeClaim
kubectl create -f deploy/examples/csi/nvmeof/pvc.yaml

7. Create pod:
$ kubectl create -f deploy/examples/csi/nvmeof/pod.yaml

8.Login to pod and write data to /mnt/nvmeof path
$  kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # df -h /mnt/nvmeof
Filesystem                Size      Used Available Use% Mounted on
/dev/nvme0n1            103.9M     24.0K    101.3M   0% /mnt/nvmeof
/ # vi /mnt/nvmeof/test.txt
/ # cat /mnt/nvmeof/test.txt
abcd

9.Restart nvmeof-controller [ip address changed]
$ kubectl -n rook-ceph delete pod rook-ceph-nvmeof-nvmeof-a-68c78cb7c8-jzcdc 
pod "rook-ceph-nvmeof-nvmeof-a-68c78cb7c8-jzcdc" deleted

$ kubectl get pods -n rook-ceph  rook-ceph-nvmeof-nvmeof-a-68c78cb7c8-z2bh7 -o wide
NAME                                         READY   STATUS    RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
rook-ceph-nvmeof-nvmeof-a-68c78cb7c8-z2bh7   1/1     Running   0          24s   10.244.0.20   minikube   <none>           <none>

10.Check pod and pvc statut and check data content: [working]
$ kubectl get pvc,pod
NAME                                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/nvmeof-external-volume   Bound    pvc-4087eed2-871f-45ac-8ee3-bb6bb21bfa9d   128Mi      RWO            ceph-nvmeof    <unset>                 53m

/mnt/nvmeof # cat test.txt 
abcd
NAME                  READY   STATUS    RESTARTS   AGE
pod/nvmeof-test-pod   1/1     Running   0          52m

11.Add data to test.txt file [working as expected]
/mnt/nvmeof # cat test.txt 
abcd efg

$ kubectl -n default exec -it pod/nvmeof-test-pod -- sh
/ # cat /mnt/nvmeof/test.txt 
abcd efg

12.Delete the pod:
kubectl delete pod nvmeof-test-pod --force 

13. Create the pod again on same pvc:
kubectl create -f deploy/examples/csi/nvmeof/pod.yaml

NAME                  READY   STATUS    RESTARTS   AGE
pod/nvmeof-test-pod   1/1     Running   0          52m
```



<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
