### PR TITLE
Build: make some tools-based linting targets self-contained

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,9 +1,9 @@
 extends: default
-ignore: |
-  deploy/examples/csi/template
-  deploy/examples/crds.yaml
-  deploy/examples/monitoring/
-  deploy/examples/csi-operator.yaml
+ignore:
+  - deploy/examples/csi/template
+  - deploy/examples/crds.yaml
+  - deploy/examples/monitoring/
+  - deploy/examples/csi-operator.yaml
 rules:
   line-length: disable
   new-lines: disable

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all: build
 CONTROLLER_GEN_VERSION=v0.19.0
 CT_VERSION := v3.13.0
 KUSTOMIZE_VERSION := v5.3.0
+MARKDOWNLINT_IMAGE_VERSION :=v0.21.0
 
 # include here and not earlier so that the version numbers are available
 # where needed
@@ -191,11 +192,11 @@ golangci-lint: $(YQ)
 
 .PHONY: markdownlint
 markdownlint: ## Check formatting of documentation sources
-	markdownlint-cli2 "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
+	@$(MARKDOWNLINT) "Documentation/**/*.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
 
 .PHONY: markdownlint.fix
 markdownlint.fix: ## Check and fix formatting of documentation sources
-	markdownlint-cli2 "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs
+	@$(MARKDOWNLINT) "Documentation/**/*.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs
 
 .PHONY: yamllint
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ all: build
 # Controller-gen version
 # f284e2e8... is master ahead of v0.5.0 which has ability to generate embedded objectmeta in CRDs
 CONTROLLER_GEN_VERSION=v0.19.0
+CT_VERSION := v3.13.0
+KUSTOMIZE_VERSION := v5.3.0
+
+# include here and not earlier so that the version numbers are available
+# where needed
+include build/makelib/common.mk
+include build/makelib/helm.mk
+
 
 # Set GOBIN
 ifeq (,$(shell go env GOBIN))
@@ -194,12 +202,12 @@ yamllint:
 	yamllint -c .yamllint deploy/examples/ --no-warnings
 
 .PHONY: helm.lint
-helm.lint: ## Check the helm charts
-	ct lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false
-	helm -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
-	helm -n rook-ceph template deploy/charts/rook-ceph-cluster >> templated.yaml
+helm.lint: | $(HELM) $(KUSTOMIZE) ## Check the helm charts
+	$(CT) lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false --validate-chart-schema=false
+	$(HELM) -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
+	$(HELM)  -n rook-ceph template deploy/charts/rook-ceph-cluster >> templated.yaml
 	echo 'resources: [templated.yaml]' > kustomization.yaml
-	kustomize build >/dev/null
+	$(KUSTOMIZE) build >/dev/null
 	rm templated.yaml kustomization.yaml
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,24 @@ CT_VERSION := v3.13.0
 KUSTOMIZE_VERSION := v5.3.0
 MARKDOWNLINT_IMAGE_VERSION :=v0.21.0
 
+# Configuration for the yamllint contaioner image:
+#
+# container image tag:
+#
+#The image tag for the yamllint container image is formed in common.mk
+# based on the Information provided here.which can be overridden from
+# the commandline.
+#
+#
+# Note that Some "versions"like 'latest' work as image tag
+# whilemany specific versions like 1.26 or 1.32.0 do not.
+# We thereforeuse the SHA for the image tag.
+# see https://hub.docker.com/r/cytopia/yamllint/tags
+#one way of extracting the SHA of a working tag like latest is this:
+# podman inspect --format='{{index .RepoDigests 0}}' docker.io/cytopia/yamllint:latest
+#
+YAMLLINT_IMAGE_SHA := sha256:3e9eb827ab2b12a5ea5f49d4257bb3aca94bba9f1ba427c8bc7f2456385a5204
+
 # include here and not earlier so that the version numbers are available
 # where needed
 include build/makelib/common.mk
@@ -200,7 +218,7 @@ markdownlint.fix: ## Check and fix formatting of documentation sources
 
 .PHONY: yamllint
 yamllint:
-	yamllint -c .yamllint deploy/examples/ --no-warnings
+	$(YAMLLINT) -c .yamllint deploy/examples/
 
 .PHONY: helm.lint
 helm.lint: | $(HELM) $(KUSTOMIZE) ## Check the helm charts

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ CONTROLLER_GEN_VERSION=v0.19.0
 CT_VERSION := v3.13.0
 KUSTOMIZE_VERSION := v5.3.0
 MARKDOWNLINT_IMAGE_VERSION :=v0.21.0
+SHELLCHECK_VERSION := v0.10.0
 
 # Configuration for the yamllint contaioner image:
 #
@@ -241,8 +242,8 @@ checkmake:
 	@$(CHECKMAKE) Makefile
 
 .PHONY: shellcheck
-shellcheck:
-	shellcheck --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
+shellcheck: | $(SHELLCHECK)
+	$(SHELLCHECK) --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
 
 .PHONY: gen.codegen
 gen.codegen: codegen

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -111,7 +111,7 @@ CACHE_DIR := $(ROOT_DIR)/.cache
 endif
 
 TOOLS_DIR := $(CACHE_DIR)/tools
-TOOLS_HOST_DIR := $(TOOLS_DIR)/$(HOST_PLATFORM)
+TOOLS_HOST_DIR := $(TOOLS_DIR)/$(REAL_HOST_PLATFORM)
 
 ifeq ($(origin HOSTNAME), undefined)
 HOSTNAME := $(shell hostname)

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -24,6 +24,8 @@ else
 $(error "please install 'shasum' or 'sha256sum'")
 endif
 
+CT := go run github.com/helm/chart-testing/v3/ct@$(CT_VERSION)
+
 ifeq ($(origin DOCKERCMD),undefined)
 DOCKERCMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
 ifeq ($(DOCKERCMD),)
@@ -87,6 +89,20 @@ TOOLS_HOST_DIR := $(TOOLS_DIR)/$(HOST_PLATFORM)
 ifeq ($(origin HOSTNAME), undefined)
 HOSTNAME := $(shell hostname)
 endif
+
+$(TOOLS_HOST_DIR):
+	@mkdir -p $@
+
+KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
+
+$(KUSTOMIZE): | $(TOOLS_HOST_DIR)
+	@echo === installing kustomize
+	@mkdir -p $(TOOLS_HOST_DIR)/tmp
+	@# kustomize releases use a specific naming convention: kustomize_vX.Y.Z_os_arch.tar.gz
+	@curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
+	@mv -f $(TOOLS_HOST_DIR)/tmp/kustomize $(KUSTOMIZE)
+	@rm -rf $(TOOLS_HOST_DIR)/tmp
+	@chmod +x $(KUSTOMIZE)
 
 # a registry that is scoped to the current build tree on this host
 ifeq ($(origin BUILD_REGISTRY), undefined)

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -33,6 +33,33 @@ DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 endif
 
+MARKDOWNLINT := $(DOCKERCMD) run --rm -v $$PWD:/workdir davidanson/markdownlint-cli2:$(MARKDOWNLINT_IMAGE_VERSION)
+
+#
+# === YAMLLINT ===
+
+# configuration of the yamllint container image:
+
+# User Inputs (from main Makefile or cmdline):
+# Set only what you need.
+# Priority: SHA > TAG > VERSION (defaulting to :latest)
+# Logic to determine the Suffix:
+ifdef YAMLLINT_IMAGE_SHA
+	YAMLLINT_IMAGE_SUFFIX := @$(YAMLLINT_IMAGE_SHA)
+else ifdef YAMLLINT_IMAGE_TAG
+	YAMLLINT_IMAGE_SUFFIX := :$(YAMLLINT_IMAGETAG)
+else ifdef YAMLLINT_VERSION
+	YAMLLINT_IMAGE_SUFFIX := :$(YAMLLINT_VERSION)
+else
+	YAMLLINT_IMAGE_SUFFIX := :latest
+endif
+
+YAMLLINT_IMAGE_BASE := cytopia/yamllint
+YAMLLINT_IMAGE := $(YAMLLINT_IMAGE_BASE)$(YAMLLINT_IMAGE_SUFFIX)
+
+YAMLLINT := $(DOCKERCMD) run  --rm -t -v $(CURDIR):/workdir:ro -w /workdir --entrypoint yamllint $(YAMLLINT_IMAGE)
+
+
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)
 GOOS := $(shell go env GOOS)

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -35,29 +35,7 @@ endif
 
 MARKDOWNLINT := $(DOCKERCMD) run --rm -v $$PWD:/workdir davidanson/markdownlint-cli2:$(MARKDOWNLINT_IMAGE_VERSION)
 
-#
-# === YAMLLINT ===
-
-# configuration of the yamllint container image:
-
-# User Inputs (from main Makefile or cmdline):
-# Set only what you need.
-# Priority: SHA > TAG > VERSION (defaulting to :latest)
-# Logic to determine the Suffix:
-ifdef YAMLLINT_IMAGE_SHA
-	YAMLLINT_IMAGE_SUFFIX := @$(YAMLLINT_IMAGE_SHA)
-else ifdef YAMLLINT_IMAGE_TAG
-	YAMLLINT_IMAGE_SUFFIX := :$(YAMLLINT_IMAGETAG)
-else ifdef YAMLLINT_VERSION
-	YAMLLINT_IMAGE_SUFFIX := :$(YAMLLINT_VERSION)
-else
-	YAMLLINT_IMAGE_SUFFIX := :latest
-endif
-
-YAMLLINT_IMAGE_BASE := cytopia/yamllint
-YAMLLINT_IMAGE := $(YAMLLINT_IMAGE_BASE)$(YAMLLINT_IMAGE_SUFFIX)
-
-YAMLLINT := $(DOCKERCMD) run  --rm -t -v $(CURDIR):/workdir:ro -w /workdir --entrypoint yamllint $(YAMLLINT_IMAGE)
+YAMLLINT := $(DOCKERCMD) run  --rm -t -v $(CURDIR):/workdir:ro -w /workdir --entrypoint yamllint cytopia/yamllint@$(YAMLLINT_IMAGE_SHA)
 
 
 ifeq ($(origin PLATFORM), undefined)

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -109,6 +109,33 @@ $(KUSTOMIZE): | $(TOOLS_HOST_DIR)
 	@rm -rf $(TOOLS_HOST_DIR)/tmp
 	@chmod +x $(KUSTOMIZE)
 
+SHELLCHECK := $(TOOLS_HOST_DIR)/shellcheck-$(SHELLCHECK_VERSION)
+
+# architecture mapping:
+# shellcheck uses aarch64 instead of arm64 for published darwin binaries
+# so we can't use go env GOHOSTARCH as usual.
+UNAME_M := $(shell uname -m)
+UNAME_S := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+# Map arm64 (Mac) and aarch64 (Linux) to ShellCheck's 'aarch64'
+ifeq ($(UNAME_M),x86_64)
+	SC_ARCH := x86_64
+else ifeq ($(UNAME_M),arm64)
+	SC_ARCH := aarch64
+else
+	SC_ARCH := $(UNAME_M)
+endif
+
+SHELLCHECK_URL := https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(UNAME_S).$(SC_ARCH).tar.xz
+
+$(SHELLCHECK): | $(TOOLS_HOST_DIR)
+	@echo === installing shellcheck ===
+	@mkdir -p $(TOOLS_HOST_DIR)/tmp
+	@curl -sSL $(SHELLCHECK_URL) | tar xJ -C $(TOOLS_HOST_DIR)/tmp
+
+	@mv -f $(TOOLS_HOST_DIR)/tmp/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $(SHELLCHECK)
+	@rm -rf $(TOOLS_HOST_DIR)/tmp
+
 # a registry that is scoped to the current build tree on this host
 ifeq ($(origin BUILD_REGISTRY), undefined)
 BUILD_REGISTRY := build-$(shell echo "$(HOSTNAME)-$(ROOT_DIR)" | $(SHA256CMD) | cut -c1-8)

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -261,7 +261,12 @@ function build_rook() {
   tests/scripts/validate_modified_files.sh build
   docker images
   if [[ "$build_type" == "build" ]]; then
-    docker tag "$(docker images | awk '/build-/ {print $1}')" docker.io/rook/ceph:local-build
+     image_name="$(docker images | awk '/build-/ {print $1}')"
+     if [[ -z "${image_name}" ]]; then
+         echo "No build-* image found!"
+	 exit 1
+     fi
+     docker tag "${image_name}" docker.io/rook/ceph:local-build
   fi
 }
 


### PR DESCRIPTION
**Description:** 

This PR has been split out of  PR #17177 .

Several linting make targets required corresponding  tools to be installed locally in the `$PATH`.

This PR makes some of them self-contained so that they don't require local tools anymore:

* `helm.lint`
* ` markdownlint`
* `markdownlint.fix`
* `yamllint`
* `shellcheck`

The `checkmake`target has already been dealt with in  PR #17153.

While at it, this PR creates a common place for handling such tooling matters in `common.mk`.








**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
