### PR TITLE
pool: set ec pool status to ready after reconcile

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -344,6 +344,8 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		if err != nil {
 			return reconcileResult, *cephBlockPool, err
 		}
+	} else {
+		statusErr = r.updateStatus(request.NamespacedName, cephv1.ConditionReady, observedGeneration, nil)
 	}
 
 	if statusErr != nil {


### PR DESCRIPTION
ec pools skip the mirroring configuration path where the status is set to ready, leaving them stuck in
progressing state forever. add status update to ready in the else branch when mirroring is skipped.


Tested on OCP4.21 ibmcloud with private image `quay.io/oviner/rook:mar17_1`
```
$ cat pool-ec-test.yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: ec-test-pool1
  namespace: rook-ceph # namespace:cluster
spec:
  failureDomain: host
  erasureCoded:
    dataChunks: 2
    codingChunks: 1

$ kubectl create -f pool-ec-test.yaml
```
```
$ kubectl get CephBlockPool ec-test-pool1 -n rook-ceph 
NAME            PHASE   TYPE            FAILUREDOMAIN   AGE
ec-test-pool1   Ready   Erasure Coded   host            25s
```

Fixes: #17198 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
