### PR TITLE
cosi: update default COSI sidecar image version

### DIFF
--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,7 +1,7 @@
  docker.io/rook/ceph:master
- gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255
+ gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
  quay.io/ceph/ceph:v19.2.3
- quay.io/ceph/cosi:v0.1.2
+ quay.io/ceph/cosi:v0.1.4
  quay.io/cephcsi/ceph-csi-operator:v0.6.0
  quay.io/cephcsi/cephcsi:v3.16.2
  quay.io/csiaddons/k8s-sidecar:v0.14.0

--- a/pkg/operator/ceph/object/cosi/spec.go
+++ b/pkg/operator/ceph/object/cosi/spec.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	defaultCOSISideCarImage    = "gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20240513-v0.1.0-35-gefb3255"
-	defaultCephCOSIDriverImage = "quay.io/ceph/cosi:v0.1.2"
+	defaultCOSISideCarImage    = "gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2"
+	defaultCephCOSIDriverImage = "quay.io/ceph/cosi:v0.1.4"
 )
 
 func createCephCOSIDriverDeployment(cephCOSIDriver *cephv1.CephCOSIDriver) (*appsv1.Deployment, error) {


### PR DESCRIPTION
Bumping the cosi sidecar image to https://github.com/kubernetes-sigs/container-object-storage-interface/releases/tag/v0.2.2

Encountered this bug in current image https://github.com/kubernetes-sigs/container-object-storage-interface/issues/173 which is fixed in recent release via https://github.com/kubernetes-sigs/container-object-storage-interface/pull/197

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
