### PR TITLE
helm: Support cephConfig for CephCluster

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.cephConfig }}
+  cephConfig: {{- toYaml .Values.cephConfig | nindent 4 }}
+  {{- end }}
   {{- with .Values.monitoring }}
   monitoring:
     enabled: {{ .enabled | default false }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -20,6 +20,10 @@ configOverride:
 #   osd_pool_default_size = 3
 #   osd_pool_default_min_size = 2
 
+cephConfig:
+  # global:
+  #   bluestore_slow_ops_warn_lifetime: '600'
+
 # Installs a debugging toolbox deployment
 toolbox:
   # -- Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md)


### PR DESCRIPTION
This allows you to set parameters such as bluestore_slow_ops_warn_lifetime through Helm.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
