### PR TITLE
pool: clean up erasure code profile on pool deletion

### DIFF
--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -95,7 +95,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterInfo *ClusterInf
 
 	args := []string{"osd", "erasure-code-profile", "set", profileName, "--force"}
 	args = append(args, profilePairs...)
-	_, err = NewCephCommand(context, clusterInfo, args).Run()
+	cmd := NewCephCommand(context, clusterInfo, args)
+	cmd.JsonOutput = false
+	_, err = cmd.Run()
 	if err != nil {
 		return errors.Wrap(err, "failed to set ec-profile")
 	}

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -726,7 +726,9 @@ func DeletePools(ctx *Context, lastStore bool, poolPrefix string) error {
 		return errors.Wrapf(err, "failed to list erasure code profiles for cluster %s", ctx.clusterInfo.Namespace)
 	}
 	// cleans up the EC profile for the data pool only. Metadata pools don't support EC (only replication is supported).
-	ecProfileName := cephclient.GetErasureCodeProfileForPool(ctx.Name)
+	// The profile name must match the full pool name used during creation (e.g., "<store>.rgw.buckets.data_ecprofile").
+	dataPool := poolName(poolPrefix, dataPoolName)
+	ecProfileName := cephclient.GetErasureCodeProfileForPool(dataPool)
 	for i := range erasureCodes {
 		if erasureCodes[i] == ecProfileName {
 			if err := cephclient.DeleteErasureCodeProfile(ctx.Context, ctx.clusterInfo, ecProfileName); err != nil {

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -431,13 +431,13 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 			}
 			if args[1] == "erasure-code-profile" {
 				if args[2] == "ls" {
-					return `["default","myobj_ecprofile"]`, nil
+					return `["default","myobj.rgw.buckets.data_ecprofile"]`, nil
 				}
 				if args[2] == "rm" {
-					if args[3] == "myobj_ecprofile" {
+					if args[3] == "myobj.rgw.buckets.data_ecprofile" {
 						deletedErasureCodeProfile = true
 					} else {
-						assert.Fail(t, fmt.Sprintf("the erasure code profile to be deleted should be myobj_ecprofile. Actual: %s ", args[3]))
+						assert.Fail(t, fmt.Sprintf("the erasure code profile to be deleted should be myobj.rgw.buckets.data_ecprofile. Actual: %s ", args[3]))
 					}
 					return "", nil
 				}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -589,6 +589,16 @@ func deletePool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 			return errors.Wrapf(err, "failed to delete pool %q", p.Name)
 		}
 	}
+
+	// Clean up the erasure code profile for EC pools so that recreating with
+	// different settings does not fail
+	if p.IsErasureCoded() {
+		ecProfileName := cephclient.GetErasureCodeProfileForPool(p.Name)
+		if err := cephclient.DeleteErasureCodeProfile(context, clusterInfo, ecProfileName); err != nil {
+			logger.Warningf("failed to delete erasure code profile %q for pool %q: %v", ecProfileName, p.Name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -200,6 +200,45 @@ func TestDeletePool(t *testing.T) {
 	p = &cephv1.NamedPoolSpec{Name: "mypool"}
 	err = deletePool(context, clusterInfo, p)
 	assert.Error(t, err)
+
+	// delete an erasure coded pool should also delete the EC profile
+	ecProfileDeleted := false
+	failOnDelete = false
+	ecExecutor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
+			if command == "ceph" && args[1] == "lspools" {
+				return `[{"poolnum":1,"poolname":"ecpool"}]`, nil
+			} else if command == "ceph" && args[1] == "pool" && args[2] == "get" {
+				return `{"pool": "ecpool","pool_id": 1,"size":1}`, nil
+			} else if command == "ceph" && args[1] == "pool" && args[2] == "delete" {
+				return "", nil
+			} else if command == "ceph" && args[1] == "erasure-code-profile" && args[2] == "rm" {
+				assert.Equal(t, "ecpool_ecprofile", args[3])
+				ecProfileDeleted = true
+				return "", nil
+			} else if args[0] == "pool" {
+				if args[1] == "stats" {
+					return emptyPool, nil
+				}
+				return "", errors.Errorf("rbd: error opening pool %q: (2) No such file or directory", args[3])
+			}
+			return "", errors.Errorf("unexpected rbd command %q", args)
+		},
+	}
+	ecContext := &clusterd.Context{Executor: ecExecutor}
+	ecPool := &cephv1.NamedPoolSpec{
+		Name: "ecpool",
+		PoolSpec: cephv1.PoolSpec{
+			ErasureCoded: cephv1.ErasureCodedSpec{
+				DataChunks:   2,
+				CodingChunks: 1,
+			},
+		},
+	}
+	err = deletePool(ecContext, clusterInfo, ecPool)
+	assert.NoError(t, err)
+	assert.True(t, ecProfileDeleted)
 }
 
 // TestCephBlockPoolController runs ReconcileCephBlockPool.Reconcile() against a


### PR DESCRIPTION
deleting an erasure coded CephBlockPool left the ec profile orphaned. recreating with different settings failed because the old profile could not be overridden.
- delete ec profile during CephBlockPool deletion
- disable --format json on ec profile set command
- fix ec profile name mismatch in CephObjectStore deletion


Tested on OCP4.21[AWS] with rook with 6 osds [private image: quay.io/oviner/rook:mar18_1]
```
1.Create the EC pool
cat <<'EOF' | kubectl apply -f -
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: ec-test-pool-new
  namespace: rook-ceph
spec:
  failureDomain: host
  erasureCoded:
    dataChunks: 2
    codingChunks: 1
EOF

2. Verify pool and EC profile were created
$ kubectl -n rook-ceph get cephblockpool ec-test-pool-new 
NAME               PHASE   TYPE            FAILUREDOMAIN   AGE
ec-test-pool-new   Ready   Erasure Coded   host            12s

$  kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool-new_ecprofile
ec-test-pool_ecprofile
my-store.rgw.buckets.data_ecprofile

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile get ec-test-pool-new_ecprofile
crush-device-class=
crush-failure-domain=host
crush-num-failure-domains=0
crush-osds-per-failure-domain=0
crush-root=default
k=2
m=1
plugin=isa
technique=reed_sol_van

3. Delete the pool CR
$ kubectl -n rook-ceph delete cephblockpool ec-test-pool-new
cephblockpool.ceph.rook.io "ec-test-pool-new" deleted

4.Verify the EC profile is deleted [ec-test-pool-new_ecprofile does not exit]
$  kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool_ecprofile
my-store.rgw.buckets.data_ecprofile

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile get ec-test-pool-new_ecprofile
Error ENOENT: unknown erasure code profile 'ec-test-pool-new_ecprofile'
command terminated with exit code 2

5.Recreate with different settings:
cat <<'EOF' | kubectl apply -f -
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: ec-test-pool-new
  namespace: rook-ceph
spec:
  failureDomain: host
  erasureCoded:
    dataChunks: 3
    codingChunks: 2
EOF

6.Profile  shows new values k=3, m=3 
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool_ecprofile

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile get ec-test-pool-new_ecprofile
crush-device-class=
crush-failure-domain=host
crush-num-failure-domains=0
crush-osds-per-failure-domain=0
crush-root=default
k=3
m=2
plugin=isa
technique=reed_sol_van

$ kubectl get cephblockpool -n rook-ceph ec-test-pool-new
NAME               PHASE   TYPE            FAILUREDOMAIN   AGE
ec-test-pool-new   Ready   Erasure Coded   host            37s
  
```


Test CephObjectStore:
```
1. Create a CephObjectStore with EC data pool
cat <<'EOF' | kubectl apply -f -
apiVersion: ceph.rook.io/v1
kind: CephObjectStore
metadata:
  name: my-store-new
  namespace: rook-ceph
spec:
  metadataPool:
    replicated:
      size: 3
  dataPool:
    erasureCoded:
      dataChunks: 2
      codingChunks: 1
  preservePoolsOnDelete: false
  gateway:
    port: 80
    instances: 1
EOF

2. Wait for the store to be ready
)$ kubectl -n rook-ceph get cephobjectstore my-store-new 
NAME           PHASE   ENDPOINT                                             SECUREENDPOINT   AGE
my-store-new   Ready   http://rook-ceph-rgw-my-store-new.rook-ceph.svc:80                    23s

3. Verify the EC profile exists
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool-new_ecprofile
ec-test-pool_ecprofile
my-store-new.rgw.buckets.data_ecprofile
my-store.rgw.buckets.data_ecprofile

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile get my-store-new.rgw.buckets.data_ecprofile
crush-device-class=
crush-failure-domain=host
crush-num-failure-domains=0
crush-osds-per-failure-domain=0
crush-root=default
k=2
m=1
plugin=isa
technique=reed_sol_van

4.Delete the object store
$  kubectl -n rook-ceph delete cephobjectstore my-store-new
cephobjectstore.ceph.rook.io "my-store-new" deleted


5.Verify the EC profile deleted [my-store-new.rgw.buckets.data_ecprofile does not exist]
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool-new_ecprofile
ec-test-pool_ecprofile
my-store.rgw.buckets.data_ecprofile

6. Recreate with different EC settings
cat <<'EOF' | kubectl apply -f -
apiVersion: ceph.rook.io/v1
kind: CephObjectStore
metadata:
  name: my-store-new
  namespace: rook-ceph
spec:
  metadataPool:
    replicated:
      size: 3
  dataPool:
    erasureCoded:
      dataChunks: 3
      codingChunks: 2
  preservePoolsOnDelete: false
  gateway:
    port: 80
    instances: 1
EOF

7.Verify cephobjectstore my-store-new  in Ready state and with new parms k=3, m=2:
$ kubectl -n rook-ceph get cephobjectstore my-store-new 
NAME           PHASE   ENDPOINT                                             SECUREENDPOINT   AGE
my-store-new   Ready   http://rook-ceph-rgw-my-store-new.rook-ceph.svc:80                    25s


$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile ls
default
ec-test-pool-new_ecprofile
ec-test-pool_ecprofile
my-store-new.rgw.buckets.data_ecprofile
my-store.rgw.buckets.data_ecprofile

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd erasure-code-profile get my-store-new.rgw.buckets.data_ecprofile
crush-device-class=
crush-failure-domain=host
crush-num-failure-domains=0
crush-osds-per-failure-domain=0
crush-root=default
k=3
m=2
plugin=isa
technique=reed_sol_van
```

Fixes: #2016 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
