### PR TITLE
doc: fixed formatting issue in minikube guide

### DIFF
--- a/Documentation/Contributing/development-environment.md
+++ b/Documentation/Contributing/development-environment.md
@@ -56,13 +56,13 @@ install it from system packages or follow the [official Helm guide](https://helm
 Developers can test quickly their changes by building and using the local Rook image
 on their minikube cluster.
 
-1) Set the local Docker environment to use minikube:
+1. Set the local Docker environment to use minikube:
 
     ```console
     eval $(minikube docker-env -p minikube)
     ```
 
-2) Build your local Rook image. The following command will generate a Rook image
+2. Build your local Rook image. The following command will generate a Rook image
 labeled in the format `local/ceph-<arch>`.
 
     ```console
@@ -70,13 +70,13 @@ labeled in the format `local/ceph-<arch>`.
     make BUILD_REGISTRY=local
     ```
 
-3) Tag the generated image as `rook/ceph:master` so operator will pick it.
+3. Tag the generated image as `rook/ceph:master` so operator will pick it.
 
     ```console
     docker tag "local/ceph-$(go env GOARCH)" 'rook/ceph:master'
     ```
 
-4) Create a Rook cluster in minikube, or if the Rook cluster is already configured, apply the new
+4. Create a Rook cluster in minikube, or if the Rook cluster is already configured, apply the new
 operator image by restarting the operator.
 
 


### PR DESCRIPTION
The ```console formatting was visible in the rendered document. Fixed it by changing all ')' to '.' in the list.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
