### PR TITLE
ci: update checkout action to v4.2.2 to fix auth issues

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'rook/rook'
     steps:
       - name: checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

The github checkout action v5/v6 has security changes that break the docs publishing workflow when pushing to the rook.github.io repo.

## Changes

- Updated 
actions/checkout
 from v5.0.0 to v4.2.2

## Issue

Fixes #17212

## Checklist

- [x] Workflow syntax validated
- [x] Action version pinned to specific commit SHA
- [x] Follows project contribution guidelines