### PR TITLE
ci: upgrade github checkout action v5 to v6 with cross-repo auth fix

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'rook/rook'
     steps:
       - name: checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

This PR updates the checkout action in `push-build.yaml` from v5.0.0 (commit 08c690) to v6.0.2 (commit de0fac2) to match other workflows in the repository.

## Breaking Changes in GitHub Actions Checkout v6

The v6 migration introduced improved credential security:
- **v5 and earlier**: Token credentials stored directly in `.git/config`
- **v6**: Credentials stored in separate file under `RUNNER_TEMP` via credential helper
- **Impact**: Automatic `http.https://github.com/.extraheader` is added to all requests

## Cross-Repository Operations

Rook's release pipeline pushes documentation to **rook.github.io** (separate repository) using a custom `GIT_API_TOKEN` secret with broader permissions than the default `GITHUB_TOKEN`.

### The Solution

The required workaround is **already implemented** in `tests/scripts/build-release.sh`:

```bash
# If we are running in GitHub actions, remove the extraheader so our custom GitHub API token is used
if test "$$GITHUB_ACTIONS" = "true"; then git config --unset 'http.https://github.com/.extraheader'; fi
```

This removes the automatic `GITHUB_TOKEN` header set by v6, allowing the custom `GIT_API_TOKEN` to be used for cross-repo authentication as intended.

## Testing

- Verified that `build-release.sh` contains the required workaround
- Confirmed v6.0.2 is already used in other workflows (`build.yml`, `canary-integration-test.yml`)
- This change brings `push-build.yaml` into alignment with repository standards

Fixes #17212