### PR TITLE
ci: add osd capacity expansion e2e test

### DIFF
--- a/.github/workflows/integration-test-add-capacity-suite.yaml
+++ b/.github/workflows/integration-test-add-capacity-suite.yaml
@@ -1,0 +1,132 @@
+name: Integration test CephAddCapacitySuite
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+    paths-ignore:
+      - "Documentation/**"
+      - "design/**"
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Required for go-ceph rgw/admin account APIs which are gated behind
+  # the ceph_preview build tag. Can be removed when go-ceph promotes
+  # the account API out of preview.
+  GOFLAGS: "-tags=ceph_preview"
+
+jobs:
+  TestCephAddCapacitySuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: ["v1.35.0"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: consider (pre-job) debugging
+        uses: ./.github/workflows/tmate_debug
+        with:
+          use-tmate: ${{ secrets.USE_TMATE }}
+          debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
+
+      - name: create loop devices and PVs for OSD expansion test
+        run: |
+          # Label the node before creating PVs that use rook.io/has-disk nodeAffinity
+          node_name=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+          kubectl label nodes "${node_name}" rook.io/has-disk=true --overwrite
+
+          # Create StorageClass for static PV provisioning
+          cat <<'EOF' | kubectl apply -f -
+          kind: StorageClass
+          apiVersion: storage.k8s.io/v1
+          metadata:
+            name: manual
+          provisioner: kubernetes.io/no-provisioner
+          volumeBindingMode: WaitForFirstConsumer
+          reclaimPolicy: Delete
+          EOF
+
+          # Create 6 sparse-file-backed loop devices (6Gi each) for OSD PVCs
+          tests/scripts/github-action-helper.sh prepare_loop_devices 6
+          tests/scripts/loopDevicePV.sh 6
+
+          # Create mon PV (filesystem mode) on a host directory
+          sudo mkdir -p /var/lib/rook/rook-integration-test/mon1
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            name: local-mon-vol1
+            labels:
+              type: local
+          spec:
+            storageClassName: manual
+            capacity:
+              storage: 5Gi
+            accessModes:
+              - ReadWriteOnce
+            persistentVolumeReclaimPolicy: Retain
+            volumeMode: Filesystem
+            local:
+              path: "/var/lib/rook/rook-integration-test/mon1"
+            nodeAffinity:
+              required:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: rook.io/has-disk
+                        operator: In
+                        values:
+                        - "true"
+          EOF
+
+          kubectl get pv -o wide
+          kubectl get sc
+
+      - name: TestCephAddCapacitySuite
+        run: |
+          tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+          export TEST_STORAGE_CLASS=manual
+          go test -v -timeout 2400s -failfast -run CephAddCapacitySuite github.com/rook/rook/tests/integration
+
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="rook-ceph"
+          export OPERATOR_NAMESPACE="rook-ceph-system"
+          tests/scripts/collect-logs.sh
+
+      - name: Artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: ceph-add-capacity-suite-artifact-${{ matrix.kubernetes-version }}
+          path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
+      - name: consider (post-job) debugging
+        uses: ./.github/workflows/upterm_debug
+        with:
+          debug-ci: ${{ contains(github.event.pull_request.labels.*.name, 'debug-ci') }}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -220,7 +220,7 @@ spec:
       ` + crushRoot + `
     storageClassDeviceSets:
     - name: set1
-      count: 1
+      count: ` + strconv.Itoa(m.settings.osdCount()) + `
       portable: false
       tuneDeviceClass: true
       encrypted: false
@@ -230,7 +230,7 @@ spec:
         spec:
           resources:
             requests:
-              storage: 10Gi
+              storage: ` + m.settings.osdPVCSize() + `
           storageClassName: ` + m.settings.StorageClassName + `
           volumeMode: Block
           accessModes:

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -54,6 +54,26 @@ type TestCephSettings struct {
 	KubernetesVersion           string
 	EnableCsiOperator           bool
 	ClusterConcurrency          int
+	// OsdCount is the number of OSDs in PVC-based storageClassDeviceSets (defaults to 1)
+	OsdCount int
+	// OsdPVCSize is the storage request for each OSD PVC (defaults to "10Gi")
+	OsdPVCSize string
+	// AllowLoopDevices sets ROOK_CEPH_ALLOW_LOOP_DEVICES to allow loop devices in test clusters
+	AllowLoopDevices bool
+}
+
+func (s *TestCephSettings) osdCount() int {
+	if s.OsdCount <= 0 {
+		return 1
+	}
+	return s.OsdCount
+}
+
+func (s *TestCephSettings) osdPVCSize() string {
+	if s.OsdPVCSize == "" {
+		return "10Gi"
+	}
+	return s.OsdPVCSize
 }
 
 func (s *TestCephSettings) ApplyEnvVars() {
@@ -101,6 +121,9 @@ func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
 	}
 	if s.ClusterConcurrency > 1 {
 		manifest = strings.ReplaceAll(manifest, `ROOK_RECONCILE_CONCURRENT_CLUSTERS: "1"`, fmt.Sprintf(`ROOK_RECONCILE_CONCURRENT_CLUSTERS: "%d"`, s.ClusterConcurrency))
+	}
+	if s.AllowLoopDevices {
+		manifest = strings.ReplaceAll(manifest, `ROOK_CEPH_ALLOW_LOOP_DEVICES: "false"`, `ROOK_CEPH_ALLOW_LOOP_DEVICES: "true"`)
 	}
 	return manifest
 }

--- a/tests/integration/ceph_add_capacity_test.go
+++ b/tests/integration/ceph_add_capacity_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rook/rook/tests/framework/clients"
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	initialOSDCount = 3
+	targetOSDCount  = 6
+)
+
+// ************************************************
+// *** Major scenarios tested by the AddCapacitySuite ***
+// Setup
+// - Deploy a CephCluster with PVC-based storage (storageClassDeviceSets) and 3 OSDs
+// - Verify the cluster is healthy with 3 OSDs
+// Add Capacity
+// - Increase storageClassDeviceSets count from 3 to 6
+// - Verify 6 OSD pods reach Running state
+// - Verify CephCluster CR reaches Ready phase
+// - Verify ceph health is HEALTH_OK
+// ************************************************
+func TestCephAddCapacitySuite(t *testing.T) {
+	s := new(AddCapacitySuite)
+	defer func(s *AddCapacitySuite) {
+		HandlePanics(recover(), s.TearDownSuite, s.T)
+	}(s)
+	suite.Run(t, s)
+}
+
+type AddCapacitySuite struct {
+	suite.Suite
+	helper    *clients.TestClient
+	k8sh      *utils.K8sHelper
+	settings  *installer.TestCephSettings
+	installer *installer.CephInstaller
+}
+
+func (s *AddCapacitySuite) SetupSuite() {
+	namespace := "rook-ceph"
+	s.settings = &installer.TestCephSettings{
+		ClusterName:       "rook-ceph",
+		Namespace:         namespace,
+		OperatorNamespace: installer.SystemNamespace(namespace),
+		StorageClassName:  installer.StorageClassName(),
+		UseHelm:           false,
+		UsePVC:            true,
+		Mons:              1,
+		SkipOSDCreation:   false,
+		RookVersion:       installer.LocalBuildTag,
+		CephVersion:       installer.ReturnCephVersion(),
+		OsdCount:          initialOSDCount,
+		OsdPVCSize:        "6Gi",
+		AllowLoopDevices:  true,
+	}
+	s.settings.ApplyEnvVars()
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
+	s.helper = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
+}
+
+func (s *AddCapacitySuite) AfterTest(suiteName, testName string) {
+	s.installer.CollectOperatorLog(suiteName, testName)
+}
+
+func (s *AddCapacitySuite) TearDownSuite() {
+	s.installer.UninstallRook()
+}
+
+func (s *AddCapacitySuite) TestAddOSDCapacity() {
+	logger.Infof("================================================================")
+	logger.Infof("  ADD OSD CAPACITY TEST: scaling from %d to %d OSDs", initialOSDCount, targetOSDCount)
+	logger.Infof("  Namespace: %s, Cluster: %s", s.settings.Namespace, s.settings.ClusterName)
+	logger.Infof("================================================================")
+
+	// Step 1: Verify the cluster has 3 OSDs running and ceph health is HEALTH_OK
+	logger.Infof("*** STEP 1: Verifying initial cluster state (%d OSDs expected) ***", initialOSDCount)
+	s.logOSDPods()
+
+	require.True(s.T(), s.k8sh.CheckPodCountAndState("rook-ceph-osd", s.settings.Namespace, initialOSDCount, "Running"),
+		fmt.Sprintf("expected %d OSD pods in Running state before expansion", initialOSDCount))
+	logger.Infof("STEP 1: confirmed %d OSD pods are Running", initialOSDCount)
+
+	s.waitForHealthOK(300 * time.Second)
+	checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+	logger.Infof("STEP 1 PASSED: cluster is healthy with %d OSDs", initialOSDCount)
+
+	// Step 2: Increase the storageClassDeviceSets count from 3 to 6
+	logger.Infof("*** STEP 2: Patching CephCluster CR to increase OSD count from %d to %d ***", initialOSDCount, targetOSDCount)
+	patchJSON := fmt.Sprintf(`[{"op":"replace","path":"/spec/storage/storageClassDeviceSets/0/count","value":%d}]`, targetOSDCount)
+	logger.Infof("STEP 2: applying JSON patch: %s", patchJSON)
+
+	_, err := s.k8sh.Kubectl("-n", s.settings.Namespace, "patch", "CephCluster", s.settings.ClusterName,
+		"--type=json", "-p", patchJSON)
+	require.NoError(s.T(), err)
+	logger.Infof("STEP 2 PASSED: CephCluster CR patched, storageClassDeviceSets[0].count is now %d", targetOSDCount)
+
+	// Step 3: Verify 6 OSD pods reach Running state
+	logger.Infof("*** STEP 3: Waiting for %d OSD pods to reach Running state ***", targetOSDCount)
+	require.True(s.T(), s.k8sh.CheckPodCountAndState("rook-ceph-osd", s.settings.Namespace, targetOSDCount, "Running"),
+		fmt.Sprintf("expected %d OSD pods in Running state after capacity expansion", targetOSDCount))
+
+	s.logOSDPods()
+	logger.Infof("STEP 3 PASSED: %d OSD pods are Running", targetOSDCount)
+
+	// Step 4: Verify CephCluster CR reaches Ready state
+	logger.Infof("*** STEP 4: Waiting for CephCluster CR to reach Ready phase ***")
+	err = s.k8sh.WaitForStatusPhase(s.settings.Namespace, "CephCluster", s.settings.ClusterName, "Ready", 300*time.Second)
+	require.NoError(s.T(), err)
+	logger.Infof("STEP 4 PASSED: CephCluster CR is in Ready phase")
+
+	// Step 5: Verify ceph health is HEALTH_OK
+	logger.Infof("*** STEP 5: Waiting for ceph health to be HEALTH_OK ***")
+	s.waitForHealthOK(600 * time.Second)
+	checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+	logger.Infof("STEP 5 PASSED: ceph health is HEALTH_OK")
+
+	logger.Infof("================================================================")
+	logger.Infof("  ADD OSD CAPACITY TEST PASSED: %d -> %d OSDs", initialOSDCount, targetOSDCount)
+	logger.Infof("================================================================")
+}
+
+func (s *AddCapacitySuite) logOSDPods() {
+	pods, err := s.k8sh.Clientset.CoreV1().Pods(s.settings.Namespace).List(
+		context.TODO(), metav1.ListOptions{LabelSelector: "app=rook-ceph-osd"})
+	if err != nil {
+		logger.Warningf("failed to list OSD pods: %v", err)
+		return
+	}
+	logger.Infof("--- OSD pods in namespace %s (%d total) ---", s.settings.Namespace, len(pods.Items))
+	for _, pod := range pods.Items {
+		logger.Infof("  pod=%s  phase=%s  node=%s", pod.Name, pod.Status.Phase, pod.Spec.NodeName)
+	}
+	logger.Infof("---")
+}
+
+// waitForHealthOK polls the CephCluster CR status until ceph health reports HEALTH_OK.
+func (s *AddCapacitySuite) waitForHealthOK(timeout time.Duration) {
+	ctx := context.TODO()
+	var lastHealth string
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			cluster, err := s.k8sh.RookClientset.CephV1().CephClusters(s.settings.Namespace).Get(ctx, s.settings.ClusterName, metav1.GetOptions{})
+			if err != nil {
+				logger.Warningf("failed to get CephCluster CR: %v", err)
+				return false, nil
+			}
+			lastHealth = cluster.Status.CephStatus.Health
+			if lastHealth == "HEALTH_OK" {
+				logger.Infof("ceph health is HEALTH_OK")
+				return true, nil
+			}
+			logger.Infof("waiting for HEALTH_OK, current health: %s", lastHealth)
+			return false, nil
+		})
+	require.NoError(s.T(), err, "timed out waiting for HEALTH_OK, last health: %s", lastHealth)
+}


### PR DESCRIPTION
add a dedicated integration test suite that deploys a ceph cluster with 3 pvc-based osds, scales to 6, and verifies health.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
