### PR TITLE
osd: zap disks for forceful OSD installation

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -861,6 +861,69 @@ func (a *OsdAgent) appendDeviceClassArg(device *DeviceOsdIDEntry, args []string)
 	return args
 }
 
+// ZapDevice wipes a device using two methods for maximum reliability:
+//  1. First, run ceph-volume lvm zap to let Ceph handle cleanup
+//  2. Then, perform direct cleanup as a follow-up to ensure all metadata is removed:
+//     a. Unmount the device if mounted
+//     b. Remove filesystem signatures with wipefs
+//     c. Remove BlueStore signatures with ceph-bluestore-tool
+//     d. Zero the first 10MB of the device to clear any previous filesystem traces
+//
+// Running both methods ensures the device is fully cleaned regardless of
+// changes in ceph-volume behavior across Ceph versions.
+func ZapDevice(context *clusterd.Context, devicePath string) error {
+	// First, attempt ceph-volume lvm zap
+	output, err := context.Executor.ExecuteCommandWithCombinedOutput("stdbuf", "-oL", cephVolumeCmd, "lvm", "zap", devicePath)
+	if err != nil {
+		// log and continue with direct cleanup
+		logger.Warningf("ceph-volume lvm zap failed for %q (will continue with direct cleanup): %s. %v", devicePath, output, err)
+	} else {
+		logger.Infof("ceph-volume lvm zap output for %q: %s", devicePath, output)
+	}
+
+	// Follow up with Rook's internal cleanup to ensure all metadata is removed
+	logger.Infof("running rook's internal cleanup for device %q", devicePath)
+
+	// Unmount the device if it's mounted
+	if err := unmountDevice(context, devicePath); err != nil {
+		logger.Warningf("failed to unmount %q (may not be mounted): %v", devicePath, err)
+	}
+
+	// Remove all filesystem signatures with wipefs
+	output, err = context.Executor.ExecuteCommandWithCombinedOutput("wipefs", "--all", devicePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to wipefs on %q: %s", devicePath, output)
+	}
+	logger.Infof("wipefs output for %q: %s", devicePath, output)
+
+	// Remove any BlueStore signatures
+	output, err = context.Executor.ExecuteCommandWithCombinedOutput("ceph-bluestore-tool", "zap-device", "--dev", devicePath, "--yes-i-really-really-mean-it")
+	if err != nil {
+		// Non-fatal: device may not have BlueStore signatures
+		logger.Warningf("ceph-bluestore-tool zap-device failed for %q (may not have BlueStore data): %s. %v", devicePath, output, err)
+	}
+
+	// Zero out the first 10MB to clear any remaining metadata
+	output, err = context.Executor.ExecuteCommandWithCombinedOutput("dd", "if=/dev/zero", fmt.Sprintf("of=%s", devicePath), "bs=1M", "count=10", "conv=fsync")
+	if err != nil {
+		return errors.Wrapf(err, "failed to zero device %q: %s", devicePath, output)
+	}
+
+	logger.Infof("successfully zapped device %q", devicePath)
+	return nil
+}
+
+func unmountDevice(context *clusterd.Context, devicePath string) error {
+	output, err := context.Executor.ExecuteCommandWithCombinedOutput("umount", devicePath)
+	if err != nil {
+		if strings.Contains(output, "not mounted") || strings.Contains(err.Error(), "not mounted") {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to unmount %q: %s", devicePath, output)
+	}
+	return nil
+}
+
 // WipeDevicesFromOtherClusters wipes the OSD backed disks if they have metadata from a different ceph cluster.
 // The wiped disks can then be used to prepare OSDs for the current ceph cluster.
 func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error {
@@ -908,11 +971,9 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 				}
 				logger.Infof("begin wiping OSD %d device %q belonging to a different ceph cluster %q ", osdID, deviceToWipe, existingOSD.CephFsid)
 				logger.Infof("zap OSD.%d on device path %q", osdID, deviceToWipe)
-				output, err := context.Executor.ExecuteCommandWithCombinedOutput("stdbuf", "-oL", cephVolumeCmd, "lvm", "zap", deviceToWipe)
-				if err != nil {
-					return errors.Wrapf(err, "failed to zap osd.%d path %q. %s.", osdID, deviceToWipe, output)
+				if err := ZapDevice(context, deviceToWipe); err != nil {
+					return errors.Wrapf(err, "failed to zap osd.%d path %q", osdID, deviceToWipe)
 				}
-				logger.Infof("ceph-volume output: %s", output)
 				logger.Infof("successfully zapped osd.%d path %q", osdID, deviceToWipe)
 				logger.Infof("completed wiping OSD %d device %q belonging to a different ceph cluster", osdID, deviceToWipe)
 				// Since the device is wiped clean, clear the stale filesystem reference on the disk so that the wiped disk is not filtered out for filesystem check.
@@ -945,9 +1006,8 @@ func wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context, currentClu
 			currentDiskCephFSID := strings.SplitAfter(ceph_fsid, "=")[1]
 			if currentDiskCephFSID != currentClusterFSID {
 				logger.Infof("cleaning encrypted disk %q (%q) that is part of a different ceph cluster %q", disk.Name, disk.RealPath, currentDiskCephFSID)
-				output, err := context.Executor.ExecuteCommandWithCombinedOutput("stdbuf", "-oL", cephVolumeCmd, "lvm", "zap", disk.RealPath)
-				if err != nil {
-					return errors.Wrapf(err, "failed to zap encrypted disk with different ceph cluster %q. %s.", disk.RealPath, output)
+				if err := ZapDevice(context, disk.RealPath); err != nil {
+					return errors.Wrapf(err, "failed to zap encrypted disk with different ceph cluster %q", disk.RealPath)
 				}
 				logger.Infof("completed wiping device %q belonging to a different ceph cluster", disk.RealPath)
 				// Since the device is wiped clean, clear the stale filesystem reference on the disk so that the wiped disk is not filtered out for filesystem check.

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2240,10 +2240,26 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 			return luksDump, nil
 		}
 
-		if slices.Contains(args, "zap") {
-			if !slices.Contains(args, devicePath) {
-				return "", errors.Errorf("device %s should not be zapped", devicePath)
+		// ZapDevice calls: stdbuf (ceph-volume lvm zap), umount, wipefs, ceph-bluestore-tool, dd
+		if command == "stdbuf" {
+			if !slices.Contains(args, "zap") || !slices.Contains(args, devicePath) {
+				return "", errors.Errorf("device %s should not be zapped, got %v", devicePath, args)
 			}
+			return "", nil
+		}
+		if command == "umount" {
+			return "not mounted", errors.New("not mounted")
+		}
+		if command == "wipefs" {
+			if args[1] != devicePath {
+				return "", errors.Errorf("device %s should not be zapped, got %s", devicePath, args[1])
+			}
+			return "", nil
+		}
+		if command == "ceph-bluestore-tool" {
+			return "", nil
+		}
+		if command == "dd" {
 			return "", nil
 		}
 		return "", errors.Errorf("unknown command %s %s", command, args)
@@ -2309,10 +2325,27 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		devicePath := "/dev/mapper/rhel-ceph--data"
-		if slices.Contains(args, "zap") {
-			if !slices.Contains(args, devicePath) {
+
+		// ZapDevice calls: stdbuf (ceph-volume lvm zap), umount, wipefs, ceph-bluestore-tool, dd
+		if command == "stdbuf" {
+			if !slices.Contains(args, "zap") || !slices.Contains(args, devicePath) {
 				return "", errors.Errorf("expected device %s to be zapped but got %v", devicePath, args)
 			}
+			return "", nil
+		}
+		if command == "umount" {
+			return "not mounted", errors.New("not mounted")
+		}
+		if command == "wipefs" {
+			if args[1] != devicePath {
+				return "", errors.Errorf("expected device %s to be zapped but got %v", devicePath, args)
+			}
+			return "", nil
+		}
+		if command == "ceph-bluestore-tool" {
+			return "", nil
+		}
+		if command == "dd" {
 			return "", nil
 		}
 		return "", errors.Errorf("unknown command %s %s", command, args)


### PR DESCRIPTION
When cephCluster is resinstalled and WipeDevicesFromOtherClusters is set to true, then Rook cleans up the OSD disks using ceph-volum lvm zap, so that new OSD can created on this disk. This PR removes the dependencies of the "ceph-volume lvm zap" and provides implements the entry disk "ceph-volume lvm zap" logic within rook

Why is this change required? 
- Ceph duplicates the OSD metadata across different locations on the disk. 
- Recently ceph introduced a change that checks only the first location for bluestore metedata, and it skips cleaning up of the bluestore metadata from the other locations if the first location does not have it. 
- Ceph should be checking for all the locations. 

With this PR, rook does cleaning of the disks similar to how `ceph-volum lvm zap` cleans it. 


Testing: 

```
2026-03-24 06:47:04.319121 I | cephosd: checking for OSD disks from a different cluster
2026-03-24 06:47:04.319487 D | exec: Running command: stdbuf -oL ceph-volume --log-path /tmp/ceph-log raw list --format json
2026-03-24 06:47:06.829394 D | cephosd: {
    "2e9c547c-2933-464c-bc18-63b6bacb5510": {
        "ceph_fsid": "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab",
        "device": "/dev/vdb",
        "osd_id": 0,
        "osd_uuid": "2e9c547c-2933-464c-bc18-63b6bacb5510",
        "type": "bluestore"
    },
    "42e9c577-4721-4004-8d8a-cabd2e58ea45": {
        "ceph_fsid": "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab",
        "device": "/dev/vdc",
        "osd_id": 1,
        "osd_uuid": "42e9c577-4721-4004-8d8a-cabd2e58ea45",
        "type": "bluestore"
    },
    "696b7d88-1505-4839-8183-a2ce6d4e4024": {
        "ceph_fsid": "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab",
        "device": "/dev/vdd",
        "osd_id": 2,
        "osd_uuid": "696b7d88-1505-4839-8183-a2ce6d4e4024",
        "type": "bluestore"
    }
}
2026-03-24 06:47:06.829551 I | cephosd: begin wiping OSD 0 device "/dev/vdb" belonging to a different ceph cluster "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab"
2026-03-24 06:47:06.829581 I | cephosd: zap OSD.0 on device path "/dev/vdb"
2026-03-24 06:47:06.829597 D | exec: Running command: stdbuf -oL ceph-volume lvm zap /dev/vdb
2026-03-24 06:47:09.275054 I | cephosd: ceph-volume lvm zap output for "/dev/vdb": --> Zapping: /dev/vdb
--> --destroy was not specified, but zapping a whole device will remove the partition table
--> Removing all BlueStore signature on /dev/vdb if any...
Running command: /usr/bin/ceph-bluestore-tool zap-device --dev /dev/vdb --yes-i-really-really-mean-it
Running command: /usr/bin/dd if=/dev/zero of=/dev/vdb bs=1M count=10 conv=fsync
--> Zapping successful for: <Raw Device: /dev/vdb>
2026-03-24 06:47:09.275091 I | cephosd: running rook's internal cleanup for device "/dev/vdb"
2026-03-24 06:47:09.275105 D | exec: Running command: umount /dev/vdb
2026-03-24 06:47:09.294805 D | exec: Running command: wipefs --all /dev/vdb
2026-03-24 06:47:09.313313 I | cephosd: wipefs output for "/dev/vdb":
2026-03-24 06:47:09.313925 D | exec: Running command: ceph-bluestore-tool zap-device --dev /dev/vdb --yes-i-really-really-mean-it
2026-03-24 06:47:09.437063 D | exec: Running command: dd if=/dev/zero of=/dev/vdb bs=1M count=10 conv=fsync
2026-03-24 06:47:09.477918 I | cephosd: successfully zapped device "/dev/vdb"
2026-03-24 06:47:09.477948 I | cephosd: successfully zapped osd.0 path "/dev/vdb"
2026-03-24 06:47:09.477961 I | cephosd: completed wiping OSD 0 device "/dev/vdb" belonging to a different ceph cluster
2026-03-24 06:47:09.477977 I | cephosd: skip wiping OSD 1 device "/dev/vdc" belonging to a different ceph cluster "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab" since not a desired device
2026-03-24 06:47:09.477990 I | cephosd: skip wiping OSD 2 device "/dev/vdd" belonging to a different ceph cluster "832ecfc9-fd6d-46fe-b1df-4fc2c2c33bab" since not a desired device
2026-03-24 06:47:09.478001 I | cephosd: creating and starting the osds
2026-03-24 06:47:09.478029 D | cephosd: desiredDevices are [{Name:/mnt/set1-data-0bcghd OSDsPerDevice:1 MetadataDevice: DatabaseSizeMB:0 DeviceClass: InitialWeight: IsFilter:false IsDevicePathFilter:false}]
2026-03-24 06:47:09.478040 D | cephosd: context.Devices are:

```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
