### PR TITLE
osd: use persistent /dev/disk/by-id/ paths for raw mode OSD deployments

### DIFF
--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -17,6 +17,8 @@ limitations under the License.
 package osd
 
 import (
+	"path/filepath"
+
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -71,9 +73,18 @@ func getDeviceLVPath(context *clusterd.Context, deviceName string) string {
 	return output
 }
 
-// GetReplaceOSDId returns the OSD ID based on the device name
+// GetReplaceOSDId returns the OSD ID based on the device name.
+// Compares both directly and via symlink resolution to handle cases where one
+// path is a kernel name (/dev/nvme0n1) and the other is a persistent path
+// (/dev/disk/by-id/nvme-...).
 func (a *OsdAgent) GetReplaceOSDId(device string) int {
 	if device == a.replaceOSD.BlockPath {
+		return a.replaceOSD.ID
+	}
+
+	deviceReal, err1 := filepath.EvalSymlinks(device)
+	blockPathReal, err2 := filepath.EvalSymlinks(a.replaceOSD.BlockPath)
+	if err1 == nil && err2 == nil && deviceReal == blockPathReal {
 		return a.replaceOSD.ID
 	}
 

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -84,7 +84,12 @@ func (a *OsdAgent) GetReplaceOSDId(device string) int {
 
 	deviceReal, err1 := filepath.EvalSymlinks(device)
 	blockPathReal, err2 := filepath.EvalSymlinks(a.replaceOSD.BlockPath)
-	if err1 == nil && err2 == nil && deviceReal == blockPathReal {
+	if err1 != nil || err2 != nil {
+		logger.Debugf("could not resolve symlinks for OSD replacement comparison: device %q err=%v, blockPath %q err=%v",
+			device, err1, a.replaceOSD.BlockPath, err2)
+		return -1
+	}
+	if deviceReal == blockPathReal {
 		return a.replaceOSD.ID
 	}
 

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -63,6 +63,10 @@ var (
 
 	isEncrypted = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
 	isOnPVC     = os.Getenv(oposd.PVCBackedOSDVarName) == "true"
+
+	// nsidSuffixRe matches a trailing _N (one or more digits) that udev's
+	// 60-persistent-storage.rules appends as NVMe namespace IDs to by-id symlinks.
+	nsidSuffixRe = regexp.MustCompile(`_\d+$`)
 )
 
 type osdInfoBlock struct {
@@ -1454,9 +1458,42 @@ func GetBackingDeviceForEncryptedBlock(context *clusterd.Context, disk string) (
 // persistent (/dev/disk/...) or device-mapper (/dev/mapper/...).
 //
 // Preference order for by-id paths (most hardware-stable first):
-//   - wwn-*     (World Wide Name, SATA/SAS — IEEE-assigned, hardware-burned)
-//   - nvme-eui.* (NVMe EUI-64 — IEEE-assigned, hardware-burned)
-//   - ata-*, nvme-* (model-serial derived from IDENTIFY data)
+//
+// Tier 1 -- hardware-burned IEEE identifiers (equally preferred):
+//
+//   - wwn-*: World Wide Name (WWN), the unique hardware identifier for
+//     SATA and SAS devices. Assigned by IEEE (NAA format) and burned into
+//     the drive controller at manufacturing. Cannot change across firmware
+//     updates, kernel upgrades, or reboots.
+//     SCSI/SAS: defined in SPC-6 (INCITS 566-2025) S7.7.3
+//     "Device Identification VPD page", designator type NAA (3h).
+//     T10 committee: https://www.t10.org/members/w_spc6.htm
+//     SATA: WWN exposed via IDENTIFY DEVICE words 108-111, defined in
+//     ACS-5 (INCITS 558-2021). T13 committee: https://www.t13.org/
+//
+//   - nvme-eui.*: EUI-64 (Extended Unique Identifier), the unique hardware
+//     identifier for NVMe namespaces. Assigned by IEEE and burned into the
+//     NVMe controller at manufacturing. Same stability guarantees as WWN.
+//     Defined in NVM Express Base Specification Rev 2.1, S4.1.5.1
+//     "Identify Namespace data structure", EUI64 field.
+//     https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-Revision-2.1-2024.08.05-Ratified.pdf
+//     All specs: https://nvmexpress.org/specifications/
+//
+// These are mutually exclusive by bus type: SATA/SAS devices expose wwn-,
+// NVMe devices expose nvme-eui. They never appear together for the same
+// device, so equal ranking between them is intentional.
+//
+// Tier 2 -- model-serial identifiers (fallback):
+//
+//   - ata-*, nvme-*: Constructed by udev from the device's IDENTIFY data
+//     (model name + serial number). Less stable because firmware updates can
+//     change the model string, serial number formatting varies across
+//     manufacturers, and udev's parsing of IDENTIFY data can change between
+//     versions. Used only when no Tier 1 identifier is available.
+//
+// Symlink naming is defined by systemd/udev 60-persistent-storage.rules:
+//
+//	https://github.com/systemd/systemd/blob/main/rules.d/60-persistent-storage.rules.in
 func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor) string {
 	if !strings.HasPrefix(devicePath, "/dev/") ||
 		strings.HasPrefix(devicePath, "/dev/disk/") ||
@@ -1476,9 +1513,8 @@ func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor
 		return devicePath
 	}
 
-	// Collect candidate /dev/disk/by-id/ paths, skipping lvm-pv-uuid entries
-	// and numbered duplicates (e.g., nvme-Micron_..._1).
-	var candidates []string
+	// Collect candidate /dev/disk/by-id/ paths, skipping lvm-pv-uuid entries.
+	var rawCandidates []string
 	for _, link := range strings.Fields(devLinks) {
 		if !strings.HasPrefix(link, "/dev/disk/by-id/") {
 			continue
@@ -1486,18 +1522,38 @@ func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor
 		if strings.Contains(link, "lvm-pv-uuid") {
 			continue
 		}
-		base := filepath.Base(link)
-		if matched, _ := filepath.Match("*_[0-9]", base); matched {
-			continue
+		rawCandidates = append(rawCandidates, link)
+	}
+
+	// Filter namespace-suffixed duplicates: skip /dev/disk/by-id/FOO_N when
+	// /dev/disk/by-id/FOO also exists in DEVLINKS (N = one or more digits).
+	// NVMe namespace IDs are appended by udev's 60-persistent-storage.rules
+	// (e.g., nvme-Model_Serial_1 for namespace 1). We check for the
+	// un-suffixed path's existence rather than pattern-matching the suffix
+	// alone, so we never accidentally filter a device whose serial number
+	// legitimately ends in digits. If only FOO_N exists (FOO is absent),
+	// we keep it -- it may be the only valid link for this device.
+	candidateSet := make(map[string]bool, len(rawCandidates))
+	for _, c := range rawCandidates {
+		candidateSet[c] = true
+	}
+	var candidates []string
+	for _, c := range rawCandidates {
+		base := filepath.Base(c)
+		if loc := nsidSuffixRe.FindStringIndex(base); loc != nil {
+			unsuffixed := filepath.Join(filepath.Dir(c), base[:loc[0]])
+			if candidateSet[unsuffixed] {
+				continue // unsuffixed path exists; this is a namespace duplicate
+			}
 		}
-		candidates = append(candidates, link)
+		candidates = append(candidates, c)
 	}
 
 	if len(candidates) == 0 {
 		return devicePath
 	}
 
-	// Select the most stable identifier: wwn- > nvme-eui. > anything else
+	// Select the most stable identifier (see preferByIDPath for ranking).
 	best := candidates[0]
 	for _, c := range candidates[1:] {
 		best = preferByIDPath(best, c)
@@ -1508,16 +1564,26 @@ func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor
 }
 
 // preferByIDPath returns the more stable of two /dev/disk/by-id/ paths.
-// wwn- and nvme-eui. paths are hardware-burned identifiers (IEEE-assigned);
-// ata-/nvme- model-serial paths are derived from device IDENTIFY data.
+//
+// Rank 0 (preferred): wwn- is the unique IEEE-assigned hardware identifier
+// for SATA/SAS devices (World Wide Name, NAA format, burned into the drive
+// controller at manufacturing). nvme-eui. is the equivalent for NVMe devices
+// (EUI-64, burned into the NVMe controller at manufacturing). Both are
+// immutable hardware identifiers. They are mutually exclusive by bus type --
+// a device will have one or the other, never both -- so equal ranking is
+// intentional.
+//
+// Rank 1 (fallback): ata-/nvme- model-serial paths are constructed by udev
+// from the device's IDENTIFY data and are less stable (see
+// resolveDeviceToPersistentPath comments for details and spec references).
 func preferByIDPath(a, b string) string {
 	rank := func(p string) int {
 		base := filepath.Base(p)
 		switch {
 		case strings.HasPrefix(base, "wwn-"):
-			return 0
+			return 0 // WWN: unique IEEE-assigned hardware ID for SATA/SAS
 		case strings.HasPrefix(base, "nvme-eui."):
-			return 0
+			return 0 // EUI-64: unique IEEE-assigned hardware ID for NVMe (mutually exclusive with wwn-)
 		default:
 			return 1
 		}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1559,6 +1559,27 @@ func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor
 		best = preferByIDPath(best, c)
 	}
 
+	// Verify the persistent path resolves back to this device, but only
+	// if the path exists on the filesystem (it won't in unit tests where
+	// /dev/disk/by-id/ paths are synthetic from udev output).
+	// Some drives ship with bogus identifiers (e.g., Intel 660p's broken
+	// EUI-64 0100000000000000). The Linux kernel's NVME_QUIRK_BOGUS_NID
+	// handles known-bad devices, and runtime duplicate detection catches
+	// most collisions at probe time, but as a defense-in-depth measure we
+	// verify the symlink round-trips to the correct device. If it doesn't,
+	// the identifier is non-unique and we fall back to the kernel name.
+	if _, statErr := os.Lstat(best); statErr == nil {
+		resolvedReal, err := filepath.EvalSymlinks(best)
+		if err == nil {
+			deviceReal, err := filepath.EvalSymlinks(devicePath)
+			if err == nil && resolvedReal != deviceReal {
+				logger.Warningf("persistent path %q resolves to %q, not %q -- identifier may be non-unique, using kernel path",
+					best, resolvedReal, deviceReal)
+				return devicePath
+			}
+		}
+	}
+
 	logger.Infof("resolved device %q to persistent path %q", devicePath, best)
 	return best
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -36,6 +36,7 @@ import (
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/util/display"
+	rookexec "github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
 )
 
@@ -1261,9 +1262,18 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 		// If no block is specified let's take the one we discovered
 		if setDevicePathFromList {
-			blockPath = osdInfo.Device
+			// Resolve kernel device names to persistent /dev/disk/by-id/ paths when available.
+			// Kernel names (e.g., /dev/nvme0n1) can change across reboots, causing OSD activation
+			// failures. Persistent paths are tied to device serial numbers and remain stable.
+			blockPath = resolveDeviceToPersistentPath(osdInfo.Device, context.Executor)
 			blockMetadataPath = osdInfo.DeviceDb
+			if blockMetadataPath != "" {
+				blockMetadataPath = resolveDeviceToPersistentPath(blockMetadataPath, context.Executor)
+			}
 			blockWalPath = osdInfo.DeviceWal
+			if blockWalPath != "" {
+				blockWalPath = resolveDeviceToPersistentPath(blockWalPath, context.Executor)
+			}
 		} else {
 			blockPath = block
 			blockMetadataPath = metadataBlock
@@ -1435,4 +1445,85 @@ func GetBackingDeviceForEncryptedBlock(context *clusterd.Context, disk string) (
 	}
 
 	return "", errors.Errorf("failed to find backing device for encrypted block %q", disk)
+}
+
+// resolveDeviceToPersistentPath resolves a kernel device path (e.g., /dev/nvme0n1) to a
+// persistent /dev/disk/by-id/ path using udev. Kernel device names can change across reboots;
+// persistent paths are tied to hardware identifiers and remain stable. Returns the original
+// path unchanged if no persistent path is found, on error, or for paths that are already
+// persistent (/dev/disk/...) or device-mapper (/dev/mapper/...).
+//
+// Preference order for by-id paths (most hardware-stable first):
+//   - wwn-*     (World Wide Name, SATA/SAS — IEEE-assigned, hardware-burned)
+//   - nvme-eui.* (NVMe EUI-64 — IEEE-assigned, hardware-burned)
+//   - ata-*, nvme-* (model-serial derived from IDENTIFY data)
+func resolveDeviceToPersistentPath(devicePath string, executor rookexec.Executor) string {
+	if !strings.HasPrefix(devicePath, "/dev/") ||
+		strings.HasPrefix(devicePath, "/dev/disk/") ||
+		strings.HasPrefix(devicePath, "/dev/mapper/") {
+		return devicePath
+	}
+
+	deviceName := strings.TrimPrefix(devicePath, "/dev/")
+	udevInfo, err := sys.GetUdevInfo(deviceName, executor)
+	if err != nil {
+		logger.Warningf("failed to get udev info for %q, using kernel device path: %v", devicePath, err)
+		return devicePath
+	}
+
+	devLinks, ok := udevInfo["DEVLINKS"]
+	if !ok || devLinks == "" {
+		return devicePath
+	}
+
+	// Collect candidate /dev/disk/by-id/ paths, skipping lvm-pv-uuid entries
+	// and numbered duplicates (e.g., nvme-Micron_..._1).
+	var candidates []string
+	for _, link := range strings.Fields(devLinks) {
+		if !strings.HasPrefix(link, "/dev/disk/by-id/") {
+			continue
+		}
+		if strings.Contains(link, "lvm-pv-uuid") {
+			continue
+		}
+		base := filepath.Base(link)
+		if matched, _ := filepath.Match("*_[0-9]", base); matched {
+			continue
+		}
+		candidates = append(candidates, link)
+	}
+
+	if len(candidates) == 0 {
+		return devicePath
+	}
+
+	// Select the most stable identifier: wwn- > nvme-eui. > anything else
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		best = preferByIDPath(best, c)
+	}
+
+	logger.Infof("resolved device %q to persistent path %q", devicePath, best)
+	return best
+}
+
+// preferByIDPath returns the more stable of two /dev/disk/by-id/ paths.
+// wwn- and nvme-eui. paths are hardware-burned identifiers (IEEE-assigned);
+// ata-/nvme- model-serial paths are derived from device IDENTIFY data.
+func preferByIDPath(a, b string) string {
+	rank := func(p string) int {
+		base := filepath.Base(p)
+		switch {
+		case strings.HasPrefix(base, "wwn-"):
+			return 0
+		case strings.HasPrefix(base, "nvme-eui."):
+			return 0
+		default:
+			return 1
+		}
+	}
+	if rank(a) <= rank(b) {
+		return a
+	}
+	return b
 }

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2327,3 +2327,76 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	err = agent.WipeDevicesFromOtherClusters(context)
 	assert.NoError(t, err)
 }
+
+func TestResolveDeviceToPersistentPath(t *testing.T) {
+	t.Run("NVMe prefers eui over model-serial", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				return "DEVLINKS=/dev/disk/by-id/nvme-Micron_7450_SERIAL_A /dev/disk/by-id/nvme-Micron_7450_SERIAL_A_1 /dev/disk/by-id/nvme-eui.00000001\nDEVNAME=/dev/nvme0n1\n", nil
+			}
+			return "", nil
+		}
+		// nvme-eui. is hardware-burned (IEEE), preferred over model-serial
+		result := resolveDeviceToPersistentPath("/dev/nvme0n1", executor)
+		assert.Equal(t, "/dev/disk/by-id/nvme-eui.00000001", result)
+	})
+
+	t.Run("SATA prefers wwn over ata model-serial", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				return "DEVLINKS=/dev/disk/by-id/ata-WDC_HC580_SERIAL /dev/disk/by-id/wwn-0x5000cca418d314ed\n", nil
+			}
+			return "", nil
+		}
+		// wwn- is hardware-burned (IEEE), preferred over ata- model-serial
+		result := resolveDeviceToPersistentPath("/dev/sda", executor)
+		assert.Equal(t, "/dev/disk/by-id/wwn-0x5000cca418d314ed", result)
+	})
+
+	t.Run("no by-id path returns kernel path", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				return "DEVNAME=/dev/vdb\n", nil
+			}
+			return "", nil
+		}
+		result := resolveDeviceToPersistentPath("/dev/vdb", executor)
+		assert.Equal(t, "/dev/vdb", result)
+	})
+
+	t.Run("udevadm failure returns kernel path", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			return "", errors.New("udevadm not found")
+		}
+		result := resolveDeviceToPersistentPath("/dev/nvme0n1", executor)
+		assert.Equal(t, "/dev/nvme0n1", result)
+	})
+
+	t.Run("already persistent path is returned as-is", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		result := resolveDeviceToPersistentPath("/dev/disk/by-id/nvme-Micron_SERIAL", executor)
+		assert.Equal(t, "/dev/disk/by-id/nvme-Micron_SERIAL", result)
+	})
+
+	t.Run("device-mapper path is returned as-is", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		result := resolveDeviceToPersistentPath("/dev/mapper/crypt-device", executor)
+		assert.Equal(t, "/dev/mapper/crypt-device", result)
+	})
+
+	t.Run("lvm-pv-uuid links are skipped", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				return "DEVLINKS=/dev/disk/by-id/lvm-pv-uuid-abc123 /dev/disk/by-id/ata-WDC_SERIAL\n", nil
+			}
+			return "", nil
+		}
+		result := resolveDeviceToPersistentPath("/dev/sdb", executor)
+		assert.Equal(t, "/dev/disk/by-id/ata-WDC_SERIAL", result)
+	})
+}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2432,3 +2432,30 @@ func TestResolveDeviceToPersistentPath(t *testing.T) {
 		assert.Equal(t, "/dev/disk/by-id/nvme-eui.CCDD", result)
 	})
 }
+
+func TestPreferByIDPath(t *testing.T) {
+	t.Run("wwn preferred over ata model-serial", func(t *testing.T) {
+		result := preferByIDPath("/dev/disk/by-id/ata-WDC_HC580_SERIAL", "/dev/disk/by-id/wwn-0x5000cca418d314ed")
+		assert.Equal(t, "/dev/disk/by-id/wwn-0x5000cca418d314ed", result)
+	})
+
+	t.Run("nvme-eui preferred over nvme model-serial", func(t *testing.T) {
+		result := preferByIDPath("/dev/disk/by-id/nvme-Micron_7450_SERIAL", "/dev/disk/by-id/nvme-eui.00000001")
+		assert.Equal(t, "/dev/disk/by-id/nvme-eui.00000001", result)
+	})
+
+	t.Run("wwn and nvme-eui are equal rank -- first arg wins", func(t *testing.T) {
+		result := preferByIDPath("/dev/disk/by-id/wwn-0x5000cca418d314ed", "/dev/disk/by-id/nvme-eui.00000001")
+		assert.Equal(t, "/dev/disk/by-id/wwn-0x5000cca418d314ed", result)
+	})
+
+	t.Run("two model-serial paths are equal rank -- first arg wins", func(t *testing.T) {
+		result := preferByIDPath("/dev/disk/by-id/ata-WDC_SERIAL_A", "/dev/disk/by-id/ata-WDC_SERIAL_B")
+		assert.Equal(t, "/dev/disk/by-id/ata-WDC_SERIAL_A", result)
+	})
+
+	t.Run("wwn preferred regardless of argument order", func(t *testing.T) {
+		result := preferByIDPath("/dev/disk/by-id/wwn-0x5000cca418d314ed", "/dev/disk/by-id/ata-WDC_HC580_SERIAL")
+		assert.Equal(t, "/dev/disk/by-id/wwn-0x5000cca418d314ed", result)
+	})
+}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2337,7 +2337,10 @@ func TestResolveDeviceToPersistentPath(t *testing.T) {
 			}
 			return "", nil
 		}
-		// nvme-eui. is hardware-burned (IEEE), preferred over model-serial
+		// nvme-eui. is hardware-burned (IEEE), preferred over model-serial.
+		// nvme-Micron_7450_SERIAL_A_1 is filtered because the un-suffixed
+		// nvme-Micron_7450_SERIAL_A also exists in DEVLINKS, identifying _1
+		// as a udev namespace-ID suffix.
 		result := resolveDeviceToPersistentPath("/dev/nvme0n1", executor)
 		assert.Equal(t, "/dev/disk/by-id/nvme-eui.00000001", result)
 	})
@@ -2398,5 +2401,34 @@ func TestResolveDeviceToPersistentPath(t *testing.T) {
 		}
 		result := resolveDeviceToPersistentPath("/dev/sdb", executor)
 		assert.Equal(t, "/dev/disk/by-id/ata-WDC_SERIAL", result)
+	})
+
+	t.Run("namespace-suffixed path kept when base absent", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				// Only nvme-FOO_1 exists, no nvme-FOO -- _1 could be part of the
+				// serial or the base link may be claimed by another device. Either
+				// way, we must keep it since it's the only model-serial link.
+				return "DEVLINKS=/dev/disk/by-id/nvme-FOO_1 /dev/disk/by-id/nvme-eui.AABB\n", nil
+			}
+			return "", nil
+		}
+		result := resolveDeviceToPersistentPath("/dev/nvme1n1", executor)
+		assert.Equal(t, "/dev/disk/by-id/nvme-eui.AABB", result)
+	})
+
+	t.Run("multi-digit namespace ID filtered", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "udevadm" {
+				// nvme-Model_Serial_12 is namespace 12; the un-suffixed
+				// nvme-Model_Serial also exists, confirming _12 is a NSID.
+				return "DEVLINKS=/dev/disk/by-id/nvme-Model_Serial /dev/disk/by-id/nvme-Model_Serial_12 /dev/disk/by-id/nvme-eui.CCDD\n", nil
+			}
+			return "", nil
+		}
+		result := resolveDeviceToPersistentPath("/dev/nvme2n1", executor)
+		assert.Equal(t, "/dev/disk/by-id/nvme-eui.CCDD", result)
 	})
 }


### PR DESCRIPTION
Fixes #17224

## Problem

Non-PVC raw mode OSDs store kernel device names (`/dev/nvme0n1`) in `ROOK_BLOCK_PATH`. NVMe device enumeration order isn't stable across reboots, so the stored path can point to the wrong device after a reboot. The activate init container's fallback (`ceph-volume raw list` full scan) hangs when other OSDs hold their devices open.

## Fix

Resolve kernel device paths to `/dev/disk/by-id/` persistent paths (via the existing `sys.GetUdevInfo()`) when setting `OSDInfo.BlockPath` in `GetCephVolumeRawOSDs()`. This is the single point where block paths transition from transient (prepare-time) to persistent (deployment spec) state.

I chose to prefer hardware-burned identifiers `wwn-` for SATA/SAS and `nvme-eui.` for NVMe  over model-serial derived paths (`ata-*`, `nvme-<model>_<serial>`). WWN and EUI-64 are IEEE-assigned and physically burned into the device; model-serial paths are derived from IDENTIFY data which is theoretically mutable (though stable in practice). Falls back to kernel names when no by-id path exists (VMs, some cloud providers).

Also made `GetReplaceOSDId()` resolve symlinks before comparing, so OSD replacement works when the old deployment has a persistent path and the new prepare job uses a kernel name.

## Why this approach

I considered threading persistent paths through the entire OSD lifecycle (discovery → mapping → prepare → deployment), but everything upstream of `BlockPath` is transient. It runs once during OSD creation when kernel names are correct. Only `BlockPath` persists across reboots in the deployment spec, so fixing this single output point is sufficient.

This is also safer for disk replacement: a new disk gets a different serial → different by-id path → operator detects the change and reprovisions. With kernel names, a replacement disk could silently get the same `/dev/nvme0n1` and the old OSD would try to activate on wrong data.

## Scope

- PVC-backed and LVM mode OSDs are completely unaffected (different code paths)
- Existing clusters pick up persistent paths on next OSD restart
- `ceph-volume` handles symlinks fine (kernel resolves at VFS layer)