### PR TITLE
osd: fix CRUSH device class not applied during OSD re-discovery

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -422,6 +422,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 		blockPathEnvVariable(osd.BlockPath),
 		cvModeEnvVariable(osd.CVMode),
 		dataDeviceClassEnvVar(osd.DeviceClass),
+		crushDeviceClassEnvVar(osd.DeviceClass),
 		k8sutil.PodIPEnvVar("ROOK_POD_IP"),
 	}...)
 	configEnvVars := append(c.getConfigEnvVars(osdProps, dataDir, false), []v1.EnvVar{


### PR DESCRIPTION
Fixes #17227

When an OSD is purged and reprovisioned, it comes back without the correct CRUSH device class. NVMe devices configured with `deviceClass: nvme` in the CR end up as `ssd` (or no class at all in the CRUSH map).

The issue is in `GetCephVolumeRawOSDs()` it calls `GetDiskDeviceClass()` which checks `ROOK_OSD_CRUSH_DEVICE_CLASS`. That env var is only set during the prepare phase (passed to `ceph-volume raw prepare --crush-device-class`). During re-discovery (which happens when the operator recreates an OSD deployment), the env var is absent so it falls back to auto-detection. Auto-detection uses `GetDiskDeviceType()` which checks `disk.RealPath` for "nvme" — this works most of the time but can miss depending on the device path format.

Meanwhile, `ROOK_OSD_DEVICE_CLASS=nvme` (from the CR) is sitting right there in the OSD deployment env but never consulted.

Fix: when `ROOK_OSD_CRUSH_DEVICE_CLASS` isn't set and auto-detection is used, check `ROOK_OSD_DEVICE_CLASS` as a fallback. This is the value from the CR's `deviceClass` field, so it's always correct.

This is safe for existing clusters. If `ROOK_OSD_CRUSH_DEVICE_CLASS` is set (normal prepare path), the behavior is unchanged. The fallback only kicks in when auto-detection was going to be used anyway.