### PR TITLE
ceph: add labels support to CephObjectStore RGW service

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -9193,7 +9193,7 @@ int
 <h3 id="ceph.rook.io/v1.Labels">Labels
 (<code>map[string]string</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirroringSpec">FilesystemMirroringSpec</a>, <a href="#ceph.rook.io/v1.GaneshaServerSpec">GaneshaServerSpec</a>, <a href="#ceph.rook.io/v1.GatewaySpec">GatewaySpec</a>, <a href="#ceph.rook.io/v1.MetadataServerSpec">MetadataServerSpec</a>, <a href="#ceph.rook.io/v1.NVMeOFGatewaySpec">NVMeOFGatewaySpec</a>, <a href="#ceph.rook.io/v1.RBDMirroringSpec">RBDMirroringSpec</a>)
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirroringSpec">FilesystemMirroringSpec</a>, <a href="#ceph.rook.io/v1.GaneshaServerSpec">GaneshaServerSpec</a>, <a href="#ceph.rook.io/v1.GatewaySpec">GatewaySpec</a>, <a href="#ceph.rook.io/v1.MetadataServerSpec">MetadataServerSpec</a>, <a href="#ceph.rook.io/v1.NVMeOFGatewaySpec">NVMeOFGatewaySpec</a>, <a href="#ceph.rook.io/v1.RBDMirroringSpec">RBDMirroringSpec</a>, <a href="#ceph.rook.io/v1.RGWServiceSpec">RGWServiceSpec</a>)
 </p>
 <div>
 <p>Labels are label for a given daemons</p>
@@ -13955,6 +13955,20 @@ Annotations
 <p>The annotations-related configuration to add/set on each rgw service.
 nullable
 optional</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.Labels">
+Labels
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The labels-related configuration to add/set on each rgw service.</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -14075,6 +14075,11 @@ spec:
                             nullable
                             optional
                           type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: The labels-related configuration to add/set on each rgw service.
+                          type: object
                       type: object
                     sslCertificateRef:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -14064,6 +14064,11 @@ spec:
                             nullable
                             optional
                           type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: The labels-related configuration to add/set on each rgw service.
+                          type: object
                       type: object
                     sslCertificateRef:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections

--- a/deploy/examples/object.yaml
+++ b/deploy/examples/object.yaml
@@ -93,6 +93,13 @@ spec:
     # A key/value list of labels
     labels:
     #  key: value
+    # service:
+    #   # A key/value list of annotations to add to the rgw service
+    #   annotations:
+    #     key: value
+    #   # A key/value list of labels to add to the rgw service
+    #   labels:
+    #     key: value
     resources:
     # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
     #  limits:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2740,6 +2740,9 @@ type RGWServiceSpec struct {
 	// nullable
 	// optional
 	Annotations Annotations `json:"annotations,omitempty"`
+	// The labels-related configuration to add/set on each rgw service.
+	// +optional
+	Labels Labels `json:"labels,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -5079,6 +5079,13 @@ func (in *RGWServiceSpec) DeepCopyInto(out *RGWServiceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(Labels, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -742,6 +742,7 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 
 	if c.store.Spec.Gateway.Service != nil {
 		c.store.Spec.Gateway.Service.Annotations.ApplyToObjectMeta(&svc.ObjectMeta)
+		c.store.Spec.Gateway.Service.Labels.ApplyToObjectMeta(&svc.ObjectMeta)
 	}
 	if c.store.Spec.IsHostNetwork(c.clusterSpec) {
 		svc.Spec.ClusterIP = v1.ClusterIPNone

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -1715,3 +1715,21 @@ func TestRgwReadAffinity(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateServiceLabels(t *testing.T) {
+	store := simpleStore()
+	store.Spec.Gateway.Service = &cephv1.RGWServiceSpec{
+		Labels: cephv1.Labels{"my-label": "my-value"},
+	}
+	info := clienttest.CreateTestClusterInfo(1)
+	c := &clusterConfig{
+		clusterInfo: info,
+		store:       store,
+		clusterSpec: &cephv1.ClusterSpec{},
+	}
+	svc := c.generateService(store)
+	// Verify custom labels are applied
+	assert.Equal(t, "my-value", svc.ObjectMeta.Labels["my-label"])
+	// Verify default labels are still present
+	assert.Equal(t, "rook-ceph-rgw", svc.ObjectMeta.Labels["app"])
+}


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #17235

Add a `Labels` field to `RGWServiceSpec` following the existing `Annotations` pattern, so users can set custom labels on the RGW service created by CephObjectStore.

**Changes:**
- Added `Labels Labels` field to `RGWServiceSpec` in `types.go`
- Called `Labels.ApplyToObjectMeta()` in `generateService()` alongside the existing annotations call
- Added unit test verifying custom labels appear on the generated service
- Updated `deploy/examples/object.yaml` with commented-out labels example
- Ran `make codegen` and `make crds` to regenerate deepcopy and CRD manifests

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.