### PR TITLE
osd: Remove obsolete osd methods

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -72,17 +71,6 @@ type OSDDump struct {
 	FullRatio         float64             `json:"full_ratio"`
 	BackfillFullRatio float64             `json:"backfillfull_ratio"`
 	NearFullRatio     float64             `json:"nearfull_ratio"`
-}
-
-// IsFlagSet checks if an OSD flag is set
-func (dump *OSDDump) IsFlagSet(checkFlag string) bool {
-	flags := strings.SplitSeq(dump.Flags, ",")
-	for flag := range flags {
-		if flag == checkFlag {
-			return true
-		}
-	}
-	return false
 }
 
 // IsFlagSetOnCrushUnit checks if an OSD flag is set on specified Crush unit
@@ -280,21 +268,6 @@ func SetDeviceClass(context *clusterd.Context, clusterInfo *ClusterInfo, osdID i
 	return nil
 }
 
-func GetOSDPerfStats(context *clusterd.Context, clusterInfo *ClusterInfo) (*OSDPerfStats, error) {
-	args := []string{"osd", "perf"}
-	buf, err := NewCephCommand(context, clusterInfo, args).Run()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get osd perf")
-	}
-
-	var osdPerfStats OSDPerfStats
-	if err := json.Unmarshal(buf, &osdPerfStats); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal osd perf response")
-	}
-
-	return &osdPerfStats, nil
-}
-
 func GetOSDDump(context *clusterd.Context, clusterInfo *ClusterInfo) (*OSDDump, error) {
 	args := []string{"osd", "dump"}
 	cmd := NewCephCommand(context, clusterInfo, args)
@@ -309,12 +282,6 @@ func GetOSDDump(context *clusterd.Context, clusterInfo *ClusterInfo) (*OSDDump, 
 	}
 
 	return &osdDump, nil
-}
-
-func OSDOut(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) (string, error) {
-	args := []string{"osd", "out", strconv.Itoa(osdID)}
-	buf, err := NewCephCommand(context, clusterInfo, args).Run()
-	return string(buf), err
 }
 
 func OsdSafeToDestroy(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) (bool, error) {


### PR DESCRIPTION
Remove helper methods for querying and configuring various osd settings that are no longer in use anywhere in Rook
Just a small cleanup after poking around in this file. There are likely others across Rook in need of cleanup too, but I did not dig very far.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
