### PR TITLE
helm: Update csi operator to v0.6.0

### DIFF
--- a/deploy/charts/rook-ceph/Chart.yaml
+++ b/deploy/charts/rook-ceph/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     version: "0.0.1"
     repository: "file://../library"
   - name: ceph-csi-operator
-    version: 0.5.0
+    version: 0.6.0
     repository: https://ceph.github.io/ceph-csi-operator
     alias: ceph-csi-operator
     condition: csi.rookUseCsiOperator


### PR DESCRIPTION
With the release of the ceph csi operator v0.6.0, update the helm chart dependency that was missed when the csi-operator.yaml manifest was updated.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
