### PR TITLE
object: add CephObjectStoreUser.Spec.DefaultPlacement

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2248,6 +2248,18 @@ When set, the user is created as an account user with no default permissions,
 and resources created by this user are owned by the account.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>defaultPlacement</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Override the default pool placement for buckets created by this user. If not provided, the default pool placement from the zone group will be used.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -12666,6 +12678,18 @@ ObjectStoreUserAccountRef
 The referenced account must be in the same namespace as the user.
 When set, the user is created as an account user with no default permissions,
 and resources created by this user are owned by the account.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>defaultPlacement</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Override the default pool placement for buckets created by this user. If not provided, the default pool placement from the zone group will be used.</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -15335,6 +15335,11 @@ spec:
                 clusterNamespace:
                   description: The namespace where the parent CephCluster and CephObjectStore are found
                   type: string
+                defaultPlacement:
+                  description: Override the default pool placement for buckets created by this user. If not provided, the default pool placement from the zone group will be used.
+                  maxLength: 2048
+                  minLength: 0
+                  type: string
                 displayName:
                   description: The display name for the ceph user.
                   type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -15323,6 +15323,11 @@ spec:
                 clusterNamespace:
                   description: The namespace where the parent CephCluster and CephObjectStore are found
                   type: string
+                defaultPlacement:
+                  description: Override the default pool placement for buckets created by this user. If not provided, the default pool placement from the zone group will be used.
+                  maxLength: 2048
+                  minLength: 0
+                  type: string
                 displayName:
                   description: The display name for the ceph user.
                   type: string

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2401,6 +2401,11 @@ type ObjectStoreUserSpec struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:message="accountRef is immutable",rule="self == oldSelf"
 	AccountRef ObjectStoreUserAccountRef `json:"accountRef,omitzero"`
+	// Override the default pool placement for buckets created by this user. If not provided, the default pool placement from the zone group will be used.
+	// +optional
+	// +kubebuilder:validation:MinLength=0
+	// +kubebuilder:validation:MaxLength=2048
+	DefaultPlacement *string `json:"defaultPlacement,omitempty"`
 }
 
 // ObjectStoreUserAccountRef is a reference to a CephObjectStoreAccount

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -4606,6 +4606,11 @@ func (in *ObjectStoreUserSpec) DeepCopyInto(out *ObjectStoreUserSpec) {
 		}
 	}
 	out.AccountRef = in.AccountRef
+	if in.DefaultPlacement != nil {
+		in, out := &in.DefaultPlacement, &out.DefaultPlacement
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -649,6 +649,10 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) (*admin.User, error) {
 
 	userConfig.OpMask = opMask
 
+	if user.Spec.DefaultPlacement != nil {
+		userConfig.DefaultPlacement = *user.Spec.DefaultPlacement
+	}
+
 	return userConfig, nil
 }
 
@@ -1031,6 +1035,10 @@ func isUserSync(targetUser, liveUser *admin.User) bool {
 	}
 
 	if targetUser.OpMask != liveUser.OpMask {
+		return false
+	}
+
+	if targetUser.DefaultPlacement != liveUser.DefaultPlacement {
 		return false
 	}
 

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -859,4 +859,24 @@ func TestIsUserSync(t *testing.T) {
 
 		assert.False(t, isUserSync(&a, &b))
 	})
+
+	t.Run("DefaultPlacement same", func(t *testing.T) {
+		a := admin.User{
+			DefaultPlacement: "HDD-EC",
+		}
+		b := admin.User{
+			DefaultPlacement: "HDD-EC",
+		}
+
+		assert.True(t, isUserSync(&a, &b))
+	})
+
+	t.Run("DefaultPlacement different", func(t *testing.T) {
+		a := admin.User{
+			DefaultPlacement: "HDD-EC",
+		}
+		b := admin.User{}
+
+		assert.False(t, isUserSync(&a, &b))
+	})
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -54,6 +54,7 @@ import (
 	usercaps "github.com/rook/rook/tests/integration/object/user/caps"
 	userkeys "github.com/rook/rook/tests/integration/object/user/keys"
 	useropmask "github.com/rook/rook/tests/integration/object/user/opmask"
+	userplacement "github.com/rook/rook/tests/integration/object/user/placement"
 	"github.com/rook/rook/tests/integration/object/util/sharedstore"
 )
 
@@ -223,6 +224,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 		topickafka.Namespace,
 		useropmask.Namespace,
 		usercaps.Namespace,
+		userplacement.Namespace,
 		cosi.Namespace,
 		notification.Namespace,
 	)
@@ -236,6 +238,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	topickafka.TestBucketTopicKafka(s.T(), k8sh, sharedObjectStore)
 	useropmask.TestObjectStoreUserOpMask(s.T(), k8sh, sharedObjectStore)
 	usercaps.TestObjectStoreUserCaps(s.T(), k8sh, sharedObjectStore)
+	userplacement.TestObjectStoreUserDefaultPlacement(s.T(), k8sh, sharedObjectStore)
 	// the ceph-cosi driver cannot reach a TLS object store endpoint, so this
 	// suite skips itself in the TLS pass
 	cosi.TestCephCOSIDriver(s.T(), k8sh, sharedObjectStore)

--- a/tests/integration/object/user/placement/placement.go
+++ b/tests/integration/object/user/placement/placement.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const Namespace = "test-userplacement"
+
+func TestObjectStoreUserDefaultPlacement(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		defaultName = Namespace
+		objectStore = store.ObjectStore()
+		adminClient = store.AdminClient()
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultName,
+			},
+		}
+
+		osu1 = cephv1.CephObjectStoreUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-user1",
+				Namespace: ns.Name,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				Store:            objectStore.Name,
+				ClusterNamespace: objectStore.Namespace,
+				// "bar" is the non-default placement added to the shared store's
+				// zone; the zonegroup default is "default".
+				DefaultPlacement: ptr.To("bar"),
+			},
+		}
+
+		osuClient = k8sh.RookClientset.CephV1().CephObjectStoreUsers(ns.Name)
+	)
+
+	t.Run("ObjectStoreUser defaultPlacement", func(t *testing.T) {
+		ctx := t.Context()
+
+		fixture.RequireNamespace(t, k8sh, ns)
+
+		t.Run(fmt.Sprintf("create CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
+			// user creation may be slow right after rgw start up
+			wait4.RequireCreate(ctx, t, osuClient, &osu1, wait4.ObjectStoreUser, wait4.TimeoutLong)
+		})
+
+		t.Run(fmt.Sprintf("verify defaultPlacement set on rgw user %q", osu1.Name), func(t *testing.T) {
+			liveUser, err := adminClient.GetUser(ctx, admin.User{ID: osu1.Name})
+			require.NoError(t, err)
+			assert.Equal(t, "bar", liveUser.DefaultPlacement)
+		})
+
+		t.Run(fmt.Sprintf("update defaultPlacement on CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
+			liveOsu, err := osuClient.Get(ctx, osu1.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			liveOsu.Spec.DefaultPlacement = ptr.To("default")
+
+			_, err = osuClient.Update(ctx, liveOsu, metav1.UpdateOptions{})
+			require.NoError(t, err)
+		})
+
+		t.Run(fmt.Sprintf("verify updated defaultPlacement set on rgw user %q", osu1.Name), func(t *testing.T) {
+			wait4.AssertEventually(ctx, t, wait4.TimeoutShort, `rgw user defaultPlacement is "default"`, func(ctx context.Context) error {
+				liveUser, err := adminClient.GetUser(ctx, admin.User{ID: osu1.Name})
+				if err != nil {
+					return err
+				}
+
+				if liveUser.DefaultPlacement != "default" {
+					return fmt.Errorf("defaultPlacement not yet %q: %q", "default", liveUser.DefaultPlacement)
+				}
+				return nil
+			})
+		})
+
+		t.Run(fmt.Sprintf("delete CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
+			wait4.AssertDelete(ctx, t, osuClient, osu1.Name, wait4.TimeoutShort)
+		})
+
+		t.Run(fmt.Sprintf("no CephObjectStoreUsers in ns %q", ns.Name), func(t *testing.T) {
+			osus, err := osuClient.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+
+			assert.Len(t, osus.Items, 0)
+		})
+	})
+}

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -127,6 +127,12 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 							},
 						},
 					},
+					{
+						// a second, non-default target for placement-override tests
+						Name:             "bar",
+						MetadataPoolName: storeName + ".rgw.buckets.index",
+						DataPoolName:     storeName + ".rgw.buckets.data.bar",
+					},
 				},
 			},
 		},
@@ -141,6 +147,7 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 		storeName + ".rgw.buckets.index":    "",
 		storeName + ".rgw.buckets.data":     "",
 		storeName + ".rgw.buckets.data.foo": "",
+		storeName + ".rgw.buckets.data.bar": "",
 	}
 
 	objectStore := &cephv1.CephObjectStore{


### PR DESCRIPTION
Resolves #17274

Adds an optional `defaultPlacement` field to `CephObjectStoreUser.Spec`. When set, it overrides the RGW default pool placement for buckets created by that user; when unset the user inherits the zonegroup's default placement, so existing users are unaffected.

This exposes RGW's per-user `default_placement` so a user's new buckets can be steered to a specific placement target without setting it on every bucket.

**AI assistance:** AI was used to locate the change sites, draft the controller wiring and the integration-test package, and prepare the commit messages and this description.

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
