### PR TITLE
ceph: fix block pool cleanup startup log flags

### DIFF
--- a/cmd/rook/ceph/cleanup.go
+++ b/cmd/rook/ceph/cleanup.go
@@ -184,7 +184,7 @@ func startRadosNamespaceCleanup(cmd *cobra.Command, args []string) error {
 
 func startBlockPoolCleanup(cmd *cobra.Command, args []string) error {
 	rook.SetLogLevel()
-	rook.LogStartupInfo(cleanUpRadosNamespaceCmd.Flags())
+	rook.LogStartupInfo(cleanUpBlockPoolCmd.Flags())
 
 	ctx := cmd.Context()
 	context := createContext()


### PR DESCRIPTION
## Description

`startBlockPoolCleanup` was incorrectly passing `cleanUpRadosNamespaceCmd.Flags()` to `rook.LogStartupInfo` instead of `cleanUpBlockPoolCmd.Flags()`. Startup logging for the CephBlockPool cleanup command now reflects the correct command flags.

## Checklist

- [x] Commit message follows project convention (`subsystem: what` with body explaining why)
- [x] DCO sign-off included