### PR TITLE
ceph: fix MonInQuorumResponseMany monitor count in test helper

### DIFF
--- a/pkg/daemon/ceph/client/test/mon.go
+++ b/pkg/daemon/ceph/client/test/mon.go
@@ -53,8 +53,8 @@ func MonInQuorumResponseFromMons(mons map[string]*client.MonInfo) string {
 
 func MonInQuorumResponseMany(count int) string {
 	resp := client.MonStatusResponse{Quorum: []int{0}}
-	resp.MonMap.Mons = []client.MonMapEntry{}
-	for i := 0; i <= count; i++ {
+	resp.MonMap.Mons = make([]client.MonMapEntry, 0, count)
+	for i := 0; i < count; i++ {
 		resp.MonMap.Mons = append(resp.MonMap.Mons, client.MonMapEntry{
 			Name:    fmt.Sprintf("rook-ceph-mon%d", i),
 			Rank:    0,


### PR DESCRIPTION
## Description

The `MonInQuorumResponseMany` test helper loop used `i <= count`, which produced `count+1` monitor entries in the mocked JSON. The loop now uses `i < count`, and the slice is preallocated with `make(..., 0, count)` to avoid extra allocations.

## Checklist

- [x] Commit message follows project convention
- [x] DCO sign-off included