### PR TITLE
WIP: osd: report error when duplicate osd id is detected

### DIFF
--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -90,10 +90,21 @@ func (c *createConfig) createNewOSDsFromStatus(
 		return
 	}
 
+	nodeOrPVC := "node"
+	if status.PvcBackedOSD {
+		nodeOrPVC = "PVC"
+	}
+
 	for i, osd := range status.OSDs {
 		if c.deployments.Exists(osd.ID) {
-			// This OSD will be handled by the updater
-			log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
+			if existing, ok := c.deployments.Get(osd.ID); ok && existing.UUID != "" && osd.UUID != "" && existing.UUID != osd.UUID {
+				errs.addError("duplicate OSD ID %d detected: the OSD on %s %q has UUID %q, but an existing OSD deployment already uses ID %d with a different UUID %q (on %q). "+
+					"The disk may not have been fully cleaned from a previous install. "+
+					"See https://rook.io/docs/rook/latest-release/Getting-Started/ceph-teardown/#zapping-devices for details on cleaning disks",
+					osd.ID, nodeOrPVC, nodeOrPVCName, osd.UUID, osd.ID, existing.UUID, existing.NodeOrPVCName)
+			} else {
+				log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
+			}
 			continue
 		}
 

--- a/pkg/operator/ceph/cluster/osd/create_test.go
+++ b/pkg/operator/ceph/cluster/osd/create_test.go
@@ -299,6 +299,79 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		assert.True(t, createConfig.finishedStatusConfigMaps.Has(statusNamePVC1))
 		induceFailureCreatingOSD = -1 // off
 	})
+
+	t.Run("node: duplicate OSD ID with different UUID is reported as error", func(t *testing.T) {
+		doSetup()
+		awaitingStatusConfigMaps.Insert(statusConfigMapName("node0"))
+		createConfig = c.newCreateConfig(c.newProvisionConfig(), awaitingStatusConfigMaps, deployments)
+
+		deploymentsWithDetails := newExistenceListWithCapacity(3)
+		deploymentsWithDetails.AddWithDetail(3, existingOSDDetail{UUID: "uuid-aaa", NodeOrPVCName: "server175"})
+		deploymentsWithDetails.AddWithDetail(4, existingOSDDetail{UUID: "uuid-bbb", NodeOrPVCName: "server175"})
+		deploymentsWithDetails.AddWithDetail(6, existingOSDDetail{UUID: "uuid-ccc", NodeOrPVCName: "server175"})
+		createConfig.deployments = deploymentsWithDetails
+
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 3, UUID: "uuid-different"},
+				{ID: 5, UUID: "uuid-eee"},
+			},
+			PvcBackedOSD: false,
+		}
+		createConfig.createNewOSDsFromStatus(status, "node0", errs)
+		assert.Equal(t, 1, errs.len())
+		assert.Contains(t, errs.asMessages(), "duplicate OSD ID 3 detected")
+		assert.Contains(t, errs.asMessages(), "node0")
+		assert.Contains(t, errs.asMessages(), "server175")
+		assert.Contains(t, errs.asMessages(), "zapping-devices")
+		assert.ElementsMatch(t, createCallsOnNode, []int{5})
+		assert.Len(t, createCallsOnPVC, 0)
+	})
+
+	t.Run("node: same OSD ID with same UUID is not an error", func(t *testing.T) {
+		doSetup()
+		awaitingStatusConfigMaps.Insert(statusConfigMapName("node0"))
+		createConfig = c.newCreateConfig(c.newProvisionConfig(), awaitingStatusConfigMaps, deployments)
+
+		deploymentsWithDetails := newExistenceListWithCapacity(1)
+		deploymentsWithDetails.AddWithDetail(3, existingOSDDetail{UUID: "uuid-aaa", NodeOrPVCName: "node0"})
+		createConfig.deployments = deploymentsWithDetails
+
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 3, UUID: "uuid-aaa"},
+			},
+			PvcBackedOSD: false,
+		}
+		createConfig.createNewOSDsFromStatus(status, "node0", errs)
+		assert.Zero(t, errs.len())
+		assert.Len(t, createCallsOnNode, 0)
+		assert.Len(t, createCallsOnPVC, 0)
+	})
+
+	t.Run("pvc: duplicate OSD ID with different UUID is reported as error", func(t *testing.T) {
+		doSetup()
+		awaitingStatusConfigMaps.Insert(statusConfigMapName("pvc1"))
+		createConfig = c.newCreateConfig(c.newProvisionConfig(), awaitingStatusConfigMaps, deployments)
+
+		deploymentsWithDetails := newExistenceListWithCapacity(1)
+		deploymentsWithDetails.AddWithDetail(55, existingOSDDetail{UUID: "uuid-server175-osd55", NodeOrPVCName: "pvc-original"})
+		createConfig.deployments = deploymentsWithDetails
+
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 55, UUID: "uuid-server178-sdf"},
+			},
+			PvcBackedOSD: true,
+		}
+		createConfig.createNewOSDsFromStatus(status, "pvc1", errs)
+		assert.Equal(t, 1, errs.len())
+		assert.Contains(t, errs.asMessages(), "duplicate OSD ID 55 detected")
+		assert.Contains(t, errs.asMessages(), "pvc1")
+		assert.Contains(t, errs.asMessages(), "pvc-original")
+		assert.Len(t, createCallsOnNode, 0)
+		assert.Len(t, createCallsOnPVC, 0)
+	})
 }
 
 func Test_startProvisioningOverPVCs(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -852,6 +852,19 @@ func (c *Cluster) getOSDInfo(d *appsv1.Deployment) (OSDInfo, error) {
 	return osd, nil
 }
 
+func getOSDUUIDFromDeployment(d *appsv1.Deployment) string {
+	container, err := findOSDContainer(d.Spec.Template.Spec.Containers)
+	if err != nil {
+		return ""
+	}
+	for _, envVar := range container.Env {
+		if envVar.Name == "ROOK_OSD_UUID" {
+			return envVar.Value
+		}
+	}
+	return ""
+}
+
 func osdIsOnPVC(d *appsv1.Deployment) bool {
 	if _, ok := d.Labels[OSDOverPVCLabelKey]; ok {
 		return true

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -255,8 +255,12 @@ func (c *Cluster) getOSDUpdateInfo(errs *provisionErrors) (*updateQueue, *existe
 			errs.addError("%v. did a user create their own deployment with label %q?", selector, err)
 			continue
 		}
-		// all OSD deployments should be marked as existing
-		existenceList.Add(id)
+		detail := existingOSDDetail{
+			UUID: getOSDUUIDFromDeployment(&deps.Items[i]),
+		}
+		detail.NodeOrPVCName, _ = getNodeOrPVCName(&deps.Items[i])
+
+		existenceList.AddWithDetail(id, detail)
 		updateQueue.Push(id)
 	}
 
@@ -336,16 +340,22 @@ func (q *updateQueue) Remove(osdIDs []int) {
 	q.q = q.q[:lastIdx]
 }
 
+// existingOSDDetail stores identifying details about an existing OSD deployment.
+type existingOSDDetail struct {
+	UUID          string
+	NodeOrPVCName string
+}
+
 // An existenceList keeps track of which OSDs already have Deployments created for them that is
 // queryable in O(1) time.
 type existenceList struct {
-	m map[int]bool
+	m map[int]existingOSDDetail
 }
 
 // Create a new existenceList with capacity reserved.
 func newExistenceListWithCapacity(cap int) *existenceList {
 	return &existenceList{
-		m: make(map[int]bool, cap),
+		m: make(map[int]existingOSDDetail, cap),
 	}
 }
 
@@ -362,15 +372,26 @@ func (e *existenceList) Len() int {
 	return len(e.m)
 }
 
-// Add adds an item to the existenceList.
+// Add adds an item to the existenceList with no detail.
 func (e *existenceList) Add(osdID int) {
-	e.m[osdID] = true
+	e.m[osdID] = existingOSDDetail{}
+}
+
+// AddWithDetail adds an item to the existenceList along with its deployment details.
+func (e *existenceList) AddWithDetail(osdID int, detail existingOSDDetail) {
+	e.m[osdID] = detail
 }
 
 // Exists returns true if an item is recorded in the existence list or false if it does not.
 func (e *existenceList) Exists(osdID int) bool {
 	_, ok := e.m[osdID]
 	return ok
+}
+
+// Get returns the detail for an existing OSD or an empty detail and false if the OSD is not found.
+func (e *existenceList) Get(osdID int) (existingOSDDetail, bool) {
+	d, ok := e.m[osdID]
+	return d, ok
 }
 
 // return a function that will list only OSD deployments with the IDs given


### PR DESCRIPTION
when a disk is not fully wiped from a previous ceph install, ceph-volume may reuse an osd id that is already active on another node. previously, rook silently skipped creating the deployment. now, rook detects the uuid mismatch between the newly prepared osd and the existing deployment, and reports a clear error message with a link to the disk cleanup docs.

fixes #17239

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
