### PR TITLE
docs: fix broken links and outdated Go version in contributing docs

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -3,11 +3,11 @@ title: Development Flow
 ---
 
 Thank you for your time and effort to help us improve Rook! Here are a few steps to get started. If you have any questions,
-don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev channel. Sign up for the Rook Slack [here](https://slack.rook.io).
+don't hesitate to reach out to us on our [Slack](https://rook-io.slack.com) dev channel. Sign up for the Rook Slack [here](https://slack.rook.io).
 
 ## Prerequisites
 
-1. [GO 1.22](https://golang.org/dl/) or greater installed
+1. Recent [GO](https://golang.org/dl/) version installed
 2. Git client installed
 3. GitHub account
 

--- a/Documentation/Getting-Started/release-cycle.md
+++ b/Documentation/Getting-Started/release-cycle.md
@@ -23,7 +23,7 @@ maintenance does not indicate any SLA on response time.
 ## K8s Versions
 
 The minimum version supported by a Rook release is specified in the
-[Quickstart Guide](quickstart.md#minimum-version).
+[Quickstart Guide](quickstart.md#kubernetes-version).
 
 Rook expects to support the most recent six versions of Kubernetes. While these K8s
 versions may not all be supported by the K8s release cycle, we understand that


### PR DESCRIPTION
Fix Slack URL capitalization (returns 404), broken anchor link to quickstart section, and outdated Go version reference (1.22 → 1.25).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotemd) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.