### PR TITLE
helm: add defaultServiceAccountName value

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |
 | `csiDriverNamePrefix` | CSI driver name prefix for cephfs, rbd and nfs. | `namespace name where rook-ceph operator is deployed` |
+| `defaultServiceAccountName` | Name of the default service account used when there is not a service specific service account. For example, it is used by the tool box and crash collector pods. | `"rook-ceph-default"` |
 | `ingress.dashboard` | Enable an ingress for the ceph-dashboard | `{}` |
 | `kubeVersion` | Optional override of the target kubernetes version | `nil` |
 | `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts | `false` |

--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.topology.enabled` | Enable topology based provisioning | `false` |
 | `currentNamespaceOnly` | Whether the operator should watch cluster CRD in its own namespace or not | `false` |
 | `customHostnameLabel` | Custom label to identify node hostname. If not set `kubernetes.io/hostname` will be used | `nil` |
+| `defaultServiceAccountName` | Name of the default service account used when there is not a service specific service account. For example, it is used by the tool box and crash collector pods. | `"rook-ceph-default"` |
 | `disableDeviceHotplug` | Disable automatic orchestration when new devices are discovered. | `false` |
 | `discover.nodeAffinity` | The node labels for affinity of `discover-agent` [^1] | `nil` |
 | `discover.podLabels` | Labels to add to the discover pods | `nil` |

--- a/deploy/charts/library/templates/_cluster-serviceaccount.tpl
+++ b/deploy/charts/library/templates/_cluster-serviceaccount.tpl
@@ -57,7 +57,7 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: rook-ceph-default
+  name: {{ .Values.defaultServiceAccountName }}
   namespace: {{ .Release.Namespace }} # namespace:cluster
   labels:
     {{- include "library.rook-ceph.labels" . | nindent 4 }}

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
             - name: rook-config-override
               mountPath: /etc/rook-config-override
               readOnly: true
-      serviceAccountName: rook-ceph-default
+      serviceAccountName: {{ .Values.defaultServiceAccountName }}
       volumes:
         - name: ceph-admin-secret
           secret:

--- a/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
@@ -41,7 +41,7 @@ volumes:
   - secret
 users:
   # A user needs to be added for each rook service account.
-  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-default
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.defaultServiceAccountName }}
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-mgr
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-osd
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-rgw

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -81,6 +81,9 @@ monitoring:
     # -- Annotations applied to PrometheusRule
     annotations: {}
 
+# -- Name of the default service account used when there is not a service specific service account. For example, it is used by the tool box and crash collector pods.
+defaultServiceAccountName: rook-ceph-default
+
 # imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 # imagePullSecrets:
 # - name: my-registry-secret

--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -44,7 +44,7 @@ volumes:
 users:
   # A user needs to be added for each rook service account.
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-system
-  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-default
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.defaultServiceAccountName }}
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-mgr
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-osd
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-rgw

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -660,6 +660,9 @@ revisionHistoryLimit:
 # -- Blacklist certain disks according to the regex provided.
 discoverDaemonUdev:
 
+# -- Name of the default service account used when there is not a service specific service account. For example, it is used by the tool box and crash collector pods.
+defaultServiceAccountName: rook-ceph-default
+
 # -- imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 imagePullSecrets:
 # - name: my-registry-secret


### PR DESCRIPTION
This allows the name of the default sa to be changed. For example. this would be useful if an sa named `rook-ceph-default` already exists.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
