### PR TITLE
build: improve image building logic and control

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -37,6 +37,9 @@ else
 S5CMD_ARCH = Linux-arm64
 endif
 
+# build by default; allow opt-out by setting to false
+BUILD_CONTAINER_IMAGE ?= true
+
 # s5cmd's version
 S5CMD_VERSION = 2.3.0
 
@@ -57,12 +60,14 @@ do.build:
 	@mkdir -p $(BUILD_CONTEXT_DIR)/rook-external/test-data
 	@cp $(MANIFESTS_DIR)/create-external-cluster-resources.* $(BUILD_CONTEXT_DIR)/rook-external/
 	@cd $(BUILD_CONTEXT_DIR) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
-	@if [ -z "$(BUILD_CONTAINER_IMAGE)" ]; then\
+	@if [ "$(BUILD_CONTAINER_IMAGE)" != "false" ]; then\
 		$(DOCKERCMD) build --platform linux/$(GOARCH) $(BUILD_ARGS) \
 		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
 		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
 		-t $(CEPH_IMAGE) \
 		$(BUILD_CONTEXT_DIR);\
+	else \
+		echo "=== skipping container build because BUILD_CONTAINER_IMAGE=false"; \
 	fi
 	@if [ -z "$(SAVE_BUILD_CONTEXT_DIR)" ]; then\
 		rm -fr $(BUILD_CONTEXT_DIR);\


### PR DESCRIPTION
**Description:**

the ceph based container image build is controlled by a make variable `BUILD_CONTAINER_IMAGE`.

So far, the image build was only performed when this variable was set to the empty string. For any non-empty value, for example "false", like set by some CI workflow, the image build was skipped.

This change improves the logic to build images by default and allowing to opt out by explicitly setting "false".

While not changing the default behavior at all, this makes the code and behavior more explicit and obvious and more like what seems to have been the intention originally while also improving the level and granularity of control with the variable.

For reference: This change was created as a by-product of troubleshooting issues with PR #17276 



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
