### PR TITLE
doc: add CSI operator resource cleanup steps to teardown guide

### DIFF
--- a/Documentation/Storage-Configuration/ceph-teardown.md
+++ b/Documentation/Storage-Configuration/ceph-teardown.md
@@ -75,6 +75,19 @@ kubectl delete storageclass csi-cephfs
     The cleanup jobs might not start if the resources created on top of Rook Cluster are not deleted completely.
     See [deleting block and file artifacts](#delete-the-block-and-file-artifacts)
 
+### Delete the CSI Operator Resources
+
+These commands clean up the CSI operator resources.
+
+```console
+kubectl -n rook-ceph delete operatorconfigs.csi.ceph.io --all
+kubectl -n rook-ceph delete drivers.csi.ceph.io --all
+kubectl -n rook-ceph delete clientprofiles.csi.ceph.io --all
+kubectl -n rook-ceph delete clientprofilemappings.csi.ceph.io --all
+kubectl -n rook-ceph delete cephconnections.csi.ceph.io --all
+kubectl delete -f csi-operator.yaml
+```
+
 ### Delete the Operator Resources
 
 Remove the Rook operator, RBAC, and CRDs, and the `rook-ceph` namespace.


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #17051

Adds a section to the teardown documentation with cleanup commands for
CSI operator resources (OperatorConfig, Driver, ClientProfile,
CephConnection). The Rook operator removes CephConnection and
ClientProfile automatically via ownerRefs when the CephCluster is
deleted; the commands cover all four for thoroughness.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.