### PR TITLE
csi: remove old crush rule when pool device class or failure domain changes

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -571,6 +571,17 @@ func updatePoolCrushRule(context *clusterd.Context, clusterInfo *ClusterInfo, cl
 		return errors.Wrapf(err, "failed to set crush rule on pool %q", pool.Name)
 	}
 
+	// Remove the old crush rule that is no longer in use.
+	// The command will fail safely if the rule is still referenced by another pool.
+	oldRule := details.CrushRule
+	args := []string{"osd", "crush", "rule", "rm", oldRule}
+	output, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		logger.Infof("old crush rule %q not removed (may still be in use by another pool): %v. %s", oldRule, err, string(output))
+	} else {
+		logger.Infof("removed old crush rule %q that is no longer in use", oldRule)
+	}
+
 	logger.Infof("Successfully updated pool %q failure domain to %q", pool.Name, pool.FailureDomain)
 	return nil
 }

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -255,6 +255,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 
 func TestUpdateFailureDomain(t *testing.T) {
 	var newCrushRule string
+	var removedCrushRule string
 	currentFailureDomain := "rack"
 	currentDeviceClass := "default"
 	testCrushRuleName := "test_rule"
@@ -279,6 +280,10 @@ func TestUpdateFailureDomain(t *testing.T) {
 		if args[1] == "crush" {
 			if args[2] == "rule" && args[3] == "dump" {
 				return fmt.Sprintf(`{"steps": [{"item_name":"%s"},{"type":"%s"}]}`, currentDeviceClass, currentFailureDomain), nil
+			}
+			if args[2] == "rule" && args[3] == "rm" {
+				removedCrushRule = args[4]
+				return "", nil
 			}
 			newCrushRule = "foo"
 			return "", nil
@@ -332,6 +337,7 @@ func TestUpdateFailureDomain(t *testing.T) {
 	})
 
 	t.Run("changing failure domain", func(t *testing.T) {
+		removedCrushRule = ""
 		p := cephv1.NamedPoolSpec{
 			Name: "mypool",
 			PoolSpec: cephv1.PoolSpec{
@@ -344,6 +350,7 @@ func TestUpdateFailureDomain(t *testing.T) {
 		err := updatePoolCrushRule(context, AdminTestClusterInfo("mycluster"), clusterSpec, p)
 		assert.NoError(t, err)
 		assert.Equal(t, "mypool_zone", newCrushRule)
+		assert.Equal(t, testCrushRuleName, removedCrushRule)
 	})
 
 	t.Run("stretch cluster skips crush rule update", func(t *testing.T) {


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #17087

When a pool's device class or failure domain changes, Rook creates a new
CRUSH rule and reassigns the pool, but the old rule is left behind. Over
time these orphaned rules accumulate, making troubleshooting harder.

This PR removes the old CRUSH rule immediately after the pool is switched
to the new one. The `osd crush rule rm` command fails safely if the rule
is still referenced by another pool, so no additional checks are needed.

This prevents future orphaned rules from accumulating. Pre-existing
orphaned rules from older deployments can be cleaned up manually with
`ceph osd crush rule rm <rule_name>`.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.