### PR TITLE
csi: add helm ownership annotation to csi resources

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -31,8 +31,26 @@ import (
 )
 
 const (
-	opConfigCRName = "ceph-csi-operator-config"
+	opConfigCRName                = "ceph-csi-operator-config"
+	operatorHelmReleaseName       = "rook-ceph"
+	cephCsiHelmDriversReleaseName = "ceph-csi-drivers"
 )
+
+func setHelmLabels(objMeta *metav1.ObjectMeta, clusterMeta metav1.ObjectMeta, releaseName, releaseNamespace string) {
+	// Skip helm annotations/labels if the cluster is not managed by Helm.
+	if _, ok := clusterMeta.Annotations["meta.helm.sh/release-name"]; !ok {
+		return
+	}
+	if objMeta.Labels == nil {
+		objMeta.Labels = map[string]string{}
+	}
+	if objMeta.Annotations == nil {
+		objMeta.Annotations = map[string]string{}
+	}
+	objMeta.Labels["app.kubernetes.io/managed-by"] = "Helm"
+	objMeta.Annotations["meta.helm.sh/release-name"] = releaseName
+	objMeta.Annotations["meta.helm.sh/release-namespace"] = releaseNamespace
+}
 
 func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) error {
 	logger.Info("Creating ceph-CSI operator config CR")
@@ -41,7 +59,7 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 	opConfig.Name = opConfigCRName
 	opConfig.Namespace = r.opConfig.OperatorNamespace
 
-	imageSetCmName, err := r.createImageSetConfigmap()
+	imageSetCmName, err := r.createImageSetConfigmap(cluster.ObjectMeta)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create ceph-CSI operator config ImageSetConfigmap for CR %s", opConfigCRName)
 	}
@@ -52,6 +70,7 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			opConfig.Spec = spec
+			setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, opConfig)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create ceph-CSI operator operator config CR %q", opConfig.Name)
@@ -64,6 +83,7 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 	}
 
 	opConfig.Spec = spec
+	setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, opConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update ceph-CSI operator operator config CR %q", opConfig.Name)
@@ -137,7 +157,7 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 	return opConfig.Spec
 }
 
-func (r *ReconcileCSI) createImageSetConfigmap() (string, error) {
+func (r *ReconcileCSI) createImageSetConfigmap(clusterMeta metav1.ObjectMeta) (string, error) {
 	data := map[string]string{
 		"provisioner": CSIParam.ProvisionerImage,
 		"attacher":    CSIParam.AttacherImage,
@@ -159,6 +179,7 @@ func (r *ReconcileCSI) createImageSetConfigmap() (string, error) {
 	err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: cm.Name, Namespace: r.opConfig.OperatorNamespace}, cm)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
+			setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, cm)
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to create imageSet cm  %q for ceph-CSI operator-config CR %q", cm.Name, opConfigCRName)
@@ -171,6 +192,7 @@ func (r *ReconcileCSI) createImageSetConfigmap() (string, error) {
 	}
 
 	cm.Data = data
+	setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, cm)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to updated imageSet cm  %q ceph-CSI operator-config CR %q", cm.Name, opConfigCRName)

--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -115,7 +115,7 @@ func (r *ReconcileCSI) createOrUpdateRBDDriverResource(cluster cephv1.CephCluste
 	podVolumes := getPodVolumes(rbdPluginVolume, rbdPluginVolumeMount)
 	rbdDriver.Spec.NodePlugin.PodCommonSpec.Volumes = podVolumes
 
-	err = r.createOrUpdateDriverResource(clusterInfo, rbdDriver)
+	err = r.createOrUpdateDriverResource(clusterInfo, rbdDriver, cluster.ObjectMeta)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create or update RBD driver resource %q", rbdDriver.Name)
 	}
@@ -169,7 +169,7 @@ func (r *ReconcileCSI) createOrUpdateCephFSDriverResource(cluster cephv1.CephClu
 	podVolumes := getPodVolumes(cephFSPluginVolume, cephFSPluginVolumeMount)
 	cephFsDriver.Spec.NodePlugin.PodCommonSpec.Volumes = podVolumes
 
-	err = r.createOrUpdateDriverResource(clusterInfo, cephFsDriver)
+	err = r.createOrUpdateDriverResource(clusterInfo, cephFsDriver, cluster.ObjectMeta)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create or update cephFS driver resource %q", cephFsDriver.Name)
 	}
@@ -215,7 +215,7 @@ func (r *ReconcileCSI) createOrUpdateNFSDriverResource(cluster cephv1.CephCluste
 		}
 	}
 
-	err = r.createOrUpdateDriverResource(clusterInfo, NFSDriver)
+	err = r.createOrUpdateDriverResource(clusterInfo, NFSDriver, cluster.ObjectMeta)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create or update NFS driver resource %q", NFSDriver.Name)
 	}
@@ -223,12 +223,13 @@ func (r *ReconcileCSI) createOrUpdateNFSDriverResource(cluster cephv1.CephCluste
 	return nil
 }
 
-func (r ReconcileCSI) createOrUpdateDriverResource(clusterInfo *cephclient.ClusterInfo, driverResource *csiopv1.Driver) error {
+func (r ReconcileCSI) createOrUpdateDriverResource(clusterInfo *cephclient.ClusterInfo, driverResource *csiopv1.Driver, clusterMeta metav1.ObjectMeta) error {
 	spec := driverResource.Spec
 
 	err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: driverResource.Name, Namespace: r.opConfig.OperatorNamespace}, driverResource)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, driverResource)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create CSI-operator driver CR %q", driverResource.Name)
@@ -241,6 +242,7 @@ func (r ReconcileCSI) createOrUpdateDriverResource(clusterInfo *cephclient.Clust
 	}
 
 	driverResource.Spec = spec
+	setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, driverResource)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update CSI-operator driver CR %q", driverResource.Name)
@@ -255,7 +257,7 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 	if CSIParam.ForceCephFSKernelClient == "false" {
 		cephfsClientType = csiopv1.AutoDetectCephFsClient
 	}
-	imageSetCmName, err := r.createImageSetConfigmap()
+	imageSetCmName, err := r.createImageSetConfigmap(cluster.ObjectMeta)
 	if err != nil {
 		return csiopv1.DriverSpec{}, errors.Wrapf(err, "failed to create ceph-CSI operator config ImageSetConfigmap for CR %s", opConfigCRName)
 	}


### PR DESCRIPTION
We are moving the CSI management to the admin and currently, the CSI resources are created at runtime so the cluster installed with helm will face an error that resources are not managed by helm. To avoid this error, we are adding the annotation at runtime so that during upgrade users do not face issues.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
