### PR TITLE
osd: warn when duplicate OSD ID is detected on a different node

### DIFF
--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -92,8 +92,15 @@ func (c *createConfig) createNewOSDsFromStatus(
 
 	for i, osd := range status.OSDs {
 		if c.deployments.Exists(osd.ID) {
-			// This OSD will be handled by the updater
-			log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
+			existingLocation := c.deployments.Location(osd.ID)
+			if existingLocation != "" && existingLocation != nodeOrPVCName {
+				log.NamespacedWarning(c.cluster.clusterInfo.Namespace, logger, "duplicate OSD ID detected: OSD %d is already running on %q but was also found on %q. "+
+					"The disk on %q likely contains stale OSD data from a previous deployment. "+
+					"See https://rook.io/docs/rook/latest/Getting-Started/ceph-teardown/#zapping-devices for cleanup instructions",
+					osd.ID, existingLocation, nodeOrPVCName, nodeOrPVCName)
+			} else {
+				log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
+			}
 			continue
 		}
 

--- a/pkg/operator/ceph/cluster/osd/create_test.go
+++ b/pkg/operator/ceph/cluster/osd/create_test.go
@@ -84,11 +84,11 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		return nil
 	}
 
-	// Simulate an environment where deployments exist for OSDs 3, 4, and 6
+	// Simulate an environment where deployments exist for OSDs 3, 4, and 6 on known nodes
 	deployments := newExistenceListWithCapacity(5)
-	deployments.Add(3)
-	deployments.Add(4)
-	deployments.Add(6)
+	deployments.AddWithLocation(3, "node0")
+	deployments.AddWithLocation(4, "node0")
+	deployments.AddWithLocation(6, "node2")
 
 	spec := cephv1.ClusterSpec{}
 	var status *OrchestrationStatus
@@ -169,6 +169,38 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		assert.Equal(t, 4, awaitingStatusConfigMaps.Len())
 		assert.Equal(t, 1, createConfig.finishedStatusConfigMaps.Len())
 		assert.True(t, createConfig.finishedStatusConfigMaps.Has(statusNameNode0))
+	})
+
+	t.Run("node: warn on duplicate OSD from different node", func(t *testing.T) {
+		doSetup()
+		// OSD 3 exists on "node0" (from AddWithLocation above), prepare reports it from "node2"
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 3}, // duplicate — already on node0
+				{ID: 8}, // new OSD
+			},
+			PvcBackedOSD: false,
+		}
+		createConfig.createNewOSDsFromStatus(status, "node2", errs)
+		assert.Zero(t, errs.len())
+		// Only OSD 8 should be created, OSD 3 is skipped (warning logged but not an error)
+		assert.ElementsMatch(t, createCallsOnNode, []int{8})
+		assert.Len(t, createCallsOnPVC, 0)
+	})
+
+	t.Run("node: no warning on same-node duplicate", func(t *testing.T) {
+		doSetup()
+		// OSD 3 exists on "node0", prepare also reports it from "node0" — same node, no warning
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 3}, // duplicate on same node
+			},
+			PvcBackedOSD: false,
+		}
+		createConfig.createNewOSDsFromStatus(status, "node0", errs)
+		assert.Zero(t, errs.len())
+		assert.Len(t, createCallsOnNode, 0) // OSD 3 skipped, nothing new to create
+		assert.Len(t, createCallsOnPVC, 0)
 	})
 
 	t.Run("node: skip creating OSDs for status configmaps that weren't created for this reconcile", func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -255,8 +255,13 @@ func (c *Cluster) getOSDUpdateInfo(errs *provisionErrors) (*updateQueue, *existe
 			errs.addError("%v. did a user create their own deployment with label %q?", selector, err)
 			continue
 		}
-		// all OSD deployments should be marked as existing
-		existenceList.Add(id)
+		// all OSD deployments should be marked as existing along with their location
+		nodeOrPVC, err := getNodeOrPVCName(&deps.Items[i])
+		if err != nil {
+			existenceList.Add(id)
+		} else {
+			existenceList.AddWithLocation(id, nodeOrPVC)
+		}
 		updateQueue.Push(id)
 	}
 
@@ -342,15 +347,15 @@ func (q *updateQueue) Remove(osdIDs []int) {
 }
 
 // An existenceList keeps track of which OSDs already have Deployments created for them that is
-// queryable in O(1) time.
+// queryable in O(1) time. It also records the node or PVC name where each OSD is deployed.
 type existenceList struct {
-	m map[int]bool
+	m map[int]string // OSD ID -> node or PVC name
 }
 
 // Create a new existenceList with capacity reserved.
 func newExistenceListWithCapacity(cap int) *existenceList {
 	return &existenceList{
-		m: make(map[int]bool, cap),
+		m: make(map[int]string, cap),
 	}
 }
 
@@ -367,15 +372,27 @@ func (e *existenceList) Len() int {
 	return len(e.m)
 }
 
-// Add adds an item to the existenceList.
+// Add adds an item to the existenceList with an empty location.
 func (e *existenceList) Add(osdID int) {
-	e.m[osdID] = true
+	if _, ok := e.m[osdID]; !ok {
+		e.m[osdID] = ""
+	}
+}
+
+// AddWithLocation adds an item to the existenceList with the node or PVC name where it is deployed.
+func (e *existenceList) AddWithLocation(osdID int, nodeOrPVCName string) {
+	e.m[osdID] = nodeOrPVCName
 }
 
 // Exists returns true if an item is recorded in the existence list or false if it does not.
 func (e *existenceList) Exists(osdID int) bool {
 	_, ok := e.m[osdID]
 	return ok
+}
+
+// Location returns the node or PVC name where the OSD is deployed, or empty string if unknown.
+func (e *existenceList) Location(osdID int) string {
+	return e.m[osdID]
 }
 
 // return a function that will list only OSD deployments with the IDs given

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -783,6 +783,25 @@ func Test_existenceList(t *testing.T) {
 	l.Add(1)
 	assert.True(t, l.Exists(1))
 	assert.Equal(t, 4, l.Len())
+
+	// assert AddWithLocation and Location
+	l2 := newExistenceListWithCapacity(2)
+	l2.AddWithLocation(0, "node-a")
+	l2.AddWithLocation(1, "node-b")
+	assert.True(t, l2.Exists(0))
+	assert.True(t, l2.Exists(1))
+	assert.Equal(t, "node-a", l2.Location(0))
+	assert.Equal(t, "node-b", l2.Location(1))
+	assert.Equal(t, "", l2.Location(99)) // non-existent OSD
+
+	// Add without location should not overwrite existing location
+	l2.Add(0)
+	assert.Equal(t, "node-a", l2.Location(0))
+
+	// Add without location for new OSD should set empty location
+	l2.Add(5)
+	assert.True(t, l2.Exists(5))
+	assert.Equal(t, "", l2.Location(5))
 }
 
 func TestCluster_rotateCephxKey(t *testing.T) {


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #17239

When a disk contains stale OSD metadata from a previous deployment (e.g.
the disk was not fully wiped before reuse), ceph-volume may report an OSD
ID that is already running on another node. Previously, Rook silently
skipped the duplicate with a debug log, leaving the operator with no
indication of the problem.

This PR enhances the `existenceList` to track which node or PVC each OSD
is deployed on. When a duplicate OSD ID is found on a different node, a
warning is logged with:
- The OSD ID and both node names
- An explanation that the disk likely contains stale data
- A link to the device zapping guide for resolution

Same-node duplicates (normal reconciliation) continue to use the existing
debug log.

Tested on a minikube lab cluster by copying an OSD superblock between
disks to simulate stale metadata from a previous deployment.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.