### PR TITLE
fix(helm): ensure configOverride ends with newline

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }} # namespace:cluster
 data:
   config: |
-    {{- .Values.configOverride | nindent 4 }}
+    {{- .Values.configOverride | trimSuffix "\n" | printf "%s\n" | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
**Problem:**
Ceph config parser requires a trailing newline at EOF. Without it, daemons fail to start with:
```
global_init: error reading config file. parse error: expected '<empty_line>' in line 4 at position 34
```

**Root Cause:**
When users set `configOverride` in values.yaml without a trailing newline, the Helm template renders the ConfigMap without a newline at EOF.

**Solution:**
Modified the Helm template to ensure configOverride always ends with a newline:
```yaml
config: |
  {{- .Values.configOverride | trimSuffix "\n" | printf "%s\n" | nindent 4 }}
```

This:
1. Removes any existing trailing newline (to avoid double newlines)
2. Adds a single newline at the end
3. Ensures Ceph config parser works correctly

**Testing:**
- Verified the template modification
- Tested with YAML block string without trailing newline

**Fixes:** #17285

**Signed-off-by:** xingzihai <1315258019@qq.com>