### PR TITLE
fix: ensure rook-config-override always has trailing newline

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }} # namespace:cluster
 data:
   config: |
-    {{- .Values.configOverride | nindent 4 }}
+    {{- .Values.configOverride | trimSuffix "\n" | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## Problem

Ceph 19.2.3's config file parser requires configuration files to end with a trailing newline. When users provide `configOverride` in the Helm chart without a trailing newline, the generated ConfigMap's config file would also lack it, causing Ceph daemons to fail with parse errors:

```
global_init: error reading config file. parse error: expected '<empty_line>' in line 4 at position 34
```

And toolbox/client commands would fail with:
```
Error initializing cluster client: InvalidArgumentError('RADOS invalid argument (error calling conf_read_file)')
```

## Solution

Use `trimSuffix "\n"` to normalize the input in the Helm template. This ensures that:
1. Any existing trailing newline is removed (normalization)
2. The YAML block scalar `|` automatically adds a proper trailing newline

This guarantees that the config file always ends with a newline, regardless of how the user provides the `configOverride` value.

## Testing

Users can test this fix by providing configOverride without a trailing newline:

```yaml
configOverride: |
  [global]
  bdev_enable_discard = true
  bdev_async_discard = true
  osd_class_update_on_start = false
```

The resulting ConfigMap's `config` key will now always end with a trailing newline.

Fixes: #17285