### PR TITLE
build:  make the shellcheck target  self-contained

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -25,9 +25,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: install shellcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
       - name: Run ShellCheck
         run: make shellcheck

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ CONTROLLER_GEN_VERSION=v0.19.0
 CT_VERSION := v3.13.0
 KUSTOMIZE_VERSION := v5.3.0
 MARKDOWNLINT_IMAGE_VERSION := v0.22.0
+SHELLCHECK_VERSION := v0.10.0
 
 # include here and not earlier so that the version numbers are available
 # where needed
@@ -218,8 +219,8 @@ checkmake:
 	@$(CHECKMAKE) Makefile
 
 .PHONY: shellcheck
-shellcheck:
-	shellcheck --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
+shellcheck: | $(SHELLCHECK)
+	$(SHELLCHECK) --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
 
 .PHONY: gen.codegen
 gen.codegen: codegen

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -107,6 +107,37 @@ $(KUSTOMIZE): | $(TOOLS_HOST_DIR)
 	@rm -rf $(TOOLS_HOST_DIR)/tmp
 	@chmod +x $(KUSTOMIZE)
 
+ifneq ($(strip $(SHELLCHECK_VERSION)),)
+
+SHELLCHECK := $(TOOLS_HOST_DIR)/shellcheck-$(SHELLCHECK_VERSION)
+
+# architecture mapping:
+# shellcheck uses aarch64 instead of arm64 for published darwin binaries
+# so we can't use go env GOHOSTARCH as usual.
+UNAME_M := $(shell uname -m)
+UNAME_S := $(shell uname -s)
+UNAME_S_LC := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+SC_OS := $(UNAME_S_LC)
+
+# Map arm64 (Mac) and aarch64 (Linux) to ShellCheck's 'aarch64'
+ifeq ($(UNAME_M),x86_64)
+	SC_ARCH := x86_64
+else ifeq ($(UNAME_M),arm64)
+	SC_ARCH := aarch64
+else
+	SC_ARCH := $(UNAME_M)
+endif
+
+$(SHELLCHECK): | $(TOOLS_HOST_DIR)
+	@echo === installing shellcheck ===
+	@mkdir -p $(TOOLS_HOST_DIR)/tmp
+	@curl -fsSL -o $(TOOLS_HOST_DIR)/tmp/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(SC_OS).$(SC_ARCH).tar.xz
+	@tar xJf $(TOOLS_HOST_DIR)/tmp/shellcheck.tar.xz -C $(TOOLS_HOST_DIR)/tmp
+
+	@mv -f $(TOOLS_HOST_DIR)/tmp/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $(SHELLCHECK)
+	@rm -rf $(TOOLS_HOST_DIR)/tmp
+endif # SHELLCHECK_VERSION
+
 # a registry that is scoped to the current build tree on this host
 ifeq ($(origin BUILD_REGISTRY), undefined)
 BUILD_REGISTRY := build-$(shell echo "$(HOSTNAME)-$(ROOT_DIR)" | $(SHA256CMD) | cut -c1-8)


### PR DESCRIPTION
**Description:**

`make shellcheck required` shellcheck to be installed
locally in the `$PATH`.

This change renders make shellcheck self-contained
by installing shellcheck in the local tools cache directory
    like with other tools.


This PR depends on PR #17307 -- that PR should get merged first so this can be rebased.
 
**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
