### PR TITLE
build: make the yamllint target  self-contained

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -27,14 +27,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.9
-
-      - name: Install yamllint
-        run: pip install yamllint
-
       - name: Lint YAML files
         run: make yamllint
 

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -256,13 +256,13 @@ Common cases that may need tests:
 
 ## Linting
 
-Run `make lint` to run all linters. This will require the following CLI tools to be installed on the system:
+Run `make lint` to run several linters. This will require
+the [pylint](https://www.pylint.org/) CLI tool to be installed on the system in the PATH
 
-* [yamllint](https://www.yamllint.com/)
-* [pylint](https://www.pylint.org/)
-
-Many of those tools are available via `brew` for MacOS or as Linux distribution packages.
-Otherwise refer to the respective project websites for installation instructions.
+pylint is available via `brew` for MacOS and as a distribution package
+for many Linux distributions. It can also be installed into the system
+or a python virtual environment (venv) with `pip`.
+Refer to the respective project website for more installation instructions.
 
 !!! tip
     Run `make help` to see a list of all possible make targets

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ KUSTOMIZE_VERSION := v5.3.0
 MARKDOWNLINT_IMAGE_VERSION := v0.22.0
 SHELLCHECK_VERSION := v0.10.0
 
+# For future updates,the SHA of the 'latest' tag can be obtained like this:
+# podman inspect --format='{{index .RepoDigests 0}}' docker.io/cytopia/yamllint:latest
+#
+YAMLLINT_IMAGE_SHA ?= sha256:3e9eb827ab2b12a5ea5f49d4257bb3aca94bba9f1ba427c8bc7f2456385a5204
+
 # include here and not earlier so that the version numbers are available
 # where needed
 include build/makelib/common.mk
@@ -196,7 +201,7 @@ markdownlint.fix: ## Check and fix formatting of documentation sources
 
 .PHONY: yamllint
 yamllint:
-	yamllint -c .yamllint deploy/examples/ --no-warnings
+	$(YAMLLINT) -c .yamllint deploy/examples/ --no-warnings
 
 .PHONY: helm.lint
 helm.lint: $(HELM) $(KUSTOMIZE) ## Check the helm charts

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -37,6 +37,10 @@ endif
 
 MARKDOWNLINT := $(DOCKERCMD) run --rm -v $$PWD:/workdir davidanson/markdownlint-cli2:$(MARKDOWNLINT_IMAGE_VERSION)
 
+ifneq ($(strip $(YAMLLINT_IMAGE_SHA)),)
+YAMLLINT := $(DOCKERCMD) run  --rm -t -v $(CURDIR):/workdir:ro -w /workdir --entrypoint yamllint cytopia/yamllint@$(YAMLLINT_IMAGE_SHA)
+endif
+
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)
 GOOS := $(shell go env GOOS)


### PR DESCRIPTION
**Description:**

`make yamllint`required yamllint to be installed
in the `$PATH`.
    
This change renders it self-contained
by using a container image instead.

This PR depends on PRs #17311 and #17422  



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
