### PR TITLE
object: migrate s3agent object methods to aws sdk v2

### DIFF
--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -30,7 +30,6 @@ import (
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -172,7 +171,7 @@ func (s *S3Agent) DeleteBucket(name string) (bool, error) {
 func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 	contentType string,
 ) (bool, error) {
-	_, err := s.Client.PutObject(&s3.PutObjectInput{
+	_, err := s.ClientV2.PutObject(context.TODO(), &s3v2.PutObjectInput{
 		Body:        strings.NewReader(body),
 		Bucket:      &bucketname,
 		Key:         &key,
@@ -181,21 +180,19 @@ func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 	if err != nil {
 		logger.Errorf("failed to put object in bucket. %v", err)
 		return false, err
-
 	}
 	return true, nil
 }
 
 // GetObjectInBucket function retrieves an object from a bucket using s3 client
 func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, error) {
-	result, err := s.Client.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(bucketname),
-		Key:    aws.String(key),
+	result, err := s.ClientV2.GetObject(context.TODO(), &s3v2.GetObjectInput{
+		Bucket: &bucketname,
+		Key:    &key,
 	})
 	if err != nil {
 		logger.Errorf("failed to retrieve object from bucket. %v", err)
 		return "ERROR_ OBJECT NOT FOUND", err
-
 	}
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(result.Body)
@@ -208,22 +205,18 @@ func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, erro
 
 // DeleteObjectInBucket function deletes given bucket using s3 client
 func (s *S3Agent) DeleteObjectInBucket(bucketname string, key string) (bool, error) {
-	_, err := s.Client.DeleteObject(&s3.DeleteObjectInput{
-		Bucket: aws.String(bucketname),
-		Key:    aws.String(key),
+	_, err := s.ClientV2.DeleteObject(context.TODO(), &s3v2.DeleteObjectInput{
+		Bucket: &bucketname,
+		Key:    &key,
 	})
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case s3.ErrCodeNoSuchBucket:
-				return true, nil
-			case s3.ErrCodeNoSuchKey:
-				return true, nil
-			}
+		var noSuchBucket *s3types.NoSuchBucket
+		var noSuchKey *s3types.NoSuchKey
+		if errors.As(err, &noSuchBucket) || errors.As(err, &noSuchKey) {
+			return true, nil
 		}
 		logger.Errorf("failed to delete object from bucket. %v", err)
 		return false, err
-
 	}
 	return true, nil
 }

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -265,10 +265,10 @@ func checkCephObjectUser(
 	namespace, storeName, userID string, checkQuotaAndCaps bool,
 ) {
 	logger.Infof("checking object store \"%s/%s\" user %q", namespace, storeName, userID)
-	assert.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userID))
+	require.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userID), "user secret not found for %q", userID)
 
 	userInfo, err := helper.ObjectUserClient.GetUser(namespace, storeName, userID)
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 	assert.Equal(s.T(), userID, userInfo.UserID)
 	assert.Equal(s.T(), userdisplayname, *userInfo.DisplayName)
 

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -294,8 +294,16 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, poErr)
 			logger.Infof("Testing the max object limit")
-			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
-			assert.Error(t, poErr)
+			quotaEnforced := utils.Retry(10, 2*time.Second, "user quota enforced", func() bool {
+				_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
+				if err != nil {
+					return true
+				}
+				// delete so next attempt creates a new object rather than overwriting
+				s3client.DeleteObjectInBucket(bucketname, ObjectKey3) //nolint:errcheck
+				return false
+			})
+			assert.True(t, quotaEnforced)
 		})
 
 		t.Run("update user quota limits", func(t *testing.T) {
@@ -308,8 +316,16 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			logger.Infof("Testing the updated object limit")
 			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 			assert.NoError(t, poErr)
-			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
-			assert.Error(t, poErr)
+			quotaEnforced := utils.Retry(30, 2*time.Second, "updated user quota enforced", func() bool {
+				_, putErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
+				if putErr != nil {
+					return true
+				}
+				// delete so next attempt creates a new object rather than overwriting
+				s3client.DeleteObjectInBucket(bucketname, ObjectKey4) //nolint:errcheck
+				return false
+			})
+			assert.True(t, quotaEnforced)
 		})
 
 		t.Run("delete objects", func(t *testing.T) {


### PR DESCRIPTION
migrate PutObjectInBucket, GetObjectInBucket, and
DeleteObjectInBucket to use aws sdk v2 client.
replace v1 awserr error handling in DeleteObjectInBucket with v2 typed errors (errors.As).
remove unused v1 awserr import.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
