### PR TITLE
mon: mute MON_NETSPLIT health warning in stretch clusters

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -315,3 +315,11 @@ func isCephHealthy(status CephStatus) bool {
 
 	return false
 }
+
+func MuteHealthWarning(context *clusterd.Context, clusterInfo *ClusterInfo, warning string) {
+	args := []string{"health", "mute", warning, "--sticky"}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		logger.Warningf("failed to mute health warning %q: %v", warning, err)
+	}
+}

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -20,6 +20,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -150,4 +153,47 @@ func TestIsCephHealthy(t *testing.T) {
 	statusFake.Health.Status = "HEALTH_ERR"
 	s = isCephHealthy(statusFake)
 	assert.False(t, s)
+}
+
+func TestMuteHealthWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		warning        string
+		mockError      error
+		expectsWarning bool
+	}{
+		{
+			name:           "successful mute",
+			warning:        "MON_NETSPLIT",
+			mockError:      nil,
+			expectsWarning: false,
+		},
+		{
+			name:           "command failure logs warning",
+			warning:        "MON_NETSPLIT",
+			mockError:      errors.New("command execution failed"),
+			expectsWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &exectest.MockExecutor{}
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+				assert.Equal(t, "ceph", command)
+				assert.Equal(t, "health", args[0])
+				assert.Equal(t, "mute", args[1])
+				assert.Equal(t, tt.warning, args[2])
+				assert.Equal(t, "--sticky", args[3])
+				return "", tt.mockError
+			}
+
+			context := &clusterd.Context{Executor: executor}
+			clusterInfo := AdminTestClusterInfo("mycluster")
+
+			assert.NotPanics(t, func() {
+				MuteHealthWarning(context, clusterInfo, tt.warning)
+			})
+		})
+	}
 }

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -533,6 +533,13 @@ func (c *cluster) postMonStartupActions() error {
 		return errors.Wrap(err, "failed to configure storage settings")
 	}
 
+	// Mute the MON_NETSPLIT health warning in stretch clusters since ceph raises it incorrectly.
+	// This can be removed once ceph fixes the health warning: https://tracker.ceph.com/issues/71344
+	if c.Spec.IsStretchCluster() {
+		logger.Debugf("stretch cluster detected, muting MON_NETSPLIT health warning")
+		client.MuteHealthWarning(c.context, c.ClusterInfo, "MON_NETSPLIT")
+	}
+
 	crushRoot := client.GetCrushRootFromSpec(c.Spec)
 	if crushRoot != "default" {
 		// Remove the root=default and replicated_rule which are created by


### PR DESCRIPTION
Ceph incorrectly raises the MON_NETSPLIT health warning in stretch cluster configurations. Added a call to MuteHealthWarning() in postMonStartupActions() which runs `ceph health mute MON_NETSPLIT --sticky` to suppress the warning during reconcile. All errors are logged as warnings and the reconcile proceeds.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
