### PR TITLE
helm: set ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS from chart values

### DIFF
--- a/deploy/charts/rook-ceph/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - effect: NoExecute
           key: node.kubernetes.io/unreachable
           operator: Exists
-          tolerationSeconds: 5
+          tolerationSeconds: {{ .Values.unreachableNodeTolerationSeconds }}
         {{- with .Values.tolerations }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
@@ -104,6 +104,8 @@ spec:
               value: {{ .Values.disableDeviceHotplug | quote }}
             - name: ROOK_DISCOVER_DEVICES_INTERVAL
               value: {{ .Values.discoveryDaemonInterval | quote }}
+            - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
+              value: {{ .Values.unreachableNodeTolerationSeconds | quote }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Previously the unreachable node toleration on the operator pod was hardcoded to 5 seconds in the Helm chart and the ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS env var was not set up at all. This change reads both from .Values.unreachableNodeTolerationSeconds (defaulting to 5).

Fixes #17303

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
