### PR TITLE
build: Keep default ceph version at 19.2.3

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -70,7 +70,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `cephFileSystems` | A list of CephFileSystem configurations to deploy | See [below](#ceph-file-systems) |
 | `cephImage.allowUnsupported` |  | `false` |
 | `cephImage.repository` |  | `"quay.io/ceph/ceph"` |
-| `cephImage.tag` |  | `"v20.2.1"` |
+| `cephImage.tag` |  | `"v19.2.3"` |
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -98,7 +98,7 @@ cephImage:
   # In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
   # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
   # To be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v19.2.3-20250717
-  tag: v20.2.1
+  tag: v19.2.3
   # Whether to allow unsupported versions of Ceph. Currently Squid and Tentacle are supported.
   # Future versions such as Tentacle (v20) would require this to be set to `true`.
   # Do not set to true in production.

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -21,7 +21,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v20.2.1-20260402
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: quay.io/ceph/ceph:v20.2.1
+    image: quay.io/ceph/ceph:v19.2.3
     # Whether to allow unsupported versions of Ceph. Currently Squid and Tentacle are supported.
     # Future versions such as Umbrella (v21) would require this to be set to `true`.
     # Do not set to true in production.

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,6 +1,6 @@
  docker.io/rook/ceph:v1.19.3
  gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
- quay.io/ceph/ceph:v20.2.1
+ quay.io/ceph/ceph:v19.2.3
  quay.io/ceph/cosi:v0.1.4
  quay.io/cephcsi/ceph-csi-operator:v0.6.0
  quay.io/cephcsi/cephcsi:v3.16.2


### PR DESCRIPTION
As discussed in the community meeting, wait until the next Rook minor release v1.20 to change the default Ceph version to tentacle v20. While v20 is already supported with v1.19.x, we will just wait to change the default version in Rook.

This partially reverts PR #17327 that changed the default in the v1.19 branch.
 
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
