### PR TITLE
Build: reduce build runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@
 # Set locale `LC_ALL=C` because different OSes have different sort behavior;
 # `C` sorting order is based on the byte values,
 # Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
-LC_ALL=C
-export LC_ALL
+export LC_ALL=C
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,10 @@ build.version:
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version
 
-# This target exists only for setting the variable
-.PHONY: build.common.var
-build.common.var: export SKIP_GEN_CRD_DOCS=true
+
 
 .PHONY: build.common
-build.common:  build.common.var build.version helm.build mod.check crds gen-rbac
+build.common: build.version helm.build mod.check crds.manifests gen.rbac
 	@$(MAKE) go.init
 	@$(MAKE) go.validate
 	@$(MAKE) -C images/ceph list-image
@@ -251,12 +249,20 @@ prune: ## Prune cached artifacts.
 	@$(MAKE) -C images prune
 
 .PHONY: gen.crds
-gen.crds: crds
-.PHONY: crds
-crds: $(CONTROLLER_GEN) $(YQ)
+gen.crds: crds.manifests crds.docs
+
+.PHONY: crds.manifests
+crds.manifests: $(CONTROLLER_GEN) $(YQ)
 	@echo Updating CRD manifests
 	@build/crds/build-crds.sh $(CONTROLLER_GEN) $(YQ)
-	@GOBIN=$(GOBIN) build/crds/generate-crd-docs.sh
+
+.PHONY: crds.docs
+crds.docs: ## Build the documentation for CRDs
+	@# default behavior: generate unless user sets SKIP_GEN_CRD_DOCS=true
+	@SKIP_GEN_CRD_DOCS=$(SKIP_GEN_CRD_DOCS) GOBIN=$(GOBIN) build/crds/generate-crd-docs.sh
+
+.PHONY: crds
+crds: crds.manifests crds.docs
 
 .PHONY: gen.rbac
 gen.rbac: gen-rbac
@@ -290,11 +296,10 @@ docs-build:  ## Build the documentation to the `site/` directory
 
 .PHONY: gen.crd-docs
 gen.crd-docs: generate-docs-crds
-generate-docs-crds: ## Build the documentation for CRD
-	@GOBIN=$(GOBIN) build/crds/generate-crd-docs.sh
+generate-docs-crds: crds.docs ## Build the documentation for CRDs
 
 .PHONY: generate
-generate: gen.codegen gen.crds gen.rbac gen.docs gen.crd-docs ## Update all generated files (code, manifests, charts, and docs).
+generate: gen.codegen gen.crds gen.rbac ## Update all generated files (code, manifests, charts, and docs).
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ include build/makelib/golang.mk
 # ====================================================================================
 # Targets
 
+.PHONY: build.version
 build.version:
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "$(VERSION)" > $(OUTPUT_DIR)/version

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -131,7 +131,6 @@ SPACE :=
 SPACE +=
 
 # define a newline
-define \n
-
+define NEWLINE
 
 endef

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -127,13 +127,13 @@ go.init:
 go.build:
 	@echo === go build $(PLATFORM)
 	$(info Go version: $(shell $(GO) version))
-	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) build -v -o $(GO_OUT_DIR)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p)${\n})
-	$(foreach p,$(GO_TEST_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) test -v -c -o $(GO_TEST_OUTPUT)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p)${\n})
+	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) build -v -o $(GO_OUT_DIR)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p)$(NEWLINE))
+	$(foreach p,$(GO_TEST_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) test -v -c -o $(GO_TEST_OUTPUT)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p)$(NEWLINE))
 
 .PHONY: go.install
 go.install:
 	@echo === go install $(PLATFORM)
-	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) install -v $(GO_STATIC_FLAGS) $(p)${\n})
+	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GO) install -v $(GO_STATIC_FLAGS) $(p)$(NEWLINE))
 
 # GOJUNIT need to happen in order and NOT in parallel, so call them explicitly
 .PHONY: go.test.unit


### PR DESCRIPTION
**Description:**

Commit 8a80743bf has led to a significant increase runtime for
`make build`. More precisely, the runtime of
 `make build.common` was increased.
    
The reason for this was that the  prerequisite `build.common` target implicitly ran crd docs generation while it shouldn't and originally didn't.

This additional operation caused the extra time consumption.


This change re-establishes old behavior and build time
by ensuring  that crd docs generation  happens only when desired.


**Issue resolved by this Pull Request:**
Resolves #17335 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
