### PR TITLE
Increase default provisioner pod priority to system-node-critical

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.provisioner.repository` | Kubernetes CSI provisioner image repository | `"registry.k8s.io/sig-storage/csi-provisioner"` |
 | `csi.provisioner.tag` | Provisioner image tag | `"v6.1.1"` |
 | `csi.provisionerNodeAffinity` | The node labels for affinity of the CSI provisioner deployment [^1] | `nil` |
-| `csi.provisionerPriorityClassName` | PriorityClassName to be set on csi driver provisioner pods | `"system-cluster-critical"` |
+| `csi.provisionerPriorityClassName` | PriorityClassName to be set on csi driver provisioner pods | `"system-node-critical"` |
 | `csi.provisionerReplicas` | Set replicas for csi provisioner deployment | `2` |
 | `csi.provisionerTolerations` | Array of tolerations in YAML format which will be added to CSI provisioner deployment | `nil` |
 | `csi.rbdAttachRequired` | Whether to skip any attach operation altogether for RBD PVCs. See more details [here](https://kubernetes-csi.github.io/docs/skip-attach.html#skip-attach-with-csi-driver-object). If set to false it skips the volume attachments and makes the creation of pods using the RBD PVC fast. **WARNING** It's highly discouraged to use this for RWO volumes as it can cause data corruption. csi-addons operations like Reclaimspace and PVC Keyrotation will also not be supported if set to false since we'll have no VolumeAttachments to determine which node the PVC is mounted on. Refer to this [issue](https://github.com/kubernetes/kubernetes/issues/103305) for more details. | `true` |

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -118,7 +118,7 @@ csi:
   pluginPriorityClassName: system-node-critical
 
   # -- PriorityClassName to be set on csi driver provisioner pods
-  provisionerPriorityClassName: system-cluster-critical
+  provisionerPriorityClassName: system-node-critical
 
   # -- Policy for modifying a volume's ownership or permissions when the RBD PVC is being mounted.
   # supported values are documented at https://kubernetes-csi.github.io/docs/support-fsgroup.html


### PR DESCRIPTION
Currently the default provisioner pod (nodeplugin) priority is system-cluster-critical. This causes a problem when other pods that have system-cluster-critical mounts an RBD-backed volume: At node shutdown, if the nodeplugin pod is killed before the workload pod that mounts RBD, the unmount will hang, delaying shutdown time significantly. The proper way to solve this is by configuring kubelet's [graceful shutdown by priority](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#pod-priority-graceful-node-shutdown), but in order for this to work the nodeplugin priority must be higher than system-cluster-critical.

Therefore this PR changes the default nodeplugin pod priority to be system-node-critical, higher than system-cluster-critical, allowing kubelet to differentiate the 2 priorities for graceful shutdown.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
