### PR TITLE
Fix swapped provisionerPriorityClassName with pluginPriorityClassName

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -95,7 +95,7 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 			FsGroupPolicy:    k8scsiv1.FileFSGroupPolicy,
 			NodePlugin: &csiopv1.NodePluginSpec{
 				PodCommonSpec: csiopv1.PodCommonSpec{
-					PrioritylClassName: &CSIParam.ProvisionerPriorityClassName,
+					PrioritylClassName: &CSIParam.PluginPriorityClassName,
 					Affinity: &v1.Affinity{
 						NodeAffinity: getNodeAffinity(pluginNodeAffinityEnv, &v1.NodeAffinity{}),
 					},
@@ -112,7 +112,7 @@ func (r *ReconcileCSI) generateCSIOpConfigSpec(cluster cephv1.CephCluster, opCon
 				},
 				HostNetwork: &controllerPluginHostNetwork,
 				PodCommonSpec: csiopv1.PodCommonSpec{
-					PrioritylClassName: &CSIParam.PluginPriorityClassName,
+					PrioritylClassName: &CSIParam.ProvisionerPriorityClassName,
 					Affinity: &v1.Affinity{
 						NodeAffinity: getNodeAffinity(provisionerNodeAffinityEnv, &v1.NodeAffinity{}),
 					},

--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -273,7 +273,7 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 		FsGroupPolicy:    k8scsiv1.FileFSGroupPolicy,
 		NodePlugin: &csiopv1.NodePluginSpec{
 			PodCommonSpec: csiopv1.PodCommonSpec{
-				PrioritylClassName: &CSIParam.ProvisionerPriorityClassName,
+				PrioritylClassName: &CSIParam.PluginPriorityClassName,
 				Affinity: &corev1.Affinity{
 					NodeAffinity: getNodeAffinity(pluginNodeAffinityEnv, &corev1.NodeAffinity{}),
 				},
@@ -285,7 +285,7 @@ func (r *ReconcileCSI) generateDriverSpec(cluster cephv1.CephCluster) (csiopv1.D
 		},
 		ControllerPlugin: &csiopv1.ControllerPluginSpec{
 			PodCommonSpec: csiopv1.PodCommonSpec{
-				PrioritylClassName: &CSIParam.PluginPriorityClassName,
+				PrioritylClassName: &CSIParam.ProvisionerPriorityClassName,
 				Affinity: &corev1.Affinity{
 					NodeAffinity: getNodeAffinity(provisionerNodeAffinityEnv, &corev1.NodeAffinity{}),
 				},


### PR DESCRIPTION
Previously `provisionerPriorityClassName` config is applied to node plugin but `pluginPriorityClassName` is applied to controller plugin. This causes a misconfiguration since the default values for `provisionerPriorityClassName` is `system-cluster-critical` and `pluginPriorityClassName` is `system-node-critical`.

The default priority for node plugin ought to be `system-node-critical` so we can leverage this information to kill the pods in this priority last, allowing other pods that may mount RBD-backed volume to unmount cleanly first, otherwise the shutdown sequence may hang due to failure unmounting RBD-backed volume when the node plugin pod is already killed.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
