### PR TITLE
fix(mds): sync allow_standby_replay in updateFilesystem

### DIFF
--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -230,6 +230,13 @@ func (f *Filesystem) updateFilesystem(context *clusterd.Context, clusterInfo *ce
 			err)
 	}
 
+	// set allow_standby_replay to match the spec, in case it changed since filesystem creation
+	if err := cephclient.AllowStandbyReplay(context, clusterInfo, f.Name, spec.MetadataServer.ActiveStandby); err != nil {
+		log.NamedWarning(opcontroller.NsName(f.Namespace, f.Name), logger,
+			"failed to set allow_standby_replay to %t for filesystem %s. %v",
+			spec.MetadataServer.ActiveStandby, f.Name, err)
+	}
+
 	if err := createOrUpdatePools(f, context, clusterInfo, clusterSpec, spec); err != nil {
 		return errors.Wrap(err, "failed to set pools size")
 	}


### PR DESCRIPTION
## Description

When a CephFilesystem is updated (not just created), the `activeStandby` setting was not being synchronized to Ceph. If a filesystem was created with `activeStandby: true` and later updated to `activeStandby: false`, the Ceph flag `allow_standby_replay` remained true, causing Ceph to emit `insufficient standby MDS daemons available` HEALTH_WARN.

Now `updateFilesystem()` also calls `AllowStandbyReplay()` to ensure the Ceph flag stays in sync with the spec.

## Bug
rook/rook#17372

## Testing
- Unit tests pass (existing tests cover the update path)
- Manual: Create a filesystem with `activeStandby: true`, update to `activeStandby: false`, verify no HEALTH_WARN about insufficient standbys