### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -12,15 +12,16 @@ defaults:
     # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
     shell: bash --noprofile --norc -eo pipefail -x {0}
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write # for cosign OIDC keyless signing
+permissions: {}
 
 jobs:
   push-image-to-container-registry:
     runs-on: ubuntu-22.04
     if: github.repository == 'rook/rook'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # for cosign OIDC keyless signing
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

**Issue resolved by this Pull Request:**
Resolves #17380

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] ~[Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.~
  - ~Overwriting Ceph's configurations should be marked as breaking changes.~
- [ ] ~Documentation has been updated, if necessary.~
- [ ] ~Unit tests have been added, if necessary.~
- [ ] ~Integration tests have been added, if necessary.~
