### PR TITLE
mon: fix floating mon validation in TNF deployments

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -307,8 +307,12 @@ func preClusterStartValidation(cluster *cluster) error {
 	}
 	if !cluster.Spec.Mon.AllowMultiplePerNode {
 		// Check that there are enough nodes to have a chance of starting the requested number of mons
+		monCountToSchedule := cluster.Spec.Mon.Count
+		if cluster.Spec.Mon.FloatingMon.Name != "" {
+			monCountToSchedule--
+		}
 		nodes, err := cluster.context.Clientset.CoreV1().Nodes().List(cluster.ClusterInfo.Context, metav1.ListOptions{})
-		if err == nil && len(nodes.Items) < cluster.Spec.Mon.Count {
+		if err == nil && len(nodes.Items) < monCountToSchedule {
 			return errors.Errorf("cannot start %d mons on %d node(s) when allowMultiplePerNode is false", cluster.Spec.Mon.Count, len(nodes.Items))
 		}
 	}

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -81,6 +81,10 @@ func TestPreClusterStartValidation(t *testing.T) {
 			{Name: "b"},
 			{Name: "c"},
 		}}}}}}, true},
+		{"TNF cluster with floating mon", args{&cluster{ClusterInfo: cephclient.AdminTestClusterInfo("rook-ceph"), context: &clusterd.Context{Clientset: testop.New(t, 2)}, Spec: &cephv1.ClusterSpec{Mon: cephv1.MonSpec{Count: 3, AllowMultiplePerNode: false, FloatingMon: cephv1.FloatingMonSpec{
+			Name:          "c",
+			ConfigMapName: "rook-floating-mon-config",
+		}}}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The floating mon in a TNF cluster is designed to share a node with a pinned mon. Fixed the pre-cluster start evaluation logic to allow the same when allowMultiplePerNode is set to false.

Closes #17339 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
