### PR TITLE
osd: split osd listing and class/type resolve logic into separate met…

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -266,7 +266,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	}
 
 	// destroy the OSD using the OSD ID
-	var replaceOSD *oposd.OSDInfo
+	var replaceOSD *oposd.OSDInfoBase
 	if replaceOSDID != -1 {
 		logger.Infof("destroying osd.%d and cleaning its backing device", replaceOSDID)
 		replaceOSD, err = osddaemon.DestroyOSD(context, &clusterInfo, replaceOSDID, cfg.pvcBacked)

--- a/pkg/daemon/ceph/cleanup/disk.go
+++ b/pkg/daemon/ceph/cleanup/disk.go
@@ -70,7 +70,7 @@ func (s *DiskSanitizer) StartSanitizeDisks() {
 	}
 
 	// Raw based OSDs
-	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", "", false, true)
+	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", "", false)
 	if err != nil {
 		logger.Errorf("failed to list raw osd(s). %v", err)
 	} else {
@@ -79,7 +79,7 @@ func (s *DiskSanitizer) StartSanitizeDisks() {
 	}
 }
 
-func (s *DiskSanitizer) SanitizeRawDisk(osdRawList []oposd.OSDInfo) {
+func (s *DiskSanitizer) SanitizeRawDisk(osdRawList []oposd.OSDInfoBase) {
 	// Initialize work group to wait for completion of all the go routine
 	var wg sync.WaitGroup
 
@@ -118,7 +118,7 @@ func (s *DiskSanitizer) SanitizeLVMDisk(osdLVMList []oposd.OSDInfo) {
 	// purge remaining LVM2 metadata from PV
 	for _, pv := range pvs {
 		wg2.Add(1)
-		go s.executeSanitizeCommand(oposd.OSDInfo{BlockPath: pv}, &wg2)
+		go s.executeSanitizeCommand(oposd.OSDInfoBase{BlockPath: pv}, &wg2)
 	}
 	wg2.Wait()
 }
@@ -197,7 +197,7 @@ func (s *DiskSanitizer) buildShredCommands(disk string) []ShredCommand {
 	return shredCommands
 }
 
-func (s *DiskSanitizer) executeSanitizeCommand(osdInfo oposd.OSDInfo, wg *sync.WaitGroup) {
+func (s *DiskSanitizer) executeSanitizeCommand(osdInfo oposd.OSDInfoBase, wg *sync.WaitGroup) {
 	// On return, notify the WaitGroup that we’re done
 	defer wg.Done()
 

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -38,14 +38,14 @@ type OsdAgent struct {
 	storeConfig                  config.StoreConfig
 	kv                           *k8sutil.ConfigMapKVStore
 	pvcBacked                    bool
-	replaceOSD                   *oposd.OSDInfo
+	replaceOSD                   *oposd.OSDInfoBase
 	wipeDevicesFromOtherClusters bool
 }
 
 // NewAgent is the instantiation of the OSD agent
 func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice string, forceFormat bool,
 	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore,
-	replaceOSD *oposd.OSDInfo, pvcBacked, wipDevicesFromOtherClusters bool,
+	replaceOSD *oposd.OSDInfoBase, pvcBacked, wipDevicesFromOtherClusters bool,
 ) *OsdAgent {
 	return &OsdAgent{
 		devices:                      devices,

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -415,7 +415,7 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 		rejectedReason := ""
 		if agent.pvcBacked {
 			block := fmt.Sprintf("/mnt/%s", agent.nodeName)
-			rawOsds, err := GetCephVolumeRawOSDs(context, agent.clusterInfo, agent.clusterInfo.FSID, block, agent.metadataDevice, "", false, true)
+			rawOsds, err := GetCephVolumeRawOSDs(context, agent.clusterInfo, agent.clusterInfo.FSID, block, agent.metadataDevice, "", false)
 			if err != nil {
 				isAvailable = false
 				rejectedReason = fmt.Sprintf("failed to detect if there is already an osd. %v", err)
@@ -525,7 +525,6 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 
 				if matched {
 					matchedDevice = desiredDevice
-					matchedDevice.UpdateDeviceClass(agent, device)
 					break
 				}
 			}
@@ -598,7 +597,7 @@ func getVolumeGroupName(lvPath string) string {
 }
 
 // GetOSDInfoById returns the osdInfo using the ceph volume list
-func GetOSDInfoById(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID int) (*oposd.OSDInfo, error) {
+func GetOSDInfoById(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID int) (*oposd.OSDInfoBase, error) {
 	// LVM mode OSDs
 	osdLVMList, err := GetCephVolumeLVMOSDs(context, clusterInfo, clusterInfo.FSID, "", false, false)
 	if err != nil {
@@ -607,12 +606,13 @@ func GetOSDInfoById(context *clusterd.Context, clusterInfo *client.ClusterInfo, 
 
 	for _, osdInfo := range osdLVMList {
 		if osdInfo.ID == osdID {
-			return &osdInfo, nil
+			base := osdInfo.OSDInfoBase
+			return &base, nil
 		}
 	}
 
 	// Raw mode OSDs
-	osdRawList, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, "", "", "", false, true)
+	osdRawList, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, "", "", "", false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list raw osd(s)")
 	}

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -19,6 +19,7 @@ package osd
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/util/sys"
@@ -71,28 +72,46 @@ func (m *DeviceOsdMapping) String() string {
 	return string(b)
 }
 
-func (d *DesiredDevice) UpdateDeviceClass(agent *OsdAgent, device *sys.LocalDisk) {
-	// Rook sets the storage class of a device with the following priority.
-	//
-	// 1. the device-level configuration
-	// 2. the global or node-local configuration
-	// 3. the default value estimated from sysfs.
+// deviceClass resolves the CRUSH device class for a configured device:
+// per-device value first, node/cluster-level default otherwise. Returns "" when
+// nothing is configured.
+func (a *OsdAgent) deviceClass(d DesiredDevice) string {
 	if d.DeviceClass != "" {
-		return
+		return d.DeviceClass
 	}
+	return a.defaultDeviceClass()
+}
 
-	if agent.pvcBacked {
-		crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-		if crushDeviceClass != "" {
-			d.DeviceClass = crushDeviceClass
-			return
+// deviceClassByPath returns the CRUSH device class for an OSD identified by
+// any of the given candidate paths (typically the block path plus its udev
+// DevLinks), with the following priority:
+//
+//  1. the device-level configuration from the CR, matched against any candidate
+//  2. the global or node-local default
+//
+// When multiple specs could match, the first configured device wins.
+// Returns "" when nothing is configured.
+func (a *OsdAgent) deviceClassByPath(paths []string) string {
+	for _, d := range a.devices {
+		if d.IsFilter || d.IsDevicePathFilter {
+			continue
 		}
-	} else {
-		if agent.storeConfig.DeviceClass != "" {
-			d.DeviceClass = agent.storeConfig.DeviceClass
-			return
+		normSpec := strings.TrimPrefix(d.Name, "/dev/")
+		for _, p := range paths {
+			if strings.TrimPrefix(p, "/dev/") == normSpec {
+				return a.deviceClass(d)
+			}
 		}
 	}
+	return a.defaultDeviceClass()
+}
 
-	d.DeviceClass = sys.GetDiskDeviceType(device)
+// defaultDeviceClass returns the node or cluster-level default CRUSH class.
+// PVC-backed prepare jobs read it from ROOK_OSD_CRUSH_DEVICE_CLASS (injected
+// by the operator); non-PVC jobs read it from a.storeConfig.DeviceClass.
+func (a *OsdAgent) defaultDeviceClass() string {
+	if a.pvcBacked {
+		return os.Getenv(oposd.CrushDeviceClassVarName)
+	}
+	return a.storeConfig.DeviceClass
 }

--- a/pkg/daemon/ceph/osd/device_test.go
+++ b/pkg/daemon/ceph/osd/device_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
-	"github.com/rook/rook/pkg/util/sys"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,35 +50,182 @@ func TestOSDBootstrap(t *testing.T) {
 	assert.NotEqual(t, -1, strings.Index(string(contents), "caps mon = \"allow profile bootstrap-osd\""))
 }
 
-func TestUpdateDeviceClass(t *testing.T) {
-	d := &DesiredDevice{}
-	agent := &OsdAgent{}
-	disk := &sys.LocalDisk{}
+func TestDeviceClassFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		devices      []DesiredDevice
+		pvcBacked    bool
+		storeDefault string
+		envDefault   string
+		paths        []string
+		expected     string
+	}{
+		{
+			name:         "per-device wins over default",
+			devices:      []DesiredDevice{{Name: "sda", DeviceClass: "fast"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda"},
+			expected:     "fast",
+		},
+		{
+			name:         "non-PVC falls back to storeConfig default when no per-device match",
+			devices:      []DesiredDevice{{Name: "sdb", DeviceClass: "fast"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sdc"},
+			expected:     "ssd",
+		},
+		{
+			name:         "PVC reads default from env var, ignoring storeConfig",
+			pvcBacked:    true,
+			envDefault:   "env-class",
+			storeDefault: "ignored-when-pvc",
+			paths:        []string{"/mnt/pvc-0"},
+			expected:     "env-class",
+		},
+		{
+			name:     "returns empty when nothing is configured",
+			paths:    []string{"/dev/sda"},
+			expected: "",
+		},
+		{
+			name:         "IsFilter entries do not match concrete blockPaths",
+			devices:      []DesiredDevice{{Name: "^sd.$", DeviceClass: "huge", IsFilter: true}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda"},
+			expected:     "ssd",
+		},
+		{
+			name:         "IsDevicePathFilter entries do not match concrete blockPaths",
+			devices:      []DesiredDevice{{Name: "^/dev/sd", DeviceClass: "tiny", IsDevicePathFilter: true}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda"},
+			expected:     "ssd",
+		},
+		{
+			// Empty DeviceClass on a matching spec means "unset"; resolution
+			// falls through to the default rather than returning "".
+			name:         "matching entry with empty DeviceClass falls through to default",
+			devices:      []DesiredDevice{{Name: "sda"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda"},
+			expected:     "ssd",
+		},
+		{
+			name:     "matching entry with empty DeviceClass and no default returns empty",
+			devices:  []DesiredDevice{{Name: "sda"}},
+			paths:    []string{"/dev/sda"},
+			expected: "",
+		},
+		{
+			// filepath.Base("/dev/mapper/sda") is "sda"; a plain base-name match
+			// would incorrectly pick up a {name: "sda"} spec.
+			name:         "dm-mapper path does not match a short-name spec",
+			devices:      []DesiredDevice{{Name: "sda", DeviceClass: "fast"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/mapper/sda"},
+			expected:     "ssd",
+		},
+		{
+			name:         "fullpath spec matches via DevLinks candidate",
+			devices:      []DesiredDevice{{Name: "/dev/disk/by-id/wwn-0xabc", DeviceClass: "fast"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/disk/by-id/wwn-0xabc", "/dev/sda"},
+			expected:     "fast",
+		},
+		{
+			name:         "fullpath spec with no DevLinks candidate falls through to default",
+			devices:      []DesiredDevice{{Name: "/dev/disk/by-id/wwn-0xabc", DeviceClass: "fast"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda"},
+			expected:     "ssd",
+		},
+		{
+			name:         "first configured device wins when multiple could match",
+			devices:      []DesiredDevice{{Name: "sda", DeviceClass: "first"}, {Name: "/dev/disk/by-id/wwn-0xabc", DeviceClass: "second"}},
+			storeDefault: "ssd",
+			paths:        []string{"/dev/sda", "/dev/disk/by-id/wwn-0xabc"},
+			expected:     "first",
+		},
+	}
 
-	d.DeviceClass = "test"
-	d.UpdateDeviceClass(agent, disk)
-	assert.Equal(t, "test", d.DeviceClass)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(oposd.CrushDeviceClassVarName, tt.envDefault)
+			a := &OsdAgent{
+				devices:     tt.devices,
+				pvcBacked:   tt.pvcBacked,
+				storeConfig: config.StoreConfig{DeviceClass: tt.storeDefault},
+			}
+			assert.Equal(t, tt.expected, a.deviceClassByPath(tt.paths))
+		})
+	}
+}
 
-	d.DeviceClass = ""
-	agent.pvcBacked = true
-	t.Setenv(osd.CrushDeviceClassVarName, "test")
-	d.UpdateDeviceClass(agent, disk)
-	assert.Equal(t, "test", d.DeviceClass)
+func TestDeviceClass(t *testing.T) {
+	tests := []struct {
+		name         string
+		device       DesiredDevice
+		pvcBacked    bool
+		storeDefault string
+		envDefault   string
+		expected     string
+	}{
+		{
+			name:         "per-device wins over default",
+			device:       DesiredDevice{Name: "sda", DeviceClass: "fast"},
+			storeDefault: "ssd",
+			expected:     "fast",
+		},
+		{
+			name:         "non-PVC falls back to storeConfig default",
+			device:       DesiredDevice{Name: "sda"},
+			storeDefault: "ssd",
+			expected:     "ssd",
+		},
+		{
+			name:         "PVC reads default from env var, ignoring storeConfig",
+			device:       DesiredDevice{Name: "/mnt/pvc"},
+			pvcBacked:    true,
+			envDefault:   "env-class",
+			storeDefault: "ignored-when-pvc",
+			expected:     "env-class",
+		},
+		{
+			name:     "empty everywhere returns empty",
+			device:   DesiredDevice{Name: "sda"},
+			expected: "",
+		},
+	}
 
-	d.DeviceClass = ""
-	t.Setenv(osd.CrushDeviceClassVarName, "")
-	d.UpdateDeviceClass(agent, disk)
-	t.Log(d)
-	t.Log(disk)
-	assert.Equal(t, "ssd", d.DeviceClass)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(oposd.CrushDeviceClassVarName, tt.envDefault)
+			a := &OsdAgent{
+				pvcBacked:   tt.pvcBacked,
+				storeConfig: config.StoreConfig{DeviceClass: tt.storeDefault},
+			}
+			assert.Equal(t, tt.expected, a.deviceClass(tt.device))
+		})
+	}
+}
 
-	d.DeviceClass = ""
-	agent.pvcBacked = false
-	d.UpdateDeviceClass(agent, disk)
-	assert.Equal(t, "ssd", d.DeviceClass)
-
-	d.DeviceClass = ""
-	agent.storeConfig.DeviceClass = "test"
-	d.UpdateDeviceClass(agent, disk)
-	assert.Equal(t, "test", d.DeviceClass)
+func TestDeviceClassFor_NameNormalization(t *testing.T) {
+	// A spec "sda" matches blockPath "/dev/sda" and vice versa.
+	tests := []struct {
+		specName  string
+		blockPath string
+	}{
+		{"sda", "/dev/sda"},
+		{"sda", "sda"},
+		{"/dev/sdb", "sdb"},
+		{"/dev/sdb", "/dev/sdb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.specName+"_vs_"+tt.blockPath, func(t *testing.T) {
+			a := &OsdAgent{
+				devices: []DesiredDevice{{Name: tt.specName, DeviceClass: "fast"}},
+			}
+			assert.Equal(t, "fast", a.deviceClassByPath([]string{tt.blockPath}))
+		})
+	}
 }

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -242,7 +242,7 @@ func archiveCrash(clusterdContext *clusterd.Context, clusterInfo *client.Cluster
 }
 
 // DestroyOSD fetches the OSD to be replaced based on the ID and then destroys that OSD and zaps the backing device
-func DestroyOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, id int, isPVC bool) (*oposd.OSDInfo, error) {
+func DestroyOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, id int, isPVC bool) (*oposd.OSDInfoBase, error) {
 	osdInfo, err := GetOSDInfoById(context, clusterInfo, id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get OSD info for OSD.%d", id)

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -145,7 +145,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// I'm leaving this code with an empty metadata device for now
 			metadataBlock, walBlock = "", ""
 
-			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
+			rawOsds, err = a.listRawOSDsEnriched(context, block, metadataBlock, walBlock, lvBackedPV)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
@@ -160,7 +160,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			osds = append(osds, lvmOsds...)
 
 			// List existing OSD(s) configured with ceph-volume raw mode
-			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false)
+			rawOsds, err = a.listRawOSDsEnriched(context, block, "", "", false)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
@@ -212,7 +212,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if !a.pvcBacked {
 		block = ""
 	}
-	rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
+	rawOsds, err = a.listRawOSDsEnriched(context, block, metadataBlock, walBlock, lvBackedPV)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
@@ -298,10 +298,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				}
 			}
 
-			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-			if crushDeviceClass != "" {
-				immediateExecuteArgs = append(immediateExecuteArgs, []string{crushDeviceClassFlag, crushDeviceClass}...)
-			}
+			immediateExecuteArgs = a.appendDeviceClassArg(device, immediateExecuteArgs)
 
 			if isEncrypted {
 				immediateExecuteArgs = append(immediateExecuteArgs, encryptedFlag)
@@ -663,8 +660,8 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 				} else {
 					metadataDevices[md] = make(map[string]string)
 					metadataDevices[md]["osdsperdevice"] = deviceOSDCount
-					if device.Config.DeviceClass != "" {
-						metadataDevices[md]["deviceclass"] = device.Config.DeviceClass
+					if dc := a.deviceClass(device.Config); dc != "" {
+						metadataDevices[md]["deviceclass"] = dc
 					}
 					metadataDevices[md]["devices"] = deviceArg
 				}
@@ -847,18 +844,44 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 }
 
 func (a *OsdAgent) appendDeviceClassArg(device *DeviceOsdIDEntry, args []string) []string {
-	deviceClass := device.Config.DeviceClass
-	if deviceClass == "" {
-		// fall back to the device class for all devices on the node
-		deviceClass = a.storeConfig.DeviceClass
-	}
-	if deviceClass != "" {
-		args = append(args, []string{
-			crushDeviceClassFlag,
-			deviceClass,
-		}...)
+	if dc := a.deviceClass(device.Config); dc != "" {
+		args = append(args, crushDeviceClassFlag, dc)
 	}
 	return args
+}
+
+// listRawOSDsEnriched returns raw-mode OSDs with DeviceType and DeviceClass resolved via the agent.
+func (a *OsdAgent) listRawOSDsEnriched(context *clusterd.Context, block, metadataBlock, walBlock string, lvBackedPV bool) ([]oposd.OSDInfo, error) {
+	bases, err := GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV)
+	if err != nil {
+		return nil, err
+	}
+	osds := make([]oposd.OSDInfo, len(bases))
+	for i, base := range bases {
+		disk, err := clusterd.PopulateDeviceInfo(base.BlockPath, context.Executor)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get device info for %q", base.BlockPath)
+		}
+		// populate also udev DEVLINKS for cases when device fullPath is used in CR:
+		if _, err := clusterd.PopulateDeviceUdevInfo(disk.KernelName, context.Executor, disk); err != nil {
+			logger.Warningf("failed to populate udev info for %q: %v", base.BlockPath, err)
+		}
+		autoType := sys.GetDiskDeviceType(disk)
+		paths := append(strings.Fields(disk.DevLinks), base.BlockPath)
+		dc := a.deviceClassByPath(paths)
+		source := "configured"
+		if dc == "" {
+			dc = autoType
+			source = "autodetected"
+		}
+		osds[i] = oposd.OSDInfo{
+			OSDInfoBase: base,
+			DeviceType:  autoType,
+			DeviceClass: dc,
+		}
+		logger.Infof("device %q: device-type=%q device-class=%q (%s)", disk.Name, osds[i].DeviceType, osds[i].DeviceClass, source)
+	}
+	return osds, nil
 }
 
 // ZapDevice wipes a device using two methods for maximum reliability:
@@ -1137,15 +1160,17 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 		}
 
 		osd := oposd.OSDInfo{
-			ID:            id,
-			Cluster:       "ceph",
-			UUID:          osdFSID,
-			BlockPath:     lvPath,
-			SkipLVRelease: skipLVRelease,
-			LVBackedPV:    lvBackedPV,
-			CVMode:        cvMode,
-			Store:         osdStore,
-			DeviceClass:   osdDeviceClass,
+			OSDInfoBase: oposd.OSDInfoBase{
+				ID:            id,
+				Cluster:       "ceph",
+				UUID:          osdFSID,
+				BlockPath:     lvPath,
+				SkipLVRelease: skipLVRelease,
+				LVBackedPV:    lvBackedPV,
+				CVMode:        cvMode,
+				Store:         osdStore,
+			},
+			DeviceClass: osdDeviceClass,
 		}
 		osds = append(osds, osd)
 	}
@@ -1180,7 +1205,7 @@ func readCVLogContent(cvLogFilePath string) string {
 // On the other hand, the PVC scenario always uses the PVC block as a block to check whether the
 // disk is an OSD or not.
 // The same goes for "metadataBlock" and "walBlock" they are only used in the prepare job.
-func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock, walBlock string, lvBackedPV, skipDeviceClass bool) ([]oposd.OSDInfo, error) {
+func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock, walBlock string, lvBackedPV bool) ([]oposd.OSDInfoBase, error) {
 	// lv can be a block device if raw mode is used
 	cvMode := "raw"
 
@@ -1288,7 +1313,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}
 
-	var osds []oposd.OSDInfo
+	var osds []oposd.OSDInfoBase
 	var cephVolumeResult map[string]osdInfoBlock
 	err = json.Unmarshal([]byte(result), &cephVolumeResult)
 	if err != nil {
@@ -1332,7 +1357,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 		osdStore := osdInfo.Type
 
-		osd := oposd.OSDInfo{
+		osd := oposd.OSDInfoBase{
 			ID:      osdID,
 			Cluster: "ceph",
 			UUID:    osdFSID,
@@ -1349,20 +1374,6 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 			CVMode:        cvMode,
 			Store:         osdStore,
 			Encrypted:     strings.Contains(blockPath, "-dmcrypt"),
-		}
-
-		if !skipDeviceClass {
-			diskInfo, err := clusterd.PopulateDeviceInfo(blockPath, context.Executor)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get device info for %q", blockPath)
-			}
-			deviceType := sys.GetDiskDeviceType(diskInfo)
-			osd.DeviceType = deviceType
-			logger.Infof("setting device type %q for device %q", osd.DeviceType, diskInfo.Name)
-
-			crushDeviceClass := sys.GetDiskDeviceClass(oposd.CrushDeviceClassVarName, deviceType)
-			osd.DeviceClass = crushDeviceClass
-			logger.Infof("setting device class %q for device %q", osd.DeviceClass, diskInfo.Name)
 		}
 
 		// If this is an encrypted OSD

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -1604,7 +1605,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
 	}
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", pvcBacked: true, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}},
@@ -1631,7 +1632,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition when osd is prepared with existing osd ID
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", pvcBacked: true, storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfoBase{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sda"}},
@@ -1653,7 +1654,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition that --osd-id is not passed for the devices that don't match the OSD to be replaced.
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", pvcBacked: true, storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfoBase{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sdb"}},
@@ -1723,7 +1724,7 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
 	}
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", pvcBacked: true, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
 
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
@@ -1783,7 +1784,7 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "name"}
 
 	context := &clusterd.Context{Executor: executor, Clientset: test.New(t, 3)}
-	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false, false)
+	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false)
 	assert.Nil(t, err)
 	require.NotNil(t, osds)
 	assert.Equal(t, 2, len(osds))
@@ -2119,14 +2120,14 @@ func TestAppendOSDInfo(t *testing.T) {
 	// Set 1: duplicate entries
 	{
 		currentOSDs := []oposd.OSDInfo{
-			{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/ceph-48b22180-8358-4ab4-aec0-3fb83a20328b/osd-block-275950b5-dcb3-4c3e-b0df-014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/ceph-140a1344-636d-4442-85b3-bb3cd18ca002/osd-block-3206c1c0-7ea2-412b-bd42-708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/ceph-0c466524-57a3-4e5f-b4e3-04538ff0aced/osd-block-7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/ceph-48b22180-8358-4ab4-aec0-3fb83a20328b/osd-block-275950b5-dcb3-4c3e-b0df-014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/ceph-140a1344-636d-4442-85b3-bb3cd18ca002/osd-block-3206c1c0-7ea2-412b-bd42-708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/ceph-0c466524-57a3-4e5f-b4e3-04538ff0aced/osd-block-7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
 		}
 		newOSDs := []oposd.OSDInfo{
-			{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--0c466524--57a3--4e5f--b4e3--04538ff0aced-osd--block--7ea5e98b--755c--4837--a2a3--9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--48b22180--8358--4ab4--aec0--3fb83a20328b-osd--block--275950b5--dcb3--4c3e--b0df--014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--140a1344--636d--4442--85b3--bb3cd18ca002-osd--block--3206c1c0--7ea2--412b--bd42--708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--0c466524--57a3--4e5f--b4e3--04538ff0aced-osd--block--7ea5e98b--755c--4837--a2a3--9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--48b22180--8358--4ab4--aec0--3fb83a20328b-osd--block--275950b5--dcb3--4c3e--b0df--014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/mapper/ceph--140a1344--636d--4442--85b3--bb3cd18ca002-osd--block--3206c1c0--7ea2--412b--bd42--708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
 		}
 		trimmedOSDs := appendOSDInfo(currentOSDs, newOSDs)
 		assert.Equal(t, 3, len(trimmedOSDs))
@@ -2136,14 +2137,14 @@ func TestAppendOSDInfo(t *testing.T) {
 	// Set 2: no duplicate entries, just a mix of RAW and LVM OSDs should not trim anything
 	{
 		currentOSDs := []oposd.OSDInfo{
-			{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/ceph-48b22180-8358-4ab4-aec0-3fb83a20328b/osd-block-275950b5-dcb3-4c3e-b0df-014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/ceph-140a1344-636d-4442-85b3-bb3cd18ca002/osd-block-3206c1c0-7ea2-412b-bd42-708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/ceph-0c466524-57a3-4e5f-b4e3-04538ff0aced/osd-block-7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 0, Cluster: "ceph", UUID: "275950b5-dcb3-4c3e-b0df-014b16755dc5", DevicePartUUID: "", BlockPath: "/dev/ceph-48b22180-8358-4ab4-aec0-3fb83a20328b/osd-block-275950b5-dcb3-4c3e-b0df-014b16755dc5", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 1, Cluster: "ceph", UUID: "3206c1c0-7ea2-412b-bd42-708cfe5e4acb", DevicePartUUID: "", BlockPath: "/dev/ceph-140a1344-636d-4442-85b3-bb3cd18ca002/osd-block-3206c1c0-7ea2-412b-bd42-708cfe5e4acb", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 2, Cluster: "ceph", UUID: "7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", DevicePartUUID: "", BlockPath: "/dev/ceph-0c466524-57a3-4e5f-b4e3-04538ff0aced/osd-block-7ea5e98b-755c-4837-a2a3-9ad61e67cf6f", MetadataPath: "", WalPath: "", SkipLVRelease: false, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "lvm", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
 		}
 		newOSDs := []oposd.OSDInfo{
-			{ID: 3, Cluster: "ceph", UUID: "35e61dbc-4455-45fd-b5c8-39be2a29db02", DevicePartUUID: "", BlockPath: "/dev/sdb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 4, Cluster: "ceph", UUID: "f5c0ce2c-76ee-4cbf-94df-9e480da6c614", DevicePartUUID: "", BlockPath: "/dev/sdd", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 5, Cluster: "ceph", UUID: "4aadb152-2b30-477a-963e-44447ded6a66", DevicePartUUID: "", BlockPath: "/dev/sde", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 3, Cluster: "ceph", UUID: "35e61dbc-4455-45fd-b5c8-39be2a29db02", DevicePartUUID: "", BlockPath: "/dev/sdb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 4, Cluster: "ceph", UUID: "f5c0ce2c-76ee-4cbf-94df-9e480da6c614", DevicePartUUID: "", BlockPath: "/dev/sdd", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 5, Cluster: "ceph", UUID: "4aadb152-2b30-477a-963e-44447ded6a66", DevicePartUUID: "", BlockPath: "/dev/sde", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
 		}
 		trimmedOSDs := appendOSDInfo(currentOSDs, newOSDs)
 		assert.Equal(t, 6, len(trimmedOSDs))
@@ -2152,9 +2153,9 @@ func TestAppendOSDInfo(t *testing.T) {
 	{
 		currentOSDs := []oposd.OSDInfo{}
 		newOSDs := []oposd.OSDInfo{
-			{ID: 3, Cluster: "ceph", UUID: "35e61dbc-4455-45fd-b5c8-39be2a29db02", DevicePartUUID: "", BlockPath: "/dev/sdb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 4, Cluster: "ceph", UUID: "f5c0ce2c-76ee-4cbf-94df-9e480da6c614", DevicePartUUID: "", BlockPath: "/dev/sdd", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
-			{ID: 5, Cluster: "ceph", UUID: "4aadb152-2b30-477a-963e-44447ded6a66", DevicePartUUID: "", BlockPath: "/dev/sde", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 3, Cluster: "ceph", UUID: "35e61dbc-4455-45fd-b5c8-39be2a29db02", DevicePartUUID: "", BlockPath: "/dev/sdb", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 4, Cluster: "ceph", UUID: "f5c0ce2c-76ee-4cbf-94df-9e480da6c614", DevicePartUUID: "", BlockPath: "/dev/sdd", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
+			{OSDInfoBase: oposd.OSDInfoBase{ID: 5, Cluster: "ceph", UUID: "4aadb152-2b30-477a-963e-44447ded6a66", DevicePartUUID: "", BlockPath: "/dev/sde", MetadataPath: "", WalPath: "", SkipLVRelease: true, Location: "root=default host=minikube rack=rack1 zone=b", LVBackedPV: false, CVMode: "raw", Store: "bluestore", TopologyAffinity: "topology.rook.io/rack=rack1"}},
 		}
 		trimmedOSDs := appendOSDInfo(currentOSDs, newOSDs)
 		assert.Equal(t, 3, len(trimmedOSDs))
@@ -2359,4 +2360,210 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	context.Executor = executor
 	err = agent.WipeDevicesFromOtherClusters(context)
 	assert.NoError(t, err)
+}
+
+func newRawListExecutor(rawJSON string, lvmListEmpty bool, devLinksByDevice map[string]string) *exectest.MockExecutor {
+	return &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if command == "lsblk" && len(args) > 0 && strings.HasPrefix(args[0], "/dev/") {
+				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
+			}
+			if command == "sgdisk" {
+				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
+			}
+			if command == "udevadm" && len(args) >= 3 && args[0] == "info" {
+				devPath := args[len(args)-1]
+				short := strings.TrimPrefix(devPath, "/dev/")
+				links := devLinksByDevice[short]
+				return fmt.Sprintf("DEVLINKS=%s\nID_FS_TYPE=\n", links), nil
+			}
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+				return rawJSON, nil
+			}
+			if lvmListEmpty && slices.Contains(args, "lvm") && slices.Contains(args, "list") {
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		},
+	}
+}
+
+func TestListRawOSDsEnrichesDeviceClass(t *testing.T) {
+	const clusterFSID = "4bfe8b72-5e69-4330-b6c0-4d914db8ab89"
+	rawJSON := fmt.Sprintf(`{
+		"0": {"ceph_fsid": "%s", "device": "/dev/sda", "osd_id": 0, "osd_uuid": "uuid-a", "type": "bluestore"},
+		"1": {"ceph_fsid": "%s", "device": "/dev/sdb", "osd_id": 1, "osd_uuid": "uuid-b", "type": "bluestore"}
+	}`, clusterFSID, clusterFSID)
+
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{FSID: clusterFSID},
+		storeConfig: config.StoreConfig{DeviceClass: "ssd"},
+		devices: []DesiredDevice{
+			{Name: "sda", DeviceClass: "fast"},
+		},
+	}
+
+	osds, err := agent.listRawOSDsEnriched(&clusterd.Context{Executor: newRawListExecutor(rawJSON, false, nil)}, "", "", "", false)
+	require.NoError(t, err)
+	require.Len(t, osds, 2)
+
+	byID := map[int]oposd.OSDInfo{}
+	for _, o := range osds {
+		byID[o.ID] = o
+	}
+	assert.Equal(t, "fast", byID[0].DeviceClass, "sda has per-device class")
+	assert.Equal(t, "hdd", byID[0].DeviceType)
+	assert.Equal(t, "ssd", byID[1].DeviceClass, "sdb has no per-device class, falls back to default")
+	assert.Equal(t, "hdd", byID[1].DeviceType)
+}
+
+func TestListRawOSDsEnriched_FullpathViaDevLinks(t *testing.T) {
+	const clusterFSID = "4bfe8b72-5e69-4330-b6c0-4d914db8ab89"
+	rawJSON := fmt.Sprintf(`{
+		"0": {"ceph_fsid": "%s", "device": "/dev/sda", "osd_id": 0, "osd_uuid": "uuid-a", "type": "bluestore"}
+	}`, clusterFSID)
+
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{FSID: clusterFSID},
+		devices: []DesiredDevice{
+			{Name: "/dev/disk/by-id/wwn-0xabc", DeviceClass: "fast"},
+		},
+	}
+
+	executor := newRawListExecutor(rawJSON, false, map[string]string{
+		"sda": "/dev/disk/by-id/wwn-0xabc /dev/disk/by-path/pci-0000:00:01.0",
+	})
+
+	osds, err := agent.listRawOSDsEnriched(&clusterd.Context{Executor: executor}, "", "", "", false)
+	require.NoError(t, err)
+	require.Len(t, osds, 1)
+	assert.Equal(t, "fast", osds[0].DeviceClass, "fullpath spec must match via DevLinks")
+}
+
+func TestListRawOSDsEnriched_UdevFailureDegrades(t *testing.T) {
+	const clusterFSID = "4bfe8b72-5e69-4330-b6c0-4d914db8ab89"
+	rawJSON := fmt.Sprintf(`{
+		"0": {"ceph_fsid": "%s", "device": "/dev/sda", "osd_id": 0, "osd_uuid": "uuid-a", "type": "bluestore"}
+	}`, clusterFSID)
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if command == "lsblk" && len(args) > 0 && strings.HasPrefix(args[0], "/dev/") {
+				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
+			}
+			if command == "sgdisk" {
+				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
+			}
+			if command == "udevadm" {
+				return "", errors.New("udev broken")
+			}
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+				return rawJSON, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		},
+	}
+
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{FSID: clusterFSID},
+		storeConfig: config.StoreConfig{DeviceClass: "ssd"},
+		devices: []DesiredDevice{
+			{Name: "/dev/disk/by-id/wwn-0xabc", DeviceClass: "fast"},
+		},
+	}
+
+	osds, err := agent.listRawOSDsEnriched(&clusterd.Context{Executor: executor}, "", "", "", false)
+	require.NoError(t, err, "udev failure must not abort listing")
+	require.Len(t, osds, 1)
+	// fullpath spec couldn't match (no DevLinks), so class falls through to the
+	// node-level default rather than the per-device "fast".
+	assert.Equal(t, "ssd", osds[0].DeviceClass)
+}
+
+func TestListRawOSDsEnriched_FallsBackToDeviceType(t *testing.T) {
+	const clusterFSID = "4bfe8b72-5e69-4330-b6c0-4d914db8ab89"
+	rawJSON := fmt.Sprintf(`{
+		"0": {"ceph_fsid": "%s", "device": "/dev/sda", "osd_id": 0, "osd_uuid": "uuid-a", "type": "bluestore"}
+	}`, clusterFSID)
+
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{FSID: clusterFSID},
+	}
+
+	osds, err := agent.listRawOSDsEnriched(&clusterd.Context{Executor: newRawListExecutor(rawJSON, false, nil)}, "", "", "", false)
+	require.NoError(t, err)
+	require.Len(t, osds, 1)
+	assert.Equal(t, "hdd", osds[0].DeviceType)
+	assert.Equal(t, "hdd", osds[0].DeviceClass, "with no config anywhere, class falls back to DeviceType")
+}
+
+func TestConfigureCVDevicesPerDeviceClassIdempotent(t *testing.T) {
+	const (
+		clusterFSID = "4bfe8b72-5e69-4330-b6c0-4d914db8ab89"
+		osdUUID     = "c03d7353-96e5-4a41-98de-830dfff97d06"
+	)
+	rawJSON := fmt.Sprintf(`{
+		"0": {
+			"ceph_fsid": "%s",
+			"device": "/dev/vdb",
+			"osd_id": 0,
+			"osd_uuid": "%s",
+			"type": "bluestore"
+		}
+	}`, clusterFSID, osdUUID)
+	executor := newRawListExecutor(rawJSON, true, nil)
+
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{
+			CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
+			FSID:        clusterFSID,
+		},
+		nodeName:    "lima-rook",
+		storeConfig: config.StoreConfig{StoreType: "bluestore"},
+		devices:     []DesiredDevice{{Name: "vdb", DeviceClass: "fast"}},
+	}
+
+	// Empty entries: the OSD is already provisioned, so getAvailableDevices
+	// filtered it out.
+	devices := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{}}
+
+	deviceOSDs, err := agent.configureCVDevices(&clusterd.Context{Executor: executor}, devices)
+	require.NoError(t, err)
+	require.Len(t, deviceOSDs, 1)
+	assert.Equal(t, "fast", deviceOSDs[0].DeviceClass)
+	assert.Equal(t, "hdd", deviceOSDs[0].DeviceType)
+}
+
+func TestInitializeDevicesLVMMode_MetadataHonorsNodeDefault(t *testing.T) {
+	var sawDeviceClass bool
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommand = func(command string, args ...string) error {
+		for i, a := range args {
+			if a == "--crush-device-class" && i+1 < len(args) && args[i+1] == "fast" {
+				sawDeviceClass = true
+			}
+		}
+		return nil
+	}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		return `[{"block_db": "/dev/sdb", "data": "/dev/sda"}]`, nil
+	}
+
+	devices := &DeviceOsdMapping{
+		Entries: map[string]*DeviceOsdIDEntry{
+			"sda": {Data: -1, Config: DesiredDevice{Name: "/dev/sda", MetadataDevice: "sdb"}, DeviceInfo: &sys.LocalDisk{Type: sys.DiskType}},
+		},
+	}
+	a := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}},
+		nodeName:    "node1",
+		storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "fast"},
+	}
+	ctx := &clusterd.Context{
+		Executor: executor,
+		Devices:  []*sys.LocalDisk{{Name: "sda"}, {Name: "sdb"}},
+	}
+
+	require.NoError(t, a.initializeDevicesLVMMode(ctx, devices))
+	assert.True(t, sawDeviceClass, "expected ceph-volume lvm batch to emit --crush-device-class fast")
 }

--- a/pkg/operator/ceph/cluster/osd/create_test.go
+++ b/pkg/operator/ceph/cluster/osd/create_test.go
@@ -136,7 +136,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: false,
 		}
@@ -154,10 +154,10 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 3}, {ID: 4}, // already exist
-				{ID: 5}, // does not exist
-				{ID: 6}, // already exists
-				{ID: 7}, // does not exist
+				{OSDInfoBase: OSDInfoBase{ID: 3}}, {OSDInfoBase: OSDInfoBase{ID: 4}}, // already exist
+				{OSDInfoBase: OSDInfoBase{ID: 5}}, // does not exist
+				{OSDInfoBase: OSDInfoBase{ID: 6}}, // already exists
+				{OSDInfoBase: OSDInfoBase{ID: 7}}, // does not exist
 			},
 			PvcBackedOSD: false,
 		}
@@ -175,7 +175,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: false,
 		}
@@ -193,7 +193,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: false,
 		}
@@ -228,7 +228,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: true,
 		}
@@ -246,10 +246,10 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 3}, {ID: 4}, // already exist
-				{ID: 5}, // does not exist
-				{ID: 6}, // already exists
-				{ID: 7}, // does not exist
+				{OSDInfoBase: OSDInfoBase{ID: 3}}, {OSDInfoBase: OSDInfoBase{ID: 4}}, // already exist
+				{OSDInfoBase: OSDInfoBase{ID: 5}}, // does not exist
+				{OSDInfoBase: OSDInfoBase{ID: 6}}, // already exists
+				{OSDInfoBase: OSDInfoBase{ID: 7}}, // does not exist
 			},
 			PvcBackedOSD: true,
 		}
@@ -267,7 +267,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: true,
 		}
@@ -285,7 +285,7 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		doSetup()
 		status = &OrchestrationStatus{
 			OSDs: []OSDInfo{
-				{ID: 0}, {ID: 1}, {ID: 2},
+				{OSDInfoBase: OSDInfoBase{ID: 0}}, {OSDInfoBase: OSDInfoBase{ID: 1}}, {OSDInfoBase: OSDInfoBase{ID: 2}},
 			},
 			PvcBackedOSD: true,
 		}

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -665,10 +665,12 @@ func setStatusConfigMapToCompleted(t *testing.T, cm *corev1.ConfigMap, numOSDsIf
 		osdID := testIDGenerator.osdID(t, cm.Name)
 		status.OSDs = []OSDInfo{
 			{
-				ID:        osdID,
-				UUID:      fmt.Sprintf("%032d", osdID),
-				BlockPath: "/dev/path/to/block",
-				CVMode:    "raw",
+				OSDInfoBase: OSDInfoBase{
+					ID:        osdID,
+					UUID:      fmt.Sprintf("%032d", osdID),
+					BlockPath: "/dev/path/to/block",
+					CVMode:    "raw",
+				},
 			},
 		}
 	} else {
@@ -679,10 +681,12 @@ func setStatusConfigMapToCompleted(t *testing.T, cm *corev1.ConfigMap, numOSDsIf
 			osdID := testIDGenerator.osdID(t, fmt.Sprintf("%s-%d", cm.Name, i))
 			disk := k8sutil.IndexToName(i)
 			status.OSDs = append(status.OSDs, OSDInfo{
-				ID:        osdID,
-				UUID:      fmt.Sprintf("%032d", osdID),
-				BlockPath: fmt.Sprintf("/dev/vd%s", disk),
-				CVMode:    "raw",
+				OSDInfoBase: OSDInfoBase{
+					ID:        osdID,
+					UUID:      fmt.Sprintf("%032d", osdID),
+					BlockPath: fmt.Sprintf("/dev/vd%s", disk),
+					CVMode:    "raw",
+				},
 			})
 		}
 	}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -512,6 +512,12 @@ func deploymentOnNode(c *Cluster, osd *OSDInfo, nodeName string, config *provisi
 		return nil, errors.Wrapf(err, "failed to generate config for %s", osdLongName)
 	}
 
+	// Set the per-device class here so the update check at spec.go:357 does not
+	// overwrite it with the node-level default when AllowDeviceClassUpdate is enabled.
+	if dc := perDeviceClassForOSD(osd, osdProps.devices); dc != "" {
+		osdProps.storeConfig.DeviceClass = dc
+	}
+
 	d, err := c.makeDeployment(osdProps, osd, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate deployment for %s", osdLongName)
@@ -586,6 +592,22 @@ func (c *Cluster) getOSDPropsForNode(nodeName, deviceClass string) (osdPropertie
 	}
 
 	return osdProps, nil
+}
+
+func perDeviceClassForOSD(osd *OSDInfo, devices []cephv1.Device) string {
+	if osd.BlockPath == "" {
+		return ""
+	}
+	short := strings.TrimPrefix(osd.BlockPath, "/dev/")
+	for _, d := range devices {
+		if d.Name != "" && strings.TrimPrefix(d.Name, "/dev/") == short {
+			return d.Config[osdconfig.DeviceClassKey]
+		}
+		if d.FullPath != "" && d.FullPath == osd.BlockPath {
+			return d.Config[osdconfig.DeviceClassKey]
+		}
+	}
+	return ""
 }
 
 func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -109,13 +109,13 @@ func New(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, spec ce
 	}
 }
 
-// OSDInfo represent all the properties of a given OSD
-type OSDInfo struct {
+// OSDInfoBase is the physical identity of an OSD as reported by ceph-volume,
+// without CRUSH metadata. See OSDInfo for the full shape.
+type OSDInfoBase struct {
 	ID             int    `json:"id"`
 	Cluster        string `json:"cluster"`
 	UUID           string `json:"uuid"`
 	DevicePartUUID string `json:"device-part-uuid"`
-	DeviceClass    string `json:"device-class"`
 	// BlockPath is the logical Volume path for an OSD created by Ceph-volume with format '/dev/<Volume Group>/<Logical Volume>' or simply /dev/vdb if block mode is used
 	BlockPath     string `json:"lv-path"`
 	MetadataPath  string `json:"metadata-path"`
@@ -126,13 +126,21 @@ type OSDInfo struct {
 	CVMode        string `json:"lv-mode"`
 	Store         string `json:"store"`
 	// Ensure the OSD daemon has affinity with the same topology from the OSD prepare pod
-	TopologyAffinity string             `json:"topologyAffinity"`
-	Encrypted        bool               `json:"encrypted"`
-	ExportService    bool               `json:"exportService"`
-	NodeName         string             `json:"nodeName"`
-	PVCName          string             `json:"pvcName"`
-	DeviceType       string             `json:"device-type"`
-	CephxStatus      cephv1.CephxStatus `json:"cephxStatus"`
+	TopologyAffinity string `json:"topologyAffinity"`
+	Encrypted        bool   `json:"encrypted"`
+	ExportService    bool   `json:"exportService"`
+	NodeName         string `json:"nodeName"`
+	PVCName          string `json:"pvcName"`
+}
+
+// OSDInfo is the wire format between the prepare job and the operator. It
+// embeds OSDInfoBase (ceph-volume output) and adds fields resolved from the CR
+// or managed by the operator.
+type OSDInfo struct {
+	OSDInfoBase
+	DeviceClass string             `json:"device-class"`
+	DeviceType  string             `json:"device-type"`
+	CephxStatus cephv1.CephxStatus `json:"cephxStatus"`
 }
 
 // OrchestrationStatus represents the status of an OSD orchestration

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -445,9 +446,9 @@ func TestPostReconcileUpdateOSDProperties(t *testing.T) {
 
 	// Start the first time
 	desiredOSDs := map[int]*OSDInfo{
-		0: {ID: 0, DeviceClass: "hdd"},
-		1: {ID: 1, DeviceClass: "hdd"},
-		2: {ID: 2, DeviceClass: "newclass"},
+		0: {OSDInfoBase: OSDInfoBase{ID: 0}, DeviceClass: "hdd"},
+		1: {OSDInfoBase: OSDInfoBase{ID: 1}, DeviceClass: "hdd"},
+		2: {OSDInfoBase: OSDInfoBase{ID: 2}, DeviceClass: "newclass"},
 	}
 	t.Run("test device class change", func(t *testing.T) {
 		c.spec.Storage = cephv1.StorageScopeSpec{AllowDeviceClassUpdate: true}
@@ -662,7 +663,7 @@ func TestGetPVCHostName(t *testing.T) {
 	clusterInfo.SetName("mycluster")
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	c := &Cluster{context: &clusterd.Context{Clientset: clientset}, clusterInfo: clusterInfo}
-	osdInfo := OSDInfo{ID: 23}
+	osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 23}}
 	pvcName := "test-pvc"
 
 	// fail to get the host name when there is no pod or deployment
@@ -719,9 +720,9 @@ func TestGetOSDInfo(t *testing.T) {
 
 	node := "n1"
 	location := "root=default host=myhost zone=myzone"
-	osd1 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location, TopologyAffinity: "topology.rook.io/rack=rack0"}
-	osd2 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true}
-	osd3 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "raw"}
+	osd1 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location, TopologyAffinity: "topology.rook.io/rack=rack0"}}
+	osd2 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true}}
+	osd3 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "raw"}}
 	osdProp := osdProperties{
 		crushHostname: node,
 		pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
@@ -772,8 +773,8 @@ func TestGetOSDInfo(t *testing.T) {
 
 	t.Run("get info from node-based OSDs", func(t *testing.T) {
 		useAllDevices := true
-		osd4 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "lvm", Location: location}
-		osd5 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm"}
+		osd4 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "lvm", Location: location}}
+		osd5 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm"}}
 		osdProp = osdProperties{
 			crushHostname: node,
 			devices:       []cephv1.Device{},
@@ -800,10 +801,12 @@ func TestGetOSDInfo(t *testing.T) {
 	t.Run("verify the existence of labels if the corresponding fields are set on OSDInfo and OSDProperties", func(t *testing.T) {
 		pvcName := "test-pvc"
 		osdInfo := &OSDInfo{
-			UUID:       "osd-uuid",
-			BlockPath:  "dev/logical-volume-path",
-			CVMode:     "raw",
-			Store:      "bluestore",
+			OSDInfoBase: OSDInfoBase{
+				UUID:      "osd-uuid",
+				BlockPath: "dev/logical-volume-path",
+				CVMode:    "raw",
+				Store:     "bluestore",
+			},
 			DeviceType: "ssd",
 		}
 		osdProp := osdProperties{
@@ -842,9 +845,11 @@ func TestGetOSDInfo(t *testing.T) {
 	t.Run("verify the non-existence of labels if the corresponding fields are not set on OSDInfo and OSDProperties", func(t *testing.T) {
 		useAllDevices := true
 		osdInfo := &OSDInfo{
-			UUID:      "osd-uuid",
-			BlockPath: "vg1/lv1",
-			CVMode:    "lvm",
+			OSDInfoBase: OSDInfoBase{
+				UUID:      "osd-uuid",
+				BlockPath: "vg1/lv1",
+				CVMode:    "lvm",
+			},
 			// Store and DeviceType are empty (zero values)
 		}
 		osdProp := osdProperties{
@@ -994,9 +999,9 @@ func TestGetOSDInfoWithCustomRoot(t *testing.T) {
 
 	node := "n1"
 	location := "root=custom-root host=myhost zone=myzone"
-	osd1 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location}
-	osd2 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true, Location: location}
-	osd3 := &OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "lvm", Location: location}
+	osd1 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location}}
+	osd2 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true, Location: location}}
+	osd3 := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "lvm", Location: location}}
 	osdProp := osdProperties{
 		crushHostname: node,
 		pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
@@ -1379,4 +1384,65 @@ func TestValidateOSDSettings(t *testing.T) {
 		}
 		assert.Error(t, c.validateOSDSettings())
 	})
+}
+
+func TestOSDInfoJSON(t *testing.T) {
+	original := OSDInfo{
+		OSDInfoBase: OSDInfoBase{
+			ID:               7,
+			Cluster:          "ceph",
+			UUID:             "osd-uuid",
+			DevicePartUUID:   "part-uuid",
+			BlockPath:        "/dev/sda",
+			MetadataPath:     "/dev/sdb",
+			WalPath:          "/dev/sdc",
+			SkipLVRelease:    true,
+			Location:         "root=default host=h",
+			LVBackedPV:       true,
+			CVMode:           "raw",
+			Store:            "bluestore",
+			TopologyAffinity: "topology.rook.io/rack=rack0",
+			Encrypted:        true,
+			ExportService:    true,
+			NodeName:         "node1",
+			PVCName:          "pvc1",
+		},
+		DeviceClass: "fast",
+		DeviceType:  "ssd",
+		CephxStatus: cephv1.CephxStatus{KeyGeneration: 2, KeyCephVersion: "19.2.6-0"},
+	}
+
+	// Marshal and unmarshal back.
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var decoded OSDInfo
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, original, decoded)
+
+	// Unmarshal from a literal JSON string to catch struct-tag drift.
+	literal := `{
+		"id": 7,
+		"cluster": "ceph",
+		"uuid": "osd-uuid",
+		"device-part-uuid": "part-uuid",
+		"device-class": "fast",
+		"lv-path": "/dev/sda",
+		"metadata-path": "/dev/sdb",
+		"wal-path": "/dev/sdc",
+		"skip-lv-release": true,
+		"location": "root=default host=h",
+		"lv-backed-pv": true,
+		"lv-mode": "raw",
+		"store": "bluestore",
+		"topologyAffinity": "topology.rook.io/rack=rack0",
+		"encrypted": true,
+		"exportService": true,
+		"nodeName": "node1",
+		"pvcName": "pvc1",
+		"device-type": "ssd",
+		"cephxStatus": {"keyGeneration": 2, "keyCephVersion": "19.2.6-0"}
+	}`
+	var fromLiteral OSDInfo
+	assert.NoError(t, json.Unmarshal([]byte(literal), &fromLiteral))
+	assert.Equal(t, original, fromLiteral)
 }

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -1386,6 +1386,76 @@ func TestValidateOSDSettings(t *testing.T) {
 	})
 }
 
+func TestPerDeviceClassForOSD(t *testing.T) {
+	tests := []struct {
+		name     string
+		osd      *OSDInfo
+		devices  []cephv1.Device
+		expected string
+	}{
+		{
+			name:     "match by short name, /dev/ prefix on blockPath",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/vdb"}},
+			devices:  []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "fast",
+		},
+		{
+			name:     "match by name with /dev/ prefix in spec",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/vdb"}},
+			devices:  []cephv1.Device{{Name: "/dev/vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "fast",
+		},
+		{
+			name:     "match by FullPath literal equality",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/disk/by-id/wwn-0xabc"}},
+			devices:  []cephv1.Device{{FullPath: "/dev/disk/by-id/wwn-0xabc", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "fast",
+		},
+		{
+			name:     "no match across devices returns empty",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/vdb"}},
+			devices:  []cephv1.Device{{Name: "vdc", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "",
+		},
+		{
+			name:     "matching spec without deviceClass returns empty",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/vdb"}},
+			devices:  []cephv1.Device{{Name: "vdb"}},
+			expected: "",
+		},
+		{
+			name:     "empty blockPath returns empty",
+			osd:      &OSDInfo{},
+			devices:  []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "",
+		},
+		{
+			name: "first matching entry wins on duplicate names",
+			osd:  &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/vdb"}},
+			devices: []cephv1.Device{
+				{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}},
+				{Name: "vdb", Config: map[string]string{"deviceClass": "slow"}},
+			},
+			expected: "fast",
+		},
+		{
+			// LVM blockPath can't be matched to a short kernel name. Caller
+			// must rely on osd.DeviceClass already being resolved by the
+			// daemon list-back path in that case.
+			name:     "LVM blockPath does not match short-name spec",
+			osd:      &OSDInfo{OSDInfoBase: OSDInfoBase{BlockPath: "/dev/ceph-xxx/osd-block-yyy"}},
+			devices:  []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, perDeviceClassForOSD(tt.osd, tt.devices))
+		})
+	}
+}
+
 func TestOSDInfoJSON(t *testing.T) {
 	original := OSDInfo{
 		OSDInfoBase: OSDInfoBase{

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -122,10 +122,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	if len(devices) == 0 && len(dataDir) == 0 {
 		return
 	}
-	osd := &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 
 	osdProp := osdProperties{
 		crushHostname: n.Name,
@@ -203,10 +200,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc"},
 	}
 	// Not needed when running on PVC
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "lvm",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "lvm"}}
 
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
@@ -227,10 +221,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 9, len(cont.VolumeMounts), cont.VolumeMounts)
 
 	// Test OSD on PVC with RAW
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
@@ -270,10 +261,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 11, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes)
 
 	// // Test OSD on PVC with RAW and metadata device
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
@@ -296,10 +284,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 11, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes)
 
 	// // Test encrypted OSD on PVC with RAW and metadata device
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 	osdProp.encrypted = true
 	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
@@ -330,10 +315,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 13, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes)
 
 	// // Test OSD on PVC with RAW / metadata and wal device
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
@@ -358,10 +340,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 13, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes)
 
 	// // Test encrypted OSD on PVC with RAW / metadata and wal device
-	osd = &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd = &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 	osdProp.encrypted = true
 	osdProp.metadataPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
 	osdProp.walPVC = corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
@@ -664,8 +643,10 @@ func TestHostNetwork(t *testing.T) {
 
 	n := c.spec.Storage.ResolveNode(storageSpec.Nodes[0].Name)
 	osd := &OSDInfo{
-		ID:          0,
-		CVMode:      "raw",
+		OSDInfoBase: OSDInfoBase{
+			ID:     0,
+			CVMode: "raw",
+		},
 		DeviceClass: "myclass",
 	}
 
@@ -773,11 +754,13 @@ func TestClusterGetPVCEncryptionInitContainerActivate(t *testing.T) {
 // WARNING! modifies c.deviceSets
 func getDummyDeploymentOnPVC(clientset *fake.Clientset, c *Cluster, pvcName string, osdID int) *appsv1.Deployment {
 	osd := &OSDInfo{
-		ID:        osdID,
-		UUID:      "some-uuid",
-		BlockPath: "/some/path",
-		CVMode:    "raw",
-		Store:     "bluestore",
+		OSDInfoBase: OSDInfoBase{
+			ID:        osdID,
+			UUID:      "some-uuid",
+			BlockPath: "/some/path",
+			CVMode:    "raw",
+			Store:     "bluestore",
+		},
 	}
 	c.deviceSets = append(c.deviceSets, deviceSet{
 		Name: pvcName,
@@ -797,11 +780,13 @@ func getDummyDeploymentOnPVC(clientset *fake.Clientset, c *Cluster, pvcName stri
 // WARNING! modifies c.ValidStorage
 func getDummyDeploymentOnNode(clientset *fake.Clientset, c *Cluster, nodeName string, osdID int) *appsv1.Deployment {
 	osd := &OSDInfo{
-		ID:        osdID,
-		UUID:      "some-uuid",
-		BlockPath: "/dev/vda",
-		CVMode:    "raw",
-		Store:     "bluestore",
+		OSDInfoBase: OSDInfoBase{
+			ID:        osdID,
+			UUID:      "some-uuid",
+			BlockPath: "/dev/vda",
+			CVMode:    "raw",
+			Store:     "bluestore",
+		},
 	}
 	c.ValidStorage.Nodes = append(c.ValidStorage.Nodes, cephv1.Node{Name: nodeName})
 	config := c.newProvisionConfig()
@@ -917,10 +902,7 @@ func TestOSDPlacement(t *testing.T) {
 	}
 
 	c := New(context, clusterInfo, spec, "rook/rook:myversion")
-	osd := &OSDInfo{
-		ID:     0,
-		CVMode: "raw",
-	}
+	osd := &OSDInfo{OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"}}
 
 	dataPathMap := &provisionConfig{
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, "/var/lib/rook"),
@@ -986,8 +968,7 @@ func TestCreateOSDService(t *testing.T) {
 	}
 	c := New(context, clusterInfo, spec, "rook/rook:myversion")
 	osd := OSDInfo{
-		ID:     0,
-		CVMode: "raw",
+		OSDInfoBase: OSDInfoBase{ID: 0, CVMode: "raw"},
 	}
 	service, err := c.createOSDService(osd, map[string]string{})
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -797,6 +797,57 @@ func getDummyDeploymentOnNode(clientset *fake.Clientset, c *Cluster, nodeName st
 	return d
 }
 
+func TestDeploymentOnNodePerDeviceClassBeatsNodeLevel(t *testing.T) {
+	nodeName := "node1"
+	clientset := fake.NewClientset()
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", CephVersion: cephver.Squid}
+	clusterInfo.SetName("testing")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
+	ctx := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
+
+	spec := cephv1.ClusterSpec{
+		DataDirHostPath: "/var/lib/rook",
+		Storage: cephv1.StorageScopeSpec{
+			AllowDeviceClassUpdate: true,
+			Nodes: []cephv1.Node{
+				{
+					Name:   nodeName,
+					Config: map[string]string{"deviceClass": "slow"},
+					Selection: cephv1.Selection{
+						Devices: []cephv1.Device{
+							{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	c := New(ctx, clusterInfo, spec, "myversion")
+	c.ValidStorage.Nodes = spec.Storage.Nodes
+
+	osd := &OSDInfo{
+		OSDInfoBase: OSDInfoBase{
+			ID:        0,
+			UUID:      "some-uuid",
+			BlockPath: "/dev/vdb",
+			CVMode:    "raw",
+			Store:     "bluestore",
+		},
+		DeviceClass: "fast",
+	}
+	d, err := deploymentOnNode(c, osd, nodeName, c.newProvisionConfig())
+	assert.NoError(t, err)
+
+	var envClass string
+	for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "ROOK_OSD_DEVICE_CLASS" {
+			envClass = e.Value
+			break
+		}
+	}
+	assert.Equal(t, "fast", envClass, "per-device class should beat node-level class when AllowDeviceClassUpdate=true")
+}
+
 func TestOSDPlacement(t *testing.T) {
 	clientset := fake.NewClientset()
 	clusterInfo := &cephclient.ClusterInfo{

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -85,11 +85,13 @@ func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatch
 				status = &OrchestrationStatus{
 					OSDs: []OSDInfo{
 						{
-							ID:        1,
-							UUID:      "000000-0000-00000001",
-							Cluster:   "rook",
-							CVMode:    "raw",
-							BlockPath: "/dev/some/path",
+							OSDInfoBase: OSDInfoBase{
+								ID:        1,
+								UUID:      "000000-0000-00000001",
+								Cluster:   "rook",
+								CVMode:    "raw",
+								BlockPath: "/dev/some/path",
+							},
 						},
 					},
 					Status: OrchestrationStatusCompleted,

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -826,10 +826,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 
 	t.Run("empty status and config", func(t *testing.T) {
 		c := newTest(cephv1.CephxConfig{})
-		osdInfo := OSDInfo{
-			ID:          1,
-			CephxStatus: cephv1.CephxStatus{},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 1}, CephxStatus: cephv1.CephxStatus{}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.NoError(t, err)
@@ -842,10 +839,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 			KeyRotationPolicy: "Disabled",
 			KeyGeneration:     3,
 		})
-		osdInfo := OSDInfo{
-			ID:          1,
-			CephxStatus: cephv1.CephxStatus{},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 1}, CephxStatus: cephv1.CephxStatus{}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.NoError(t, err)
@@ -858,10 +852,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 			KeyRotationPolicy: "KeyGeneration",
 			KeyGeneration:     3,
 		})
-		osdInfo := OSDInfo{
-			ID:          1,
-			CephxStatus: cephv1.CephxStatus{},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 1}, CephxStatus: cephv1.CephxStatus{}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.NoError(t, err)
@@ -872,7 +863,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 	t.Run("undefined status, empty config", func(t *testing.T) { // greenfield, no rotation
 		c := newTest(cephv1.CephxConfig{})
 		osdInfo := OSDInfo{
-			ID:          1,
+			OSDInfoBase: OSDInfoBase{ID: 1},
 			CephxStatus: keyring.UninitializedCephxStatus(), // shouldn't happen in reality
 		}
 
@@ -886,10 +877,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 
 	t.Run("set status, empty config", func(t *testing.T) {
 		c := newTest(cephv1.CephxConfig{})
-		osdInfo := OSDInfo{
-			ID:          1,
-			CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 1}, CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.NoError(t, err)
@@ -902,10 +890,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 			KeyRotationPolicy: "KeyGeneration",
 			KeyGeneration:     4,
 		})
-		osdInfo := OSDInfo{
-			ID:          2,
-			CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 2}, CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.NoError(t, err)
@@ -925,10 +910,7 @@ func TestCluster_rotateCephxKey(t *testing.T) {
 				return "", fmt.Errorf("mock error")
 			},
 		}
-		osdInfo := OSDInfo{
-			ID:          2,
-			CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"},
-		}
+		osdInfo := OSDInfo{OSDInfoBase: OSDInfoBase{ID: 2}, CephxStatus: cephv1.CephxStatus{KeyGeneration: 1, KeyCephVersion: "19.2.6-0"}}
 
 		cephxStatus, err := c.rotateCephxKey(osdInfo)
 		assert.Error(t, err)

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -19,7 +19,6 @@ package sys
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	osexec "os/exec"
 	"strconv"
 	"strings"
@@ -287,15 +286,6 @@ func GetDiskDeviceType(disk *LocalDisk) string {
 		return "nvme"
 	}
 	return "ssd"
-}
-
-func GetDiskDeviceClass(crushDeviceClassVarName, deviceType string) string {
-	crushDeviceClass := os.Getenv(crushDeviceClassVarName)
-	if crushDeviceClass != "" {
-		return crushDeviceClass
-	} else {
-		return deviceType
-	}
 }
 
 // CheckIfDeviceAvailable checks if a device is available for consumption. The caller

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -204,12 +204,3 @@ func TestGetDiskDeviceType(t *testing.T) {
 	d.RealPath = "nvme"
 	assert.Equal(t, "nvme", GetDiskDeviceType(d))
 }
-
-func TestGetDiskDeviceClass(t *testing.T) {
-	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "test")
-	assert.Equal(t, "test", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "hdd"))
-	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "test1")
-	assert.Equal(t, "test1", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "hdd"))
-	t.Setenv("ROOK_OSD_CRUSH_DEVICE_CLASS", "")
-	assert.Equal(t, "nvme", GetDiskDeviceClass("ROOK_OSD_CRUSH_DEVICE_CLASS", "nvme"))
-}


### PR DESCRIPTION
Closes #16834.

**Problem trace:**
- Operator passes cluster/node-level device-class as env var (`ROOK_OSD_CRUSH_DEVICE_CLASS`) and per-device config as `--data-devices` JSON to the osd-prepare job.
- Prepare job provisions the OSD correctly: per-device value overrides cluster/node.
- Prepare job then calls `GetCephVolumeRawOSDs` to list and report OSDs back to the operator. That path called [`sys.GetDiskDeviceClass`](https://github.com/rook/rook/blob/e74fed5b28f12800a09bbf1dd6300dac61b93f81/pkg/util/sys/device.go#L292-L299) which only read the env var and ignored the per-device value.
- Operator uses the wrong class for the pod label, and with `allowDeviceClassUpdate: true` rewrites CRUSH to match.

## What changed

Before, device-class resolution was split/duplicated across four places:

- `sys.GetDiskDeviceClass` — env-var reader used by the raw list path.
- `DesiredDevice.UpdateDeviceClass` — priority logic that *did* consult CR config, but was never called on the list path.
- inline `os.Getenv(CrushDeviceClassVarName)` in [`initializeBlockPVC`](https://github.com/rook/rook/blob/e74fed5b28f12800a09bbf1dd6300dac61b93f81/pkg/daemon/ceph/osd/volume.go#L301-L303).
- `appendDeviceClassArg` — yet another variant, used only by LVM batch.

Replaced with:

1. Three helpers on `OsdAgent` — `deviceClass(d)`, `deviceClassByPath(paths)`, `defaultDeviceClass()` — one priority (per-device → node/cluster default → env var for PVC). Every site calls one of these.
2. `GetCephVolumeRawOSDs` signature simplified: no more `skipDeviceClass` bool, returns `[]OSDInfoBase` (physical identity only). Class/type enrichment lives in a thin wrapper, `listRawOSDsEnriched`, that callers use.
3. `OSDInfo` split into `OSDInfoBase` (ceph-volume output) + `OSDInfo` (embeds base + `DeviceClass` + `DeviceType` + `CephxStatus`) to prevent bugs if someone will use non-initialized struct. 

I know this is larger than the bug strictly requires. If that's too much, a minimal hotfix is: thread `DesiredDevice.DeviceClass` through `GetCephVolumeRawOSDs`, match by block path, fall back to env var only when per-device is empty; leave `OSDInfo` and `sys.GetDiskDeviceClass` untouched.

## Testing

Manually tested on minikube:
- per-device `deviceClass` (no node-level) — works.
- node-level `deviceClass` only — works.
- nothing set, autodetected from disk type — works.
- `allowDeviceClassUpdate: false` — operator doesn't touch CRUSH.
- per-device + node-level together — operator still overwrites per-device with node-level. Not fixed here. See: #17384

## Notes

**Encrypted OSDs — not tested.** I didn't set up an encrypted cluster to verify behaviour here. The provisioning flow looks different (blockPath ends up with a `-dmcrypt` suffix per [`volume.go:1378`](https://github.com/rook/rook/blob/e74fed5b28f12800a09bbf1dd6300dac61b93f81/pkg/daemon/ceph/osd/volume.go#L1378)), so matching the spec back through the listing path may or may not work the same way. Worth a separate check.

[`GetCephVolumeLVMOSDs`](https://github.com/rook/rook/blob/e74fed5b28f12800a09bbf1dd6300dac61b93f81/pkg/daemon/ceph/osd/volume.go#L1139-L1150) constructs `OSDInfo` without `DeviceType`, and I couldn't find anywhere else that fills it in for LVM-mode OSDs. I don't know if it was intentional. Possibly related to #16865 / #17113 which fixed a similar-looking "label disappears" symptom on the raw path.
