### PR TITLE
mon: change default protocol to msgrv2 instead of msgrv1

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,9 @@
 ## Breaking Changes
 
 - Helm OCI chart tags no longer include the `v` prefix (e.g., `1.21.0` instead of `v1.21.0`). Update any scripts or tooling that reference the chart by tag.
+- Ceph msgrv2 is required by default. Msgrv2 requires the 5.11 kernel. If you have an older kernel, disable the msgrv2 protocol
+  with the CephCluster CR setting `network.connections.requireMsgr2: true`. If using the helm chart, this same value is applied
+  under the `cephClusterSpec` of the values.
 
 ## Features
 

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -199,7 +199,7 @@ cephClusterSpec:
       # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
       # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
       # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
-      requireMsgr2: false
+      requireMsgr2: true
   #   # enable host networking
   #   provider: host
   #   # EXPERIMENTAL: enable the Multus network provider

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -32,6 +32,9 @@ spec:
     enabled: true
   crashCollector:
     disable: true
+  network:
+    connections:
+      requireMsgr2: true
   storage:
     useAllNodes: true
     useAllDevices: true

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -111,7 +111,7 @@ spec:
       # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
       # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
       # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
-      requireMsgr2: false
+      requireMsgr2: true
     # enable host networking
     #provider: host
     # enable the Multus network provider

--- a/pkg/operator/ceph/controller/cluster_info.go
+++ b/pkg/operator/ceph/controller/cluster_info.go
@@ -202,6 +202,9 @@ func loadCsiSettings(namespace string, cephClusterSpec *cephv1.ClusterSpec) ceph
 			if cephClusterSpec.NetworkEncryptionEnabled() {
 				log.NamespacedInfo(namespace, logger, "setting default cephfs kernel mount options to 'ms_mode=secure' since encryption is enabled")
 				settings.CephFS.KernelMountOptions = "ms_mode=secure"
+			} else if cephClusterSpec.RequireMsgr2() {
+				log.NamespacedInfo(namespace, logger, "setting default cephfs kernel mount options to 'ms_mode=prefer-crc'")
+				settings.CephFS.KernelMountOptions = "ms_mode=prefer-crc"
 			}
 		}
 	}

--- a/pkg/operator/ceph/controller/cluster_info_test.go
+++ b/pkg/operator/ceph/controller/cluster_info_test.go
@@ -141,6 +141,16 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.Equal(t, "testkey", info.CephCred.Secret)
 	assert.Equal(t, "", info.CSIDriverSpec.CephFS.KernelMountOptions)
 
+	// Require msgr2 and verify the csi settings default to prefer-crc if the network is not encrypted
+	cephClusterSpec.Network = cephv1.NetworkSpec{
+		Connections: &cephv1.ConnectionsSpec{
+			RequireMsgr2: true,
+		},
+	}
+	info, _, _, err = CreateOrLoadClusterInfo(context, ctx, namespace, ownerInfo, cephClusterSpec)
+	assert.NoError(t, err)
+	assert.Equal(t, "ms_mode=prefer-crc", info.CSIDriverSpec.CephFS.KernelMountOptions)
+
 	// Verify the csi settings default to secure if the network is encrypted
 	cephClusterSpec.Network = cephv1.NetworkSpec{
 		Connections: &cephv1.ConnectionsSpec{

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -247,19 +247,20 @@ spec:
 `
 	}
 
+	msMode := "prefer-crc"
 	if m.settings.ConnectionsEncrypted {
-		clusterSpec += `
+		msMode = "secure"
+	}
+	clusterSpec += `
   csi:
     cephfs:
-      kernelMountOptions: ms_mode=secure
-  `
-	}
-	return clusterSpec + `
+      kernelMountOptions: ms_mode=` + msMode + `
   priorityClassNames:
     mon: system-node-critical
     osd: system-node-critical
     mgr: system-cluster-critical
 `
+	return clusterSpec
 }
 
 func (m *CephManifestsMaster) GetBlockSnapshotClass(snapshotClassName, reclaimPolicy string) string {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -445,9 +445,9 @@ func (s *UpgradeSuite) upgradeToMaster() {
 	s.settings.RookVersion = installer.LocalBuildTag
 	s.installer.Manifests = installer.NewCephManifests(s.settings)
 
+	logger.Info("Requiring msgr2 during helm upgrade to test the port conversion from 6789 to 3300")
+	s.settings.RequireMsgr2 = true
 	if s.settings.UseHelm {
-		logger.Info("Requiring msgr2 during helm upgrade to test the port conversion from 6789 to 3300")
-		s.settings.RequireMsgr2 = true
 		// Upgrade the operator chart
 		err := s.installer.UpgradeRookOperatorViaHelm()
 		require.NoError(s.T(), err, "failed to upgrade the operator chart")


### PR DESCRIPTION
The msgrv2 protocol has been available since the 5.11 kernel, which has been out for five years. Rook is changing by default to require the msgrv2 protocol for internal and external clusters.

If needed, it is still possible to disable this setting and enable the v1 protocol.
- Internal clusters: In the CephCluster CR: `network.connections.requireMsgr2: false`
- External clusters: `--v2-port-enable=False`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17081

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
