### PR TITLE
osd: honor per-device deviceClass in raw-mode prepare and reconcile

### DIFF
--- a/pkg/daemon/ceph/cleanup/disk.go
+++ b/pkg/daemon/ceph/cleanup/disk.go
@@ -70,7 +70,7 @@ func (s *DiskSanitizer) StartSanitizeDisks() {
 	}
 
 	// Raw based OSDs
-	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", "", false, true)
+	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", "", false, true, nil)
 	if err != nil {
 		logger.Errorf("failed to list raw osd(s). %v", err)
 	} else {

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -415,7 +415,7 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 		rejectedReason := ""
 		if agent.pvcBacked {
 			block := fmt.Sprintf("/mnt/%s", agent.nodeName)
-			rawOsds, err := GetCephVolumeRawOSDs(context, agent.clusterInfo, agent.clusterInfo.FSID, block, agent.metadataDevice, "", false, true)
+			rawOsds, err := GetCephVolumeRawOSDs(context, agent.clusterInfo, agent.clusterInfo.FSID, block, agent.metadataDevice, "", false, true, nil)
 			if err != nil {
 				isAvailable = false
 				rejectedReason = fmt.Sprintf("failed to detect if there is already an osd. %v", err)
@@ -612,7 +612,7 @@ func GetOSDInfoById(context *clusterd.Context, clusterInfo *client.ClusterInfo, 
 	}
 
 	// Raw mode OSDs
-	osdRawList, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, "", "", "", false, true)
+	osdRawList, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, "", "", "", false, true, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list raw osd(s)")
 	}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -145,7 +145,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			// I'm leaving this code with an empty metadata device for now
 			metadataBlock, walBlock = "", ""
 
-			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
+			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false, a.devices)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
@@ -160,7 +160,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			osds = append(osds, lvmOsds...)
 
 			// List existing OSD(s) configured with ceph-volume raw mode
-			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false)
+			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false, a.devices)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
@@ -212,7 +212,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if !a.pvcBacked {
 		block = ""
 	}
-	rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false)
+	rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV, false, a.devices)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
@@ -298,10 +298,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				}
 			}
 
-			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-			if crushDeviceClass != "" {
-				immediateExecuteArgs = append(immediateExecuteArgs, []string{crushDeviceClassFlag, crushDeviceClass}...)
-			}
+			immediateExecuteArgs = a.appendDeviceClassArg(device, immediateExecuteArgs)
 
 			if isEncrypted {
 				immediateExecuteArgs = append(immediateExecuteArgs, encryptedFlag)
@@ -846,6 +843,31 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 	return nil
 }
 
+// findDeviceClass returns the CR-declared deviceClass for the OSD, or "" if not found.
+func findDeviceClass(devices []DesiredDevice, blockPath, kernelName, devLinks string) string {
+	short := strings.TrimPrefix(blockPath, "/dev/")
+	for _, d := range devices {
+		if d.IsFilter || d.IsDevicePathFilter || d.DeviceClass == "" || d.Name == "" {
+			continue
+		}
+		// match by device name:
+		if shortName := strings.TrimPrefix(d.Name, "/dev/"); shortName != "" {
+			if shortName == short || shortName == kernelName {
+				return d.DeviceClass
+			}
+		}
+		// match by fullname (udev DEVLINKS):
+		if strings.HasPrefix(d.Name, "/dev/") && devLinks != "" {
+			for _, link := range strings.Fields(devLinks) {
+				if link == d.Name {
+					return d.DeviceClass
+				}
+			}
+		}
+	}
+	return ""
+}
+
 func (a *OsdAgent) appendDeviceClassArg(device *DeviceOsdIDEntry, args []string) []string {
 	deviceClass := device.Config.DeviceClass
 	if deviceClass == "" {
@@ -1180,7 +1202,7 @@ func readCVLogContent(cvLogFilePath string) string {
 // On the other hand, the PVC scenario always uses the PVC block as a block to check whether the
 // disk is an OSD or not.
 // The same goes for "metadataBlock" and "walBlock" they are only used in the prepare job.
-func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock, walBlock string, lvBackedPV, skipDeviceClass bool) ([]oposd.OSDInfo, error) {
+func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock, walBlock string, lvBackedPV, skipDeviceClass bool, devices []DesiredDevice) ([]oposd.OSDInfo, error) {
 	// lv can be a block device if raw mode is used
 	cvMode := "raw"
 
@@ -1360,8 +1382,18 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 			osd.DeviceType = deviceType
 			logger.Infof("setting device type %q for device %q", osd.DeviceType, diskInfo.Name)
 
-			crushDeviceClass := sys.GetDiskDeviceClass(oposd.CrushDeviceClassVarName, deviceType)
-			osd.DeviceClass = crushDeviceClass
+			osd.DeviceClass = sys.GetDiskDeviceClass(oposd.CrushDeviceClassVarName, deviceType)
+			if len(devices) > 0 {
+				// populate udev DevLinks to match CR device fullpath entries
+				if _, err := clusterd.PopulateDeviceUdevInfo(blockPath, context.Executor, diskInfo); err != nil {
+					logger.Warningf("failed to populate udev info for %q: %v", blockPath, err)
+				}
+				if dc := findDeviceClass(devices, blockPath, diskInfo.KernelName, diskInfo.DevLinks); dc != "" {
+					osd.DeviceClass = dc
+				} else {
+					logger.Debugf("no CR per-device spec matched blockPath=%q kernel=%q devLinks=%q; using disk-derived class", blockPath, diskInfo.KernelName, diskInfo.DevLinks)
+				}
+			}
 			logger.Infof("setting device class %q for device %q", osd.DeviceClass, diskInfo.Name)
 		}
 

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -1599,18 +1600,43 @@ func TestInitializeBlockPVC(t *testing.T) {
 
 		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
-	// Test with flag --crush-device-class.
-	t.Setenv(oposd.CrushDeviceClassVarName, "foo")
+	// node-level class via storeConfig (flag-bound to ROOK_OSD_CRUSH_DEVICE_CLASS)
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
 	}
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}},
 		},
 	}
 
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	assert.Nil(t, err)
+	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
+	assert.Equal(t, "", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
+
+	// per-device class overrides node-level
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[7] == "--crush-device-class" ||
+			args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "prepare" && args[6] == "--bluestore" && args[9] == "--crush-device-class" {
+			if len(args) > 9 {
+				assert.Equal(t, "bar", args[10])
+			} else {
+				assert.Equal(t, "bar", args[8])
+			}
+			return initializeBlockPVCTestResult, nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}}
+	devices = &DeviceOsdMapping{
+		Entries: map[string]*DeviceOsdIDEntry{
+			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k", DeviceClass: "bar"}},
+		},
+	}
 	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
@@ -1631,7 +1657,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition when osd is prepared with existing osd ID
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sda"}},
@@ -1653,7 +1679,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition that --osd-id is not passed for the devices that don't match the OSD to be replaced.
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sdb"}},
@@ -1718,12 +1744,11 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 	}
 
 	// Test with flag --block.db and --crush-device-class flag.
-	t.Setenv(oposd.CrushDeviceClassVarName, "foo")
 	context = &clusterd.Context{Executor: executor}
 	clusterInfo = &cephclient.ClusterInfo{
 		CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0},
 	}
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}}
 
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
@@ -1783,7 +1808,7 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "name"}
 
 	context := &clusterd.Context{Executor: executor, Clientset: test.New(t, 3)}
-	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false, false)
+	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false, false, nil)
 	assert.Nil(t, err)
 	require.NotNil(t, osds)
 	assert.Equal(t, 2, len(osds))
@@ -2359,4 +2384,86 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	context.Executor = executor
 	err = agent.WipeDevicesFromOtherClusters(context)
 	assert.NoError(t, err)
+}
+
+func TestFindDeviceClass(t *testing.T) {
+	tests := []struct {
+		name       string
+		devices    []DesiredDevice
+		blockPath  string
+		kernelName string
+		devLinks   string
+		want       string
+	}{
+		{"short name matches", []DesiredDevice{{Name: "vdb", DeviceClass: "fast"}}, "/dev/vdb", "vdb", "", "fast"},
+		{"/dev/-prefixed name matches", []DesiredDevice{{Name: "/dev/vdb", DeviceClass: "fast"}}, "/dev/vdb", "vdb", "", "fast"},
+		{"kernel-name fallback (LVM blockPath)", []DesiredDevice{{Name: "sdb", DeviceClass: "fast"}}, "/dev/ceph-abc/osd-block-xyz", "sdb", "", "fast"},
+		{"fullpath via DevLinks", []DesiredDevice{{Name: "/dev/disk/by-id/wwn-0x123", DeviceClass: "fast"}}, "/dev/sda", "sda", "/dev/disk/by-id/wwn-0x123 /dev/disk/by-path/pci-foo", "fast"},
+		{"fullpath without DevLinks does not match", []DesiredDevice{{Name: "/dev/disk/by-id/wwn-0x123", DeviceClass: "fast"}}, "/dev/sda", "sda", "", ""},
+		{"no match returns empty", []DesiredDevice{{Name: "vdb", DeviceClass: "fast"}}, "/dev/vdc", "vdc", "", ""},
+		{"filter entry skipped", []DesiredDevice{{Name: "vd.*", DeviceClass: "fast", IsFilter: true}}, "/dev/vdb", "vdb", "", ""},
+		{"device-path filter skipped", []DesiredDevice{{Name: "/dev/vd.*", DeviceClass: "fast", IsDevicePathFilter: true}}, "/dev/vdb", "vdb", "", ""},
+		{"entry without class skipped", []DesiredDevice{{Name: "vdb"}}, "/dev/vdb", "vdb", "", ""},
+		{"empty list returns empty", nil, "/dev/vdb", "vdb", "", ""},
+		{"entry without name skipped", []DesiredDevice{{DeviceClass: "fast"}}, "/dev/vdb", "vdb", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, findDeviceClass(tc.devices, tc.blockPath, tc.kernelName, tc.devLinks))
+		})
+	}
+}
+
+func TestGetCephVolumeRawOSDsHonorDeviceClass(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if command == "stdbuf" && args[4] == "raw" && args[5] == "list" {
+			return cephVolumeRAWTestResult, nil
+		}
+		if command == "lsblk" && (args[0] == "/dev/vdb" || args[0] == "/dev/vdc") {
+			base := strings.TrimPrefix(args[0], "/dev/")
+			return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], base), nil
+		}
+		if command == "udevadm" {
+			return "", nil
+		}
+		if command == "sgdisk" {
+			return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
+		}
+		return "", errors.Errorf("unknown command: %s, args: %#v", command, args)
+	}
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "name"}
+	ctx := &clusterd.Context{Executor: executor, Clientset: test.New(t, 3)}
+
+	tests := []struct {
+		name       string
+		perNode    string
+		devices    []DesiredDevice
+		wantPerDev map[string]string
+	}{
+		{
+			name:       "per-device class wins over disk-derived class",
+			devices:    []DesiredDevice{{Name: "vdb", DeviceClass: "fast"}},
+			wantPerDev: map[string]string{"/dev/vdb": "fast", "/dev/vdc": "hdd"},
+		},
+		{
+			name:       "per-node class only (no per-device) applies to all OSDs",
+			perNode:    "slow",
+			devices:    []DesiredDevice{{Name: "vdb"}, {Name: "vdc"}},
+			wantPerDev: map[string]string{"/dev/vdb": "slow", "/dev/vdc": "slow"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(oposd.CrushDeviceClassVarName, tc.perNode)
+			osds, err := GetCephVolumeRawOSDs(ctx, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false, false, tc.devices)
+			assert.NoError(t, err)
+			require.Len(t, osds, 2)
+			got := map[string]string{}
+			for _, o := range osds {
+				got[o.BlockPath] = o.DeviceClass
+			}
+			assert.Equal(t, tc.wantPerDev, got)
+		})
+	}
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -559,6 +559,28 @@ func (c *Cluster) resolveNode(nodeName, deviceClass string) *cephv1.Node {
 	return rookNode
 }
 
+// perDeviceClassForOSD returns the per-device deviceClass from the CR that
+// provisioned this OSD, or "" if no matching device spec is found.
+func perDeviceClassForOSD(osd *OSDInfo, devices []cephv1.Device) string {
+	if osd.BlockPath == "" {
+		return ""
+	}
+	short := strings.TrimPrefix(osd.BlockPath, "/dev/")
+	for _, device := range devices {
+		deviceConfig := device.Config[osdconfig.DeviceClassKey]
+		if deviceConfig == "" {
+			continue
+		}
+		if device.Name != "" && strings.TrimPrefix(device.Name, "/dev/") == short {
+			return deviceConfig
+		}
+		if device.FullPath != "" && device.FullPath == osd.BlockPath {
+			return deviceConfig
+		}
+	}
+	return ""
+}
+
 func (c *Cluster) getOSDPropsForNode(nodeName, deviceClass string) (osdProperties, error) {
 	// fully resolve the storage config and resources for this node
 	n := c.resolveNode(nodeName, deviceClass)

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -1380,3 +1380,70 @@ func TestValidateOSDSettings(t *testing.T) {
 		assert.Error(t, c.validateOSDSettings())
 	})
 }
+
+func TestPerDeviceClassForOSD(t *testing.T) {
+	tests := []struct {
+		name    string
+		osd     OSDInfo
+		devices []cephv1.Device
+		want    string
+	}{
+		{
+			name:    "short name match",
+			osd:     OSDInfo{BlockPath: "/dev/vdb"},
+			devices: []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			want:    "fast",
+		},
+		{
+			name:    "CR name with /dev/ prefix matches",
+			osd:     OSDInfo{BlockPath: "/dev/vdb"},
+			devices: []cephv1.Device{{Name: "/dev/vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			want:    "fast",
+		},
+		{
+			name:    "FullPath match",
+			osd:     OSDInfo{BlockPath: "/dev/disk/by-id/wwn-0x123"},
+			devices: []cephv1.Device{{FullPath: "/dev/disk/by-id/wwn-0x123", Config: map[string]string{"deviceClass": "nvmeish"}}},
+			want:    "nvmeish",
+		},
+		{
+			name:    "empty BlockPath returns empty",
+			osd:     OSDInfo{BlockPath: ""},
+			devices: []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			want:    "",
+		},
+		{
+			name:    "no match returns empty",
+			osd:     OSDInfo{BlockPath: "/dev/vdc"},
+			devices: []cephv1.Device{{Name: "vdb", Config: map[string]string{"deviceClass": "fast"}}},
+			want:    "",
+		},
+		{
+			name:    "spec without class returns empty",
+			osd:     OSDInfo{BlockPath: "/dev/vdb"},
+			devices: []cephv1.Device{{Name: "vdb"}},
+			want:    "",
+		},
+		{
+			name: "first match wins",
+			osd:  OSDInfo{BlockPath: "/dev/vdb"},
+			devices: []cephv1.Device{
+				{Name: "vdb", Config: map[string]string{"deviceClass": "first"}},
+				{Name: "vdb", Config: map[string]string{"deviceClass": "second"}},
+			},
+			want: "first",
+		},
+		{
+			// LVM limitation: BlockPath is an LV path, doesn't map to CR Name.
+			name:    "LVM BlockPath returns empty",
+			osd:     OSDInfo{BlockPath: "/dev/ceph-abc/osd-block-xyz"},
+			devices: []cephv1.Device{{Name: "sdb", Config: map[string]string{"deviceClass": "fast"}}},
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, perDeviceClassForOSD(&tc.osd, tc.devices))
+		})
+	}
+}

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -354,9 +354,15 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 		return nil, errors.Errorf("failed to generate deployment for OSD %d. required CVMode is not specified for this OSD", osd.ID)
 	}
 
-	if c.spec.Storage.AllowDeviceClassUpdate && osdProps.storeConfig.DeviceClass != "" && osdProps.storeConfig.DeviceClass != osd.DeviceClass {
-		log.NamespacedInfo(c.clusterInfo.Namespace, logger, "The device class for osd %d is changing from %q to %q", osd.ID, osd.DeviceClass, osdProps.storeConfig.DeviceClass)
-		osd.DeviceClass = osdProps.storeConfig.DeviceClass
+	if c.spec.Storage.AllowDeviceClassUpdate {
+		desiredClass := osdProps.storeConfig.DeviceClass
+		if dc := perDeviceClassForOSD(osd, osdProps.devices); dc != "" {
+			desiredClass = dc
+		}
+		if desiredClass != "" && desiredClass != osd.DeviceClass {
+			log.NamespacedInfo(c.clusterInfo.Namespace, logger, "The device class for osd %d is changing from %q to %q", osd.ID, osd.DeviceClass, desiredClass)
+			osd.DeviceClass = desiredClass
+		}
 	}
 	// Assign the resources specific to this device class
 	if resources, ok := cephv1.GetOSDResourcesForDeviceClass(c.spec.Resources, osd.DeviceClass); ok {

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -1002,3 +1002,127 @@ func TestCreateOSDService(t *testing.T) {
 	assert.Equal(t, 1, len(service.Spec.Ports))
 	assert.Equal(t, int32(osdPortv2), service.Spec.Ports[0].Port)
 }
+
+func crushDeviceClassEnvValue(t *testing.T, d *appsv1.Deployment) string {
+	t.Helper()
+	for _, c := range d.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == CrushDeviceClassVarName {
+				return e.Value
+			}
+		}
+	}
+	return ""
+}
+
+func newClusterWithAllowDeviceClassUpdate(t *testing.T, allowUpdate bool) *Cluster {
+	clientset := fake.NewClientset()
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", CephVersion: cephver.Squid}
+	clusterInfo.SetName("testing")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
+	ctx := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
+	spec := cephv1.ClusterSpec{
+		Storage: cephv1.StorageScopeSpec{AllowDeviceClassUpdate: allowUpdate},
+	}
+	return New(ctx, clusterInfo, spec, "rook/rook:myversion")
+}
+
+func TestMakeDeploymentWithAllowDeviceClassUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentOSD   string
+		perNodeNew   string
+		perDeviceNew string
+		want         string
+	}{
+		{
+			name:         "per-device class beats node-level",
+			currentOSD:   "hdd",
+			perNodeNew:   "slow",
+			perDeviceNew: "fast",
+			want:         "fast",
+		},
+		{
+			name:       "per-node updates when per-device is not set",
+			currentOSD: "slow",
+			perNodeNew: "fast",
+			want:       "fast",
+		},
+		{
+			name:         "per-device wins when per-node changes",
+			currentOSD:   "fast",
+			perNodeNew:   "very-fast",
+			perDeviceNew: "fast",
+			want:         "fast",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newClusterWithAllowDeviceClassUpdate(t, true)
+			devices := []cephv1.Device{{Name: "vdb"}}
+			if tc.perDeviceNew != "" {
+				devices[0].Config = map[string]string{"deviceClass": tc.perDeviceNew}
+			}
+			osdProps := osdProperties{
+				crushHostname: "node1",
+				devices:       devices,
+				storeConfig:   config.StoreConfig{StoreType: "bluestore", DeviceClass: tc.perNodeNew},
+			}
+			osd := &OSDInfo{ID: 0, UUID: "u", BlockPath: "/dev/vdb", CVMode: "raw", Store: "bluestore", DeviceClass: tc.currentOSD}
+			cfg := &provisionConfig{DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, "/var/lib/rook")}
+
+			d, err := c.makeDeployment(osdProps, osd, cfg)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, osd.DeviceClass)
+			assert.Equal(t, tc.want, crushDeviceClassEnvValue(t, d))
+		})
+	}
+}
+
+func TestMakeDeploymentAllowDeviceClassUpdateFalseLeavesClassAlone(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentOSD   string
+		perNodeNew   string
+		perDeviceNew string
+	}{
+		{
+			name:         "per-device set, per-node changing",
+			currentOSD:   "hdd",
+			perNodeNew:   "slow",
+			perDeviceNew: "fast",
+		},
+		{
+			name:       "per-node-only changing",
+			currentOSD: "slow",
+			perNodeNew: "fast",
+		},
+		{
+			name:         "per-device set, per-node changing again",
+			currentOSD:   "fast",
+			perNodeNew:   "very-fast",
+			perDeviceNew: "fast",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newClusterWithAllowDeviceClassUpdate(t, false)
+			devices := []cephv1.Device{{Name: "vdb"}}
+			if tc.perDeviceNew != "" {
+				devices[0].Config = map[string]string{"deviceClass": tc.perDeviceNew}
+			}
+			osdProps := osdProperties{
+				crushHostname: "node1",
+				devices:       devices,
+				storeConfig:   config.StoreConfig{StoreType: "bluestore", DeviceClass: tc.perNodeNew},
+			}
+			osd := &OSDInfo{ID: 0, UUID: "u", BlockPath: "/dev/vdb", CVMode: "raw", Store: "bluestore", DeviceClass: tc.currentOSD}
+			cfg := &provisionConfig{DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, "/var/lib/rook")}
+
+			d, err := c.makeDeployment(osdProps, osd, cfg)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.currentOSD, osd.DeviceClass)
+			assert.Equal(t, tc.currentOSD, crushDeviceClassEnvValue(t, d))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #16834 and #17384. 


Per-OSD CR deviceClass was ignored in osd prepare job when reporting the osd config back to the operator, and in the operator's reconcile override.
Fixed by resolving the per-device class from the CR devices list in GetCephVolumeRawOSDs and in makeDeployment.

Min fix alternative to reactoring in #17398