### PR TITLE
osd: fix KMS log error format specifier

### DIFF
--- a/pkg/daemon/ceph/osd/kms/kms.go
+++ b/pkg/daemon/ceph/osd/kms/kms.go
@@ -501,7 +501,7 @@ func putSecret(v secrets.Secrets, secretName, secretValue string, keyContext map
 	if key != "" {
 		logger.Debugf("key %q already exists in kms!", secretName)
 		if key != secretValue {
-			logger.Error("value for secret %q is not expected to be changed", secretName)
+			logger.Errorf("value for secret %q is not expected to be changed", secretName)
 		}
 		return nil
 	}


### PR DESCRIPTION
During OSD provisioning, the KMS error log incorrectly uses logger.Error() instead of logger.Errorf(), causing the format specifier %q to appear in the logs. Changed logger.Error to logger.Errorf to fix the same.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
