### PR TITLE
object: migrate bucket policy methods to aws sdk v2

### DIFF
--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -17,9 +17,10 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/s3"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -161,17 +162,17 @@ func NewBucketPolicy(ps ...PolicyStatement) *BucketPolicy {
 }
 
 // PutBucketPolicy applies the policy to the bucket
-func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBucketPolicyOutput, error) {
+func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3v2.PutBucketPolicyOutput, error) {
 	confirmRemoveSelfBucketAccess := false
 	serializedPolicy, _ := json.Marshal(policy)
 	consumablePolicy := string(serializedPolicy)
 
-	p := &s3.PutBucketPolicyInput{
+	p := &s3v2.PutBucketPolicyInput{
 		Bucket:                        &bucket,
 		ConfirmRemoveSelfBucketAccess: &confirmRemoveSelfBucketAccess,
 		Policy:                        &consumablePolicy,
 	}
-	out, err := s.Client.PutBucketPolicy(p)
+	out, err := s.ClientV2.PutBucketPolicy(context.TODO(), p)
 	if err != nil {
 		return out, err
 	}
@@ -179,7 +180,7 @@ func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBu
 }
 
 func (s *S3Agent) GetBucketPolicy(bucket string) (*BucketPolicy, error) {
-	out, err := s.Client.GetBucketPolicy(&s3.GetBucketPolicyInput{
+	out, err := s.ClientV2.GetBucketPolicy(context.TODO(), &s3v2.GetBucketPolicyInput{
 		Bucket: &bucket,
 	})
 	if err != nil {


### PR DESCRIPTION
migrate PutBucketPolicy and GetBucketPolicy to use aws sdk v2 client.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
