### PR TITLE
core:remove newlines from liveness probe scripts

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -82,25 +82,21 @@ type daemonConfig struct {
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "ceph-spec")
 
 var (
-	osdLivenessProbeScript = `
-outp="$(ceph --admin-daemon %s %s 2>&1)"
+	osdLivenessProbeScript = `outp="$(ceph --admin-daemon %s %s 2>&1)"
 rc=$?
 if [ $rc -ne 0 ] && [ ! -f /tmp/osd-sleep ]; then
 	echo "ceph daemon health check failed with the following output:"
 	echo "$outp" | sed -e 's/^/> /g'
 	exit $rc
-fi
-`
+fi`
 
-	livenessProbeScript = `
-outp="$(ceph --admin-daemon %s %s 2>&1)"
+	livenessProbeScript = `outp="$(ceph --admin-daemon %s %s 2>&1)"
 rc=$?
 if [ $rc -ne 0 ]; then
 	echo "ceph daemon health check failed with the following output:"
 	echo "$outp" | sed -e 's/^/> /g'
 	exit $rc
-fi
-`
+fi`
 
 	cronLogRotate = `
 CEPH_CLIENT_ID=%s


### PR DESCRIPTION
[CRI-O bug ](https://github.com/cri-o/cri-o/issues/9885)causes probe failures when the shell script argument starts with a newline. Issue is seen on OCP s390x using CRI-O 1.35. 

Strip unnecessary leading and trailing newlines from osdLivenessProbeScript and livenessProbeScript raw string literals in spec.go.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
