### PR TITLE
docs: clean linting part of the contributing guide

### DIFF
--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -253,7 +253,6 @@ Common cases that may need tests:
 Run `make lint` to run all linters. This will require the following CLI tools to be installed on the system:
 
 * [yamllint](https://www.yamllint.com/)
-* [shellcheck](https://www.shellcheck.net/)
 * [pylint](https://www.pylint.org/)
 
 Many of those tools are available via `brew` for MacOS or as Linux distribution packages.


### PR DESCRIPTION
**Description:** 

The section about make lint in the contributing guide mentions several tools that need to be installed locally to run the linters.

with PR #17311 which has made the shellcheck target self-contained, the requirement is now gone for shellcheck.

This change simlifies the guide by removing the mention of shellcheck as required to be installed.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
