### PR TITLE
build: declare generate-docs-crds PHONY to fix local checkmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,8 @@ docs-build:  ## Build the documentation to the `site/` directory
 
 .PHONY: gen.crd-docs
 gen.crd-docs: generate-docs-crds
+
+.PHONY: generate-docs-crds
 generate-docs-crds: crds.docs ## Build the documentation for CRDs
 
 .PHONY: generate


### PR DESCRIPTION
**Description:**

Locally, `make checkmake`complained that the target `generate-docs-crds` should be declared PHONY.

And it should in fact be PHONY as it is a target without recipe depending on another PHONY target.

This change fixes the local xheckmake run by declaring generate-docs-crds PHONY as desired.



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
