### PR TITLE
external: include subvolume group for cephfs in json output

### DIFF
--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -2028,6 +2028,21 @@ class RadosJSON:
                 }
             )
 
+        # if 'SUBVOLUME_GROUP' is set, emit it as a separate CephFilesystemSubVolumeGroup
+        # entity rather than a StorageClass parameter. This mirrors the
+        # CephBlockPoolRadosNamespace pattern above: the consumer creates the CR and derives
+        # the CephFS clusterID from it. A 'subvolumeGroup' key on the StorageClass would be a
+        # no-op, since the CSI driver does not read it from StorageClass parameters.
+        if self.out_map["CEPHFS_FS_NAME"] and self.out_map["SUBVOLUME_GROUP"]:
+            json_out.append(
+                {
+                    "name": self.out_map["SUBVOLUME_GROUP"],
+                    "kind": "CephFilesystemSubVolumeGroup",
+                    "data": {
+                        "filesystemName": self.out_map["CEPHFS_FS_NAME"],
+                    },
+                }
+            )
         # if 'CEPHFS_FS_NAME' exists, then only add 'cephfs' StorageClass
         if self.out_map["CEPHFS_FS_NAME"]:
             json_out.append(


### PR DESCRIPTION
This patch ensures that the cephfs subvolume group would be exported to json when it's populated.

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
