### PR TITLE
security: grant scc to rook-ceph-nvmeof service account

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
@@ -45,4 +45,5 @@ users:
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-mgr
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-osd
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-rgw
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-nvmeof
 {{- end }}

--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -48,6 +48,7 @@ users:
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-mgr
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-osd
   - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-rgw
+  - system:serviceaccount:{{ .Release.Namespace }}:rook-ceph-nvmeof
 ---
 # scc for the CSI driver
 kind: SecurityContextConstraints

--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -73,6 +73,7 @@ func NewSecurityContextConstraints(name string, namespaces ...string) *secv1.Sec
 					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-mgr", ns),
 					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-osd", ns),
 					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-rgw", ns),
+					fmt.Sprintf("system:serviceaccount:%s:rook-ceph-nvmeof", ns),
 				}...)
 			}
 			return

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -119,6 +119,7 @@ func replaceNamespaces(name, manifest, operatorNamespace, clusterNamespace strin
 	manifest = strings.ReplaceAll(manifest, "rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster", clusterNamespace+":rook-ceph-mgr")
 	manifest = strings.ReplaceAll(manifest, "rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster", clusterNamespace+":rook-ceph-osd")
 	manifest = strings.ReplaceAll(manifest, "rook-ceph:rook-ceph-rgw # serviceaccount:namespace:cluster", clusterNamespace+":rook-ceph-rgw")
+	manifest = strings.ReplaceAll(manifest, "rook-ceph:rook-ceph-nvmeof # serviceaccount:namespace:cluster", clusterNamespace+":rook-ceph-nvmeof")
 
 	// SCC namespaces for CSI driver
 	manifest = strings.ReplaceAll(manifest, "rook-ceph:rook-csi-rbd-plugin-sa # serviceaccount:namespace:operator", operatorNamespace+":rook-csi-rbd-plugin-sa")


### PR DESCRIPTION
the rook-ceph-nvmeof service account is not listed in the securitycontextconstraints users, causing cephnvmeofgateway pods to fail on openshift. add the service account to the scc in the helm charts, go scc builder, and test namespace substitution.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
