### PR TITLE
build: make make helm.lint truly self-contained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,8 @@ yamllint:
 
 .PHONY: helm.lint
 helm.lint: $(HELM) $(KUSTOMIZE) ## Check the helm charts
-	$(CT) lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false --validate-chart-schema=false
+	@ln -sf "$(notdir $(HELM))" "$(dir $(HELM))/helm"
+	PATH="$(dir $(HELM)):$$PATH" $(CT) lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false --validate-chart-schema=false
 	$(HELM) -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
 	$(HELM)  -n rook-ceph template deploy/charts/rook-ceph-cluster >> templated.yaml
 	 echo 'resources: [templated.yaml]' > kustomization.yaml


### PR DESCRIPTION
**Description:**

PR #17306 intended to make the `helm.lint` target self-contained so that it would not require tools to be installed in the system. But it missed the fact that `ct` requires `helm` to be available in the `$PATH`. So `make helm.lint` would still fail when `helm` was not installed.

This change fixes this by creating a symlink to the cached versioned helm tool and rewriting PATH for the ct invocation.

This renders the helm.lint target truly self-contained.

**Issue resolved by this Pull Request:**

Resolves #17438

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
