### PR TITLE
Build: introduce  a linting target naming taxonomy

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -31,5 +31,5 @@ jobs:
           fetch-depth: 0
 
 
-      - name: Run chart-testing (lint)
-        run: make helm.lint
+      - name: Lint the helm charts
+        run: make lint.helm

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint YAML files
-        run: make yamllint
+        run: make lint.yaml
 
   pylint:
     runs-on: ubuntu-latest
@@ -49,8 +49,8 @@ jobs:
           pip install requests
           pip install pygit2
 
-      - name: Lint Python files
-        run: make pylint
+      - name: Lint Python scripts
+        run: make lint.python
 
       - name: Setup black for py
         uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # stable

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -25,5 +25,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Run ShellCheck
-        run: make shellcheck
+      - name: Lint shell scripts
+        run: make lint.shell

--- a/Makefile
+++ b/Makefile
@@ -181,30 +181,34 @@ vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet
 
-.PHONY: fmt
-fmt: $(YQ) ## Check formatting of go sources.
+.PHONY: lint.fmt
+lint.fmt: $(YQ) ## Check formatting of go sources.
 	@$(MAKE) go.fmt
 
-fmt-fix: $(YQ) ## Reformatting of go sources.
+fix.fmt: $(YQ) ## Reformatting of go sources.
 	@$(MAKE) go.fmt-fix
 
 golangci-lint: $(YQ)
 	@$(MAKE) go.golangci-lint
 
-.PHONY: markdownlint
-markdownlint: ## Check formatting of documentation sources
+.PHONY: lint.go
+lint.go: lint.fmt vet golangci-lint ## run various go linters
+
+
+.PHONY: lint.markdown
+lint.markdown: ## Check formatting of documentation sources
 	@$(MARKDOWNLINT) "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
 
-.PHONY: markdownlint.fix
-markdownlint.fix: ## Check and fix formatting of documentation sources
+.PHONY: fix.markdown
+fix.markdown: ## Check and fix formatting of documentation sources
 	@$(MARKDOWNLINT) "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs
 
-.PHONY: yamllint
-yamllint:
+.PHONY: lint.yaml
+lint.yaml: ## lint yaml files
 	$(YAMLLINT) -c .yamllint deploy/examples/ --no-warnings
 
-.PHONY: helm.lint
-helm.lint: $(HELM) $(KUSTOMIZE) ## Check the helm charts
+.PHONY: lint.helm
+lint.helm: $(HELM) $(KUSTOMIZE) ## Check the helm charts
 	@ln -sf "$(notdir $(HELM))" "$(dir $(HELM))/helm"
 	PATH="$(dir $(HELM)):$$PATH" $(CT) lint --charts=./deploy/charts/rook-ceph,./deploy/charts/rook-ceph-cluster --validate-yaml=false --validate-maintainers=false --validate-chart-schema=false
 	$(HELM) -n rook-ceph template deploy/charts/rook-ceph > templated.yaml
@@ -214,18 +218,18 @@ helm.lint: $(HELM) $(KUSTOMIZE) ## Check the helm charts
 	rm templated.yaml kustomization.yaml
 
 .PHONY: lint
-lint: yamllint pylint shellcheck checkmake vet markdownlint golangci-lint helm.lint  ## Run various linters
+lint: lint.yaml lint.python lint.shell lint.make lint.go lint.markdown lint.helm ## Run various linters
 
-.PHONY: pylint
-pylint:
+.PHONY: lint.python
+lint.python: ## lint python scripts
 	pylint $(shell find $(ROOT_DIR) -name '*.py') -E
 
-.PHONY: checkmake
-checkmake:
+.PHONY: lint.make
+lint.make: ## lint the Makefile
 	@$(CHECKMAKE) Makefile
 
-.PHONY: shellcheck
-shellcheck: | $(SHELLCHECK)
+.PHONY: lint.shell
+lint.shell: | $(SHELLCHECK) ## lint shell scripts
 	$(SHELLCHECK) --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
 
 .PHONY: gen.codegen


### PR DESCRIPTION
**Description:**

This PR introduces a new taxonomy for the naming of linting targets in the Makefile.

The linting targets used to mostly have ad-hoc names usually reflecting
the linting tool used (like shellcheck, yamllint, and checkmake).
    
This change systematizes the names of the linting targets to follow a
pattern of lint.foo where foo usually reflects **what** is linted rather
than **how**.

so, more generally and more idiomatically, the pattern can be described as `action.thing` to indicate that `action` is to be performed on a `thing`.
   


s part of the systemtization, two targets that fix linting errors are renamed consistently.

This systematization is achieved by renaming a couple of targets:
 




| old  target|new name|
|----------------|--------------|
   shellcheck|lint.shell|
| makkdownlint| lint.markdown|
| checkmake | lint.make|
| yamllint | lint.yaml|
| helm.lint|lint.helm|
| pylint | lint.python |
| fmt | lint.fmt | 
| fmt-fix | fix.fmt |
| markdownlint.fix | fix.markdown | 

Additionally:

* a new target `lint.go`is introduced that runs various golang linters.
* The `lint` target and the CI  workflows are adjusted to align with the new taxonomy.









**Issue resolved by this Pull Request:**
Resolves #17441 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
