### PR TITLE
mon: add watcher for DRBD ConfigMap in TNF deployments

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -296,7 +296,7 @@ func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reco
 			mgr.GetCache(),
 			&corev1.ConfigMap{TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: corev1.SchemeGroupVersion.String()}},
 			handler.TypedEnqueueRequestsFromMapFunc(cmHandler),
-			predicateForOperatorConfigCMWatcher(),
+			predicateForClusterConfigMapWatcher(opManagerContext, mgr.GetClient()),
 		),
 	)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -140,12 +140,26 @@ func isHotPlugCM(cm *corev1.ConfigMap) bool {
 	return false
 }
 
-// predicateForOperatorConfigCMWatcher is the predicate function to trigger reconcile on operator config ConfigMap events
-func predicateForOperatorConfigCMWatcher[T *corev1.ConfigMap]() predicate.TypedFuncs[T] {
+// predicateForClusterConfigMapWatcher is the predicate function to trigger reconcile on operator config ConfigMap events
+func predicateForClusterConfigMapWatcher[T *corev1.ConfigMap](ctx context.Context, client client.Client) predicate.TypedFuncs[T] {
 	return predicate.TypedFuncs[T]{
 		UpdateFunc: func(e event.TypedUpdateEvent[T]) bool {
 			objNew := (*corev1.ConfigMap)(e.ObjectNew)
-			return objNew.Name == opcontroller.OperatorSettingConfigMapName
+			objOld := (*corev1.ConfigMap)(e.ObjectOld)
+
+			if objNew.Name == opcontroller.OperatorSettingConfigMapName {
+				if objOld.Data["ROOK_USE_CSI_OPERATOR"] != objNew.Data["ROOK_USE_CSI_OPERATOR"] {
+					log.NamespacedInfo(objNew.Namespace, logger, "ROOK_USE_CSI_OPERATOR changed from %q to %q", objOld.Data["ROOK_USE_CSI_OPERATOR"], objNew.Data["ROOK_USE_CSI_OPERATOR"])
+					return true
+				}
+			}
+
+			if isFloatingMonConfigMap(ctx, client, objNew) {
+				log.NamespacedInfo(objNew.Namespace, logger, "floating mon ConfigMap %q changed", objNew.Name)
+				return true
+			}
+
+			return false
 		},
 
 		CreateFunc: func(e event.TypedCreateEvent[T]) bool {
@@ -161,6 +175,25 @@ func predicateForOperatorConfigCMWatcher[T *corev1.ConfigMap]() predicate.TypedF
 			return false
 		},
 	}
+}
+
+// isFloatingMonConfigMap checks if any floating mon configuration refers to the updated ConfigMap
+func isFloatingMonConfigMap(ctx context.Context, client client.Client, cm *corev1.ConfigMap) bool {
+	clusterList := cephv1.CephClusterList{}
+	err := client.List(ctx, &clusterList)
+	if err != nil {
+		return false
+	}
+
+	for _, cluster := range clusterList.Items {
+		if cluster.Spec.Mon.FloatingMon.ConfigMapName != "" {
+			if cm.GetName() == cluster.Spec.Mon.FloatingMon.ConfigMapName {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func watchControllerPredicate[T *cephv1.CephCluster](ctx context.Context, c client.Client) predicate.TypedFuncs[T] {


### PR DESCRIPTION
Added a watcher in the cluster controller to detect changes to the DRBD ConfigMap used by floating monitors in TNF deployments. When the ConfigMap is updated, the watcher triggers a CephCluster reconciliation to ensure configuration changes are applied.

Fixes #17338

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
