### PR TITLE
osd: detect encryption label from dmcrypt path

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -797,8 +797,11 @@ func (c *Cluster) getOSDInfo(d *appsv1.Deployment) (OSDInfo, error) {
 
 	osd.Store = d.Labels[osdStore]
 	osd.DeviceType = d.Labels[deviceType]
+	// Detect encryption from the block path as a fallback for deployments that predate the
+	// "encrypted" label. On upgrade, the label won't exist yet, but the dmcrypt block path
+	// is always present on encrypted OSDs regardless of the Rook version that created them.
 	osd.Encrypted = false
-	if d.Labels[encrypted] == "true" {
+	if d.Labels[encrypted] == "true" || strings.Contains(osd.BlockPath, "-dmcrypt") {
 		osd.Encrypted = true
 	}
 

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -839,6 +839,54 @@ func TestGetOSDInfo(t *testing.T) {
 		assert.Equal(t, pvcName, updatedOSDInfo.PVCName)
 	})
 
+	t.Run("detect encryption from dmcrypt block path when encrypted label is missing", func(t *testing.T) {
+		osdInfo := &OSDInfo{
+			UUID:      "osd-uuid",
+			BlockPath: "/dev/mapper/set1-data-0-abc-block-dmcrypt",
+			CVMode:    "raw",
+		}
+		osdProp := osdProperties{
+			crushHostname: node,
+			pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+			selection:     cephv1.Selection{},
+			resources:     corev1.ResourceRequirements{},
+			storeConfig:   config.StoreConfig{},
+		}
+
+		d, err := c.makeDeployment(osdProp, osdInfo, dataPathMap)
+		assert.NoError(t, err)
+
+		// simulate a pre-label upgrade by removing the encrypted label
+		delete(d.Labels, encrypted)
+		delete(d.Spec.Template.Labels, encrypted)
+
+		updatedOSDInfo, err := c.getOSDInfo(d)
+		assert.NoError(t, err)
+		assert.True(t, updatedOSDInfo.Encrypted)
+	})
+
+	t.Run("encrypted label is set from OSDInfo when osdProps does not indicate encryption", func(t *testing.T) {
+		osdInfo := &OSDInfo{
+			UUID:      "osd-uuid",
+			BlockPath: "/dev/mapper/set1-data-0-abc-block-dmcrypt",
+			CVMode:    "raw",
+			Encrypted: true,
+		}
+		osdProp := osdProperties{
+			crushHostname: node,
+			pvc:           corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+			selection:     cephv1.Selection{},
+			resources:     corev1.ResourceRequirements{},
+			storeConfig:   config.StoreConfig{},
+			encrypted:     false,
+		}
+
+		d, err := c.makeDeployment(osdProp, osdInfo, dataPathMap)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", d.Labels[encrypted])
+		assert.Equal(t, "true", d.Spec.Template.Labels[encrypted])
+	})
+
 	t.Run("verify the non-existence of labels if the corresponding fields are not set on OSDInfo and OSDProperties", func(t *testing.T) {
 		useAllDevices := true
 		osdInfo := &OSDInfo{

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -548,7 +548,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd *OSDInfo, provision
 	osdLabels := c.getOSDLabels(*osd, failureDomainValue, osdProps.portable)
 
 	// update encryption label on the OSD deployment
-	if osdProps.storeConfig.EncryptedDevice || osdProps.encrypted {
+	if osdProps.storeConfig.EncryptedDevice || osdProps.encrypted || osd.Encrypted {
 		osdLabels[encrypted] = "true"
 	} else {
 		osdLabels[encrypted] = "false"


### PR DESCRIPTION
Detect OSD encryption from the dmcrypt block path in `getOSDInfo` as a fallback when the `encrypted` label is missing on pre-label deployments.

Include `osd.Encrypted` in the label check in `makeDeployment` so the label reflects the actual OSD state on upgrade.

Fixes a bug where upgrading to a Rook version with the `encrypted` label would set the label to `false` on already-encrypted OSDs, because the label didn't exist yet and `getOSDInfo` defaulted to `false`.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
