### PR TITLE
Build: align the vet target with the new naming taxonomy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,8 @@ test: ## Runs unit tests.
 test-integration: ## Runs integration tests.
 	@$(MAKE) go.test.integration
 
-.PHONY: vet
-vet: ## Runs lint checks on go sources.
+.PHONY: lint.vet
+lint.vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet
 
@@ -192,7 +192,7 @@ golangci-lint: $(YQ)
 	@$(MAKE) go.golangci-lint
 
 .PHONY: lint.go
-lint.go: lint.fmt vet golangci-lint ## run various go linters
+lint.go: lint.fmt lint.vet golangci-lint ## run various go linters
 
 
 .PHONY: lint.markdown


### PR DESCRIPTION
Recently, in PR #17445, a new naming taxonomy was introduced for the naming of make targets, specifically linting targets.

This change aligns the `vet`target with that taxonomy by renaming it to `lint.vet`.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
