### PR TITLE
tests: Fix flaky upgrade test during file pv teardown

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1218,7 +1218,22 @@ func (k8sh *K8sHelper) WaitUntilZeroPVs() bool {
 			return true
 		}
 		logger.Infof("waiting for PV count to be zero.")
-
+		if i%5 == 0 {
+			for _, pv := range pvList.Items {
+				logger.Infof("PV %s is in %s phase. %+v", pv.Name, pv.Status.Phase, pv)
+			}
+		}
+		allVolumesReleased := true
+		for _, pv := range pvList.Items {
+			if pv.Status.Phase == v1.VolumeReleased {
+				logger.Warningf("PV %s is in Released phase, ignoring it for deletion wait", pv.Name)
+				continue
+			}
+			allVolumesReleased = false
+		}
+		if allVolumesReleased {
+			return true
+		}
 		time.Sleep(RetryInterval * time.Second)
 	}
 	return false


### PR DESCRIPTION
The test file pod is not unmounting its volume consistently since the merge of the 1.19 upgrade changes in #17455.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
