### PR TITLE
object: migrate notification package to aws sdk v2

### DIFF
--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -20,7 +20,8 @@ package notification
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/service/s3"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -95,39 +96,40 @@ func newS3Agent(p provisioner) (*object.S3Agent, error) {
 }
 
 // TODO: convert all rules without restrictions once the AWS SDK supports that
-func createS3FilterRules(filterRules []cephv1.NotificationKeyFilterRule) (s3FilterRules []*s3.FilterRule) {
+func createS3FilterRules(filterRules []cephv1.NotificationKeyFilterRule) (s3FilterRules []s3types.FilterRule) {
 	for _, rule := range filterRules {
-		s3FilterRules = append(s3FilterRules, &s3.FilterRule{
-			Name:  &rule.DeepCopy().Name,
-			Value: &rule.DeepCopy().Value,
+		r := rule.DeepCopy()
+		s3FilterRules = append(s3FilterRules, s3types.FilterRule{
+			Name:  s3types.FilterRuleName(r.Name),
+			Value: &r.Value,
 		})
 	}
 	return
 }
 
-func createS3Filter(filter *cephv1.NotificationFilterSpec) *s3.NotificationConfigurationFilter {
+func createS3Filter(filter *cephv1.NotificationFilterSpec) *s3types.NotificationConfigurationFilter {
 	if filter == nil {
 		return nil
 	}
-	return &s3.NotificationConfigurationFilter{
-		Key: &s3.KeyFilter{
+	return &s3types.NotificationConfigurationFilter{
+		Key: &s3types.S3KeyFilter{
 			FilterRules: createS3FilterRules(filter.KeyFilters),
 		},
 	}
 }
 
-func createS3Events(events []cephv1.BucketNotificationEvent) []*string {
+func createS3Events(events []cephv1.BucketNotificationEvent) []s3types.Event {
 	// in the AWS S3 library "Events" is required field
 	// but in our CR it is optional. indicating notifications on all events
 	if len(events) == 0 {
-		createdEvent := "s3:ObjectCreated:*"
-		removedEvent := "s3:ObjectRemoved:*"
-		return []*string{&createdEvent, &removedEvent}
+		return []s3types.Event{
+			s3types.Event("s3:ObjectCreated:*"),
+			s3types.Event("s3:ObjectRemoved:*"),
+		}
 	}
-	s3Events := []*string{}
+	s3Events := make([]s3types.Event, 0, len(events))
 	for _, event := range events {
-		stringEvent := string(event)
-		s3Events = append(s3Events, &stringEvent)
+		s3Events = append(s3Events, s3types.Event(string(event)))
 	}
 	return s3Events
 }
@@ -142,10 +144,10 @@ var createNotification = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, t
 	if err != nil {
 		return errors.Wrapf(err, "failed to create S3 agent for CephBucketNotification %q provisioning for bucket %q", bnName, bucketName)
 	}
-	_, err = s3Agent.Client.PutBucketNotificationConfiguration(&s3.PutBucketNotificationConfigurationInput{
+	_, err = s3Agent.ClientV2.PutBucketNotificationConfiguration(p.opManagerContext, &s3v2.PutBucketNotificationConfigurationInput{
 		Bucket: &bucketName,
-		NotificationConfiguration: &s3.NotificationConfiguration{
-			TopicConfigurations: []*s3.TopicConfiguration{
+		NotificationConfiguration: &s3types.NotificationConfiguration{
+			TopicConfigurations: []s3types.TopicConfiguration{
 				{
 					Events:   createS3Events(notification.Spec.Events),
 					Filter:   createS3Filter(notification.Spec.Filter),
@@ -174,7 +176,7 @@ var getAllRGWNotifications = func(p provisioner, ob *bktv1alpha1.ObjectBucket) (
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create S3 agent for CephBucketNotification provisioning for bucket %q", bucketName)
 	}
-	nc, err := s3Agent.Client.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+	nc, err := s3Agent.ClientV2.GetBucketNotificationConfiguration(p.opManagerContext, &s3v2.GetBucketNotificationConfigurationInput{
 		Bucket:              &bucketName,
 		ExpectedBucketOwner: &ownerName,
 	})
@@ -202,7 +204,7 @@ var deleteNotification = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, n
 	if err != nil {
 		return errors.Wrapf(err, "failed to create S3 agent for deleting all bucket notifications from bucket %q", bucketName)
 	}
-	if err := DeleteBucketNotification(s3Agent.Client, &DeleteBucketNotificationRequestInput{
+	if err := DeleteBucketNotification(context.TODO(), s3Agent.ClientV2, &DeleteBucketNotificationRequestInput{
 		Bucket: &bucket.Spec.Endpoint.BucketName,
 	}, notificationId); err != nil {
 		return errors.Wrapf(err, "failed to delete bucket notification %q from bucket %q", notificationId, bucketName)

--- a/pkg/operator/ceph/object/notification/s3ext.go
+++ b/pkg/operator/ceph/object/notification/s3ext.go
@@ -17,73 +17,92 @@ limitations under the License.
 package notification
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/s3"
+	v4signer "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/pkg/errors"
 )
 
 type DeleteBucketNotificationRequestInput struct {
-	_ struct{} `locationName:"DeleteBucketNotificationRequestInput" type:"structure"`
-
-	// The name of the bucket for which to get the notification configuration.
-	//
 	// Bucket is a required field
-	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+	Bucket *string
 
 	// The account id of the expected bucket owner. If the bucket is owned by a
 	// different account, the request will fail with an HTTP 403 (Access Denied)
 	// error.
-	ExpectedBucketOwner *string `location:"header" locationName:"x-amz-expected-bucket-owner" type:"string"`
+	ExpectedBucketOwner *string
 }
 
-// String returns the string representation
-func (s DeleteBucketNotificationRequestInput) String() string {
-	return awsutil.Prettify(s)
-}
-
-// GoString returns the string representation
-func (s DeleteBucketNotificationRequestInput) GoString() string {
-	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *DeleteBucketNotificationRequestInput) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketNotificationRequest"}
-	if s.Bucket == nil {
-		invalidParams.Add(request.NewErrParamRequired("Bucket"))
-	}
-	if s.Bucket != nil && len(*s.Bucket) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
+func (s *DeleteBucketNotificationRequestInput) validate() error {
+	if s.Bucket == nil || *s.Bucket == "" {
+		return errors.New("Bucket is a required field")
 	}
 	return nil
 }
 
-const opDeleteBucketNotification = "DeleteBucketNotification"
+// SHA-256 hash of an empty payload, used for signing requests with no body.
+const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRequestInput, notificationId string) *request.Request {
-	op := &request.Operation{
-		Name:       opDeleteBucketNotification,
-		HTTPMethod: http.MethodDelete,
-		HTTPPath:   "/{Bucket}?notification",
-	}
-
-	if len(notificationId) > 0 {
-		op.HTTPPath = "/{Bucket}?notification=" + notificationId
-	}
+// DeleteBucketNotification sends a Ceph-specific DELETE request to remove a
+// bucket notification configuration. This is not part of the standard AWS S3
+// API, so we build and sign the HTTP request manually using the v2 client's
+// credentials and endpoint.
+func DeleteBucketNotification(ctx context.Context, client *s3v2.Client, input *DeleteBucketNotificationRequestInput, notificationId string) error {
 	if input == nil {
 		input = &DeleteBucketNotificationRequestInput{}
 	}
+	if err := input.validate(); err != nil {
+		return err
+	}
 
-	return c.NewRequest(op, input, nil)
-}
+	opts := client.Options()
 
-func DeleteBucketNotification(c *s3.S3, input *DeleteBucketNotificationRequestInput, notificationId string) error {
-	req := DeleteBucketNotificationRequest(c, input, notificationId)
-	return req.Send()
+	baseEndpoint := ""
+	if opts.BaseEndpoint != nil {
+		baseEndpoint = strings.TrimRight(*opts.BaseEndpoint, "/")
+	}
+
+	reqURL := fmt.Sprintf("%s/%s?notification", baseEndpoint, *input.Bucket)
+	if notificationId != "" {
+		reqURL = fmt.Sprintf("%s/%s?notification=%s", baseEndpoint, *input.Bucket, notificationId)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to build HTTP request for DeleteBucketNotification")
+	}
+
+	req.Header.Set("x-amz-content-sha256", emptyPayloadSHA256)
+	if input.ExpectedBucketOwner != nil {
+		req.Header.Set("x-amz-expected-bucket-owner", *input.ExpectedBucketOwner)
+	}
+
+	creds, err := opts.Credentials.Retrieve(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve credentials for DeleteBucketNotification")
+	}
+
+	signer := v4signer.NewSigner()
+	if err := signer.SignHTTP(ctx, creds, req, emptyPayloadSHA256, "s3", opts.Region, time.Now()); err != nil {
+		return errors.Wrap(err, "failed to sign DeleteBucketNotification request")
+	}
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to send DeleteBucketNotification request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("DeleteBucketNotification failed with HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -17,10 +17,11 @@ limitations under the License.
 package clients
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/s3"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/installer"
@@ -162,7 +163,7 @@ func (b *BucketOperation) CheckBucketNotificationSetonRGW(namespace, storeName, 
 		return false
 	}
 	logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
-	notifications, err := s3client.Client.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
+	notifications, err := s3client.ClientV2.GetBucketNotificationConfiguration(context.TODO(), &s3v2.GetBucketNotificationConfigurationInput{
 		Bucket: &bucketname,
 	})
 	if err != nil {


### PR DESCRIPTION
migrate bucket notification provisioner and s3 extension from aws-sdk-go (v1) to aws-sdk-go-v2.

`provisioner.go`: switch to ClientV2 for `PutBucketNotificationConfiguration` and `GetBucketNotificationConfiguration` using v2 types.

`s3ext.go`: rewrite custom ceph `DeleteBucketNotification` to use v2 signer and raw http instead of v1
`request.Request` internals.

also update integration test in `tests/framework/clients/bucket.go`.


Full Manual Upgrade Test: Rook v1.19 → aws_sdk_2_notification
```
1.Create rook on minikube with rook1.29
    """image: docker.io/rook/ceph:release-1.19"""
    
2. Create Object Store (on v1.19)
$ kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/object-test.yaml

$ kubectl -n rook-ceph get cephobjectstore/my-store 
NAME       PHASE   ENDPOINT                                         SECUREENDPOINT   AGE
my-store   Ready   http://rook-ceph-rgw-my-store.rook-ceph.svc:80                    60s

3. Create Bucket Notifications (on v1.19 / AWS SDK v1)
# Deploy notification HTTP endpoint
kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/bucket-notification-endpoint.yaml
# Create topic and notification
kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/bucket-topic.yaml
kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/bucket-notification.yaml
# Create StorageClass and OBC with notification label
kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/storageclass-bucket-delete.yaml
kubectl apply -f https://raw.githubusercontent.com/rook/rook/v1.19.5/deploy/examples/object-bucket-claim-notification.yaml

# Wait for OBC to be bound
kubectl wait obc/ceph-notification-bucket --for=jsonpath='{.status.phase}'=Bound --timeout=120s

4. Verify notification exists (pre-upgrade)
$ BUCKET=$(kubectl get obc ceph-notification-bucket -o jsonpath='{.spec.bucketName}')
$ echo "Bucket: $BUCKET"
Bucket: ceph-bkt-bc077cca-5aaa-4847-b36f-a7fdaddaf55e

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
  radosgw-admin --rgw-realm=my-store notification list --bucket=$BUCKET
{
    "notifications": [
        {
            "TopicArn": "arn:aws:sns:my-store::my-topic",
            "Id": "my-notification",
            "Events": [
                "s3:ObjectCreated:Put",
                 ....


5. Upgrade to aws_sdk_2_notification branch (AWS SDK v2)
# Update CRDs first (required - CRDs changed between versions)
kubectl apply -f deploy/examples/crds.yaml
# Update common resources
kubectl apply -f deploy/examples/common.yaml

make build
push image to : quay.io/oviner/rook:may5_1 


$ kubectl edit deployments.apps -n rook-ceph rook-ceph-operator 
deployment.apps/rook-ceph-operator edited

        image: docker.io/rook/ceph:release-1.19
        imagePullPolicy: IfNotPresent
                                -> 
        image: quay.io/oviner/rook:may5_1 
        imagePullPolicy: Always


6. Verify notification survives upgrade
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
  radosgw-admin --rgw-realm=my-store notification list --bucket=$BUCKET
{
    "notifications": [
        {
            "TopicArn": "arn:aws:sns:my-store::my-topic",
            "Id": "my-notification",
   ....

7. Test notification removal (new SDK v2 code path)

kubectl patch obc ceph-notification-bucket --type=json \
  -p='[{"op":"remove","path":"/metadata/labels/bucket-notification-my-notification"}]'
  
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
  radosgw-admin --rgw-realm=my-store notification list --bucket=$BUCKET
{
    "notifications": []
}


8. Test notification re-add (new SDK v2 code path)
kubectl patch obc ceph-notification-bucket --type=merge \
  -p='{"metadata":{"labels":{"bucket-notification-my-notification":"my-notification"}}}'
  
  $ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
  radosgw-admin --rgw-realm=my-store notification list --bucket=$BUCKET
{
    "notifications": [
        {
            "TopicArn": "arn:aws:sns:my-store::my-topic",
            "Id": "my-notification",
            ....

9.Cleanup

$ kubectl delete obc ceph-notification-bucket
objectbucketclaim.objectbucket.io "ceph-notification-bucket" deleted

$ kubectl delete sc rook-ceph-delete-bucket
storageclass.storage.k8s.io "rook-ceph-delete-bucket" deleted

$ kubectl delete cephbucketnotification my-notification
cephbucketnotification.ceph.rook.io "my-notification" deleted

$ kubectl delete cephbuckettopic my-topic
cephbuckettopic.ceph.rook.io "my-topic" deleted

$ kubectl delete -f deploy/examples/bucket-notification-endpoint.yaml
deployment.apps "my-notification-endpoint" deleted
service "my-notification-endpoint" deleted

```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
