### PR TITLE
mgr: retry self-signed cert creation on wrapped context deadline errors

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -248,7 +248,7 @@ func (c *Cluster) createSelfSignedCert() (bool, error) {
 	// retry a few times in the case that the mgr module is not ready to accept commands
 	for i := 0; i < 5; i++ {
 		_, err := client.NewCephCommand(c.context, c.clusterInfo, args).RunWithTimeout(exec.CephCommandsTimeout)
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			log.NamespacedWarning(c.clusterInfo.Namespace, logger, "cert creation timed out. trying again")
 			continue
 		}

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -187,3 +187,39 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.Equal(t, 8443, int(svc.Spec.Ports[0].Port))
 	assert.Equal(t, 8443, int(svc.Spec.Ports[0].TargetPort.IntVal))
 }
+
+func TestCreateSelfSignedCertRetriesWrappedDeadlineExceeded(t *testing.T) {
+	ctx := context.TODO()
+	clientset := test.New(t, 3)
+	attempts := 0
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, arg ...string) (string, error) {
+			if arg[0] == "config-key" && arg[1] == "get" {
+				return "", errors.New("cert not found")
+			}
+			if arg[0] == "dashboard" && arg[1] == "create-self-signed-cert" {
+				attempts++
+				if attempts < 3 {
+					return "", errors.Wrap(context.DeadlineExceeded, "test timeout")
+				}
+			}
+			return "", nil
+		},
+	}
+
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	clusterInfo := &cephclient.ClusterInfo{
+		Namespace: "myns",
+		OwnerInfo: ownerInfo,
+		Context:   ctx,
+	}
+	c := &Cluster{
+		clusterInfo: clusterInfo,
+		context:     &clusterd.Context{Clientset: clientset, Executor: executor},
+	}
+
+	alreadyCreated, err := c.createSelfSignedCert()
+	assert.NoError(t, err)
+	assert.False(t, alreadyCreated)
+	assert.Equal(t, 3, attempts)
+}


### PR DESCRIPTION
Fixes a bug in the Rook manager dashboard's self-signed cert creation where the retry logic was not catching wrapped timeout errors. The code only matched `context.DeadlineExceeded` directly, so a lower layer wrapping the error could skip the retry path and fail the operation immediately.

This change uses wrapped-error matching so deadline errors wrapped by lower layers still trigger the expected retry behavior. It also adds test coverage for a wrapped deadline error that fails a few attempts before succeeding.

Validated with:

```console
go test ./pkg/operator/ceph/cluster/mgr
```

AI assistance disclosure: I used AI assistance for parts of the implementation and to explore test cases. I reviewed the final diff before pushing.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
