### PR TITLE
object: use HTTPS in bucket provisioning when object store advertises TLS

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -606,15 +607,23 @@ func (p *Provisioner) populateDomainAndPort(sc *storagev1.StorageClass) error {
 	endpoint := getObjectStoreEndpoint(sc)
 	// if endpoint is present, let's introspect it
 	if endpoint != "" {
-		p.storeDomainName = cephutil.GetIPFromEndpoint(endpoint)
+		endpointHostPort := endpoint
+		p.storeUseTLS = false
+		if u, err := url.Parse(endpoint); err == nil && u.Scheme != "" {
+			if u.Scheme == "https" {
+				p.storeUseTLS = true
+			}
+			endpointHostPort = u.Host
+		}
+
+		p.storeDomainName = cephutil.GetIPFromEndpoint(endpointHostPort)
 		if p.storeDomainName == "" {
 			return errors.New("failed to discover endpoint IP (is empty)")
 		}
-		p.storePort = cephutil.GetPortFromEndpoint(endpoint)
+		p.storePort = cephutil.GetPortFromEndpoint(endpointHostPort)
 		if p.storePort == 0 {
 			return errors.New("failed to discover endpoint port (is empty)")
 		}
-		p.storeUseTLS = false
 		// If no endpoint exists let's see if CephObjectStore exists
 	} else {
 		if err := p.setObjectStoreDomainNameAndPort(sc); err != nil {

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -51,6 +51,7 @@ type Provisioner struct {
 	bucketName      string
 	storeDomainName string
 	storePort       int32
+	storeUseTLS     bool
 	// access keys for acct for the bucket *owner*
 	cephUserName         string
 	accessKeyID          string
@@ -564,12 +565,13 @@ func (p *Provisioner) setObjectStoreDomainNameAndPort(sc *storagev1.StorageClass
 		return err
 	}
 
-	domainName, port, _, err := store.GetAdvertiseEndpoint()
+	domainName, port, useTLS, err := store.GetAdvertiseEndpoint()
 	if err != nil {
 		return errors.Wrapf(err, `failed to get advertise endpoint for CephObjectStore "%s/%s"`, p.clusterInfo.Namespace, p.objectStoreName)
 	}
 	p.storeDomainName = domainName
 	p.storePort = port
+	p.storeUseTLS = useTLS
 
 	return nil
 }
@@ -594,6 +596,9 @@ func (p *Provisioner) setEndpoint(sc *storagev1.StorageClass) {
 }
 
 func (p Provisioner) getObjectStoreEndpoint() string {
+	if p.storeUseTLS {
+		return object.BuildDNSEndpoint(p.storeDomainName, p.storePort, true)
+	}
 	return fmt.Sprintf("%s:%d", p.storeDomainName, p.storePort)
 }
 
@@ -609,6 +614,7 @@ func (p *Provisioner) populateDomainAndPort(sc *storagev1.StorageClass) error {
 		if p.storePort == 0 {
 			return errors.New("failed to discover endpoint port (is empty)")
 		}
+		p.storeUseTLS = false
 		// If no endpoint exists let's see if CephObjectStore exists
 	} else {
 		if err := p.setObjectStoreDomainNameAndPort(sc); err != nil {
@@ -893,7 +899,7 @@ func (p *Provisioner) setTlsCaCert() error {
 		return err
 	}
 	p.tlsCert = make([]byte, 0)
-	if objStore.Spec.Gateway.SecurePort == p.storePort {
+	if objStore.Spec.Gateway.SecurePort == p.storePort || p.storeUseTLS {
 		p.tlsCert, p.insecureTLS, err = object.GetTlsCaCert(p.objectContext, &objStore.Spec)
 		if err != nil {
 			return err

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -79,6 +79,26 @@ func TestPopulateDomainAndPort(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "192.168.0.1", p.storeDomainName)
 	assert.Equal(t, int32(80), p.storePort)
+	assert.False(t, p.storeUseTLS)
+	assert.Equal(t, "192.168.0.1:80", p.getObjectStoreEndpoint())
+
+	// Endpoint is HTTPS URL
+	sc.Parameters["endpoint"] = "https://s3.domain.com:443"
+	err = p.populateDomainAndPort(sc)
+	assert.NoError(t, err)
+	assert.Equal(t, "s3.domain.com", p.storeDomainName)
+	assert.Equal(t, int32(443), p.storePort)
+	assert.True(t, p.storeUseTLS)
+	assert.Equal(t, "https://s3.domain.com:443", p.getObjectStoreEndpoint())
+
+	// Endpoint is HTTP URL
+	sc.Parameters["endpoint"] = "http://s3.domain.com:80"
+	err = p.populateDomainAndPort(sc)
+	assert.NoError(t, err)
+	assert.Equal(t, "s3.domain.com", p.storeDomainName)
+	assert.Equal(t, int32(80), p.storePort)
+	assert.False(t, p.storeUseTLS)
+	assert.Equal(t, "s3.domain.com:80", p.getObjectStoreEndpoint())
 
 	// No endpoint but a CephObjectStore
 	sc.Parameters["endpoint"] = ""

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -117,6 +117,25 @@ func TestPopulateDomainAndPort(t *testing.T) {
 	err = p.populateDomainAndPort(sc)
 	assert.NoError(t, err)
 	assert.Equal(t, "rook-ceph-rgw-test-store.ns.svc", p.storeDomainName)
+	assert.Equal(t, int32(80), p.storePort)
+	assert.False(t, p.storeUseTLS)
+	assert.Equal(t, "rook-ceph-rgw-test-store.ns.svc:80", p.getObjectStoreEndpoint())
+
+	cephObjectStore.Spec.Hosting = &cephv1.ObjectStoreHostingSpec{
+		AdvertiseEndpoint: &cephv1.ObjectEndpointSpec{
+			DnsName: "s3.domain.com",
+			Port:    443,
+			UseTls:  true,
+		},
+	}
+	_, err = p.context.RookClientset.CephV1().CephObjectStores(namespace).Update(ctx, cephObjectStore, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	err = p.populateDomainAndPort(sc)
+	assert.NoError(t, err)
+	assert.Equal(t, "s3.domain.com", p.storeDomainName)
+	assert.Equal(t, int32(443), p.storePort)
+	assert.True(t, p.storeUseTLS)
+	assert.Equal(t, "https://s3.domain.com:443", p.getObjectStoreEndpoint())
 }
 
 func TestQuanityToInt64(t *testing.T) {

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -51,10 +51,8 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 		logLevel = aws.LogDebug
 	}
 
-	tlsEnabled := false
-	if len(tlsCert) > 0 || insecure {
-		tlsEnabled = true
-	}
+	u, perr := url.Parse(endpoint)
+	tlsEnabled := len(tlsCert) > 0 || insecure || (perr == nil && u.Scheme == "https")
 	if httpClient == nil {
 		httpClient = &http.Client{
 			Timeout: HttpTimeOut,
@@ -90,7 +88,6 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 	if tlsEnabled {
 		scheme = "https"
 	}
-	u, perr := url.Parse(endpoint)
 	if perr != nil || (u.Scheme != "http" && u.Scheme != "https") {
 		u, _ = url.Parse(scheme + "://" + endpoint)
 	}

--- a/pkg/operator/ceph/object/s3-handlers_test.go
+++ b/pkg/operator/ceph/object/s3-handlers_test.go
@@ -86,6 +86,18 @@ func TestNewS3Agent(t *testing.T) {
 		assert.NotNil(t, s3Agent.ClientV2)
 		assert.Equal(t, "https://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
 	})
+	t.Run("test with https endpoint without custom tls", func(t *testing.T) {
+		debug := false
+		insecure := false
+		endpoint := "https://endpoint"
+		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, nil, insecure, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.RootCAs)
+		assert.False(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+		assert.False(t, *s3Agent.Client.Config.DisableSSL)
+		assert.NotNil(t, s3Agent.ClientV2)
+		assert.Equal(t, "https://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+	})
 	t.Run("test with custom http.Client", func(t *testing.T) {
 		debug := true
 		logLevel := aws.LogDebug


### PR DESCRIPTION
When a CephObjectStore advertises an HTTPS endpoint (`useTls: true`), the bucket provisioning path was not carrying that TLS info through, so the S3 agent could end up talking HTTP to an HTTPS endpoint.

This change preserves the advertised TLS info in the bucket provisioner and passes an HTTPS endpoint down to the S3 agent. It also treats an explicit `https://` endpoint as TLS even when there is no custom CA secret configured.

Validated with:

```console
go test -tags ceph_preview ./pkg/operator/ceph/object -run TestNewS3Agent
go test -tags ceph_preview ./pkg/operator/ceph/object/bucket
```

AI assistance disclosure: I used AI assistance for parts of the implementation and to explore test cases. I reviewed the final diff before pushing.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
