### PR TITLE
mon: check node existence on every health check iteration

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -293,10 +293,11 @@ func (c *Cluster) checkHealth(ctx context.Context) error {
 		rescheduleImmediately := false
 		if _, ok := c.monTimeoutList[mon.Name]; !ok {
 			c.monTimeoutList[mon.Name] = time.Now()
-
-			// If the assigned node is not found, skip the timeout wait
-			rescheduleImmediately = c.shouldFailoverMonImmediately(ctx, mon.Name)
 		}
+
+		// Check if the assigned node exists on every health check iteration
+		// to detect if a node is deleted during the timeout
+		rescheduleImmediately = c.shouldFailoverMonImmediately(ctx, mon.Name)
 
 		// when the timeout for the mon has been reached, continue to the
 		// normal failover mon pod part of the code

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -242,6 +242,11 @@ func TestScheduleFailoverImmediately(t *testing.T) {
 	assert.False(t, c.shouldFailoverMonImmediately((context.TODO()), "b"))
 	// mon c is assigned to a non-existent node, so it should failover immediately
 	assert.True(t, c.shouldFailoverMonImmediately((context.TODO()), "c"))
+	// Test that the function detects node deletion when called repeatedly
+	err = clientset.CoreV1().Nodes().Delete(context.TODO(), "a", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	// node a has been deleted, so mon a should failover immediately
+	assert.True(t, c.shouldFailoverMonImmediately((context.TODO()), "a"))
 }
 
 func TestTrackMonsOutOfQuorum(t *testing.T) {


### PR DESCRIPTION
Previously, shouldFailoverMonImmediately() was called only when a mon first went out of quorum. If the node gets deleted after the timeout starts, it does not get detected until the timeout expires. Moved the call outside the timeout initialization block so it runs on every health check iteration and detects node deletion immediately.

Fixes #15953 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
