### PR TITLE
build: introduce a make target lint.quick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,10 @@ lint.helm: $(HELM) $(KUSTOMIZE) ## Check the helm charts
 	$(KUSTOMIZE) build >/dev/null
 	rm templated.yaml kustomization.yaml
 
+.PHONY: lint.quick
+lint.quick: lint.yaml lint.shell lint.make lint.go lint.helm lint.markdown ## run some (faster) linters
 .PHONY: lint
-lint: lint.yaml lint.python lint.shell lint.make lint.go lint.markdown lint.helm ## Run various linters
+lint: lint.quick lint.python ## Run various linters
 
 .PHONY: lint.python
 lint.python: ## lint python scripts


### PR DESCRIPTION
**Description:**

`make lint` runs all available linters and takes quite some time (around 25 to 35 seconds) to complete, eventually failing on lint.python, at least locally on some machines.

This change splits a target `lint.quick` out of `lint`. `make lint.quick` runs all linters except for `lint.python` and consistently takes some 20 seconds of runtime to complete successfully.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
