### PR TITLE
mgr: fix the race condition bw mgr pool and pod

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -51,6 +52,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -138,6 +140,18 @@ func (c *cluster) reconcileCephDaemons(rookImage string, cephVersion cephver.Cep
 	err = c.postMonStartupActions()
 	if err != nil {
 		return errors.Wrap(err, "failed to execute post actions after all the ceph monitors started")
+	}
+
+	// Before entering mgr creation, we must create at least one pool based on the default stretch rule
+	// Wait for the .mgr pool to be created, which we expect is defined as a CephBlockPool
+	log.NamespacedInfo(c.Namespace, logger, "waiting for the builtin .mgr pool to be created")
+	pollInterval := 5 * time.Second
+	totalWaitTime := 2 * time.Minute
+	err = wait.PollUntilContextTimeout(c.ClusterInfo.Context, pollInterval, totalWaitTime, true, func(ctx context.Context) (bool, error) {
+		return c.mons.BuiltinMgrPoolExists(), nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to wait for .mgr pool to be created")
 	}
 
 	// Start Ceph manager

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -418,7 +418,7 @@ func (c *Cluster) ConfigureArbiter() error {
 	//  https://github.com/ceph/ceph/pull/61371
 	log.NamespacedInfo(c.Namespace, logger, "enabling stretch mode... waiting for the builtin .mgr pool to be created")
 	err = wait.PollUntilContextTimeout(c.ClusterInfo.Context, pollInterval, totalWaitTime, true, func(ctx context.Context) (bool, error) {
-		return c.builtinMgrPoolExists(), nil
+		return c.BuiltinMgrPoolExists(), nil
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to wait for .mgr pool to be created before setting the stretch tiebreaker")
@@ -432,7 +432,7 @@ func (c *Cluster) ConfigureArbiter() error {
 	return nil
 }
 
-func (c *Cluster) builtinMgrPoolExists() bool {
+func (c *Cluster) BuiltinMgrPoolExists() bool {
 	_, err := cephclient.GetPoolDetails(c.context, c.ClusterInfo, ".mgr")
 
 	// If the call fails, either the pool does not exist or else there is some Ceph error.


### PR DESCRIPTION
the devicehealth module gets started when we create the mgr pod, but the devicehealth needs to wait for the .mgr pool to get created so it can create a
device_health pool based on the .mgr pool crush rule

so wait for .mgr pool before proceeding to create mgr

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
