### PR TITLE
docs: fix duplicated words in docs and comments

### DIFF
--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
@@ -108,7 +108,7 @@ OBCs in unexpected ways. At worst, users may brick the whole S3 object store for
 (`bucketPolicy` in particular). Administrators should take care to enable features only when they
 are personally willing to take on the risks.
 
-OBC `additionalConfig` fields can be enabled and disabled using the the `rook-ceph-operator-config`
+OBC `additionalConfig` fields can be enabled and disabled using the `rook-ceph-operator-config`
 configmap value `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`.
 
 ### OBC Custom Resource after Bucket Provisioning

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -684,7 +684,7 @@ The Ceph Object Gateway supports accessing buckets using
 [virtual host-style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
 addressing, which allows addressing buckets using the bucket name as a subdomain in the endpoint.
 
-AWS has deprecated the the alternative path-style addressing mode which is Rook and Ceph's default.
+AWS has deprecated the alternative path-style addressing mode which is Rook and Ceph's default.
 As a result, many end-user applications have begun to remove path-style support entirely. Many
 production clusters will have to enable virtual host-style address.
 

--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -109,7 +109,7 @@ func init() {
 			"The namespace for validation test resources. "+
 				"It is recommended to set this to the namespace in which Rook's Ceph cluster will be installed.")
 
-		// VarPF() keeps the the specific var passed to it for setting at runtime, and the current
+		// VarPF() keeps the specific var passed to it for setting at runtime, and the current
 		// val of that var when VarPF() is called is used as the default
 		validationConfig.ResourceTimeout = defaultConfig.ResourceTimeout
 		t := (*timeoutMinutes)(&validationConfig.ResourceTimeout)

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -525,7 +525,7 @@ func listSubVolumeSnapshotPendingClones(context *clusterd.Context, clusterInfo *
 	}
 
 	if err := json.Unmarshal(buf, &pendingClones); err != nil {
-		return pendingClones, errors.Wrapf(err, "failed to unmarshal pending clones list for for snapshot %q in filesystem %q subvolume group %q", snap, fsName, groupName)
+		return pendingClones, errors.Wrapf(err, "failed to unmarshal pending clones list for snapshot %q in filesystem %q subvolume group %q", snap, fsName, groupName)
 	}
 
 	return pendingClones, nil

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -63,7 +63,7 @@ type DeviceOsdIDEntry struct {
 	Config                DesiredDevice // Device specific config options
 	PersistentDevicePaths []string
 	DeviceInfo            *sys.LocalDisk // low-level info about the device
-	RestoreOSD            bool           // Restore OSD by reparing it with with OSD ID
+	RestoreOSD            bool           // Restore OSD by repairing it with OSD ID
 }
 
 func (m *DeviceOsdMapping) String() string {

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -348,7 +348,7 @@ func TestUpdateServiceSelectors(t *testing.T) {
 		_, err2 := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Create(clusterInfo.Context, &svc2, metav1.CreateOptions{})
 		assert.NoError(t, err2)
 
-		// Check the the label has been only removed from svc1
+		// Check the label has been only removed from svc1
 		c.updateServiceSelectors()
 
 		// Make sure we remove controller.DaemonIDLabel label from all services tagged as 'app: rook-ceph-mgr'

--- a/pkg/operator/ceph/file/dependent.go
+++ b/pkg/operator/ceph/file/dependent.go
@@ -60,7 +60,7 @@ func filesystemExists(clusterdCtx *clusterd.Context, clusterInfo *cephclient.Clu
 	_, err := cephclient.GetFilesystem(clusterdCtx, clusterInfo, name)
 	if err != nil {
 		if code, ok := kexec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
-			log.NamedInfo(nsName, logger, "filesystem deletion will continue without checking for dependencies since the the filesystem does not exist within Ceph")
+			log.NamedInfo(nsName, logger, "filesystem deletion will continue without checking for dependencies since the filesystem does not exist within Ceph")
 			return false, nil
 		}
 		return false, errors.Wrapf(err, "failed to check for existence of CephFilesystem %q", nsName)


### PR DESCRIPTION
Tiny cleanup, low-key. A few docs/comments and one user-facing error string had duplicated words like `the the` / `for for`, plus `reparing`.

Repro:
```bash
rg -n "\bthe the\b|\bwith with\b|\bfor for\b|\breparing\b" \
  cmd/rook/userfacing/multus/validation/validation.go \
  pkg/daemon/ceph/osd/device.go \
  pkg/daemon/ceph/client/filesystem.go \
  pkg/operator/ceph/cluster/mgr/mgr_test.go \
  pkg/operator/ceph/file/dependent.go \
  Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md \
  Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
```

Before: it finds the stale text. After: no matches, nice and tidy.

Checks:
```bash
go test ./cmd/rook/userfacing/multus/... ./pkg/daemon/ceph/osd/... ./pkg/daemon/ceph/client ./pkg/operator/ceph/cluster/mgr ./pkg/operator/ceph/file
uvx codespell --skip=".git,*.png,*.jpg,*.svg,*.sum,./LICENSE,./deploy/examples/crds.yaml,./deploy/charts/rook-ceph/templates/resources.yaml,./deploy/examples/csi-operator.yaml,*Dashboard.json" --ignore-words-list="aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,ro,RO,addin,NotIn,Parth" --check-filenames --check-hidden
go run github.com/client9/misspell/cmd/misspell@latest -error <touched files>
git diff --check HEAD~1..HEAD
npx --yes -p @commitlint/cli -p @commitlint/config-conventional commitlint --from HEAD~1 --to HEAD
```

No related issue found; this is just a small polish pass.