### PR TITLE
core: skip crush rule cleanup if no pools exist yet

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -607,6 +607,15 @@ func CleanupUnusedCrushRules(context *clusterd.Context, clusterInfo *ClusterInfo
 		return err
 	}
 
+	// Skip cleanup when no pools exist yet. During initial cluster setup, this function
+	// runs after MGR startup but before pools are created. Deleting the default
+	// "replicated_rule" in this window leaves the cluster with zero CRUSH rules, causing
+	// Ceph internal modules (e.g. devicehealth) to crash when they try to create pools.
+	if len(usedRules) == 0 {
+		logger.Infof("no crush rules are in use yet, skipping cleanup")
+		return nil
+	}
+
 	crushMap, err := GetCrushMap(context, clusterInfo)
 	if err != nil {
 		return err
@@ -616,6 +625,10 @@ func CleanupUnusedCrushRules(context *clusterd.Context, clusterInfo *ClusterInfo
 	for _, rule := range crushMap.Rules {
 		if _, inUse := usedRules[rule.Name]; inUse {
 			logger.Debugf("crush rule %q is still in use", rule.Name)
+			continue
+		}
+		if rule.Name == "replicated_rule" {
+			logger.Debugf("skipping deletion of default crush rule %q", rule.Name)
 			continue
 		}
 		logger.Infof("crush rule %q is unused and will be deleted", rule.Name)

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -397,7 +397,8 @@ func TestCleanupUnusedCrushRules(t *testing.T) {
 				{"rule_name":"mypool_zone","steps":[{},{"type":"zone"}]},
 				{"rule_name":"mypool_zone_ssd","steps":[{},{"type":"zone","item_name":"default~ssd"}]},
 				{"rule_name":"shared_rule","steps":[{"item_name":"default"},{"type":"host"}]},
-				{"rule_name":"custom_rule","steps":[{"item_name":"default"},{"type":"zone"}]}
+				{"rule_name":"custom_rule","steps":[{"item_name":"default"},{"type":"zone"}]},
+				{"rule_name":"replicated_rule","steps":[{"item_name":"default"},{"type":"host"}]}
 			]}`, nil
 		}
 		if command == "ceph" && args[1] == "crush" && args[2] == "rule" && args[3] == "rm" {
@@ -413,6 +414,28 @@ func TestCleanupUnusedCrushRules(t *testing.T) {
 	slices.Sort(removedRules)
 	expected := []string{"custom_rule", "mypool", "mypool_zone"}
 	assert.Equal(t, expected, removedRules)
+	assert.NotContains(t, removedRules, "replicated_rule")
+}
+
+func TestCleanupUnusedCrushRulesNoPools(t *testing.T) {
+	removedRules := []string{}
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if command == "ceph" && args[1] == "lspools" {
+			return `[]`, nil
+		}
+		if command == "ceph" && args[1] == "crush" && args[2] == "rule" && args[3] == "rm" {
+			removedRules = append(removedRules, args[4])
+			return "", nil
+		}
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+
+	err := CleanupUnusedCrushRules(context, AdminTestClusterInfo("mycluster"))
+	assert.NoError(t, err)
+	assert.Empty(t, removedRules)
 }
 
 func TestExtractPoolDetails(t *testing.T) {


### PR DESCRIPTION
During the initial cluster setup, CleanUnusedCrushRules() runs after MGR startup but before any pools are created (if user does not create the .mgr pool along with the cephCluster manifest). It deletes the default replicated_rule since no pool references it.

This leaves the cluster in a state if Zero crush rules. When the MGR tries to start the device_health_metris during this window, thne it fails to find the crush rule and crashes.

Skip the cleanup when no pools exists yet, since there is nothing meaninful to cleanup.


Testing: 

Deployed cluster-test.yaml without the `.mgr` block pool 


**Before fix:** 

```
kubectl get cephblockpool -n rook-ceph                                                                                                                                                                        ─╯
No resources found in rook-ceph namespace.
```


```
2026-05-11 14:51:27.908495 I | op-config: successfully applied settings to the mon configuration database
2026-05-11 14:51:27.908544 I | cephclient: [rook-ceph] attempting to acquire crush cleanup lock
2026-05-11 14:51:27.908547 I | cephclient: [rook-ceph] acquired crush cleanup lock
2026-05-11 14:51:28.253019 I | cephclient: crush rule "replicated_rule" is unused and will be deleted
2026-05-11 14:51:28.429758 I | cephclient: deleted unused crush rule "replicated_rule"
```

```
oc exec -it -n rook-ceph rook-ceph-tools-9db6fc564-w49sk sh                                                                                                                                                   ─╯
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
sh-5.1$ ceph status
  cluster:
    id:     aeb352d6-7882-4ae9-a707-0770d6e02454
    health: HEALTH_ERR
            Module 'devicehealth' has failed: osd pool create failed: No suitable CRUSH rule exists, check 'osd pool default crush *' config options retval: -2

  services:
    mon: 1 daemons, quorum a (age 3m) [leader: a]
    mgr: a(active, since 2m)
    osd: 2 osds: 2 up (since 2m), 2 in (since 2m)

  data:
    pools:   0 pools, 0 pgs
    objects: 0 objects, 0 B
    usage:   453 MiB used, 40 GiB / 40 GiB avail
    pgs:

sh-5.1$ ceph osd pool ls
sh-5.1$
```


After fix: 

```
kubectl get cephblockpool -n rook-ceph                                                                                                                                                                        ─╯
No resources found in rook-ceph namespace.
```

```

2026-05-11 14:24:54.109803 I | op-config: successfully applied settings to the mon configuration database
2026-05-11 14:24:54.109880 I | cephclient: [rook-ceph] attempting to acquire crush cleanup lock
2026-05-11 14:24:54.109883 I | cephclient: [rook-ceph] acquired crush cleanup lock
2026-05-11 14:24:54.322325 I | cephclient: no crush rules are in use yet, skipping cleanup
2026-05-11 14:24:54.415870 I | op-osd: [rook-ceph] Starting validateTopologyAcrossNodes()
2026-05-11 14:24:54.415895 I | op-osd: [rook-ceph] Validating node topology across all cluster nodes
2026-05-11 14:24:54.417045 I | op-osd: [rook-ceph] Fetched nodelist with 1 nodes
2026-05-11 14:24:54.417057 I | op-osd: [rook-ceph] Node topology validation passed without conflicts

```

```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
sh-5.1$ ceph status
  cluster:
    id:     fd208458-bdba-480e-9ac8-d81e6fa04df0
    health: HEALTH_OK

  services:
    mon: 1 daemons, quorum a (age 11m) [leader: a]
    mgr: a(active, since 10m)
    osd: 2 osds: 2 up (since 10m), 2 in (since 11m)

  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   53 MiB used, 40 GiB / 40 GiB avail
    pgs:     1 active+clean

sh-5.1$ ceph osd pool ls
.mgr
sh-5.1$

```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
