### PR TITLE
nvmeof: add sys_admin to scc allowedcapabilities for gateway pods

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/securityContextConstraints.yaml
@@ -17,7 +17,7 @@ allowHostNetwork: false
 allowHostPorts: false
 {{- end }}
 priority:
-allowedCapabilities: ["MKNOD"]
+allowedCapabilities: ["MKNOD", "SYS_ADMIN"]
 allowHostIPC: true
 readOnlyRootFilesystem: false
 # drop all default privileges

--- a/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
+++ b/deploy/charts/rook-ceph/templates/securityContextConstraints.yaml
@@ -19,7 +19,7 @@ allowHostNetwork: false
 allowHostPorts: false
 {{- end }}
 priority:
-allowedCapabilities: ["MKNOD"]
+allowedCapabilities: ["MKNOD", "SYS_ADMIN"]
 allowHostIPC: true
 readOnlyRootFilesystem: false
 # drop all default privileges

--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -41,7 +41,7 @@ func NewSecurityContextConstraints(name string, namespaces ...string) *secv1.Sec
 		AllowHostIPC:             true,
 		AllowHostNetwork:         false,
 		AllowHostPorts:           false,
-		AllowedCapabilities:      []corev1.Capability{"MKNOD"},
+		AllowedCapabilities:      []corev1.Capability{"MKNOD", "SYS_ADMIN"},
 		RequiredDropCapabilities: []corev1.Capability{"ALL"},
 		DefaultAddCapabilities:   []corev1.Capability{},
 		RunAsUser: secv1.RunAsUserStrategyOptions{


### PR DESCRIPTION
the nvmeof gateway requires privileged containers with sys_admin capability. the rook-ceph scc only allowed mknod, causing pod creation to fail on openshift with:
"unable to validate against any security context constraint"

add sys_admin to allowedcapabilities in the helm chart sccs and the go scc helper. this does not affect other daemons (osd, rgw, mgr, mon) since they do not request sys_admin.

the operator-openshift.yaml example already includes sys_admin, so this aligns the helm charts to match.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
