### PR TITLE
core: rm unused consts

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -41,8 +41,6 @@ import (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephclient")
 
 const (
-	// DefaultKeyringFile is the default name of the file where Ceph stores its keyring info
-	DefaultKeyringFile = "keyring"
 	// Msgr2port is the listening port of the messenger v2 protocol
 	Msgr2port = 3300
 	// Msgr1port is the listening port of the messenger v1 protocol

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -52,7 +52,6 @@ type Images struct {
 }
 
 const (
-	mirrorModeDisabled = "disabled"
 	mirrorModeInitOnly = "init-only"
 )
 

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -37,8 +37,6 @@ const (
 	reallyConfirmFlag       = "--yes-i-really-really-mean-it"
 	targetSizeRatioProperty = "target_size_ratio"
 	CompressionModeProperty = "compression_mode"
-	PgAutoscaleModeProperty = "pg_autoscale_mode"
-	PgAutoscaleModeOn       = "on"
 )
 
 // crushRuleMutex coordinates crush rule cleanup with pool reconciles. Pool

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -25,18 +25,6 @@ import (
 )
 
 const (
-	// CephHealthOK denotes the status of ceph cluster when healthy.
-	CephHealthOK = "HEALTH_OK"
-
-	// CephHealthWarn denotes the status of ceph cluster when unhealthy but recovering.
-	CephHealthWarn = "HEALTH_WARN"
-
-	// CephHealthErr denotes the status of ceph cluster when unhealthy but usually needs
-	// manual intervention.
-	CephHealthErr = "HEALTH_ERR"
-)
-
-const (
 	defaultPgHealthyRegex = `^active(\+(clean|deep|scrubbing|snaptrim|snaptrim_wait))+$`
 )
 

--- a/pkg/daemon/ceph/osd/kms/kmip.go
+++ b/pkg/daemon/ceph/osd/kms/kmip.go
@@ -53,14 +53,13 @@ const (
 
 	// value not credential, just configuration keys.
 	//nolint:gosec
-	kmipEndpoint         = "KMIP_ENDPOINT"
-	kmipTLSServerName    = "TLS_SERVER_NAME"
-	kmipReadTimeOut      = "READ_TIMEOUT"
-	kmipWriteTimeOut     = "WRITE_TIMEOUT"
-	KmipCACert           = "CA_CERT"
-	KmipClientCert       = "CLIENT_CERT"
-	KmipClientKey        = "CLIENT_KEY"
-	KmipUniqueIdentifier = "UNIQUE_IDENTIFIER"
+	kmipEndpoint      = "KMIP_ENDPOINT"
+	kmipTLSServerName = "TLS_SERVER_NAME"
+	kmipReadTimeOut   = "READ_TIMEOUT"
+	kmipWriteTimeOut  = "WRITE_TIMEOUT"
+	KmipCACert        = "CA_CERT"
+	KmipClientCert    = "CLIENT_CERT"
+	KmipClientKey     = "CLIENT_KEY"
 
 	// EtcKmipDir is kmip config dir.
 	EtcKmipDir = "/etc/kmip"

--- a/pkg/daemon/ceph/util/util.go
+++ b/pkg/daemon/ceph/util/util.go
@@ -23,12 +23,6 @@ import (
 	"github.com/coreos/pkg/capnslog"
 )
 
-const (
-	RBDSysBusPathDefault = "/sys/bus/rbd"
-	RBDDevicesDir        = "devices"
-	RBDDevicePathPrefix  = "/dev/rbd"
-)
-
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-ceph-util")
 
 // GetIPFromEndpoint return the IP from an endpoint string (192.168.0.1:6789)

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -59,9 +59,7 @@ const (
 )
 
 const (
-	// DefaultClusterName states the default name of the rook-cluster if not provided.
-	DefaultClusterName = "rook-ceph"
-	disableHotplugEnv  = "ROOK_DISABLE_DEVICE_HOTPLUG"
+	disableHotplugEnv = "ROOK_DISABLE_DEVICE_HOTPLUG"
 )
 
 var (

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -44,11 +44,10 @@ const (
 	dashboardPortHTTP   = 7000
 	dashboardUsername   = "admin"
 	//nolint:gosec // because of the word `Password`
-	dashboardPasswordName          = "rook-ceph-dashboard-password"
-	passwordLength                 = 20
-	passwordKeyName                = "password"
-	certAlreadyConfiguredErrorCode = 5
-	invalidArgErrorCode            = int(syscall.EINVAL)
+	dashboardPasswordName = "rook-ceph-dashboard-password"
+	passwordLength        = 20
+	passwordKeyName       = "password"
+	invalidArgErrorCode   = int(syscall.EINVAL)
 )
 
 var (

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -55,8 +55,6 @@ const (
 	mgrRoleLabelName          = "mgr_role"
 	activeMgrStatus           = "active"
 	standbyMgrStatus          = "standby"
-	monitoringPath            = "/etc/ceph-monitoring/"
-	serviceMonitorFile        = "service-monitor.yaml"
 	serviceMonitorPort        = "http-metrics"
 	// minimum amount of memory in MB to run the pod
 	cephMgrPodMinimumMemory uint64 = 512

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -78,8 +78,6 @@ const (
 
 	// DefaultMonCount Default mon count for a cluster
 	DefaultMonCount = 3
-	// MaxMonCount Maximum allowed mon count for a cluster
-	MaxMonCount = 9
 
 	// DefaultMsgr1Port is the default port Ceph mons use to communicate amongst themselves prior
 	// to Ceph Nautilus.

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -43,8 +43,6 @@ import (
 )
 
 const (
-	monitoringPath                   = "/etc/ceph-monitoring/"
-	serviceMonitorFile               = "exporter-service-monitor.yaml"
 	sockDir                          = "/run/ceph"
 	defaultPrioLimit                 = "5"
 	defaultStatsPeriod               = "5"

--- a/pkg/operator/ceph/cluster/nodedaemon/keyring.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/keyring.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	crashClient          = `client.crash`
-	exporterClient       = `client.ceph-exporter`
 	crashKeyringTemplate = `
 [client.crash]
 	key = %s

--- a/pkg/operator/ceph/cluster/osd/config/scheme.go
+++ b/pkg/operator/ceph/cluster/osd/config/scheme.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config
 
 const (
-	// Bluestore represents a bluestore OSD
-	Bluestore = "bluestore"
 	// WalDefaultSizeMB is the default WAL size in Megabytes for Rocksdb in Bluestore
 	WalDefaultSizeMB = 576
 )

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -60,12 +60,6 @@ const (
 
 	// CrashType defines the crash collector DaemonType
 	CrashType = "crashcollector"
-
-	// CephUser is the Linux Ceph username
-	CephUser = "ceph"
-
-	// CephGroup is the Linux Ceph groupname
-	CephGroup = "ceph"
 )
 
 var (

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -73,10 +73,6 @@ var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
 
-	// ImmediateRetryResultNoBackoff Return this for a immediate retry of the reconciliation loop with the same request object.
-	// Override the exponential backoff behavior by setting the RequeueAfter time explicitly.
-	ImmediateRetryResultNoBackoff = reconcile.Result{Requeue: true, RequeueAfter: time.Second}
-
 	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
 	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -60,7 +60,6 @@ const (
 	DaemonIDLabel                           = "ceph_daemon_id"
 	daemonTypeLabel                         = "ceph_daemon_type"
 	ExternalMgrAppName                      = "rook-ceph-mgr-external"
-	ExternalCephExporterName                = "rook-ceph-exporter-external"
 	ServiceExternalMetricName               = "http-external-metrics"
 	CephUserID                              = int64(167)
 	livenessProbeTimeoutSeconds       int32 = 5

--- a/pkg/operator/ceph/object/cosi/controller.go
+++ b/pkg/operator/ceph/object/cosi/controller.go
@@ -45,7 +45,6 @@ import (
 )
 
 const (
-	packageName               = "ceph-cosi"
 	controllerName            = "ceph-cosi-controller"
 	CephCOSIDriverName        = "ceph-cosi-driver"
 	COSISideCarName           = "objectstorage-provisioner-sidecar"

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -44,8 +44,6 @@ const (
 	// PrivateIPEnvVar pod IP env var
 	PrivateIPEnvVar = "ROOK_PRIVATE_IP"
 
-	// DefaultRepoPrefix repo prefix
-	DefaultRepoPrefix = "rook"
 	// ConfigOverrideName config override name
 	ConfigOverrideName = "rook-config-override"
 	// ConfigOverrideVal config override value

--- a/pkg/operator/k8sutil/status.go
+++ b/pkg/operator/k8sutil/status.go
@@ -19,8 +19,6 @@ package k8sutil
 const (
 	// ReadyStatus reflects the completeness of tasks for ceph related CRs
 	ReadyStatus = "Ready"
-	// ProcessingStatus reflects that the tasks are in progress for ceph related CRs
-	ProcessingStatus = "Processing"
 	// FailedStatus reflects that some task failed for ceph related CRs
 	FailedStatus = "Failed"
 	// ReconcilingStatus indicates the CR is reconciling

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -50,8 +50,6 @@ const (
 	sgdiskCmd = "sgdisk"
 	// CephLVPrefix is the prefix of a LV owned by ceph-volume
 	CephLVPrefix = "ceph--"
-	// DeviceMapperPrefix is the prefix of a LV from the device mapper interface
-	DeviceMapperPrefix = "dm-"
 )
 
 // CephVolumeInventory represents the output of the ceph-volume inventory command

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -31,11 +31,6 @@ import (
 const (
 	// LocalBuildTag tag for the latest manifests
 	LocalBuildTag = "local-build"
-
-	// test suite names
-	CassandraTestSuite = "cassandra"
-	CephTestSuite      = "ceph"
-	NFSTestSuite       = "nfs"
 )
 
 var (


### PR DESCRIPTION
The major of the unused consts were identified by Opus 4.7.
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
