### PR TITLE
chore: fix duplicated words in ceph CRD type and object spec comments

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -818,7 +818,7 @@ type ClusterCephxStatus struct {
 	Mon CephxStatus `json:"mon,omitempty"`
 	// Mgr represents the cephx key rotation status of the ceph manager daemon
 	Mgr CephxStatus `json:"mgr,omitempty"`
-	// OSD shows the CephX key status of of OSDs
+	// OSD shows the CephX key status of OSDs
 	OSD CephxStatus `json:"osd,omitempty"`
 	// CSI shows the CephX key status for Ceph-CSI components.
 	CSI CephxStatusWithKeyCount `json:"csi,omitempty"`

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -108,7 +108,7 @@ var (
 	}
 	// Filename to store RGW ops log per pod.
 	// Relies on the on environment variables to get the pod name and namespace.
-	// podNameEnvVars have to be passed to to log collector container.
+	// podNameEnvVars have to be passed to log collector container.
 	opsLogFilename    = "ops-log.$(POD_NS).$(POD_NAME).log"
 	opsLogAbsFilename = path.Join(cephconfig.VarLogCephDir, opsLogFilename)
 )


### PR DESCRIPTION
Two small comment-only typos: doubled `of of` in `pkg/apis/ceph.rook.io/v1/types.go` and doubled `to to` in `pkg/operator/ceph/object/spec.go`. No functional change.