### PR TITLE
security: remove net_raw from operator-openshift.yaml scc

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -18,7 +18,7 @@ allowHostNetwork: false
 # set to true if running rook with the provider as host
 allowHostPorts: false
 priority:
-allowedCapabilities: ["MKNOD", "SYS_ADMIN", "NET_RAW"]
+allowedCapabilities: ["MKNOD", "SYS_ADMIN"]
 allowHostIPC: true
 readOnlyRootFilesystem: false
 # drop all default privileges


### PR DESCRIPTION
net_raw is listed in the rook-ceph scc allowedcapabilities but no daemon uses it — all pods explicitly drop net_raw. remove it to align with the go scc helper and helm charts.

Fixes: #17536 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
