### PR TITLE
helm: update prometheus rules from upstream ceph/ceph; add `cluster` label to all scraped metrics

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/externalrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/externalrules.yaml
@@ -3,23 +3,23 @@ groups:
     rules:
       - alert: PersistentVolumeUsageNearFull
         annotations:
-          description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 75%. Free up some space or expand the PVC.
-          message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion or PVC expansion is required.
+          description: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} utilization has crossed 75%. Free up some space or expand the PVC.
+          message: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} is nearing full. Data deletion or PVC expansion is required.
           severity_level: warning
           storage_type: ceph
         expr: |
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
+          (kubelet_volume_stats_used_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
         for: 5s
         labels:
           severity: warning
       - alert: PersistentVolumeUsageCritical
         annotations:
-          description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 85%. Free up some space or expand the PVC immediately.
-          message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data deletion or PVC expansion is required.
+          description: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} utilization has crossed 85%. Free up some space or expand the PVC immediately.
+          message: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} is critically full. Data deletion or PVC expansion is required.
           severity_level: error
           storage_type: ceph
         expr: |
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
+          (kubelet_volume_stats_used_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
         for: 5s
         labels:
           severity: critical

--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -1,4 +1,4 @@
-# Copied from https://github.com/ceph/ceph/blob/master/monitoring/ceph-mixin/prometheus_alerts.yml
+# Copied from https://github.com/ceph/ceph/blob/4b5096cc0de40a1b80bf801b4261bb58b0702e82/monitoring/ceph-mixin/prometheus_alerts.yml
 # Attention: This is not a 1:1 copy of ceph-mixin alerts. This file contains several Rook-related adjustments.
 #   List of main adjustments:
 #     - Alerts related to cephadm are excluded
@@ -8,8 +8,8 @@ groups:
     rules:
       - alert: "CephHealthError"
         annotations:
-          description: "The cluster state has been HEALTH_ERROR for more than 5 minutes. Please check 'ceph health detail' for more information."
-          summary: "Ceph is in the ERROR state"
+          description: "The cluster state has been HEALTH_ERROR for more than 5 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the ERROR state on cluster {{ $labels.cluster }}"
         expr: "ceph_health_status == 2"
         for: "5m"
         labels:
@@ -18,8 +18,8 @@ groups:
           type: "ceph_default"
       - alert: "CephHealthWarning"
         annotations:
-          description: "The cluster state has been HEALTH_WARN for more than 15 minutes. Please check 'ceph health detail' for more information."
-          summary: "Ceph is in the WARNING state"
+          description: "The cluster state has been HEALTH_WARN for more than 15 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the WARNING state on cluster {{ $labels.cluster }}"
         expr: "ceph_health_status == 1"
         for: "15m"
         labels:
@@ -29,13 +29,13 @@ groups:
     rules:
       - alert: "CephMonDownQuorumAtRisk"
         annotations:
-          description: "{{ $min := query \"floor(count(ceph_mon_metadata) / 2) + 1\" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range query \"(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          description: "{{ $min := printf \"floor(count(ceph_mon_metadata{cluster='%s'}) / 2) + 1\" .Labels.cluster | query | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
-          summary: "Monitor quorum is at risk"
+          summary: "Monitor quorum is at risk on cluster {{ $labels.cluster }}"
         expr: |
           (
-            (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
-              count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right(cluster) (
+              count(ceph_mon_quorum_status == 1) by(cluster)== bool (floor(count(ceph_mon_metadata) by(cluster) / 2) + 1)
             )
           ) == 1
         for: "30s"
@@ -45,12 +45,11 @@ groups:
           type: "ceph_default"
       - alert: "CephMonDown"
         annotations:
-          description: |
-            {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable.  The following monitors are down: {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}   - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          description: "{{ $down := printf \"count(ceph_mon_quorum_status{cluster='%s'} == 0)\" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $down 1.0 }}{{ $s = \"s\" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
-          summary: "One or more monitors down"
+          summary: "One or more monitors down on cluster {{ $labels.cluster }}"
         expr: |
-          count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+          (count by (cluster) (ceph_mon_quorum_status == 0)) <= (count by (cluster) (ceph_mon_metadata) - floor((count by (cluster) (ceph_mon_metadata) / 2 + 1)))
         for: "30s"
         labels:
           severity: "warning"
@@ -59,7 +58,7 @@ groups:
         annotations:
           description: "The free space available to a monitor's store is critically low. You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*. Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit"
-          summary: "Filesystem space on at least one monitor is critically low"
+          summary: "Filesystem space on at least one monitor is critically low on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MON_DISK_CRIT\"} == 1"
         for: "1m"
         labels:
@@ -70,7 +69,7 @@ groups:
         annotations:
           description: "The space available to a monitor's store is approaching full (>70% is the default). You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*.  Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low"
-          summary: "Drive space on at least one monitor is approaching full"
+          summary: "Drive space on at least one monitor is approaching full on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MON_DISK_LOW\"} == 1"
         for: "5m"
         labels:
@@ -80,7 +79,7 @@ groups:
         annotations:
           description: "Ceph monitors rely on closely synchronized time to maintain quorum and cluster consistency. This event indicates that the time on at least one mon has drifted too far from the lead mon. Review cluster status with ceph -s. This will show which monitors are affected. Check the time sync status on each monitor host with 'ceph time-sync-status' and the state and peers of your ntpd or chrony daemon."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew"
-          summary: "Clock skew detected among monitors"
+          summary: "Clock skew detected among monitors on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MON_CLOCK_SKEW\"} == 1"
         for: "1m"
         labels:
@@ -90,18 +89,17 @@ groups:
     rules:
       - alert: "CephOSDDownHigh"
         annotations:
-          description: "{{ $value | humanize }}% or {{ with query \"count(ceph_osd_up == 0)\" }}{{ . | first | value }}{{ end }} of {{ with query \"count(ceph_osd_up)\" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
-          summary: "More than 10% of OSDs are down"
-        expr: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
-        for: "5m"
+          description: "{{ $value | humanize }}% or {{ with printf \"count (ceph_osd_up{cluster='%s'} == 0)\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} of {{ with printf \"count (ceph_osd_up{cluster='%s'})\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster, ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          summary: "More than 10% of OSDs are down on cluster {{ $labels.cluster }}"
+        expr: "count by (cluster) (ceph_osd_up == 0) / count by (cluster) (ceph_osd_up) * 100 >= 10"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
           severity: "critical"
           type: "ceph_default"
       - alert: "CephOSDHostDown"
         annotations:
-          description: "The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
-          summary: "An OSD host is offline"
+          description: "The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
+          summary: "An OSD host is offline on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_HOST_DOWN\"} == 1"
         for: "5m"
         labels:
@@ -110,10 +108,9 @@ groups:
           type: "ceph_default"
       - alert: "CephOSDDown"
         annotations:
-          description: |
-            {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s "" }}is{{ else }}are{{ end }} down: {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0"}} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          description: "{{ $num := printf \"count(ceph_osd_up{cluster='%s'} == 0) \" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $num 1.0 }}{{ $s = \"s\" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s \"\" }}is{{ else }}are{{ end }} down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down"
-          summary: "An OSD has been marked down"
+          summary: "An OSD has been marked down on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_DOWN\"} == 1"
         for: "5m"
         labels:
@@ -124,7 +121,7 @@ groups:
         annotations:
           description: "One or more OSDs have reached the NEARFULL threshold. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull"
-          summary: "OSD(s) running low on free space (NEARFULL)"
+          summary: "OSD(s) running low on free space (NEARFULL) on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_NEARFULL\"} == 1"
         for: "5m"
         labels:
@@ -135,7 +132,7 @@ groups:
         annotations:
           description: "An OSD has reached the FULL threshold. Writes to pools that share the affected OSD will be blocked. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full"
-          summary: "OSD full, writes blocked"
+          summary: "OSD full, writes blocked on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_FULL\"} > 0"
         for: "1m"
         labels:
@@ -146,7 +143,7 @@ groups:
         annotations:
           description: "An OSD has reached the BACKFILL FULL threshold. This will prevent rebalance operations from completing. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull"
-          summary: "OSD(s) too full for backfill operations"
+          summary: "OSD(s) too full for backfill operations on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_BACKFILLFULL\"} > 0"
         for: "1m"
         labels:
@@ -156,7 +153,7 @@ groups:
         annotations:
           description: "Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs"
-          summary: "OSD reports a high number of read errors"
+          summary: "OSD reports a high number of read errors on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_TOO_MANY_REPAIRS\"} == 1"
         for: "30s"
         labels:
@@ -165,7 +162,7 @@ groups:
       - alert: "CephOSDTimeoutsPublicNetwork"
         annotations:
           description: "OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network for latency or loss issues. Use 'ceph health detail' to show the affected OSDs."
-          summary: "Network issues delaying OSD heartbeats (public network)"
+          summary: "Network issues delaying OSD heartbeats (public network) on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_FRONT\"} == 1"
         for: "1m"
         labels:
@@ -174,7 +171,7 @@ groups:
       - alert: "CephOSDTimeoutsClusterNetwork"
         annotations:
           description: "OSD heartbeats on the cluster's 'cluster' network (backend) are slow. Investigate the network for latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs."
-          summary: "Network issues delaying OSD heartbeats (cluster network)"
+          summary: "Network issues delaying OSD heartbeats (cluster network) on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_BACK\"} == 1"
         for: "1m"
         labels:
@@ -184,7 +181,7 @@ groups:
         annotations:
           description: "One or more OSDs have an internal inconsistency between metadata and the size of the device. This could lead to the OSD(s) crashing in future. You should redeploy the affected OSDs."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch"
-          summary: "OSD size inconsistency error"
+          summary: "OSD size inconsistency error on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"BLUESTORE_DISK_SIZE_MISMATCH\"} == 1"
         for: "1m"
         labels:
@@ -194,7 +191,7 @@ groups:
         annotations:
           description: "The device health module has determined that one or more devices will fail soon. To review device status use 'ceph device ls'. To show a specific device use 'ceph device info <dev id>'. Mark the OSD out so that data may migrate to other OSDs. Once the OSD has drained, destroy the OSD, replace the device, and redeploy the OSD."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#id2"
-          summary: "Device(s) predicted to fail soon"
+          summary: "Device(s) predicted to fail soon on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"DEVICE_HEALTH\"} == 1"
         for: "1m"
         labels:
@@ -204,7 +201,7 @@ groups:
         annotations:
           description: "The device health module has determined that devices predicted to fail can not be remediated automatically, since too many OSDs would be removed from the cluster to ensure performance and availability. Prevent data integrity issues by adding new OSDs so that data may be relocated."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany"
-          summary: "Too many devices are predicted to fail, unable to resolve"
+          summary: "Too many devices are predicted to fail on cluster {{ $labels.cluster }}, unable to resolve"
         expr: "ceph_health_detail{name=\"DEVICE_HEALTH_TOOMANY\"} == 1"
         for: "1m"
         labels:
@@ -215,7 +212,7 @@ groups:
         annotations:
           description: "The device health module has determined that one or more devices will fail soon, but the normal process of relocating the data on the device to other OSDs in the cluster is blocked. \nEnsure that the cluster has available free space. It may be necessary to add capacity to the cluster to allow data from the failing device to successfully migrate, or to enable the balancer."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use"
-          summary: "Device failure is predicted, but unable to relocate data"
+          summary: "Device failure is predicted, but unable to relocate data on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"DEVICE_HEALTH_IN_USE\"} == 1"
         for: "1m"
         labels:
@@ -225,8 +222,8 @@ groups:
         annotations:
           description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was marked down and back up {{ $value | humanize }} times once a minute for 5 minutes. This may indicate a network issue (latency, packet loss, MTU mismatch) on the cluster network, or the public network if no cluster network is deployed. Check the network stats on the listed host(s)."
           documentation: "https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds"
-          summary: "Network issues are causing OSDs to flap (mark each other down)"
-        expr: "(rate(ceph_osd_up[5m]) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
+          summary: "Network issues are causing OSDs to flap (mark each other down) on cluster {{ $labels.cluster }}"
+        expr: "(rate(ceph_osd_up[5m]) * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.4.4"
           severity: "warning"
@@ -235,7 +232,7 @@ groups:
         annotations:
           description: "An OSD has encountered read errors, but the OSD has recovered by retrying the reads. This may indicate an issue with hardware or the kernel."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors"
-          summary: "Device read errors detected"
+          summary: "Device read errors detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"BLUESTORE_SPURIOUS_READ_ERRORS\"} == 1"
         for: "30s"
         labels:
@@ -243,13 +240,25 @@ groups:
           type: "ceph_default"
       - alert: "CephPGImbalance"
         annotations:
-          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count."
-          summary: "PGs are not balanced across OSDs"
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count in the device class {{ $labels.device_class }}."
+          summary: "PGs are not balanced across OSDs on cluster {{ $labels.cluster }}"
         expr: |
           abs(
-            ((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) /
-            on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-          ) * on (ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+            (
+              (
+                (ceph_osd_numpg > 0)
+                * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              )
+              - on (cluster, job, device_class) group_left avg(
+                  (ceph_osd_numpg > 0)
+                  * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                ) by (cluster, job, device_class)
+            )
+            / on (cluster, job, device_class) group_left avg(
+                (ceph_osd_numpg > 0)
+                * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              ) by (cluster, job, device_class)
+          ) > 0.30
         for: "5m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.4.5"
@@ -261,7 +270,7 @@ groups:
         annotations:
           description: "Filesystem metadata has been corrupted. Data may be inaccessible. Analyze metrics from the MDS daemon admin socket, or escalate to support."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
-          summary: "CephFS filesystem is damaged."
+          summary: "CephFS filesystem is damaged on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MDS_DAMAGE\"} > 0"
         for: "1m"
         labels:
@@ -272,7 +281,7 @@ groups:
         annotations:
           description: "All MDS ranks are unavailable. The MDS daemons managing metadata are down, rendering the filesystem offline."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down"
-          summary: "CephFS filesystem is offline"
+          summary: "CephFS filesystem is offline on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MDS_ALL_DOWN\"} > 0"
         for: "1m"
         labels:
@@ -283,7 +292,7 @@ groups:
         annotations:
           description: "One or more metadata daemons (MDS ranks) are failed or in a damaged state. At best the filesystem is partially available, at worst the filesystem is completely unusable."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded"
-          summary: "CephFS filesystem is degraded"
+          summary: "CephFS filesystem is degraded on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"FS_DEGRADED\"} > 0"
         for: "1m"
         labels:
@@ -294,7 +303,7 @@ groups:
         annotations:
           description: "The filesystem's 'max_mds' setting defines the number of MDS ranks in the filesystem. The current number of active MDS daemons is less than this value."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max"
-          summary: "Ceph MDS daemon count is lower than configured"
+          summary: "Ceph MDS daemon count is lower than configured on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MDS_UP_LESS_THAN_MAX\"} > 0"
         for: "1m"
         labels:
@@ -304,7 +313,7 @@ groups:
         annotations:
           description: "The minimum number of standby daemons required by standby_count_wanted is less than the current number of standby daemons. Adjust the standby count or increase the number of MDS daemons."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby"
-          summary: "Ceph filesystem standby daemons too few"
+          summary: "Ceph filesystem standby daemons too few on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MDS_INSUFFICIENT_STANDBY\"} > 0"
         for: "1m"
         labels:
@@ -314,7 +323,7 @@ groups:
         annotations:
           description: "An MDS daemon has failed, leaving only one active rank and no available standby. Investigate the cause of the failure or add a standby MDS."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds"
-          summary: "MDS daemon failed, no further standby available"
+          summary: "MDS daemon failed, no further standby available on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"FS_WITH_FAILED_MDS\"} > 0"
         for: "1m"
         labels:
@@ -325,7 +334,7 @@ groups:
         annotations:
           description: "The filesystem has switched to READ ONLY due to an unexpected error when writing to the metadata pool. Either analyze the output from the MDS daemon admin socket, or escalate to support."
           documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
-          summary: "CephFS filesystem in read only mode due to write error(s)"
+          summary: "CephFS filesystem in read only mode due to write error(s) on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"MDS_HEALTH_READ_ONLY\"} > 0"
         for: "1m"
         labels:
@@ -338,7 +347,7 @@ groups:
         annotations:
           description: "One or more mgr modules have crashed and have yet to be acknowledged by an administrator. A crashed module may impact functionality within the cluster. Use the 'ceph crash' command to determine which module has failed, and archive it to acknowledge the failure."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash"
-          summary: "A manager module has recently crashed"
+          summary: "A manager module has recently crashed on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"RECENT_MGR_MODULE_CRASH\"} == 1"
         for: "5m"
         labels:
@@ -360,8 +369,8 @@ groups:
       - alert: "CephPGsInactive"
         annotations:
           description: "{{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}. Inactive placement groups are not able to serve read/write requests."
-          summary: "One or more placement groups are inactive"
-        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
+          summary: "One or more placement groups are inactive on cluster {{ $labels.cluster }}"
+        expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
         for: "5m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.7.1"
@@ -370,8 +379,8 @@ groups:
       - alert: "CephPGsUnclean"
         annotations:
           description: "{{ $value }} PGs have been unclean for more than 15 minutes in pool {{ $labels.name }}. Unclean PGs have not recovered from a previous failure."
-          summary: "One or more placement groups are marked unclean"
-        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
+          summary: "One or more placement groups are marked unclean on cluster {{ $labels.cluster }}"
+        expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
         for: "15m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.7.2"
@@ -381,7 +390,7 @@ groups:
         annotations:
           description: "During data consistency checks (scrub), at least one PG has been flagged as being damaged or inconsistent. Check to see which PG is affected, and attempt a manual repair if necessary. To list problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use the 'ceph pg repair <pg_num>' command."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged"
-          summary: "Placement group damaged, manual intervention needed"
+          summary: "Placement group damaged, manual intervention needed on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=~\"PG_DAMAGED|OSD_SCRUB_ERRORS\"} == 1"
         for: "5m"
         labels:
@@ -392,7 +401,7 @@ groups:
         annotations:
           description: "Data redundancy is at risk since one or more OSDs are at or above the 'full' threshold. Add more capacity to the cluster, restore down/out OSDs, or delete unwanted data."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full"
-          summary: "OSDs are too full for recovery"
+          summary: "OSDs are too full for recovery on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"PG_RECOVERY_FULL\"} == 1"
         for: "1m"
         labels:
@@ -403,7 +412,7 @@ groups:
         annotations:
           description: "Data availability is reduced, impacting the cluster's ability to service I/O. One or more placement groups (PGs) are in a state that blocks I/O."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability"
-          summary: "PG is unavailable, blocking I/O"
+          summary: "PG is unavailable on cluster {{ $labels.cluster }}, blocking I/O"
         expr: "((ceph_health_detail{name=\"PG_AVAILABILITY\"} == 1) - scalar(ceph_health_detail{name=\"OSD_DOWN\"})) == 1"
         for: "1m"
         labels:
@@ -414,7 +423,7 @@ groups:
         annotations:
           description: "Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs have reached the 'backfillfull' threshold. Add more capacity, or delete unwanted data."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full"
-          summary: "Backfill operations are blocked due to lack of free space"
+          summary: "Backfill operations are blocked due to lack of free space on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"PG_BACKFILL_FULL\"} == 1"
         for: "1m"
         labels:
@@ -425,7 +434,7 @@ groups:
         annotations:
           description: "One or more PGs have not been scrubbed recently. Scrubs check metadata integrity, protecting against bit-rot. They check that metadata is consistent across data replicas. When PGs miss their scrub interval, it may indicate that the scrub window is too small, or PGs were not in a 'clean' state during the scrub window. You can manually initiate a scrub with: ceph pg scrub <pgid>"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed"
-          summary: "Placement group(s) have not been scrubbed"
+          summary: "Placement group(s) have not been scrubbed on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"PG_NOT_SCRUBBED\"} == 1"
         for: "5m"
         labels:
@@ -435,7 +444,7 @@ groups:
         annotations:
           description: "The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).\n Check that the pg_autoscaler has not been disabled for any pools with 'ceph osd pool autoscale-status', and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide the autoscaler based on the expected relative size of the pool ('ceph osd pool set cephfs.cephfs.meta target_size_ratio .1') or set the pg_autoscaler mode to 'warn' and adjust pg_num appropriately for one or more pools."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs"
-          summary: "Placement groups per OSD is too high"
+          summary: "Placement groups per OSD is too high on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"TOO_MANY_PGS\"} == 1"
         for: "1m"
         labels:
@@ -445,7 +454,7 @@ groups:
         annotations:
           description: "One or more PGs have not been deep scrubbed recently. Deep scrubs protect against bit-rot. They compare data replicas to ensure consistency. When PGs miss their deep scrub interval, it may indicate that the window is too small or PGs were not in a 'clean' state during the deep-scrub window."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed"
-          summary: "Placement group(s) have not been deep scrubbed"
+          summary: "Placement group(s) have not been deep scrubbed on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"PG_NOT_DEEP_SCRUBBED\"} == 1"
         for: "5m"
         labels:
@@ -485,7 +494,7 @@ groups:
       - alert: "CephNodeNetworkPacketErrors"
         annotations:
           description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
-          summary: "One or more NICs reports packet errors"
+          summary: "One or more NICs reports packet errors on cluster {{ $labels.cluster }}"
         expr: |
           (
             rate(node_network_receive_errs_total{device!="lo"}[1m]) +
@@ -504,7 +513,7 @@ groups:
       - alert: "CephNodeNetworkBondDegraded"
         annotations:
           description: "Bond {{ $labels.master }} is degraded on Node {{ $labels.instance }}."
-          summary: "Degraded Bond on Node {{ $labels.instance }}"
+          summary: "Degraded Bond on Node {{ $labels.instance }} on cluster {{ $labels.cluster }}"
         expr: |
           node_bonding_slaves - node_bonding_active != 0
         labels:
@@ -513,27 +522,51 @@ groups:
       - alert: "CephNodeDiskspaceWarning"
         annotations:
           description: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }} will be full in less than 5 days based on the 48 hour trailing fill rate."
-          summary: "Host filesystem free space is getting low"
-        expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0"
+          summary: "Host filesystem free space is getting low on cluster {{ $labels.cluster }}"
+        expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) * on(cluster, instance) group_left(nodename) node_uname_info < 0"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.8.4"
           severity: "warning"
           type: "ceph_default"
-      - alert: "CephNodeInconsistentMTU"
-        annotations:
-          description: "Node {{ $labels.instance }} has a different MTU size ({{ $value }}) than the median of devices named {{ $labels.device }}."
-          summary: "MTU settings across Ceph hosts are inconsistent"
-        expr: "node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    max by (device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )or node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    min by (device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )"
+      - alert: CephNodeInconsistentMTU
+        expr: |
+          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+          != on (cluster, device) group_left
+            quantile by (cluster, device) (
+              0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+            )
         labels:
-          severity: "warning"
-          type: "ceph_default"
+          severity: warning
+          type: ceph_default
+        annotations:
+          summary: "Node {{ $labels.instance }} has inconsistent MTU settings in cluster {{ $labels.cluster }}"
+          description: "Network interface {{ $labels.device }} on node {{ $labels.instance }} has MTU {{ $value }} which differs from the cluster median."
+          impact: |
+            - May cause packet fragmentation or packet drops
+            - Risk of degraded cluster communication and performance
+            - Potential instability in services relying on consistent networking (e.g., Ceph, Kubernetes)
+          fix: |
+            - Check the MTU of interface `{{ $labels.device }}` on node `{{ $labels.instance }}`:
+              ip link show {{ $labels.device }}
+
+            - Find the median MTU value across the cluster by running this PromQL query in Prometheus:
+              quantile by (cluster, device) (0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
+
+            - Standardize MTU across all nodes to match the median (commonly 1500 or 9000):
+              ip link set dev {{ $labels.device }} mtu <median-value>
+
+            - Make MTU setting persistent:
+              - RHEL/CentOS: edit `/etc/sysconfig/network-scripts/ifcfg-<device>`
+              - Debian/Ubuntu: edit `/etc/netplan/*.yaml` and apply with `netplan apply`
+
+            - Restart the affected interface or node if required.
   - name: "pools"
     rules:
       - alert: "CephPoolGrowthWarning"
         annotations:
           description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
-          summary: "Pool growth rate may soon exceed capacity"
-        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
+          summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
+        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
           severity: "warning"
@@ -541,16 +574,16 @@ groups:
       - alert: "CephPoolBackfillFull"
         annotations:
           description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
-          summary: "Free space in a pool is too low for recovery/backfill"
+          summary: "Free space in a pool is too low for recovery/backfill on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"POOL_BACKFILLFULL\"} > 0"
         labels:
           severity: "warning"
           type: "ceph_default"
       - alert: "CephPoolFull"
         annotations:
-          description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range query \"topk(5, sort_desc(ceph_pool_percent_used * on(pool_id) group_right ceph_pool_metadata))\" }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
+          description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range printf \"topk(5, sort_desc(ceph_pool_percent_used{cluster='%s'} * on(cluster,pool_id) group_right ceph_pool_metadata))\" .Labels.cluster | query }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full"
-          summary: "Pool is full - writes are blocked"
+          summary: "Pool is full - writes are blocked on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"POOL_FULL\"} > 0"
         for: "1m"
         labels:
@@ -560,7 +593,7 @@ groups:
       - alert: "CephPoolNearFull"
         annotations:
           description: "A pool has exceeded the warning (percent full) threshold, or OSDs supporting the pool have reached the NEARFULL threshold. Writes may continue, but you are at risk of the pool going read-only if more capacity isn't made available. Determine the affected pool with 'ceph df detail', looking at QUOTA BYTES and STORED. Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>). Also ensure that the balancer is active."
-          summary: "One or more Ceph pools are nearly full"
+          summary: "One or more Ceph pools are nearly full on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"POOL_NEAR_FULL\"} > 0"
         for: "5m"
         labels:
@@ -572,7 +605,7 @@ groups:
         annotations:
           description: "{{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-          summary: "OSD operations are slow to complete"
+          summary: "OSD operations are slow to complete on cluster {{ $labels.cluster }}"
         expr: "ceph_healthcheck_slow_ops > 0"
         for: "30s"
         labels:
@@ -582,7 +615,7 @@ groups:
         annotations:
           description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-          summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
+          summary: "{{ $labels.ceph_daemon }} operations are slow to complete on cluster {{ $labels.cluster }}"
         expr: "ceph_daemon_health_metrics{type=\"SLOW_OPS\"} > 0"
         for: "30s"
         labels:
@@ -593,7 +626,7 @@ groups:
       - alert: "HardwareStorageError"
         annotations:
           description: "Some storage devices are in error. Check `ceph health detail`."
-          summary: "Storage devices error(s) detected"
+          summary: "Storage devices error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_STORAGE\"} > 0"
         for: "30s"
         labels:
@@ -603,7 +636,7 @@ groups:
       - alert: "HardwareMemoryError"
         annotations:
           description: "DIMM error(s) detected. Check `ceph health detail`."
-          summary: "DIMM error(s) detected"
+          summary: "DIMM error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_MEMORY\"} > 0"
         for: "30s"
         labels:
@@ -613,7 +646,7 @@ groups:
       - alert: "HardwareProcessorError"
         annotations:
           description: "Processor error(s) detected. Check `ceph health detail`."
-          summary: "Processor error(s) detected"
+          summary: "Processor error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_PROCESSOR\"} > 0"
         for: "30s"
         labels:
@@ -623,7 +656,7 @@ groups:
       - alert: "HardwareNetworkError"
         annotations:
           description: "Network error(s) detected. Check `ceph health detail`."
-          summary: "Network error(s) detected"
+          summary: "Network error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_NETWORK\"} > 0"
         for: "30s"
         labels:
@@ -633,7 +666,7 @@ groups:
       - alert: "HardwarePowerError"
         annotations:
           description: "Power supply error(s) detected. Check `ceph health detail`."
-          summary: "Power supply error(s) detected"
+          summary: "Power supply error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_POWER\"} > 0"
         for: "30s"
         labels:
@@ -643,7 +676,7 @@ groups:
       - alert: "HardwareFanError"
         annotations:
           description: "Fan error(s) detected. Check `ceph health detail`."
-          summary: "Fan error(s) detected"
+          summary: "Fan error(s) detected on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"HARDWARE_FANS\"} > 0"
         for: "30s"
         labels:
@@ -678,8 +711,8 @@ groups:
         annotations:
           description: "The latest version of a RADOS object can not be found, even though all OSDs are up. I/O requests for this object from clients will block (hang). Resolving this issue may require the object to be rolled back to a prior version manually, and manually verified."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound"
-          summary: "Object(s) marked UNFOUND"
-        expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1"
+          summary: "Object(s) marked UNFOUND on cluster {{ $labels.cluster }}"
+        expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() group_right(cluster) (count(ceph_osd_up == 1) by (cluster) == bool count(ceph_osd_metadata) by(cluster)) == 1"
         for: "30s"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.10.1"
@@ -691,7 +724,7 @@ groups:
         annotations:
           description: "One or more daemons have crashed recently, and need to be acknowledged. This notification ensures that software crashes do not go unseen. To acknowledge a crash, use the 'ceph crash archive <id>' command."
           documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash"
-          summary: "One or more Ceph daemons have crashed, and are pending acknowledgement"
+          summary: "One or more Ceph daemons have crashed, and are pending acknowledgement on cluster {{ $labels.cluster }}"
         expr: "ceph_health_detail{name=\"RECENT_CRASH\"} == 1"
         for: "1m"
         labels:
@@ -703,8 +736,8 @@ groups:
       - alert: "CephRBDMirrorImagesPerDaemonHigh"
         annotations:
           description: "Number of image replications per daemon is not supposed to go beyond threshold 100"
-          summary: "Number of image replications are now above 100"
-        expr: "sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
+          summary: "Number of image replications are now above 100 on cluster {{ $labels.cluster }}"
+        expr: "sum by (cluster, ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
         for: "1m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.10.2"
@@ -713,8 +746,8 @@ groups:
       - alert: "CephRBDMirrorImagesNotInSync"
         annotations:
           description: "Both local and remote RBD mirror images should be in sync."
-          summary: "Some of the RBD mirror images are not in sync with the remote counter parts."
-        expr: "sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
+          summary: "Some of the RBD mirror images are not in sync with the remote counter parts on cluster {{ $labels.cluster }}"
+        expr: "sum by (cluster, ceph_daemon, image, namespace, pool) (topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
         for: "1m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.10.3"
@@ -722,9 +755,9 @@ groups:
           type: "ceph_default"
       - alert: "CephRBDMirrorImagesNotInSyncVeryHigh"
         annotations:
-          description: "More than 10% of the images have synchronization problems"
-          summary: "Number of unsynchronized images are very high."
-        expr: "count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
+          description: "More than 10% of the images have synchronization problems."
+          summary: "Number of unsynchronized images are very high on cluster {{ $labels.cluster }}"
+        expr: "count by (ceph_daemon, cluster) ((topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon, cluster) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
         for: "1m"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.10.4"
@@ -733,7 +766,7 @@ groups:
       - alert: "CephRBDMirrorImageTransferBandwidthHigh"
         annotations:
           description: "Detected a heavy increase in bandwidth for rbd replications (over 80%) in the last 30 min. This might not be a problem, but it is good to review the number of images being replicated simultaneously"
-          summary: "The replication network usage has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
+          summary: "The replication network usage on cluster {{ $labels.cluster }} has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
         expr: "rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80"
         for: "1m"
         labels:
@@ -745,35 +778,53 @@ groups:
       - alert: "NVMeoFSubsystemNamespaceLimit"
         annotations:
           description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}"
-          summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces "
-        expr: "(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit"
+          summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces on cluster {{ $labels.cluster }}"
+        expr: "(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMultipleNamespacesOfRBDImage"
+        annotations:
+          description: "Each NVMeoF namespace must have a unique RBD pool and image, across all different gateway groups."
+          summary: "RBD image {{ $labels.pool_name }}/{{ $labels.rbd_name }} cannot be reused for multiple NVMeoF namespace "
+        expr: "count by(pool_name, rbd_name) (count by(bdev_name, pool_name, rbd_name) (ceph_nvmeof_bdev_metadata and on (bdev_name) ceph_nvmeof_subsystem_namespace_metadata)) > 1"
         for: "1m"
         labels:
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFTooManyGateways"
         annotations:
-          description: "You may create many gateways, but 4 is the tested limit"
-          summary: "Max supported gateways exceeded "
-        expr: "count(ceph_nvmeof_gateway_info) > 4.00"
+          description: "You may create many gateways, but 32 is the tested limit"
+          summary: "Max supported gateways exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by (cluster) > 32.00"
         for: "1m"
         labels:
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFMaxGatewayGroupSize"
         annotations:
-          description: "You may create many gateways in a gateway group, but 2 is the tested limit"
-          summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded "
-        expr: "count by(group) (ceph_nvmeof_gateway_info) > 2.00"
+          description: "You may create many gateways in a gateway group, but 8 is the tested limit"
+          summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by (cluster,group) > 8.00"
         for: "1m"
         labels:
           severity: "warning"
           type: "ceph_default"
-      - alert: "NVMeoFSingleGatewayGroup"
+      - alert: "NVMeoFMaxGatewayGroups"
+        annotations:
+          description: "You may create many gateway groups, but 4 is the tested limit"
+          summary: "Max gateway groups exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(count by (group, cluster) (ceph_nvmeof_gateway_info)) by (cluster) > 4.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFSingleGateway"
         annotations:
           description: "Although a single member gateway group is valid, it should only be used for test purposes"
-          summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible "
-        expr: "count by(group) (ceph_nvmeof_gateway_info) == 1"
+          summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by(cluster,group) == 1"
         for: "5m"
         labels:
           severity: "warning"
@@ -781,8 +832,8 @@ groups:
       - alert: "NVMeoFHighGatewayCPU"
         annotations:
           description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
-          summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high "
-        expr: "label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
+          summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high on cluster {{ $labels.cluster }}"
+        expr: "label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
         for: "10m"
         labels:
           severity: "warning"
@@ -790,7 +841,7 @@ groups:
       - alert: "NVMeoFGatewayOpenSecurity"
         annotations:
           description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
-          summary: "Subsystem {{ $labels.nqn }} has been defined without host level security "
+          summary: "Subsystem {{ $labels.nqn }} has been defined without host level security on cluster {{ $labels.cluster }}"
         expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
         for: "5m"
         labels:
@@ -798,9 +849,18 @@ groups:
           type: "ceph_default"
       - alert: "NVMeoFTooManySubsystems"
         annotations:
-          description: "Although you may continue to create subsystems in {{ $labels.gateway_host }}, the configuration may not be supported"
-          summary: "The number of subsystems defined to the gateway exceeds supported values "
-        expr: "count by(gateway_host) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*):.*\")) > 16.00"
+          description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 128 subsystems. Current count: {{ $value }}."
+          summary: "The number of subsystems defined to the NVMeoF gateway reached or exceeded the supported values on cluster {{ $labels.cluster }}"
+        expr: "count by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 128.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManyNamespaces"
+        annotations:
+          description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 4096 namespaces. Current count: {{ $value }}."
+          summary: "The number of namespaces defined to the NVMeoF gateway reached or exceeded supported values on cluster {{ $labels.cluster }}"
+        expr: "sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 4096.00"
         for: "1m"
         labels:
           severity: "warning"
@@ -808,26 +868,44 @@ groups:
       - alert: "NVMeoFVersionMismatch"
         annotations:
           description: "This may indicate an issue with deployment. Check cephadm logs"
-          summary: "The cluster has different NVMe-oF gateway releases active "
-        expr: "count(count by(version) (ceph_nvmeof_gateway_info)) > 1"
+          summary: "Too many different NVMe-oF gateway releases active on cluster {{ $labels.cluster }}"
+        expr: "count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster) > 1"
         for: "1h"
         labels:
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighClientCount"
         annotations:
-          description: "The supported limit for clients connecting to a subsystem is 32"
-          summary: "The number of clients connected to {{ $labels.nqn }} is too high "
-        expr: "ceph_nvmeof_subsystem_host_count > 32.00"
+          description: "The supported limit for clients connecting to a subsystem is 128"
+          summary: "The number of clients connected to {{ $labels.nqn }} is too high on cluster {{ $labels.cluster }}"
+        expr: "ceph_nvmeof_subsystem_host_count > 128.00"
         for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMissingListener"
+        annotations:
+          description: "For every subsystem, each gateway should have a listener to balance traffic between gateways."
+          summary: "No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem"
+        expr: "ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFZeroListenerSubsystem"
+        annotations:
+          description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
+          summary: "No listeners added to {{ $labels.nqn }} subsystem"
+        expr: "sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0"
+        for: "10m"
         labels:
           severity: "warning"
           type: "ceph_default"
       - alert: "NVMeoFHighHostCPU"
         annotations:
           description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
-          summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) "
-        expr: "100-((100*(avg by(host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
+          summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) on cluster {{ $labels.cluster }}"
+        expr: "100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
         for: "10m"
         labels:
           severity: "warning"
@@ -835,7 +913,7 @@ groups:
       - alert: "NVMeoFInterfaceDown"
         annotations:
           description: "A NIC used by one or more subsystems is in a down state"
-          summary: "Network interface {{ $labels.device }} is down "
+          summary: "Network interface {{ $labels.device }} is down on cluster {{ $labels.cluster }}"
         expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
         for: "30s"
         labels:
@@ -845,7 +923,7 @@ groups:
       - alert: "NVMeoFInterfaceDuplex"
         annotations:
           description: "Until this is resolved, performance from the gateway will be degraded"
-          summary: "Network interface {{ $labels.device }} is not running in full duplex mode "
+          summary: "Network interface {{ $labels.device }} is not running in full duplex mode on cluster {{ $labels.cluster }}"
         expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
         for: "30s"
         labels:
@@ -867,5 +945,36 @@ groups:
         expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
         for: "5m"
         labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHostKeepAliveTimeout"
+        annotations:
+          description: "Host was disconnected due to host keep alive timeout"
+          summary: "Host ({{ $labels.host_nqn }}) was disconnected {{ $value }} times from subsystem ({{ $labels.nqn }}) in last 24 hours"
+        expr: "ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "certmgr"
+    rules:
+      - alert: "CephCertificateError"
+        annotations:
+          description: "{{ $labels.message }}. Please check 'ceph health detail' for more information and take appropriate action to resolve the certificate issue."
+          summary: "Ceph certificate error detected on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"CEPHADM_CERT_ERROR\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.15.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephCertificateWarning"
+        annotations:
+          description: "{{ $labels.message }}. Please check 'ceph health detail' for more information and take appropriate action to resolve the certificate issue."
+          summary: "Ceph certificate warning detected on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"CEPHADM_CERT_WARNING\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.15.2"
           severity: "warning"
           type: "ceph_default"

--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -699,7 +699,7 @@ groups:
         annotations:
           description: "The prometheus job that scrapes from Ceph Exporter is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
           summary: "The scrape job for Ceph Exporter is missing from Prometheus"
-        expr: "sum(absent(up{job=\"rook-ceph-exporter\"})) and sum(ceph_osd_metadata{ceph_version=~\"^ceph version (1[89]|[2-9][0-9]).*\"}) > 0"
+        expr: "sum(absent(up{job=\"rook-ceph-exporter\"}))"
         for: "30s"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.12.1"

--- a/deploy/examples/monitoring/externalrules.yaml
+++ b/deploy/examples/monitoring/externalrules.yaml
@@ -13,23 +13,23 @@ spec:
       rules:
         - alert: PersistentVolumeUsageNearFull
           annotations:
-            description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 75%. Free up some space or expand the PVC.
-            message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion or PVC expansion is required.
+            description: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} utilization has crossed 75%. Free up some space or expand the PVC.
+            message: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} is nearing full. Data deletion or PVC expansion is required.
             severity_level: warning
             storage_type: ceph
           expr: |
-            (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
+            (kubelet_volume_stats_used_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
           for: 5s
           labels:
             severity: warning
         - alert: PersistentVolumeUsageCritical
           annotations:
-            description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 85%. Free up some space or expand the PVC immediately.
-            message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data deletion or PVC expansion is required.
+            description: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} utilization has crossed 85%. Free up some space or expand the PVC immediately.
+            message: PVC {{ $labels.persistentvolumeclaim }} on cluster {{ $labels.cluster }} is critically full. Data deletion or PVC expansion is required.
             severity_level: error
             storage_type: ceph
           expr: |
-            (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
+            (kubelet_volume_stats_used_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (cluster,namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (cluster,storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
           for: 5s
           labels:
             severity: critical

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -13,8 +13,8 @@ spec:
       rules:
         - alert: "CephHealthError"
           annotations:
-            description: "The cluster state has been HEALTH_ERROR for more than 5 minutes. Please check 'ceph health detail' for more information."
-            summary: "Ceph is in the ERROR state"
+            description: "The cluster state has been HEALTH_ERROR for more than 5 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+            summary: "Ceph is in the ERROR state on cluster {{ $labels.cluster }}"
           expr: "ceph_health_status == 2"
           for: "5m"
           labels:
@@ -23,8 +23,8 @@ spec:
             type: "ceph_default"
         - alert: "CephHealthWarning"
           annotations:
-            description: "The cluster state has been HEALTH_WARN for more than 15 minutes. Please check 'ceph health detail' for more information."
-            summary: "Ceph is in the WARNING state"
+            description: "The cluster state has been HEALTH_WARN for more than 15 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+            summary: "Ceph is in the WARNING state on cluster {{ $labels.cluster }}"
           expr: "ceph_health_status == 1"
           for: "15m"
           labels:
@@ -34,13 +34,13 @@ spec:
       rules:
         - alert: "CephMonDownQuorumAtRisk"
           annotations:
-            description: "{{ $min := query \"floor(count(ceph_mon_metadata) / 2) + 1\" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range query \"(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+            description: "{{ $min := printf \"floor(count(ceph_mon_metadata{cluster='%s'}) / 2) + 1\" .Labels.cluster | query | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
-            summary: "Monitor quorum is at risk"
+            summary: "Monitor quorum is at risk on cluster {{ $labels.cluster }}"
           expr: |
             (
-              (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
-                count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+              (ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right(cluster) (
+                count(ceph_mon_quorum_status == 1) by(cluster)== bool (floor(count(ceph_mon_metadata) by(cluster) / 2) + 1)
               )
             ) == 1
           for: "30s"
@@ -50,12 +50,11 @@ spec:
             type: "ceph_default"
         - alert: "CephMonDown"
           annotations:
-            description: |
-              {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable.  The following monitors are down: {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}   - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+            description: "{{ $down := printf \"count(ceph_mon_quorum_status{cluster='%s'} == 0)\" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $down 1.0 }}{{ $s = \"s\" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
-            summary: "One or more monitors down"
+            summary: "One or more monitors down on cluster {{ $labels.cluster }}"
           expr: |
-            count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+            (count by (cluster) (ceph_mon_quorum_status == 0)) <= (count by (cluster) (ceph_mon_metadata) - floor((count by (cluster) (ceph_mon_metadata) / 2 + 1)))
           for: "30s"
           labels:
             severity: "warning"
@@ -64,7 +63,7 @@ spec:
           annotations:
             description: "The free space available to a monitor's store is critically low. You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*. Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit"
-            summary: "Filesystem space on at least one monitor is critically low"
+            summary: "Filesystem space on at least one monitor is critically low on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MON_DISK_CRIT\"} == 1"
           for: "1m"
           labels:
@@ -75,7 +74,7 @@ spec:
           annotations:
             description: "The space available to a monitor's store is approaching full (>70% is the default). You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*.  Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low"
-            summary: "Drive space on at least one monitor is approaching full"
+            summary: "Drive space on at least one monitor is approaching full on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MON_DISK_LOW\"} == 1"
           for: "5m"
           labels:
@@ -85,7 +84,7 @@ spec:
           annotations:
             description: "Ceph monitors rely on closely synchronized time to maintain quorum and cluster consistency. This event indicates that the time on at least one mon has drifted too far from the lead mon. Review cluster status with ceph -s. This will show which monitors are affected. Check the time sync status on each monitor host with 'ceph time-sync-status' and the state and peers of your ntpd or chrony daemon."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew"
-            summary: "Clock skew detected among monitors"
+            summary: "Clock skew detected among monitors on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MON_CLOCK_SKEW\"} == 1"
           for: "1m"
           labels:
@@ -95,17 +94,17 @@ spec:
       rules:
         - alert: "CephOSDDownHigh"
           annotations:
-            description: "{{ $value | humanize }}% or {{ with query \"count(ceph_osd_up == 0)\" }}{{ . | first | value }}{{ end }} of {{ with query \"count(ceph_osd_up)\" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
-            summary: "More than 10% of OSDs are down"
-          expr: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
+            description: "{{ $value | humanize }}% or {{ with printf \"count (ceph_osd_up{cluster='%s'} == 0)\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} of {{ with printf \"count (ceph_osd_up{cluster='%s'})\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster, ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+            summary: "More than 10% of OSDs are down on cluster {{ $labels.cluster }}"
+          expr: "count by (cluster) (ceph_osd_up == 0) / count by (cluster) (ceph_osd_up) * 100 >= 10"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
             severity: "critical"
             type: "ceph_default"
         - alert: "CephOSDHostDown"
           annotations:
-            description: "The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
-            summary: "An OSD host is offline"
+            description: "The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
+            summary: "An OSD host is offline on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_HOST_DOWN\"} == 1"
           for: "5m"
           labels:
@@ -114,10 +113,9 @@ spec:
             type: "ceph_default"
         - alert: "CephOSDDown"
           annotations:
-            description: |
-              {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s "" }}is{{ else }}are{{ end }} down: {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0"}} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+            description: "{{ $num := printf \"count(ceph_osd_up{cluster='%s'} == 0) \" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $num 1.0 }}{{ $s = \"s\" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s \"\" }}is{{ else }}are{{ end }} down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down"
-            summary: "An OSD has been marked down"
+            summary: "An OSD has been marked down on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_DOWN\"} == 1"
           for: "5m"
           labels:
@@ -128,7 +126,7 @@ spec:
           annotations:
             description: "One or more OSDs have reached the NEARFULL threshold. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull"
-            summary: "OSD(s) running low on free space (NEARFULL)"
+            summary: "OSD(s) running low on free space (NEARFULL) on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_NEARFULL\"} == 1"
           for: "5m"
           labels:
@@ -139,7 +137,7 @@ spec:
           annotations:
             description: "An OSD has reached the FULL threshold. Writes to pools that share the affected OSD will be blocked. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full"
-            summary: "OSD full, writes blocked"
+            summary: "OSD full, writes blocked on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_FULL\"} > 0"
           for: "1m"
           labels:
@@ -150,7 +148,7 @@ spec:
           annotations:
             description: "An OSD has reached the BACKFILL FULL threshold. This will prevent rebalance operations from completing. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull"
-            summary: "OSD(s) too full for backfill operations"
+            summary: "OSD(s) too full for backfill operations on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_BACKFILLFULL\"} > 0"
           for: "1m"
           labels:
@@ -160,7 +158,7 @@ spec:
           annotations:
             description: "Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs"
-            summary: "OSD reports a high number of read errors"
+            summary: "OSD reports a high number of read errors on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_TOO_MANY_REPAIRS\"} == 1"
           for: "30s"
           labels:
@@ -169,7 +167,7 @@ spec:
         - alert: "CephOSDTimeoutsPublicNetwork"
           annotations:
             description: "OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network for latency or loss issues. Use 'ceph health detail' to show the affected OSDs."
-            summary: "Network issues delaying OSD heartbeats (public network)"
+            summary: "Network issues delaying OSD heartbeats (public network) on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_FRONT\"} == 1"
           for: "1m"
           labels:
@@ -178,7 +176,7 @@ spec:
         - alert: "CephOSDTimeoutsClusterNetwork"
           annotations:
             description: "OSD heartbeats on the cluster's 'cluster' network (backend) are slow. Investigate the network for latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs."
-            summary: "Network issues delaying OSD heartbeats (cluster network)"
+            summary: "Network issues delaying OSD heartbeats (cluster network) on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_BACK\"} == 1"
           for: "1m"
           labels:
@@ -188,7 +186,7 @@ spec:
           annotations:
             description: "One or more OSDs have an internal inconsistency between metadata and the size of the device. This could lead to the OSD(s) crashing in future. You should redeploy the affected OSDs."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch"
-            summary: "OSD size inconsistency error"
+            summary: "OSD size inconsistency error on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"BLUESTORE_DISK_SIZE_MISMATCH\"} == 1"
           for: "1m"
           labels:
@@ -198,7 +196,7 @@ spec:
           annotations:
             description: "The device health module has determined that one or more devices will fail soon. To review device status use 'ceph device ls'. To show a specific device use 'ceph device info <dev id>'. Mark the OSD out so that data may migrate to other OSDs. Once the OSD has drained, destroy the OSD, replace the device, and redeploy the OSD."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#id2"
-            summary: "Device(s) predicted to fail soon"
+            summary: "Device(s) predicted to fail soon on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"DEVICE_HEALTH\"} == 1"
           for: "1m"
           labels:
@@ -208,7 +206,7 @@ spec:
           annotations:
             description: "The device health module has determined that devices predicted to fail can not be remediated automatically, since too many OSDs would be removed from the cluster to ensure performance and availability. Prevent data integrity issues by adding new OSDs so that data may be relocated."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany"
-            summary: "Too many devices are predicted to fail, unable to resolve"
+            summary: "Too many devices are predicted to fail on cluster {{ $labels.cluster }}, unable to resolve"
           expr: "ceph_health_detail{name=\"DEVICE_HEALTH_TOOMANY\"} == 1"
           for: "1m"
           labels:
@@ -219,7 +217,7 @@ spec:
           annotations:
             description: "The device health module has determined that one or more devices will fail soon, but the normal process of relocating the data on the device to other OSDs in the cluster is blocked. \nEnsure that the cluster has available free space. It may be necessary to add capacity to the cluster to allow data from the failing device to successfully migrate, or to enable the balancer."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use"
-            summary: "Device failure is predicted, but unable to relocate data"
+            summary: "Device failure is predicted, but unable to relocate data on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"DEVICE_HEALTH_IN_USE\"} == 1"
           for: "1m"
           labels:
@@ -229,8 +227,8 @@ spec:
           annotations:
             description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was marked down and back up {{ $value | humanize }} times once a minute for 5 minutes. This may indicate a network issue (latency, packet loss, MTU mismatch) on the cluster network, or the public network if no cluster network is deployed. Check the network stats on the listed host(s)."
             documentation: "https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds"
-            summary: "Network issues are causing OSDs to flap (mark each other down)"
-          expr: "(rate(ceph_osd_up[5m]) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
+            summary: "Network issues are causing OSDs to flap (mark each other down) on cluster {{ $labels.cluster }}"
+          expr: "(rate(ceph_osd_up[5m]) * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.4.4"
             severity: "warning"
@@ -239,7 +237,7 @@ spec:
           annotations:
             description: "An OSD has encountered read errors, but the OSD has recovered by retrying the reads. This may indicate an issue with hardware or the kernel."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors"
-            summary: "Device read errors detected"
+            summary: "Device read errors detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"BLUESTORE_SPURIOUS_READ_ERRORS\"} == 1"
           for: "30s"
           labels:
@@ -247,13 +245,25 @@ spec:
             type: "ceph_default"
         - alert: "CephPGImbalance"
           annotations:
-            description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count."
-            summary: "PGs are not balanced across OSDs"
+            description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count in the device class {{ $labels.device_class }}."
+            summary: "PGs are not balanced across OSDs on cluster {{ $labels.cluster }}"
           expr: |
             abs(
-              ((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) /
-              on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-            ) * on (ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+              (
+                (
+                  (ceph_osd_numpg > 0)
+                  * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                )
+                - on (cluster, job, device_class) group_left avg(
+                    (ceph_osd_numpg > 0)
+                    * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                  ) by (cluster, job, device_class)
+              )
+              / on (cluster, job, device_class) group_left avg(
+                  (ceph_osd_numpg > 0)
+                  * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                ) by (cluster, job, device_class)
+            ) > 0.30
           for: "5m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.4.5"
@@ -265,7 +275,7 @@ spec:
           annotations:
             description: "Filesystem metadata has been corrupted. Data may be inaccessible. Analyze metrics from the MDS daemon admin socket, or escalate to support."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
-            summary: "CephFS filesystem is damaged."
+            summary: "CephFS filesystem is damaged on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MDS_DAMAGE\"} > 0"
           for: "1m"
           labels:
@@ -276,7 +286,7 @@ spec:
           annotations:
             description: "All MDS ranks are unavailable. The MDS daemons managing metadata are down, rendering the filesystem offline."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down"
-            summary: "CephFS filesystem is offline"
+            summary: "CephFS filesystem is offline on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MDS_ALL_DOWN\"} > 0"
           for: "1m"
           labels:
@@ -287,7 +297,7 @@ spec:
           annotations:
             description: "One or more metadata daemons (MDS ranks) are failed or in a damaged state. At best the filesystem is partially available, at worst the filesystem is completely unusable."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded"
-            summary: "CephFS filesystem is degraded"
+            summary: "CephFS filesystem is degraded on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"FS_DEGRADED\"} > 0"
           for: "1m"
           labels:
@@ -298,7 +308,7 @@ spec:
           annotations:
             description: "The filesystem's 'max_mds' setting defines the number of MDS ranks in the filesystem. The current number of active MDS daemons is less than this value."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max"
-            summary: "Ceph MDS daemon count is lower than configured"
+            summary: "Ceph MDS daemon count is lower than configured on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MDS_UP_LESS_THAN_MAX\"} > 0"
           for: "1m"
           labels:
@@ -308,7 +318,7 @@ spec:
           annotations:
             description: "The minimum number of standby daemons required by standby_count_wanted is less than the current number of standby daemons. Adjust the standby count or increase the number of MDS daemons."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby"
-            summary: "Ceph filesystem standby daemons too few"
+            summary: "Ceph filesystem standby daemons too few on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MDS_INSUFFICIENT_STANDBY\"} > 0"
           for: "1m"
           labels:
@@ -318,7 +328,7 @@ spec:
           annotations:
             description: "An MDS daemon has failed, leaving only one active rank and no available standby. Investigate the cause of the failure or add a standby MDS."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds"
-            summary: "MDS daemon failed, no further standby available"
+            summary: "MDS daemon failed, no further standby available on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"FS_WITH_FAILED_MDS\"} > 0"
           for: "1m"
           labels:
@@ -329,7 +339,7 @@ spec:
           annotations:
             description: "The filesystem has switched to READ ONLY due to an unexpected error when writing to the metadata pool. Either analyze the output from the MDS daemon admin socket, or escalate to support."
             documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
-            summary: "CephFS filesystem in read only mode due to write error(s)"
+            summary: "CephFS filesystem in read only mode due to write error(s) on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"MDS_HEALTH_READ_ONLY\"} > 0"
           for: "1m"
           labels:
@@ -342,7 +352,7 @@ spec:
           annotations:
             description: "One or more mgr modules have crashed and have yet to be acknowledged by an administrator. A crashed module may impact functionality within the cluster. Use the 'ceph crash' command to determine which module has failed, and archive it to acknowledge the failure."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash"
-            summary: "A manager module has recently crashed"
+            summary: "A manager module has recently crashed on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"RECENT_MGR_MODULE_CRASH\"} == 1"
           for: "5m"
           labels:
@@ -364,8 +374,8 @@ spec:
         - alert: "CephPGsInactive"
           annotations:
             description: "{{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}. Inactive placement groups are not able to serve read/write requests."
-            summary: "One or more placement groups are inactive"
-          expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
+            summary: "One or more placement groups are inactive on cluster {{ $labels.cluster }}"
+          expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
           for: "5m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.7.1"
@@ -374,8 +384,8 @@ spec:
         - alert: "CephPGsUnclean"
           annotations:
             description: "{{ $value }} PGs have been unclean for more than 15 minutes in pool {{ $labels.name }}. Unclean PGs have not recovered from a previous failure."
-            summary: "One or more placement groups are marked unclean"
-          expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
+            summary: "One or more placement groups are marked unclean on cluster {{ $labels.cluster }}"
+          expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
           for: "15m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.7.2"
@@ -385,7 +395,7 @@ spec:
           annotations:
             description: "During data consistency checks (scrub), at least one PG has been flagged as being damaged or inconsistent. Check to see which PG is affected, and attempt a manual repair if necessary. To list problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use the 'ceph pg repair <pg_num>' command."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged"
-            summary: "Placement group damaged, manual intervention needed"
+            summary: "Placement group damaged, manual intervention needed on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=~\"PG_DAMAGED|OSD_SCRUB_ERRORS\"} == 1"
           for: "5m"
           labels:
@@ -396,7 +406,7 @@ spec:
           annotations:
             description: "Data redundancy is at risk since one or more OSDs are at or above the 'full' threshold. Add more capacity to the cluster, restore down/out OSDs, or delete unwanted data."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full"
-            summary: "OSDs are too full for recovery"
+            summary: "OSDs are too full for recovery on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"PG_RECOVERY_FULL\"} == 1"
           for: "1m"
           labels:
@@ -407,7 +417,7 @@ spec:
           annotations:
             description: "Data availability is reduced, impacting the cluster's ability to service I/O. One or more placement groups (PGs) are in a state that blocks I/O."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability"
-            summary: "PG is unavailable, blocking I/O"
+            summary: "PG is unavailable on cluster {{ $labels.cluster }}, blocking I/O"
           expr: "((ceph_health_detail{name=\"PG_AVAILABILITY\"} == 1) - scalar(ceph_health_detail{name=\"OSD_DOWN\"})) == 1"
           for: "1m"
           labels:
@@ -418,7 +428,7 @@ spec:
           annotations:
             description: "Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs have reached the 'backfillfull' threshold. Add more capacity, or delete unwanted data."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full"
-            summary: "Backfill operations are blocked due to lack of free space"
+            summary: "Backfill operations are blocked due to lack of free space on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"PG_BACKFILL_FULL\"} == 1"
           for: "1m"
           labels:
@@ -429,7 +439,7 @@ spec:
           annotations:
             description: "One or more PGs have not been scrubbed recently. Scrubs check metadata integrity, protecting against bit-rot. They check that metadata is consistent across data replicas. When PGs miss their scrub interval, it may indicate that the scrub window is too small, or PGs were not in a 'clean' state during the scrub window. You can manually initiate a scrub with: ceph pg scrub <pgid>"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed"
-            summary: "Placement group(s) have not been scrubbed"
+            summary: "Placement group(s) have not been scrubbed on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"PG_NOT_SCRUBBED\"} == 1"
           for: "5m"
           labels:
@@ -439,7 +449,7 @@ spec:
           annotations:
             description: "The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).\n Check that the pg_autoscaler has not been disabled for any pools with 'ceph osd pool autoscale-status', and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide the autoscaler based on the expected relative size of the pool ('ceph osd pool set cephfs.cephfs.meta target_size_ratio .1') or set the pg_autoscaler mode to 'warn' and adjust pg_num appropriately for one or more pools."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs"
-            summary: "Placement groups per OSD is too high"
+            summary: "Placement groups per OSD is too high on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"TOO_MANY_PGS\"} == 1"
           for: "1m"
           labels:
@@ -449,7 +459,7 @@ spec:
           annotations:
             description: "One or more PGs have not been deep scrubbed recently. Deep scrubs protect against bit-rot. They compare data replicas to ensure consistency. When PGs miss their deep scrub interval, it may indicate that the window is too small or PGs were not in a 'clean' state during the deep-scrub window."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed"
-            summary: "Placement group(s) have not been deep scrubbed"
+            summary: "Placement group(s) have not been deep scrubbed on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"PG_NOT_DEEP_SCRUBBED\"} == 1"
           for: "5m"
           labels:
@@ -489,7 +499,7 @@ spec:
         - alert: "CephNodeNetworkPacketErrors"
           annotations:
             description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
-            summary: "One or more NICs reports packet errors"
+            summary: "One or more NICs reports packet errors on cluster {{ $labels.cluster }}"
           expr: |
             (
               rate(node_network_receive_errs_total{device!="lo"}[1m]) +
@@ -508,7 +518,7 @@ spec:
         - alert: "CephNodeNetworkBondDegraded"
           annotations:
             description: "Bond {{ $labels.master }} is degraded on Node {{ $labels.instance }}."
-            summary: "Degraded Bond on Node {{ $labels.instance }}"
+            summary: "Degraded Bond on Node {{ $labels.instance }} on cluster {{ $labels.cluster }}"
           expr: |
             node_bonding_slaves - node_bonding_active != 0
           labels:
@@ -517,27 +527,51 @@ spec:
         - alert: "CephNodeDiskspaceWarning"
           annotations:
             description: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }} will be full in less than 5 days based on the 48 hour trailing fill rate."
-            summary: "Host filesystem free space is getting low"
-          expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0"
+            summary: "Host filesystem free space is getting low on cluster {{ $labels.cluster }}"
+          expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) * on(cluster, instance) group_left(nodename) node_uname_info < 0"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.8.4"
             severity: "warning"
             type: "ceph_default"
-        - alert: "CephNodeInconsistentMTU"
-          annotations:
-            description: "Node {{ $labels.instance }} has a different MTU size ({{ $value }}) than the median of devices named {{ $labels.device }}."
-            summary: "MTU settings across Ceph hosts are inconsistent"
-          expr: "node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    max by (device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )or node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    min by (device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )"
+        - alert: CephNodeInconsistentMTU
+          expr: |
+            node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+            != on (cluster, device) group_left
+              quantile by (cluster, device) (
+                0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+              )
           labels:
-            severity: "warning"
-            type: "ceph_default"
+            severity: warning
+            type: ceph_default
+          annotations:
+            summary: "Node {{ $labels.instance }} has inconsistent MTU settings in cluster {{ $labels.cluster }}"
+            description: "Network interface {{ $labels.device }} on node {{ $labels.instance }} has MTU {{ $value }} which differs from the cluster median."
+            impact: |
+              - May cause packet fragmentation or packet drops
+              - Risk of degraded cluster communication and performance
+              - Potential instability in services relying on consistent networking (e.g., Ceph, Kubernetes)
+            fix: |
+              - Check the MTU of interface `{{ $labels.device }}` on node `{{ $labels.instance }}`:
+                ip link show {{ $labels.device }}
+
+              - Find the median MTU value across the cluster by running this PromQL query in Prometheus:
+                quantile by (cluster, device) (0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
+
+              - Standardize MTU across all nodes to match the median (commonly 1500 or 9000):
+                ip link set dev {{ $labels.device }} mtu <median-value>
+
+              - Make MTU setting persistent:
+                - RHEL/CentOS: edit `/etc/sysconfig/network-scripts/ifcfg-<device>`
+                - Debian/Ubuntu: edit `/etc/netplan/*.yaml` and apply with `netplan apply`
+
+              - Restart the affected interface or node if required.
     - name: "pools"
       rules:
         - alert: "CephPoolGrowthWarning"
           annotations:
             description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
-            summary: "Pool growth rate may soon exceed capacity"
-          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance, pod) group_right() ceph_pool_metadata) >= 95"
+            summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
+          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
             severity: "warning"
@@ -545,16 +579,16 @@ spec:
         - alert: "CephPoolBackfillFull"
           annotations:
             description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
-            summary: "Free space in a pool is too low for recovery/backfill"
+            summary: "Free space in a pool is too low for recovery/backfill on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"POOL_BACKFILLFULL\"} > 0"
           labels:
             severity: "warning"
             type: "ceph_default"
         - alert: "CephPoolFull"
           annotations:
-            description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range query \"topk(5, sort_desc(ceph_pool_percent_used * on(pool_id) group_right ceph_pool_metadata))\" }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
+            description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range printf \"topk(5, sort_desc(ceph_pool_percent_used{cluster='%s'} * on(cluster,pool_id) group_right ceph_pool_metadata))\" .Labels.cluster | query }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full"
-            summary: "Pool is full - writes are blocked"
+            summary: "Pool is full - writes are blocked on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"POOL_FULL\"} > 0"
           for: "1m"
           labels:
@@ -564,7 +598,7 @@ spec:
         - alert: "CephPoolNearFull"
           annotations:
             description: "A pool has exceeded the warning (percent full) threshold, or OSDs supporting the pool have reached the NEARFULL threshold. Writes may continue, but you are at risk of the pool going read-only if more capacity isn't made available. Determine the affected pool with 'ceph df detail', looking at QUOTA BYTES and STORED. Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>). Also ensure that the balancer is active."
-            summary: "One or more Ceph pools are nearly full"
+            summary: "One or more Ceph pools are nearly full on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"POOL_NEAR_FULL\"} > 0"
           for: "5m"
           labels:
@@ -576,7 +610,7 @@ spec:
           annotations:
             description: "{{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-            summary: "OSD operations are slow to complete"
+            summary: "OSD operations are slow to complete on cluster {{ $labels.cluster }}"
           expr: "ceph_healthcheck_slow_ops > 0"
           for: "30s"
           labels:
@@ -586,7 +620,7 @@ spec:
           annotations:
             description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
-            summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
+            summary: "{{ $labels.ceph_daemon }} operations are slow to complete on cluster {{ $labels.cluster }}"
           expr: "ceph_daemon_health_metrics{type=\"SLOW_OPS\"} > 0"
           for: "30s"
           labels:
@@ -597,7 +631,7 @@ spec:
         - alert: "HardwareStorageError"
           annotations:
             description: "Some storage devices are in error. Check `ceph health detail`."
-            summary: "Storage devices error(s) detected"
+            summary: "Storage devices error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_STORAGE\"} > 0"
           for: "30s"
           labels:
@@ -607,7 +641,7 @@ spec:
         - alert: "HardwareMemoryError"
           annotations:
             description: "DIMM error(s) detected. Check `ceph health detail`."
-            summary: "DIMM error(s) detected"
+            summary: "DIMM error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_MEMORY\"} > 0"
           for: "30s"
           labels:
@@ -617,7 +651,7 @@ spec:
         - alert: "HardwareProcessorError"
           annotations:
             description: "Processor error(s) detected. Check `ceph health detail`."
-            summary: "Processor error(s) detected"
+            summary: "Processor error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_PROCESSOR\"} > 0"
           for: "30s"
           labels:
@@ -627,7 +661,7 @@ spec:
         - alert: "HardwareNetworkError"
           annotations:
             description: "Network error(s) detected. Check `ceph health detail`."
-            summary: "Network error(s) detected"
+            summary: "Network error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_NETWORK\"} > 0"
           for: "30s"
           labels:
@@ -637,7 +671,7 @@ spec:
         - alert: "HardwarePowerError"
           annotations:
             description: "Power supply error(s) detected. Check `ceph health detail`."
-            summary: "Power supply error(s) detected"
+            summary: "Power supply error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_POWER\"} > 0"
           for: "30s"
           labels:
@@ -647,7 +681,7 @@ spec:
         - alert: "HardwareFanError"
           annotations:
             description: "Fan error(s) detected. Check `ceph health detail`."
-            summary: "Fan error(s) detected"
+            summary: "Fan error(s) detected on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"HARDWARE_FANS\"} > 0"
           for: "30s"
           labels:
@@ -670,7 +704,7 @@ spec:
           annotations:
             description: "The prometheus job that scrapes from Ceph Exporter is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
             summary: "The scrape job for Ceph Exporter is missing from Prometheus"
-          expr: "sum(absent(up{job=\"rook-ceph-exporter\"})) and sum(ceph_osd_metadata{ceph_version=~\"^ceph version (1[89]|[2-9][0-9]).*\"}) > 0"
+          expr: "sum(absent(up{job=\"rook-ceph-exporter\"}))"
           for: "30s"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
@@ -682,8 +716,8 @@ spec:
           annotations:
             description: "The latest version of a RADOS object can not be found, even though all OSDs are up. I/O requests for this object from clients will block (hang). Resolving this issue may require the object to be rolled back to a prior version manually, and manually verified."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound"
-            summary: "Object(s) marked UNFOUND"
-          expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1"
+            summary: "Object(s) marked UNFOUND on cluster {{ $labels.cluster }}"
+          expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() group_right(cluster) (count(ceph_osd_up == 1) by (cluster) == bool count(ceph_osd_metadata) by(cluster)) == 1"
           for: "30s"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.10.1"
@@ -695,7 +729,7 @@ spec:
           annotations:
             description: "One or more daemons have crashed recently, and need to be acknowledged. This notification ensures that software crashes do not go unseen. To acknowledge a crash, use the 'ceph crash archive <id>' command."
             documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash"
-            summary: "One or more Ceph daemons have crashed, and are pending acknowledgement"
+            summary: "One or more Ceph daemons have crashed, and are pending acknowledgement on cluster {{ $labels.cluster }}"
           expr: "ceph_health_detail{name=\"RECENT_CRASH\"} == 1"
           for: "1m"
           labels:
@@ -707,8 +741,8 @@ spec:
         - alert: "CephRBDMirrorImagesPerDaemonHigh"
           annotations:
             description: "Number of image replications per daemon is not supposed to go beyond threshold 100"
-            summary: "Number of image replications are now above 100"
-          expr: "sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
+            summary: "Number of image replications are now above 100 on cluster {{ $labels.cluster }}"
+          expr: "sum by (cluster, ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
           for: "1m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.10.2"
@@ -717,8 +751,8 @@ spec:
         - alert: "CephRBDMirrorImagesNotInSync"
           annotations:
             description: "Both local and remote RBD mirror images should be in sync."
-            summary: "Some of the RBD mirror images are not in sync with the remote counter parts."
-          expr: "sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
+            summary: "Some of the RBD mirror images are not in sync with the remote counter parts on cluster {{ $labels.cluster }}"
+          expr: "sum by (cluster, ceph_daemon, image, namespace, pool) (topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
           for: "1m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.10.3"
@@ -726,9 +760,9 @@ spec:
             type: "ceph_default"
         - alert: "CephRBDMirrorImagesNotInSyncVeryHigh"
           annotations:
-            description: "More than 10% of the images have synchronization problems"
-            summary: "Number of unsynchronized images are very high."
-          expr: "count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
+            description: "More than 10% of the images have synchronization problems."
+            summary: "Number of unsynchronized images are very high on cluster {{ $labels.cluster }}"
+          expr: "count by (ceph_daemon, cluster) ((topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon, cluster) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
           for: "1m"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.10.4"
@@ -737,7 +771,7 @@ spec:
         - alert: "CephRBDMirrorImageTransferBandwidthHigh"
           annotations:
             description: "Detected a heavy increase in bandwidth for rbd replications (over 80%) in the last 30 min. This might not be a problem, but it is good to review the number of images being replicated simultaneously"
-            summary: "The replication network usage has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
+            summary: "The replication network usage on cluster {{ $labels.cluster }} has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
           expr: "rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80"
           for: "1m"
           labels:
@@ -749,35 +783,53 @@ spec:
         - alert: "NVMeoFSubsystemNamespaceLimit"
           annotations:
             description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}"
-            summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces "
-          expr: "(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit"
+            summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces on cluster {{ $labels.cluster }}"
+          expr: "(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit"
+          for: "1m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFMultipleNamespacesOfRBDImage"
+          annotations:
+            description: "Each NVMeoF namespace must have a unique RBD pool and image, across all different gateway groups."
+            summary: "RBD image {{ $labels.pool_name }}/{{ $labels.rbd_name }} cannot be reused for multiple NVMeoF namespace "
+          expr: "count by(pool_name, rbd_name) (count by(bdev_name, pool_name, rbd_name) (ceph_nvmeof_bdev_metadata and on (bdev_name) ceph_nvmeof_subsystem_namespace_metadata)) > 1"
           for: "1m"
           labels:
             severity: "warning"
             type: "ceph_default"
         - alert: "NVMeoFTooManyGateways"
           annotations:
-            description: "You may create many gateways, but 4 is the tested limit"
-            summary: "Max supported gateways exceeded "
-          expr: "count(ceph_nvmeof_gateway_info) > 4.00"
+            description: "You may create many gateways, but 32 is the tested limit"
+            summary: "Max supported gateways exceeded on cluster {{ $labels.cluster }}"
+          expr: "count(ceph_nvmeof_gateway_info) by (cluster) > 32.00"
           for: "1m"
           labels:
             severity: "warning"
             type: "ceph_default"
         - alert: "NVMeoFMaxGatewayGroupSize"
           annotations:
-            description: "You may create many gateways in a gateway group, but 2 is the tested limit"
-            summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded "
-          expr: "count by(group) (ceph_nvmeof_gateway_info) > 2.00"
+            description: "You may create many gateways in a gateway group, but 8 is the tested limit"
+            summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded on cluster {{ $labels.cluster }}"
+          expr: "count(ceph_nvmeof_gateway_info) by (cluster,group) > 8.00"
           for: "1m"
           labels:
             severity: "warning"
             type: "ceph_default"
-        - alert: "NVMeoFSingleGatewayGroup"
+        - alert: "NVMeoFMaxGatewayGroups"
+          annotations:
+            description: "You may create many gateway groups, but 4 is the tested limit"
+            summary: "Max gateway groups exceeded on cluster {{ $labels.cluster }}"
+          expr: "count(count by (group, cluster) (ceph_nvmeof_gateway_info)) by (cluster) > 4.00"
+          for: "1m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFSingleGateway"
           annotations:
             description: "Although a single member gateway group is valid, it should only be used for test purposes"
-            summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible "
-          expr: "count by(group) (ceph_nvmeof_gateway_info) == 1"
+            summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible on cluster {{ $labels.cluster }}"
+          expr: "count(ceph_nvmeof_gateway_info) by(cluster,group) == 1"
           for: "5m"
           labels:
             severity: "warning"
@@ -785,8 +837,8 @@ spec:
         - alert: "NVMeoFHighGatewayCPU"
           annotations:
             description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
-            summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high "
-          expr: "label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
+            summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high on cluster {{ $labels.cluster }}"
+          expr: "label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
           for: "10m"
           labels:
             severity: "warning"
@@ -794,7 +846,7 @@ spec:
         - alert: "NVMeoFGatewayOpenSecurity"
           annotations:
             description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
-            summary: "Subsystem {{ $labels.nqn }} has been defined without host level security "
+            summary: "Subsystem {{ $labels.nqn }} has been defined without host level security on cluster {{ $labels.cluster }}"
           expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
           for: "5m"
           labels:
@@ -802,9 +854,18 @@ spec:
             type: "ceph_default"
         - alert: "NVMeoFTooManySubsystems"
           annotations:
-            description: "Although you may continue to create subsystems in {{ $labels.gateway_host }}, the configuration may not be supported"
-            summary: "The number of subsystems defined to the gateway exceeds supported values "
-          expr: "count by(gateway_host) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*):.*\")) > 16.00"
+            description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 128 subsystems. Current count: {{ $value }}."
+            summary: "The number of subsystems defined to the NVMeoF gateway reached or exceeded the supported values on cluster {{ $labels.cluster }}"
+          expr: "count by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 128.00"
+          for: "1m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFTooManyNamespaces"
+          annotations:
+            description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 4096 namespaces. Current count: {{ $value }}."
+            summary: "The number of namespaces defined to the NVMeoF gateway reached or exceeded supported values on cluster {{ $labels.cluster }}"
+          expr: "sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 4096.00"
           for: "1m"
           labels:
             severity: "warning"
@@ -812,26 +873,44 @@ spec:
         - alert: "NVMeoFVersionMismatch"
           annotations:
             description: "This may indicate an issue with deployment. Check cephadm logs"
-            summary: "The cluster has different NVMe-oF gateway releases active "
-          expr: "count(count by(version) (ceph_nvmeof_gateway_info)) > 1"
+            summary: "Too many different NVMe-oF gateway releases active on cluster {{ $labels.cluster }}"
+          expr: "count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster) > 1"
           for: "1h"
           labels:
             severity: "warning"
             type: "ceph_default"
         - alert: "NVMeoFHighClientCount"
           annotations:
-            description: "The supported limit for clients connecting to a subsystem is 32"
-            summary: "The number of clients connected to {{ $labels.nqn }} is too high "
-          expr: "ceph_nvmeof_subsystem_host_count > 32.00"
+            description: "The supported limit for clients connecting to a subsystem is 128"
+            summary: "The number of clients connected to {{ $labels.nqn }} is too high on cluster {{ $labels.cluster }}"
+          expr: "ceph_nvmeof_subsystem_host_count > 128.00"
           for: "1m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFMissingListener"
+          annotations:
+            description: "For every subsystem, each gateway should have a listener to balance traffic between gateways."
+            summary: "No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem"
+          expr: "ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0"
+          for: "10m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFZeroListenerSubsystem"
+          annotations:
+            description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
+            summary: "No listeners added to {{ $labels.nqn }} subsystem"
+          expr: "sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0"
+          for: "10m"
           labels:
             severity: "warning"
             type: "ceph_default"
         - alert: "NVMeoFHighHostCPU"
           annotations:
             description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
-            summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) "
-          expr: "100-((100*(avg by(host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
+            summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) on cluster {{ $labels.cluster }}"
+          expr: "100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
           for: "10m"
           labels:
             severity: "warning"
@@ -839,7 +918,7 @@ spec:
         - alert: "NVMeoFInterfaceDown"
           annotations:
             description: "A NIC used by one or more subsystems is in a down state"
-            summary: "Network interface {{ $labels.device }} is down "
+            summary: "Network interface {{ $labels.device }} is down on cluster {{ $labels.cluster }}"
           expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
           for: "30s"
           labels:
@@ -849,7 +928,7 @@ spec:
         - alert: "NVMeoFInterfaceDuplex"
           annotations:
             description: "Until this is resolved, performance from the gateway will be degraded"
-            summary: "Network interface {{ $labels.device }} is not running in full duplex mode "
+            summary: "Network interface {{ $labels.device }} is not running in full duplex mode on cluster {{ $labels.cluster }}"
           expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
           for: "30s"
           labels:
@@ -871,5 +950,36 @@ spec:
           expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
           for: "5m"
           labels:
+            severity: "warning"
+            type: "ceph_default"
+        - alert: "NVMeoFHostKeepAliveTimeout"
+          annotations:
+            description: "Host was disconnected due to host keep alive timeout"
+            summary: "Host ({{ $labels.host_nqn }}) was disconnected {{ $value }} times from subsystem ({{ $labels.nqn }}) in last 24 hours"
+          expr: "ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0"
+          for: "1m"
+          labels:
+            severity: "warning"
+            type: "ceph_default"
+    - name: "certmgr"
+      rules:
+        - alert: "CephCertificateError"
+          annotations:
+            description: "{{ $labels.message }}. Please check 'ceph health detail' for more information and take appropriate action to resolve the certificate issue."
+            summary: "Ceph certificate error detected on cluster {{ $labels.cluster }}"
+          expr: "ceph_health_detail{name=\"CEPHADM_CERT_ERROR\"} == 1"
+          for: "1m"
+          labels:
+            oid: "1.3.6.1.4.1.50495.1.2.1.15.1"
+            severity: "critical"
+            type: "ceph_default"
+        - alert: "CephCertificateWarning"
+          annotations:
+            description: "{{ $labels.message }}. Please check 'ceph health detail' for more information and take appropriate action to resolve the certificate issue."
+            summary: "Ceph certificate warning detected on cluster {{ $labels.cluster }}"
+          expr: "ceph_health_detail{name=\"CEPHADM_CERT_WARNING\"} == 1"
+          for: "1m"
+          labels:
+            oid: "1.3.6.1.4.1.50495.1.2.1.15.2"
             severity: "warning"
             type: "ceph_default"

--- a/pkg/operator/k8sutil/prometheus.go
+++ b/pkg/operator/k8sutil/prometheus.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func getMonitoringClient(context *clusterd.Context) (*monitoringclient.Clientset, error) {
@@ -65,6 +66,10 @@ func GetServiceMonitor(name string, namespace string, portName string) *monitori
 					Path:        "/metrics",
 					Interval:    "10s",
 					HonorLabels: true,
+					RelabelConfigs: []monitoringv1.RelabelConfig{{
+						TargetLabel: "cluster",
+						Replacement: ptr.To(namespace),
+					}},
 				},
 			},
 		},

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -38,4 +38,6 @@ func TestGetServiceMonitor(t *testing.T) {
 	assert.NotNil(t, servicemonitor.Spec.NamespaceSelector.MatchNames)
 	assert.NotNil(t, servicemonitor.Spec.Selector.MatchLabels)
 	assert.NotNil(t, servicemonitor.Spec.Endpoints)
+	assert.Equal(t, "cluster", servicemonitor.Spec.Endpoints[0].RelabelConfigs[0].TargetLabel)
+	assert.Equal(t, namespace, *servicemonitor.Spec.Endpoints[0].RelabelConfigs[0].Replacement)
 }


### PR DESCRIPTION
The upstream ceph/ceph prometheus rules have added usage of a `cluster` to distinguish between multiple ceph clusters being monitored by a single prometheus instance.  `cephadm` deployed prometheus is configured to add the `cluster` label during metric scraping and is setting the value to `ceph fsid` to ensure a unique string. As Rook considers the "unique identifier" of a cluster to be the namespace in which the `CephCluster` resides, the the ns is being used as the `cluster` label value.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
