### PR TITLE
osd: fix flaky TestAddRemoveNode failure

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -201,7 +201,7 @@ func TestAddRemoveNode(t *testing.T) {
 	cmErr := createDiscoverConfigmap(nodeName, "rook-system", clientset)
 	assert.Nil(t, cmErr)
 
-	statusMapWatcher := watch.NewFake()
+	statusMapWatcher := watch.NewRaceFreeFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(statusMapWatcher, nil))
 
 	clusterInfo := &cephclient.ClusterInfo{
@@ -361,7 +361,7 @@ func TestAddRemoveNode(t *testing.T) {
 	c = New(context, clusterInfo, cephCluster.Spec, "myversion")
 
 	// reset the orchestration status watcher
-	statusMapWatcher = watch.NewFake()
+	statusMapWatcher = watch.NewRaceFreeFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(statusMapWatcher, nil))
 
 	startErr = nil

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -67,7 +67,7 @@ func TestOrchestrationStatus(t *testing.T) {
 	assert.Equal(t, status, *retrievedStatus)
 }
 
-func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatcher *watch.FakeWatcher) {
+func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatcher *watch.RaceFreeFakeWatcher) {
 	ctx := context.TODO()
 	// if no valid osd node, don't need to check its status, return immediately
 	if len(c.spec.Storage.Nodes) == 0 {


### PR DESCRIPTION
User RaceFreeFakeWatcher isntead of FakeWatcher in TestAddRemoveNode function. The test runs c.Start() in a goroutine whch stops the watcher when done. If mockNodeOrchestrationCompeltion sends a watch ever after, that, FakeWatcher panics with "send on a closed channel". RaceFreeFakeWatcher safely ignores sends on a stopped channel.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
