### PR TITLE
osd: fix race condition in require-osd-release after rolling upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +46,7 @@ type OSDHealthMonitor struct {
 	clusterInfo                    *client.ClusterInfo
 	removeOSDsIfOUTAndSafeToRemove bool
 	interval                       *time.Duration
+	lastRequireOSDRelease          string
 }
 
 // NewOSDHealthMonitor instantiates OSD monitoring
@@ -100,6 +102,44 @@ func (m *OSDHealthMonitor) checkOSDHealth() {
 	err := m.checkOSDDump()
 	if err != nil {
 		log.NamespacedDebug(m.clusterInfo.Namespace, logger, "failed to check OSD Dump. %v", err)
+	}
+	m.checkRequireOSDRelease()
+}
+
+// checkRequireOSDRelease checks if all OSDs report the same version and, if so,
+// sets the require-osd-release flag. This handles the case where versions had not
+// yet converged at the end of the reconcile (e.g. OSDs were still restarting).
+// The release is only set when it differs from the last value that was successfully applied.
+func (m *OSDHealthMonitor) checkRequireOSDRelease() {
+	versions, err := client.GetAllCephDaemonVersions(m.context, m.clusterInfo)
+	if err != nil {
+		log.NamespacedDebug(m.clusterInfo.Namespace, logger, "failed to get ceph daemons versions. %v", err)
+		return
+	}
+
+	if len(versions.Osd) != 1 {
+		log.NamespacedDebug(m.clusterInfo.Namespace, logger, "OSD versions have not converged to a single version yet (%d reported); will retry on next health check", len(versions.Osd))
+		return
+	}
+
+	for v := range versions.Osd {
+		osdVersion, err := cephver.ExtractCephVersion(v)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger, "failed to extract ceph version. %v", err)
+			return
+		}
+		releaseName := osdVersion.ReleaseName()
+		if releaseName == m.lastRequireOSDRelease {
+			// Already set to this release; nothing to do
+			return
+		}
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "all OSDs are running version %q, setting require-osd-release to %q", v, releaseName)
+		err = client.EnableReleaseOSDFunctionality(m.context, m.clusterInfo, releaseName)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger, "failed to enable new osd functionality. %v", err)
+			return
+		}
+		m.lastRequireOSDRelease = releaseName
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -127,8 +127,8 @@ func TestNewOSDHealthMonitor(t *testing.T) {
 		args args
 		want *OSDHealthMonitor
 	}{
-		{"default-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{}}, &OSDHealthMonitor{c, clusterInfo, false, &defaultHealthCheckInterval}},
-		{"10s-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{DaemonHealth: cephv1.DaemonHealthSpec{ObjectStorageDaemon: cephv1.HealthCheckSpec{Interval: &metav1.Duration{Duration: time10s}}}}}, &OSDHealthMonitor{c, clusterInfo, false, &time10s}},
+		{"default-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{}}, &OSDHealthMonitor{c, clusterInfo, false, &defaultHealthCheckInterval, ""}},
+		{"10s-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{DaemonHealth: cephv1.DaemonHealthSpec{ObjectStorageDaemon: cephv1.HealthCheckSpec{Interval: &metav1.Duration{Duration: time10s}}}}}, &OSDHealthMonitor{c, clusterInfo, false, &time10s, ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -137,4 +137,153 @@ func TestNewOSDHealthMonitor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCheckRequireOSDRelease validates checkRequireOSDRelease() which runs on every
+// health-monitor tick. The method:
+//  1. Queries "ceph versions" to get all OSD daemon versions
+//  2. If exactly one OSD version exists (all converged), extracts the release name
+//  3. Skips if the release name matches the cached value (avoids redundant ceph calls)
+//  4. Calls "ceph osd require-osd-release <name>" and caches on success
+//
+// Each subtest targets one branch in this flow.
+func TestCheckRequireOSDRelease(t *testing.T) {
+	clusterInfo := client.AdminTestClusterInfo("test")
+
+	// HAPPY PATH: All OSDs upgraded to squid, cache is empty → should set the flag and cache it.
+	t.Run("single converged version sets lastRequireOSDRelease", func(t *testing.T) {
+		enableCalls := 0
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				// handles: ceph versions
+				if args[0] == "versions" {
+					// All 3 OSDs report the same version (single map entry)
+					return `{"osd":{"ceph version 19.2.0 (abc) squid (stable)":3}}`, nil
+				}
+				// handles: ceph osd require-osd-release squid
+				if args[0] == "osd" && args[1] == "require-osd-release" {
+					assert.Equal(t, "squid", args[2])
+					enableCalls++
+					return "", nil
+				}
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: executor}
+		mon := &OSDHealthMonitor{
+			context:     ctx,
+			clusterInfo: clusterInfo,
+			// lastRequireOSDRelease is "" (zero value) — nothing cached yet
+		}
+
+		mon.checkRequireOSDRelease()
+
+		assert.Equal(t, "squid", mon.lastRequireOSDRelease) // cached after success
+		assert.Equal(t, 1, enableCalls)                     // called exactly once
+	})
+
+	// CACHING: Release already cached as "squid" and OSDs still report squid →
+	// should NOT call EnableReleaseOSDFunctionality again (avoids redundant work every 60s).
+	t.Run("cached release skips EnableReleaseOSDFunctionality", func(t *testing.T) {
+		enableCalls := 0
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				// handles: ceph versions
+				if args[0] == "versions" {
+					return `{"osd":{"ceph version 19.2.0 (abc) squid (stable)":3}}`, nil
+				}
+				// handles: ceph osd require-osd-release (should NOT be reached)
+				if args[0] == "osd" && args[1] == "require-osd-release" {
+					enableCalls++
+					return "", nil
+				}
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: executor}
+		mon := &OSDHealthMonitor{
+			context:               ctx,
+			clusterInfo:           clusterInfo,
+			lastRequireOSDRelease: "squid", // already cached from a previous tick
+		}
+
+		mon.checkRequireOSDRelease()
+
+		assert.Equal(t, "squid", mon.lastRequireOSDRelease) // unchanged
+		assert.Equal(t, 0, enableCalls)                     // skipped — no ceph command issued
+	})
+
+	// MIXED VERSIONS: Upgrade in progress — some OSDs on squid, some on tentacle.
+	// Should bail early without setting anything.
+	t.Run("multiple OSD versions does not set release", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				// handles: ceph versions
+				if args[0] == "versions" {
+					// Two map entries → versions have not converged
+					return `{"osd":{"ceph version 19.2.0 (abc) squid (stable)":2,"ceph version 20.1.0 (def) tentacle (stable)":1}}`, nil
+				}
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: executor}
+		mon := &OSDHealthMonitor{
+			context:     ctx,
+			clusterInfo: clusterInfo,
+		}
+
+		mon.checkRequireOSDRelease()
+
+		assert.Equal(t, "", mon.lastRequireOSDRelease) // still empty — no action taken
+	})
+
+	// ERROR QUERYING VERSIONS: "ceph versions" fails (e.g. mons unreachable).
+	// Should bail early, cache stays empty so it retries on the next tick.
+	t.Run("error from GetAllCephDaemonVersions does not set release", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				// handles: ceph versions — returns an error
+				if args[0] == "versions" {
+					return "", fmt.Errorf("simulated error")
+				}
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: executor}
+		mon := &OSDHealthMonitor{
+			context:     ctx,
+			clusterInfo: clusterInfo,
+		}
+
+		mon.checkRequireOSDRelease()
+
+		assert.Equal(t, "", mon.lastRequireOSDRelease) // no change — will retry next tick
+	})
+
+	// ERROR SETTING FLAG: Versions converged but "ceph osd require-osd-release" fails.
+	// Should NOT cache the release name, so the next tick retries the operation.
+	t.Run("error from EnableReleaseOSDFunctionality does not cache", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				// handles: ceph versions — returns converged
+				if args[0] == "versions" {
+					return `{"osd":{"ceph version 19.2.0 (abc) squid (stable)":3}}`, nil
+				}
+				// handles: ceph osd require-osd-release — returns an error
+				if args[0] == "osd" && args[1] == "require-osd-release" {
+					return "", fmt.Errorf("simulated enable error")
+				}
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: executor}
+		mon := &OSDHealthMonitor{
+			context:     ctx,
+			clusterInfo: clusterInfo,
+		}
+
+		mon.checkRequireOSDRelease()
+
+		assert.Equal(t, "", mon.lastRequireOSDRelease) // NOT cached — ensures retry
+	})
 }


### PR DESCRIPTION
After a rolling OSD update, applyUpgradeOSDFunctionality() calls ceph versions once and silently skips setting require-osd-release if not all OSDs had reported the same version to the monitors yet.

This PR adds a periodic require-osd-release check to the OSD health monitor so that the flag is set even when OSD versions haven't converged by the time the reconcile completes.

The OSD health monitor already runs every 60s in a per-cluster goroutine. A new checkRequireOSDRelease() method is called on each tick:

- If ceph versions shows a single OSD version and the release differs from the last successfully applied value, it calls EnableReleaseOSDFunctionality
- If the release was already set, it skips silently to avoid redundant commands
- Otherwise it logs at debug level and retries on the next tick


Fixes: https://github.com/rook/rook/issues/17363

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
