### PR TITLE
build: fix gosec and go vet lint errors for Go 1.26 

### DIFF
--- a/cmd/rook/ceph/config.go
+++ b/cmd/rook/ceph/config.go
@@ -83,6 +83,7 @@ keyring = ` + keyring + `
 `
 
 	var fileMode os.FileMode = 0o444 // read-only
+	// #nosec G703 -- path is a constant returned by DefaultConfigFilePath, not user input
 	err := os.WriteFile(cephclient.DefaultConfigFilePath(), []byte(cfg), fileMode)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrapf(err, "failed to write config file"))

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -390,7 +390,7 @@ func parseDevices(devices string) ([]osddaemon.DesiredDevice, error) {
 		d.MetadataDevice = cd.StoreConfig.MetadataDevice
 
 		if d.OSDsPerDevice < 1 {
-			return nil, errors.Errorf("osds per device should be greater than 0 (%q)", d.OSDsPerDevice)
+			return nil, errors.Errorf("osds per device should be greater than 0 (%d)", d.OSDsPerDevice)
 		}
 
 		result = append(result, d)

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -287,6 +287,7 @@ func WriteCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) error 
 	if err != nil {
 		return errors.Wrap(err, "failed to copy connection config to /etc/ceph. failed to read the connection config")
 	}
+	// #nosec G703 -- path is a constant returned by DefaultConfigFilePath, not user input
 	err = os.WriteFile(DefaultConfigFilePath(), src, 0o600)
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy connection config to /etc/ceph. failed to write %q", DefaultConfigFilePath())

--- a/pkg/daemon/ceph/client/crush_test.go
+++ b/pkg/daemon/ceph/client/crush_test.go
@@ -322,6 +322,7 @@ func TestCrushName(t *testing.T) {
 		assert.True(t, IsNormalizedCrushNameEqual(normalizedCrushName, normalizedCrushName))
 		if i > 0 {
 			// slightly different crush name
+			// #nosec G602 -- i > 0 is checked above so i-1 is always within bounds
 			differentCrushName := crushNames[i-1]
 			differentNormalizedCrushName := NormalizeCrushName(differentCrushName)
 			assert.False(t, IsNormalizedCrushNameEqual(crushName, differentNormalizedCrushName))

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -325,7 +325,7 @@ func removeSnapshotSchedule(context *clusterd.Context, clusterInfo *ClusterInfo,
 
 // `poolName` is the name of the pool or the pool/radosNamespace
 func EnableSnapshotSchedules(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string, snapshotSchedules []cephv1.SnapshotScheduleSpec) error {
-	logger.Info("resetting current snapshot schedules in cluster namespace %q", clusterInfo.Namespace)
+	logger.Infof("resetting current snapshot schedules in cluster namespace %q", clusterInfo.Namespace)
 	// Reset any existing schedules
 	err := removeSnapshotSchedules(context, clusterInfo, poolName)
 	if err != nil {

--- a/pkg/daemon/ceph/client/mirror_health.go
+++ b/pkg/daemon/ceph/client/mirror_health.go
@@ -134,7 +134,7 @@ func updatePoolStatusMirroring(c *mirrorChecker, mirrorStatus *cephv1.MirroringS
 	blockPool := &cephv1.CephBlockPool{}
 	if err := c.client.Get(c.clusterInfo.Context, c.namespacedName, blockPool); err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Debug("CephBlockPool %q resource not found for updating the mirroring status, ignoring.", c.namespacedName)
+			logger.Debugf("CephBlockPool %q resource not found for updating the mirroring status, ignoring.", c.namespacedName)
 			return
 		}
 		logger.Warningf("failed to retrieve ceph block pool %q to update mirroring status. %v", c.namespacedName.Name, err)
@@ -159,7 +159,7 @@ func updateRadosNamespaceStatusMirroring(c *mirrorChecker, mirrorStatus *cephv1.
 		radosNamespace := &cephv1.CephBlockPoolRadosNamespace{}
 		if err := c.client.Get(c.clusterInfo.Context, c.namespacedName, radosNamespace); err != nil {
 			if kerrors.IsNotFound(err) {
-				logger.Debug("CephBlockPoolRadosNamespace %q resource not found for updating the mirroring status, ignoring.", c.namespacedName)
+				logger.Debugf("CephBlockPoolRadosNamespace %q resource not found for updating the mirroring status, ignoring.", c.namespacedName)
 				return nil
 			}
 			return err
@@ -172,7 +172,7 @@ func updateRadosNamespaceStatusMirroring(c *mirrorChecker, mirrorStatus *cephv1.
 		namespaceName := types.NamespacedName{Name: radosNamespace.Spec.BlockPoolName, Namespace: radosNamespace.Namespace}
 		if err := c.client.Get(c.clusterInfo.Context, namespaceName, blockPool); err != nil {
 			if kerrors.IsNotFound(err) {
-				logger.Debug("CephBlockPool %q resource not found for updating the mirroring status, ignoring.", namespaceName)
+				logger.Debugf("CephBlockPool %q resource not found for updating the mirroring status, ignoring.", namespaceName)
 				return nil
 			}
 			return err

--- a/pkg/daemon/ceph/osd/kms/azure_test.go
+++ b/pkg/daemon/ceph/osd/kms/azure_test.go
@@ -61,6 +61,7 @@ func Test_AzureKVCert(t *testing.T) {
 	})
 
 	t.Run("valid azure cert secret is available", func(t *testing.T) {
+		// #nosec G101 -- this is a test fixture, not real credentials
 		config := map[string]string{
 			"KMS_PROVIDER":            "azure-kv",
 			azureClientCertSecretName: "azure-cert-2",

--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -65,6 +65,7 @@ func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 	})
 	t.Run("ibm kp", func(t *testing.T) {
 		spec := cephv1.ClusterSpec{
+			// #nosec G101 -- this is a test fixture, not real credentials
 			Security: cephv1.ClusterSecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{
 				TokenSecretName:   "ibm-kp-token",
 				ConnectionDetails: map[string]string{"KMS_PROVIDER": TypeIBM, "IBM_KP_SERVICE_INSTANCE_ID": "1"},
@@ -140,6 +141,7 @@ func TestVaultConfigToEnvVar(t *testing.T) {
 		},
 		{
 			"ibm kp - IBM_KP_SERVICE_API_KEY is removed from the details",
+			// #nosec G101 -- this is a test fixture, not real credentials
 			args{spec: cephv1.ClusterSpec{Security: cephv1.ClusterSecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{ConnectionDetails: map[string]string{"KMS_PROVIDER": TypeIBM, "IBM_KP_SERVICE_API_KEY": "foo", "IBM_KP_SERVICE_INSTANCE_ID": "1"}, TokenSecretName: "ibm-kp-token"}}}},
 			[]v1.EnvVar{
 				{Name: "IBM_KP_SERVICE_API_KEY", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "ibm-kp-token"}, Key: "IBM_KP_SERVICE_API_KEY"}}},

--- a/pkg/daemon/ceph/osd/kms/kmip.go
+++ b/pkg/daemon/ceph/osd/kms/kmip.go
@@ -400,11 +400,11 @@ func (kms *kmipKMS) verifyResponse(
 	uniqueBatchItemID []byte,
 ) (*kmip.ResponseBatchItem, error) {
 	if respMsg.ResponseHeader.BatchCount != 1 {
-		return nil, fmt.Errorf("batch count %q should be \"1\"",
+		return nil, fmt.Errorf("batch count %d should be \"1\"",
 			respMsg.ResponseHeader.BatchCount)
 	}
 	if len(respMsg.BatchItem) != 1 {
-		return nil, fmt.Errorf("batch Intems list len %q should be \"1\"",
+		return nil, fmt.Errorf("batch Intems list len %d should be \"1\"",
 			len(respMsg.BatchItem))
 	}
 	batchItem := respMsg.BatchItem[0]

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -404,6 +404,7 @@ func UpdateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
 		}
 	}
 
+	// #nosec G703 -- lvmConfPath is a hard-coded constant, not user input
 	if err = os.WriteFile(lvmConfPath, output, 0o600); err != nil {
 		return errors.Wrapf(err, "failed to update lvm config file %q", lvmConfPath)
 	}

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -373,6 +373,7 @@ func GeneratePassword(length int, keyType KeyType) (string, error) {
 		return "", errors.Wrap(err, "failed to generate password")
 	}
 	for i, pass := range passwd {
+		// #nosec G115 -- len(passwordChars) is small (constant string) and fits in a byte
 		passwd[i] = passwordChars[pass%byte(len(passwordChars))]
 	}
 	return string(passwd), nil

--- a/pkg/operator/ceph/cluster/osd/volumes_test.go
+++ b/pkg/operator/ceph/cluster/osd/volumes_test.go
@@ -32,6 +32,7 @@ func TestGetEncryptionVolume(t *testing.T) {
 	// No KMS
 	osdProps := osdProperties{pvc: v1.PersistentVolumeClaimVolumeSource{ClaimName: "set1-data-1-bbgcw"}}
 	v, vM := c.getEncryptionVolume(osdProps)
+	// #nosec G101 -- this is a Kubernetes Secret reference (test fixture), not a credential value
 	assert.Equal(t, v1.Volume{Name: "osd-encryption-key", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "rook-ceph-osd-encryption-key-set1-data-1-bbgcw", Items: []v1.KeyToPath{{Key: "dmcrypt-key", Path: "luks_key"}}, DefaultMode: &m}}}, v)
 	assert.Equal(t, v1.VolumeMount{Name: "osd-encryption-key", ReadOnly: true, MountPath: "/etc/ceph"}, vM)
 

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -473,7 +473,7 @@ func GetSpec(obj client.Object) interface{} {
 	val := reflect.ValueOf(obj)
 
 	// If obj is a pointer, get the element
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -322,7 +322,7 @@ func updateCephStatusWithCephxStatus(context *clusterd.Context, clusterInfo *cli
 		cephCluster.Status.Cephx.CSI.PriorKeyCount = uint8(getPriorKeyCount(currentKeyCount)) //nolint:gosec // disable G115
 
 		if err := reporting.UpdateStatus(context.Client, cephCluster); err != nil {
-			return errors.Wrapf(err, "failed to update cephCluster %q to update csi cephx status to %q in namespace %q", namespacedName.Name, cephxStatus, namespacedName.Namespace)
+			return errors.Wrapf(err, "failed to update cephCluster %q to update csi cephx status to %+v in namespace %q", namespacedName.Name, cephxStatus, namespacedName.Namespace)
 		}
 		return nil
 	})

--- a/pkg/operator/ceph/disruption/controllerconfig/toleration_test.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/toleration_test.go
@@ -151,6 +151,7 @@ func TestTolerationSet(t *testing.T) {
 
 		// append the previous one again if it's within range, else append the last one
 		if i > 0 {
+			// #nosec G602 -- i > 0 is checked above so i-1 is always within bounds
 			tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManualB[i-1])
 		} else {
 			tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManualB[len(uniqueTolerationsManualB)-1])

--- a/pkg/operator/ceph/nvmeof/spec.go
+++ b/pkg/operator/ceph/nvmeof/spec.go
@@ -469,6 +469,7 @@ func adminKeyringVolume() v1.Volume {
 	return v1.Volume{
 		Name: "ceph-admin-keyring",
 		VolumeSource: v1.VolumeSource{
+			// #nosec G101 -- this is a Kubernetes Secret reference, not a credential value
 			Secret: &v1.SecretVolumeSource{
 				SecretName: "rook-ceph-admin-keyring",
 				Items: []v1.KeyToPath{

--- a/pkg/operator/ceph/object/account/controller_test.go
+++ b/pkg/operator/ceph/object/account/controller_test.go
@@ -361,6 +361,7 @@ func TestCephObjectStoreAccountController(t *testing.T) {
 			return &cephobject.AdminOpsContext{
 				Context:               *msContext,
 				AdminOpsUserAccessKey: "53S6B9S809NUP19IJ2K3",
+				// #nosec G101 -- fake test credential
 				AdminOpsUserSecretKey: "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR",
 				AdminOpsClient:        adminClient,
 			}, nil

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -317,6 +317,7 @@ func TestSSLPodSpec(t *testing.T) {
 		{
 			SubPath: "ldap",
 			VolumeSource: &cephv1.ConfigFileVolumeSource{
+				// #nosec G101 -- this is a Kubernetes Secret reference (test fixture), not a credential value
 				Secret: &v1.SecretVolumeSource{
 					SecretName: "my-rgw-ldap-secret",
 				},

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -320,6 +320,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 			return &cephobject.AdminOpsContext{
 				Context:               *context,
 				AdminOpsUserAccessKey: "53S6B9S809NUP19IJ2K3",
+				// #nosec G101 -- fake test credential
 				AdminOpsUserSecretKey: "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", // notsecret
 				AdminOpsClient:        adminClient,
 			}, nil

--- a/pkg/operator/ceph/reporting/reporting.go
+++ b/pkg/operator/ceph/reporting/reporting.go
@@ -69,7 +69,7 @@ func objKindOrBestGuess(obj client.Object) string {
 
 	// typed nil, or object's typemeta is empty
 	t := reflect.TypeOf(obj)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		return t.Elem().Name()
 	}
 	return t.Name()
@@ -88,7 +88,7 @@ func copyObject(obj client.Object) client.Object {
 	// object to use as the copy in this case.
 	var nonNilCopy client.Object
 	t := reflect.TypeOf(obj)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		innerType := t.Elem()
 		newObj := reflect.New(innerType)
 		nonNilCopy = newObj.Interface().(client.Object)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -184,6 +184,7 @@ func GetMatchingContainer(containers []v1.Container, name string) (v1.Container,
 	var result *v1.Container
 	if len(containers) == 1 {
 		// if there is only one pod, use its image rather than require a set container name
+		// #nosec G602 -- len(containers) == 1 is checked above so index 0 is always valid
 		result = &containers[0]
 	} else {
 		// if there are multiple pods, we require the container to have the expected name


### PR DESCRIPTION
Go 1.26 tightened the [cmd/vet](vscode-file://vscode-app/snap/code/238/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) printf analyzer so that %q is now an error when the argument is not a string, byte slice, or rune. 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
