### PR TITLE
object: add TLS 1.3 cipher suite support for RGW beast frontend

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -346,7 +346,58 @@ Ceph RGW supports Server Side Encryption as defined in [AWS S3 protocol](https:/
 
 Refer to the [Vault KMS section](../../Storage-Configuration/Advanced/key-management-system.md#vault) for details about Vault. If these settings are defined, then RGW will establish a connection between Vault and whenever S3 client sends request with Server Side Encryption. [Ceph's Vault documentation](https://docs.ceph.com/en/latest/radosgw/vault/) has more details.
 
-The `security` section contains settings related to KMS encryption of the RGW.
+The `security` section contains settings related to KMS encryption of the RGW and TLS options for the RGW beast frontend.
+
+### Beast frontend TLS options
+
+When TLS is enabled on the gateway, Rook configures the Ceph RGW beast frontend with optional TLS settings from the `security` section. These map directly to [beast frontend options](https://docs.ceph.com/en/latest/radosgw/frontends/#options):
+
+* `sslOptions`: SSL context options (protocol versions, workarounds, etc.)
+* `ciphers`: Cipher strings for `ssl_ciphers` (TLS v1.2 and below). Requires at least one of `tlsv1_2`, `tlsv1_1`, or `tlsv1_0` to be enabled in `sslOptions`.
+* `cipherSuites`: Cipher strings for `ssl_ciphersuites` (TLS v1.3).To restrict the gateway to TLS 1.3 only, set `tlsv1_2`, `tlsv1_1`, and `tlsv1_0` to `false` in `sslOptions`.
+* `tlsGroups`: Colon-separated TLS group names for `tls_groups`
+
+Example for TLS 1.2 cipher control:
+
+```yaml
+security:
+  ciphers:
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  tlsGroups:
+    - X25519
+    - P-256
+```
+
+Example for TLS 1.3 cipher suite control:
+
+```yaml
+security:
+  sslOptions:
+    tlsv1_2: false
+    tlsv1_1: false
+    tlsv1_0: false
+  cipherSuites:
+    - TLS_AES_256_GCM_SHA384
+    - TLS_CHACHA20_POLY1305_SHA256
+  tlsGroups:
+    - X25519
+    - P-256
+```
+
+Example for TLS 1.2 and TLS 1.3 cipher control:
+
+```yaml
+security:
+  ciphers:
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  cipherSuites:
+    - TLS_AES_256_GCM_SHA384
+  tlsGroups:
+    - X25519
+    - P-256
+```
+
+### KMS encryption
 
 ```yaml
 security:

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -12101,10 +12101,23 @@ See <a href="https://docs.ceph.com/en/latest/radosgw/frontends/#options">https:/
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ciphers specifies the cipher suites used during the TLS handshake.
-Multiple suites are supported with &lsquo;:&rsquo; colon-separated.
+<p>Ciphers specifies the cipher suites used during the TLS handshake for TLS v1.2 and below.
 Each value must be a valid OpenSSL cipher suite name.
-See <a href="https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names">https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names</a></p>
+See <a href="https://docs.openssl.org/master/man1/openssl-ciphers/">https://docs.openssl.org/master/man1/openssl-ciphers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cipherSuites</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CipherSuites specifies the cipher suites used during the TLS handshake for TLS v1.3.
+Each value must be a valid OpenSSL cipher suite name.
+See <a href="https://docs.openssl.org/master/man1/openssl-ciphers/">https://docs.openssl.org/master/man1/openssl-ciphers/</a></p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -14796,12 +14796,21 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    cipherSuites:
+                      description: |-
+                        CipherSuites specifies the cipher suites used during the TLS handshake for TLS v1.3.
+                        Each value must be a valid OpenSSL cipher suite name.
+                        See https://docs.openssl.org/master/man1/openssl-ciphers/
+                      items:
+                        type: string
+                      maxItems: 1000
+                      minItems: 0
+                      type: array
                     ciphers:
                       description: |-
-                        Ciphers specifies the cipher suites used during the TLS handshake.
-                        Multiple suites are supported with ':' colon-separated.
+                        Ciphers specifies the cipher suites used during the TLS handshake for TLS v1.2 and below.
                         Each value must be a valid OpenSSL cipher suite name.
-                        See https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names
+                        See https://docs.openssl.org/master/man1/openssl-ciphers/
                       items:
                         type: string
                       maxItems: 1000

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -14785,12 +14785,21 @@ spec:
                   description: Security represents security settings
                   nullable: true
                   properties:
+                    cipherSuites:
+                      description: |-
+                        CipherSuites specifies the cipher suites used during the TLS handshake for TLS v1.3.
+                        Each value must be a valid OpenSSL cipher suite name.
+                        See https://docs.openssl.org/master/man1/openssl-ciphers/
+                      items:
+                        type: string
+                      maxItems: 1000
+                      minItems: 0
+                      type: array
                     ciphers:
                       description: |-
-                        Ciphers specifies the cipher suites used during the TLS handshake.
-                        Multiple suites are supported with ':' colon-separated.
+                        Ciphers specifies the cipher suites used during the TLS handshake for TLS v1.2 and below.
                         Each value must be a valid OpenSSL cipher suite name.
-                        See https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names
+                        See https://docs.openssl.org/master/man1/openssl-ciphers/
                       items:
                         type: string
                       maxItems: 1000

--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/ptr"
 )
 
 const ServiceServingCertKey = "service.beta.openshift.io/serving-cert-secret-name"
@@ -119,7 +120,38 @@ func ValidateObjectSpec(gs *CephObjectStore) error {
 		}
 	}
 
+	if err := validateObjectStoreSecurity(&gs.Spec); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// validateObjectStoreSecurity validates the ssl_ciphers applies to TLS v1.2 and below; ssl_ciphersuites applies to TLS v1.3 only.
+// See https://docs.ceph.com/en/latest/radosgw/frontends/#options
+func validateObjectStoreSecurity(spec *ObjectStoreSpec) error {
+	if spec.Security == nil {
+		return nil
+	}
+
+	sec := spec.Security
+	if len(sec.Ciphers) == 0 && len(sec.CipherSuites) == 0 {
+		return nil
+	}
+
+	if len(sec.Ciphers) > 0 && !isTLSv1_2orBelowEnabled(sec.SslOptions) {
+		return errors.New("ciphers requires at least one TLS version of 1.2 or below to be enabled in sslOptions")
+	}
+
+	return nil
+}
+
+// isTLS12OrBelowEnabled check if TLS v1.2 or below is enabled
+func isTLSv1_2orBelowEnabled(opts *SslOptionsSpec) bool {
+	if opts == nil {
+		return true
+	}
+	return ptr.Deref(opts.TLSv1_2, true) || ptr.Deref(opts.TLSv1_1, false) || ptr.Deref(opts.TLSv1_0, false)
 }
 
 func (s *ObjectStoreSpec) GetServiceServingCert() string {

--- a/pkg/apis/ceph.rook.io/v1/object_test.go
+++ b/pkg/apis/ceph.rook.io/v1/object_test.go
@@ -129,6 +129,47 @@ func TestValidateObjectStoreSpec(t *testing.T) {
 	})
 }
 
+func TestValidateObjectStoreSecurity(t *testing.T) {
+	objectStore := &CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-store", Namespace: "rook-ceph"},
+		Spec:       ObjectStoreSpec{},
+	}
+
+	t.Run("cipher suites allowed with TLS 1.3 enabled", func(t *testing.T) {
+		objectStore.Spec.Security = &ObjectStoreSecuritySpec{
+			CipherSuites: []string{"TLS_AES_256_GCM_SHA384"},
+		}
+		assert.NoError(t, validateObjectStoreSecurity(&objectStore.Spec))
+	})
+
+	t.Run("ciphers require TLS 1.2 or below enabled", func(t *testing.T) {
+		objectStore.Spec.Security = &ObjectStoreSecuritySpec{
+			Ciphers: []string{"AES256-SHA"},
+			SslOptions: &SslOptionsSpec{
+				TLSv1_2: boolPtr(false),
+				TLSv1_1: boolPtr(false),
+				TLSv1_0: boolPtr(false),
+			},
+		}
+		err := validateObjectStoreSecurity(&objectStore.Spec)
+		assert.ErrorContains(t, err, "ciphers requires at least one TLS version")
+
+		objectStore.Spec.Security.SslOptions.TLSv1_2 = boolPtr(true)
+		err = validateObjectStoreSecurity(&objectStore.Spec)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ciphers and cipher suites allowed together", func(t *testing.T) {
+		objectStore.Spec.Security = &ObjectStoreSecuritySpec{
+			Ciphers:      []string{"AES256-SHA"},
+			CipherSuites: []string{"TLS_AES_256_GCM_SHA384"},
+		}
+		assert.NoError(t, validateObjectStoreSecurity(&objectStore.Spec))
+	})
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 func TestIsTLSEnabled(t *testing.T) {
 	objStore := &CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -400,14 +400,21 @@ type ObjectStoreSecuritySpec struct {
 	// +optional
 	SslOptions *SslOptionsSpec `json:"sslOptions,omitzero"` //nolint:kubeapilinter // MinProperties cannot be applied to a struct pointer field
 
-	// Ciphers specifies the cipher suites used during the TLS handshake.
-	// Multiple suites are supported with ':' colon-separated.
+	// Ciphers specifies the cipher suites used during the TLS handshake for TLS v1.2 and below.
 	// Each value must be a valid OpenSSL cipher suite name.
-	// See https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names
+	// See https://docs.openssl.org/master/man1/openssl-ciphers/
 	// +kubebuilder:validation:MinItems=0
 	// +kubebuilder:validation:MaxItems=1000
 	// +optional
 	Ciphers []string `json:"ciphers,omitempty"` //nolint:kubeapilinter // List doesn't have min/max length
+
+	// CipherSuites specifies the cipher suites used during the TLS handshake for TLS v1.3.
+	// Each value must be a valid OpenSSL cipher suite name.
+	// See https://docs.openssl.org/master/man1/openssl-ciphers/
+	// +kubebuilder:validation:MinItems=0
+	// +kubebuilder:validation:MaxItems=1000
+	// +optional
+	CipherSuites []string `json:"cipherSuites,omitempty"` //nolint:kubeapilinter // List doesn't have min/max length
 
 	// TlsGroups specifies one or more TLS Group strings separated by colons.
 	// Multiple suites are supported with ':' colon-separated.

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -4443,6 +4443,11 @@ func (in *ObjectStoreSecuritySpec) DeepCopyInto(out *ObjectStoreSecuritySpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CipherSuites != nil {
+		in, out := &in.CipherSuites, &out.CipherSuites
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TlsGroups != nil {
 		in, out := &in.TlsGroups, &out.TlsGroups
 		*out = make([]string, len(*in))

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
 require (
@@ -90,7 +91,6 @@ require (
 	k8s.io/client-go v0.35.4 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -113,6 +113,9 @@ func (c *clusterConfig) rgwFrontendStr() string {
 	if len(c.store.Spec.Security.Ciphers) > 0 {
 		frontendStr = fmt.Sprintf("%s ssl_ciphers=%s", frontendStr, strings.Join(c.store.Spec.Security.Ciphers, ":"))
 	}
+	if len(c.store.Spec.Security.CipherSuites) > 0 {
+		frontendStr = fmt.Sprintf("%s ssl_ciphersuites=%s", frontendStr, strings.Join(c.store.Spec.Security.CipherSuites, ":"))
+	}
 
 	if len(c.store.Spec.Security.TlsGroups) > 0 {
 		frontendStr = fmt.Sprintf("%s tls_groups=%s", frontendStr, strings.Join(c.store.Spec.Security.TlsGroups, ":"))

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -196,6 +196,27 @@ func TestRgwFrontendStr(t *testing.T) {
 	}
 	result = cfg.rgwFrontendStr()
 	assert.Equal(t, "beast port=80 ssl_options=default_workarounds:no_compression:no_sslv2:no_sslv3:no_tlsv1:no_tlsv1_1 ssl_ciphers=TLS_DHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 tls_groups=X25519:P-256", result, "case 8")
+
+	// With cipher suites only (TLS 1.3)
+	cfg = newConfig(t)
+	cfg.clusterSpec.Network.HostNetwork = true
+	cfg.store.Spec.Gateway.Port = 80
+	cfg.store.Spec.Security = &cephv1.ObjectStoreSecuritySpec{
+		CipherSuites: []string{"TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"},
+	}
+	result = cfg.rgwFrontendStr()
+	assert.Equal(t, "beast port=80 ssl_ciphersuites=TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256", result, "case 9")
+
+	// With both ciphers (TLS 1.2) and cipher suites (TLS 1.3)
+	cfg = newConfig(t)
+	cfg.clusterSpec.Network.HostNetwork = true
+	cfg.store.Spec.Gateway.Port = 80
+	cfg.store.Spec.Security = &cephv1.ObjectStoreSecuritySpec{
+		Ciphers:      []string{"AES256-SHA"},
+		CipherSuites: []string{"TLS_AES_256_GCM_SHA384"},
+	}
+	result = cfg.rgwFrontendStr()
+	assert.Equal(t, "beast port=80 ssl_ciphers=AES256-SHA ssl_ciphersuites=TLS_AES_256_GCM_SHA384", result, "case 10")
 }
 
 func TestBuildSslOptions(t *testing.T) {


### PR DESCRIPTION
adding new tls ssl_ciphersuites supporting tls 1.3 and the existing,
ssl_cipher supports tls 1.2 and below. Adding, the docs and unit-test
changs as well.


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
