### PR TITLE
object: remove AWS SDK v1 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ replace (
 
 require (
 	github.com/IBM/keyprotect-go-client v0.16.0
-	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.17
@@ -133,7 +132,6 @@ require (
 	github.com/hashicorp/vault/api/auth/approle v0.8.0 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.44.164/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
@@ -1001,9 +999,7 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"strings"
 
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithy "github.com/aws/smithy-go"
 	"github.com/ceph/go-ceph/rgw/admin"
@@ -765,10 +765,10 @@ func (p *Provisioner) setBucketPolicy(bucket *bucket) error {
 	additionalConfig := bucket.additionalConfig
 	ctx := context.TODO()
 
-	svc := p.s3Agent.ClientV2
+	svc := p.s3Agent.Client
 	var livePolicy *string
 
-	policyResp, err := svc.GetBucketPolicy(ctx, &s3v2.GetBucketPolicyInput{
+	policyResp, err := svc.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: &p.bucketName,
 	})
 	if err != nil {
@@ -790,14 +790,14 @@ func (p *Provisioner) setBucketPolicy(bucket *bucket) error {
 
 	log.NamedDebug(nsName, logger, "Policy for bucket %q has changed. diff:%s", p.bucketName, diff)
 	if additionalConfig.bucketPolicy == nil {
-		_, err = svc.DeleteBucketPolicy(ctx, &s3v2.DeleteBucketPolicyInput{
+		_, err = svc.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
 			Bucket: &p.bucketName,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete policy for bucket %q", p.bucketName)
 		}
 	} else {
-		_, err = svc.PutBucketPolicy(ctx, &s3v2.PutBucketPolicyInput{
+		_, err = svc.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
 			Bucket: &p.bucketName,
 			Policy: additionalConfig.bucketPolicy,
 		})
@@ -814,10 +814,10 @@ func (p *Provisioner) setBucketLifecycle(bucket *bucket) error {
 	additionalConfig := bucket.additionalConfig
 	ctx := context.TODO()
 
-	svc := p.s3Agent.ClientV2
-	var liveLc *s3v2.GetBucketLifecycleConfigurationOutput
+	svc := p.s3Agent.Client
+	var liveLc *s3.GetBucketLifecycleConfigurationOutput
 
-	liveLc, err := svc.GetBucketLifecycleConfiguration(ctx, &s3v2.GetBucketLifecycleConfigurationInput{
+	liveLc, err := svc.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: &p.bucketName,
 	})
 	if err != nil {
@@ -868,14 +868,14 @@ func (p *Provisioner) setBucketLifecycle(bucket *bucket) error {
 
 	log.NamedDebug(nsName, logger, "Lifecycle configuration for bucket %q has changed. diff:%s", p.bucketName, diff)
 	if additionalConfig.bucketLifecycle == nil {
-		_, err = svc.DeleteBucketLifecycle(ctx, &s3v2.DeleteBucketLifecycleInput{
+		_, err = svc.DeleteBucketLifecycle(ctx, &s3.DeleteBucketLifecycleInput{
 			Bucket: &p.bucketName,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete lifecycle configuration for bucket %q", p.bucketName)
 		}
 	} else {
-		_, err = svc.PutBucketLifecycleConfiguration(ctx, &s3v2.PutBucketLifecycleConfigurationInput{
+		_, err = svc.PutBucketLifecycleConfiguration(ctx, &s3.PutBucketLifecycleConfigurationInput{
 			Bucket:                 &p.bucketName,
 			LifecycleConfiguration: confLc,
 		})

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/ceph/go-ceph/rgw/admin"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"

--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -20,7 +20,7 @@ package notification
 import (
 	"context"
 
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
@@ -144,7 +144,7 @@ var createNotification = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, t
 	if err != nil {
 		return errors.Wrapf(err, "failed to create S3 agent for CephBucketNotification %q provisioning for bucket %q", bnName, bucketName)
 	}
-	_, err = s3Agent.ClientV2.PutBucketNotificationConfiguration(p.opManagerContext, &s3v2.PutBucketNotificationConfigurationInput{
+	_, err = s3Agent.Client.PutBucketNotificationConfiguration(p.opManagerContext, &s3.PutBucketNotificationConfigurationInput{
 		Bucket: &bucketName,
 		NotificationConfiguration: &s3types.NotificationConfiguration{
 			TopicConfigurations: []s3types.TopicConfiguration{
@@ -176,7 +176,7 @@ var getAllRGWNotifications = func(p provisioner, ob *bktv1alpha1.ObjectBucket) (
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create S3 agent for CephBucketNotification provisioning for bucket %q", bucketName)
 	}
-	nc, err := s3Agent.ClientV2.GetBucketNotificationConfiguration(p.opManagerContext, &s3v2.GetBucketNotificationConfigurationInput{
+	nc, err := s3Agent.Client.GetBucketNotificationConfiguration(p.opManagerContext, &s3.GetBucketNotificationConfigurationInput{
 		Bucket:              &bucketName,
 		ExpectedBucketOwner: &ownerName,
 	})
@@ -204,7 +204,7 @@ var deleteNotification = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, n
 	if err != nil {
 		return errors.Wrapf(err, "failed to create S3 agent for deleting all bucket notifications from bucket %q", bucketName)
 	}
-	if err := DeleteBucketNotification(context.TODO(), s3Agent.ClientV2, &DeleteBucketNotificationRequestInput{
+	if err := DeleteBucketNotification(context.TODO(), s3Agent.Client, &DeleteBucketNotificationRequestInput{
 		Bucket: &bucket.Spec.Endpoint.BucketName,
 	}, notificationId); err != nil {
 		return errors.Wrapf(err, "failed to delete bucket notification %q from bucket %q", notificationId, bucketName)

--- a/pkg/operator/ceph/object/notification/s3ext.go
+++ b/pkg/operator/ceph/object/notification/s3ext.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	v4signer "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pkg/errors"
 )
 
@@ -53,7 +53,7 @@ const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495
 // bucket notification configuration. This is not part of the standard AWS S3
 // API, so we build and sign the HTTP request manually using the v2 client's
 // credentials and endpoint.
-func DeleteBucketNotification(ctx context.Context, client *s3v2.Client, input *DeleteBucketNotificationRequestInput, notificationId string) error {
+func DeleteBucketNotification(ctx context.Context, client *s3.Client, input *DeleteBucketNotificationRequestInput, notificationId string) error {
 	if input == nil {
 		input = &DeleteBucketNotificationRequestInput{}
 	}

--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -162,17 +162,17 @@ func NewBucketPolicy(ps ...PolicyStatement) *BucketPolicy {
 }
 
 // PutBucketPolicy applies the policy to the bucket
-func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3v2.PutBucketPolicyOutput, error) {
+func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBucketPolicyOutput, error) {
 	confirmRemoveSelfBucketAccess := false
 	serializedPolicy, _ := json.Marshal(policy)
 	consumablePolicy := string(serializedPolicy)
 
-	p := &s3v2.PutBucketPolicyInput{
+	p := &s3.PutBucketPolicyInput{
 		Bucket:                        &bucket,
 		ConfirmRemoveSelfBucketAccess: &confirmRemoveSelfBucketAccess,
 		Policy:                        &consumablePolicy,
 	}
-	out, err := s.ClientV2.PutBucketPolicy(context.TODO(), p)
+	out, err := s.Client.PutBucketPolicy(context.TODO(), p)
 	if err != nil {
 		return out, err
 	}
@@ -180,7 +180,7 @@ func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3v2.Put
 }
 
 func (s *S3Agent) GetBucketPolicy(bucket string) (*BucketPolicy, error) {
-	out, err := s.ClientV2.GetBucketPolicy(context.TODO(), &s3v2.GetBucketPolicyInput{
+	out, err := s.Client.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{
 		Bucket: &bucket,
 	})
 	if err != nil {

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -25,30 +25,25 @@ import (
 	"net/url"
 	"strings"
 
-	v2aws "github.com/aws/aws-sdk-go-v2/aws"
-	v2creds "github.com/aws/aws-sdk-go-v2/credentials"
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	awssession "github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 )
 
 // Region for aws golang sdk
 const CephRegion = "us-east-1"
 
-// S3Agent wraps the s3.S3 structure to allow for wrapper methods
+// S3Agent wraps the S3 client to allow for wrapper methods
 type S3Agent struct {
-	Client   *s3.S3       // v1 client
-	ClientV2 *s3v2.Client // v2 client
+	Client *s3.Client
 }
 
 func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byte, insecure bool, httpClient *http.Client) (*S3Agent, error) {
-	logLevel := aws.LogOff
+	var logMode aws.ClientLogMode
 	if debug {
-		logLevel = aws.LogDebug
+		logMode = aws.LogSigning
 	}
 
 	tlsEnabled := false
@@ -64,28 +59,6 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 		}
 	}
 
-	// -----------------------------
-	// SDK v1 client initialization
-	// -----------------------------
-	v1Session, err := awssession.NewSession(
-		aws.NewConfig().
-			WithRegion(CephRegion).
-			WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, "")).
-			WithEndpoint(endpoint).
-			WithS3ForcePathStyle(true).
-			WithMaxRetries(5).
-			WithDisableSSL(!tlsEnabled).
-			WithHTTPClient(httpClient).
-			WithLogLevel(logLevel),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create v1 session")
-	}
-	v1Client := s3.New(v1Session)
-
-	// -----------------------------
-	// SDK v2 client initialization
-	// -----------------------------
 	scheme := "http"
 	if tlsEnabled {
 		scheme = "https"
@@ -94,24 +67,21 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 	if perr != nil || (u.Scheme != "http" && u.Scheme != "https") {
 		u, _ = url.Parse(scheme + "://" + endpoint)
 	}
-	// Use the officially-supported v2 endpoint customization mechanism.
-	// This keeps S3's internal endpoint customizations (including hostname handling)
-	// consistent with the SDK's expectations, which is especially important for TLS.
 	baseEndpoint := u.String()
-	v2Cfg := v2aws.Config{
+	cfg := aws.Config{
 		Region:           CephRegion,
-		Credentials:      v2aws.NewCredentialsCache(v2creds.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+		Credentials:      aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
 		HTTPClient:       httpClient,
 		BaseEndpoint:     &baseEndpoint,
 		RetryMaxAttempts: 5,
-		RetryMode:        v2aws.RetryModeStandard,
+		RetryMode:        aws.RetryModeStandard,
+		ClientLogMode:    logMode,
 	}
-	v2Client := s3v2.NewFromConfig(v2Cfg, func(o *s3v2.Options) {
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.UsePathStyle = true
 	})
 	return &S3Agent{
-		Client:   v1Client,
-		ClientV2: v2Client,
+		Client: client,
 	}, nil
 }
 
@@ -132,11 +102,11 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 		logger.Debugf("creating bucket %q", name)
 	}
 
-	input := &s3v2.CreateBucketInput{
+	input := &s3.CreateBucketInput{
 		Bucket: &name,
 	}
 
-	_, err := s.ClientV2.CreateBucket(context.TODO(), input)
+	_, err := s.Client.CreateBucket(context.TODO(), input)
 	if err != nil {
 		var alreadyExists *s3types.BucketAlreadyExists
 		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
@@ -157,7 +127,7 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 
 // DeleteBucket function deletes given bucket using s3 client
 func (s *S3Agent) DeleteBucket(name string) (bool, error) {
-	_, err := s.ClientV2.DeleteBucket(context.TODO(), &s3v2.DeleteBucketInput{
+	_, err := s.Client.DeleteBucket(context.TODO(), &s3.DeleteBucketInput{
 		Bucket: &name,
 	})
 	if err != nil {
@@ -171,7 +141,7 @@ func (s *S3Agent) DeleteBucket(name string) (bool, error) {
 func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 	contentType string,
 ) (bool, error) {
-	_, err := s.ClientV2.PutObject(context.TODO(), &s3v2.PutObjectInput{
+	_, err := s.Client.PutObject(context.TODO(), &s3.PutObjectInput{
 		Body:        strings.NewReader(body),
 		Bucket:      &bucketname,
 		Key:         &key,
@@ -186,7 +156,7 @@ func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 
 // GetObjectInBucket function retrieves an object from a bucket using s3 client
 func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, error) {
-	result, err := s.ClientV2.GetObject(context.TODO(), &s3v2.GetObjectInput{
+	result, err := s.Client.GetObject(context.TODO(), &s3.GetObjectInput{
 		Bucket: &bucketname,
 		Key:    &key,
 	})
@@ -205,7 +175,7 @@ func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, erro
 
 // DeleteObjectInBucket function deletes given bucket using s3 client
 func (s *S3Agent) DeleteObjectInBucket(bucketname string, key string) (bool, error) {
-	_, err := s.ClientV2.DeleteObject(context.TODO(), &s3v2.DeleteObjectInput{
+	_, err := s.Client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
 		Bucket: &bucketname,
 		Key:    &key,
 	})

--- a/pkg/operator/ceph/object/s3-handlers_test.go
+++ b/pkg/operator/ceph/object/s3-handlers_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,34 +34,29 @@ func TestNewS3Agent(t *testing.T) {
 		insecure := false
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, nil, insecure, nil)
 		assert.NoError(t, err)
-		assert.NotEqual(t, aws.LogDebug, s3Agent.Client.Config.LogLevel)
-		assert.Equal(t, nil, s3Agent.Client.Config.HTTPClient.Transport)
-		assert.True(t, *s3Agent.Client.Config.DisableSSL)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "http://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "http://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		assert.Equal(t, aws.ClientLogMode(0), s3Agent.Client.Options().ClientLogMode)
 	})
 	t.Run("test with debug without tls", func(t *testing.T) {
 		debug := true
-		logLevel := aws.LogDebug
 		insecure := false
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, nil, insecure, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, &logLevel, s3Agent.Client.Config.LogLevel)
-		assert.Nil(t, s3Agent.Client.Config.HTTPClient.Transport)
-		assert.True(t, *s3Agent.Client.Config.DisableSSL)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "http://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "http://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		assert.Equal(t, aws.LogSigning, s3Agent.Client.Options().ClientLogMode)
 	})
 	t.Run("test without tls client cert but insecure tls", func(t *testing.T) {
 		debug := true
 		insecure := true
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, nil, insecure, nil)
 		assert.NoError(t, err)
-		assert.NotNil(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.RootCAs) // still includes sys certs
-		assert.True(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
-		assert.False(t, *s3Agent.Client.Config.DisableSSL)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "https://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "https://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		httpClient := s3Agent.Client.Options().HTTPClient.(*http.Client)
+		assert.NotNil(t, httpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs)
+		assert.True(t, httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 	})
 	t.Run("test with secure tls client cert", func(t *testing.T) {
 		debug := true
@@ -69,10 +64,11 @@ func TestNewS3Agent(t *testing.T) {
 		tlsCert := []byte("tlsCert")
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, tlsCert, insecure, nil)
 		assert.NoError(t, err)
-		assert.NotNil(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.RootCAs)
-		assert.False(t, *s3Agent.Client.Config.DisableSSL)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "https://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "https://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		httpClient := s3Agent.Client.Options().HTTPClient.(*http.Client)
+		assert.NotNil(t, httpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs)
+		assert.False(t, httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 	})
 	t.Run("test with insecure tls client cert", func(t *testing.T) {
 		debug := true
@@ -80,15 +76,14 @@ func TestNewS3Agent(t *testing.T) {
 		tlsCert := []byte("tlsCert")
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, tlsCert, insecure, nil)
 		assert.NoError(t, err)
-		assert.NotNil(t, s3Agent.Client.Config.HTTPClient.Transport)
-		assert.True(t, s3Agent.Client.Config.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
-		assert.False(t, *s3Agent.Client.Config.DisableSSL)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "https://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "https://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		httpClient := s3Agent.Client.Options().HTTPClient.(*http.Client)
+		assert.NotNil(t, httpClient.Transport)
+		assert.True(t, httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 	})
 	t.Run("test with custom http.Client", func(t *testing.T) {
 		debug := true
-		logLevel := aws.LogDebug
 		insecure := false
 		httpClient := &http.Client{
 			Transport: &http.Transport{
@@ -99,32 +94,30 @@ func TestNewS3Agent(t *testing.T) {
 		}
 		s3Agent, err := NewS3Agent(accessKey, secretKey, endpoint, debug, nil, insecure, httpClient)
 		assert.NoError(t, err)
-		assert.Equal(t, &logLevel, s3Agent.Client.Config.LogLevel)
-		assert.NotNil(t, s3Agent.Client.Config.HTTPClient.Transport)
-		assert.True(t, *s3Agent.Client.Config.DisableSSL)
-		transport := s3Agent.Client.Config.HTTPClient.Transport
-		assert.Equal(t, 7, transport.(*http.Transport).MaxIdleConns)
-		assert.Equal(t, 13, transport.(*http.Transport).MaxIdleConnsPerHost)
-		assert.Equal(t, 17, transport.(*http.Transport).MaxConnsPerHost)
-		assert.NotNil(t, s3Agent.ClientV2)
-		assert.Equal(t, "http://endpoint", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.NotNil(t, s3Agent.Client)
+		assert.Equal(t, "http://endpoint", *s3Agent.Client.Options().BaseEndpoint)
+		resolvedClient := s3Agent.Client.Options().HTTPClient.(*http.Client)
+		transport := resolvedClient.Transport.(*http.Transport)
+		assert.Equal(t, 7, transport.MaxIdleConns)
+		assert.Equal(t, 13, transport.MaxIdleConnsPerHost)
+		assert.Equal(t, 17, transport.MaxConnsPerHost)
 	})
-	t.Run("v2 endpoint with host:port for TLS", func(t *testing.T) {
+	t.Run("endpoint with host:port for TLS", func(t *testing.T) {
 		ep := "rook-ceph-rgw-store.test-ns.svc:443"
 		s3Agent, err := NewS3Agent(accessKey, secretKey, ep, false, nil, true, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://rook-ceph-rgw-store.test-ns.svc:443", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.Equal(t, "https://rook-ceph-rgw-store.test-ns.svc:443", *s3Agent.Client.Options().BaseEndpoint)
 	})
-	t.Run("v2 endpoint with host:port without TLS", func(t *testing.T) {
+	t.Run("endpoint with host:port without TLS", func(t *testing.T) {
 		ep := "rook-ceph-rgw-store.test-ns.svc:80"
 		s3Agent, err := NewS3Agent(accessKey, secretKey, ep, false, nil, false, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, "http://rook-ceph-rgw-store.test-ns.svc:80", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.Equal(t, "http://rook-ceph-rgw-store.test-ns.svc:80", *s3Agent.Client.Options().BaseEndpoint)
 	})
-	t.Run("v2 endpoint with full URL", func(t *testing.T) {
+	t.Run("endpoint with full URL", func(t *testing.T) {
 		ep := "https://rook-ceph-rgw-store.test-ns.svc:443"
 		s3Agent, err := NewS3Agent(accessKey, secretKey, ep, false, nil, true, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://rook-ceph-rgw-store.test-ns.svc:443", *s3Agent.ClientV2.Options().BaseEndpoint)
+		assert.Equal(t, "https://rook-ceph-rgw-store.test-ns.svc:443", *s3Agent.Client.Options().BaseEndpoint)
 	})
 }

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -21,7 +21,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/installer"
@@ -163,7 +163,7 @@ func (b *BucketOperation) CheckBucketNotificationSetonRGW(namespace, storeName, 
 		return false
 	}
 	logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
-	notifications, err := s3client.ClientV2.GetBucketNotificationConfiguration(context.TODO(), &s3v2.GetBucketNotificationConfigurationInput{
+	notifications, err := s3client.Client.GetBucketNotificationConfiguration(context.TODO(), &s3.GetBucketNotificationConfigurationInput{
 		Bucket: &bucketname,
 	})
 	if err != nil {

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -19,20 +19,23 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -55,6 +58,20 @@ const (
 )
 
 var objectStoreServicePrefix = "rook-ceph-rgw-"
+
+var lifecycleCmpOpts = cmp.Options{
+	cmpopts.IgnoreUnexported(
+		s3types.LifecycleRule{},
+		s3types.LifecycleExpiration{},
+		s3types.LifecycleRuleFilter{},
+		s3types.LifecycleRuleAndOperator{},
+		s3types.AbortIncompleteMultipartUpload{},
+		s3types.NoncurrentVersionExpiration{},
+		s3types.NoncurrentVersionTransition{},
+		s3types.Transition{},
+		s3types.Tag{},
+	),
+}
 
 func TestCephObjectSuite(t *testing.T) {
 	s := new(ObjectSuite)
@@ -116,7 +133,7 @@ func (s *ObjectSuite) TestWithTLS() {
 func cleanUpTLS(s *ObjectSuite) {
 	err := s.k8sh.Clientset.CoreV1().Secrets(s.settings.Namespace).Delete(context.TODO(), objectTLSSecretName, metav1.DeleteOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			logger.Fatal("failed to deleted store TLS secret")
 		}
 	}
@@ -604,7 +621,7 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		})
 
 		t.Run("policy was applied verbatim to bucket", func(t *testing.T) {
-			policyResp, err := s3client.Client.GetBucketPolicy(&s3.GetBucketPolicyInput{
+			policyResp, err := s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 				Bucket: &bucketName,
 			})
 			require.NoError(t, err)
@@ -651,7 +668,7 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		t.Run("policy update applied verbatim to bucket", func(t *testing.T) {
 			var livePolicy string
 			utils.Retry(20, time.Second, "policy changed", func() bool {
-				policyResp, err := s3client.Client.GetBucketPolicy(&s3.GetBucketPolicyInput{
+				policyResp, err := s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 					Bucket: &bucketName,
 				})
 				if err != nil {
@@ -704,15 +721,15 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		t.Run("policy was removed from bucket", func(t *testing.T) {
 			var err error
 			utils.Retry(20, time.Second, "policy is gone", func() bool {
-				_, err = s3client.Client.GetBucketPolicy(&s3.GetBucketPolicyInput{
+				_, err = s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 					Bucket: &bucketName,
 				})
 				return err != nil
 			})
 			require.Error(t, err)
-			require.Implements(t, (*awserr.Error)(nil), err)
-			aerr, _ := err.(awserr.Error)
-			assert.Equal(t, aerr.Code(), "NoSuchBucketPolicy")
+			var apiErr smithy.APIError
+			require.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, "NoSuchBucketPolicy", apiErr.ErrorCode())
 		})
 
 		t.Run("delete bucket", func(t *testing.T) {
@@ -839,16 +856,16 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		})
 
 		t.Run("lifecycle was applied verbatim to bucket", func(t *testing.T) {
-			liveLc, err := s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+			liveLc, err := s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
 				Bucket: &bucketName,
 			})
 			require.NoError(t, err)
 
-			confLc := &s3.GetBucketLifecycleConfigurationOutput{}
+			confLc := &s3types.BucketLifecycleConfiguration{}
 			err = json.Unmarshal([]byte(bucketLifecycle1), confLc)
 			require.NoError(t, err)
 
-			assert.Equal(t, confLc, liveLc)
+			assert.True(t, cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...), cmp.Diff(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...))
 		})
 
 		t.Run("update obc bucketLifecycle", func(t *testing.T) {
@@ -891,21 +908,21 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		t.Run("lifecycle update applied verbatim to bucket", func(t *testing.T) {
 			var liveLc *s3.GetBucketLifecycleConfigurationOutput
 
-			confLc := &s3.GetBucketLifecycleConfigurationOutput{}
+			confLc := &s3types.BucketLifecycleConfiguration{}
 			err = json.Unmarshal([]byte(bucketLifecycle2), confLc)
 			require.NoError(t, err)
 
 			utils.Retry(20, time.Second, "lifecycle changed", func() bool {
-				liveLc, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+				liveLc, err = s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
 					Bucket: &bucketName,
 				})
 				if err != nil {
 					return false
 				}
 
-				return cmp.Equal(confLc, liveLc)
+				return cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...)
 			})
-			assert.Equal(t, confLc, liveLc)
+			assert.True(t, cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...), cmp.Diff(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...))
 		})
 
 		t.Run("remove obc bucketLifecycle", func(t *testing.T) {
@@ -955,18 +972,19 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 				t.Skip("Waiting for rgw fix from regression in v19.2.3")
 			}
 			utils.Retry(20, time.Second, "lifecycle is gone", func() bool {
-				_, err = s3client.Client.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+				_, err = s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
 					Bucket: &bucketName,
 				})
-				if aerr, ok := err.(awserr.Error); ok {
-					return aerr.Code() == "NoSuchLifecycleConfiguration"
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					return apiErr.ErrorCode() == "NoSuchLifecycleConfiguration"
 				}
 				return false
 			})
 			require.Error(t, err)
-			require.Implements(t, (*awserr.Error)(nil), err)
-			aerr, _ := err.(awserr.Error)
-			assert.Equal(t, aerr.Code(), "NoSuchLifecycleConfiguration")
+			var apiErr smithy.APIError
+			require.True(t, errors.As(err, &apiErr))
+			assert.Equal(t, "NoSuchLifecycleConfiguration", apiErr.ErrorCode())
 		})
 
 		t.Run("delete bucket", func(t *testing.T) {


### PR DESCRIPTION
Remove the AWS SDK v1 (github.com/aws/aws-sdk-go)
dependency entirely. All S3 operations now use AWS SDK v2 exclusively.

- Remove the v1 Client field from S3Agent struct and rename ClientV2 to Client
- Remove v1 session/client initialization from NewS3Agent
- Update all call sites referencing ClientV2
- Convert integration tests to use v2 API calling conventions (context parameter) and smithy error handling
- Remove aws-sdk-go v1.55.8 from go.mod



<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
