### PR TITLE
core: select pod IP matching IP family on dual stack clusters

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -221,6 +221,8 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 			config.NewFlag("public-addr", controller.ContainerEnvVarReference(podIPEnvVar)))
 	}
 
+	controller.WrapContainerForIPFamily(&container, &c.spec)
+
 	return container
 }
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -395,6 +395,8 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 		container.Args = append(container.Args, config.NewFlag("public-bind-addr", bindaddr))
 	}
 
+	controller.WrapContainerForIPFamily(&container, &c.spec)
+
 	return container
 }
 

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -153,19 +153,38 @@ func checkMsgr2Required(t *testing.T, container v1.Container, expectedRequireMsg
 	foundMsgr2Port := false
 	foundBrackets := false
 
-	for _, arg := range container.Args {
-		if arg == "--ms-bind-msgr1=false" {
+	// When IP family selection wraps the container, args are embedded in a
+	// shell script in Args[0]. Collect all strings to search through.
+	wrapped := len(container.Command) == 2 && container.Command[0] == "/bin/sh"
+	var searchArgs []string
+	if wrapped {
+		searchArgs = []string{container.Args[0]}
+	} else {
+		searchArgs = container.Args
+	}
+
+	for _, arg := range searchArgs {
+		if strings.Contains(arg, "--ms-bind-msgr1=false") {
 			foundDisabledMsgr1 = true
 		}
-		if strings.HasPrefix(arg, "--public-bind-addr=") {
-			// flag should always refer to the env var, no matter what
-			assert.Contains(t, arg, "$(ROOK_POD_IP)")
-			if strings.HasSuffix(arg, ":3300") {
+		if strings.Contains(arg, "--public-bind-addr=") {
+			// In wrapped mode, $(ROOK_POD_IP) is replaced with $ROOK_POD_IP
+			if wrapped {
+				assert.Contains(t, arg, "$ROOK_POD_IP")
+			} else {
+				assert.Contains(t, arg, "$(ROOK_POD_IP)")
+			}
+			if strings.Contains(arg, ":3300") {
 				foundMsgr2Port = true
 			}
-			// brackets are expected for IPv6 addrs
-			if strings.Contains(arg, "[$(ROOK_POD_IP)]") {
-				foundBrackets = true
+			if wrapped {
+				if strings.Contains(arg, "[$ROOK_POD_IP]") {
+					foundBrackets = true
+				}
+			} else {
+				if strings.Contains(arg, "[$(ROOK_POD_IP)]") {
+					foundBrackets = true
+				}
 			}
 		}
 	}

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -415,6 +415,56 @@ func ContainerEnvVarReference(envVarName string) string {
 	return fmt.Sprintf("$(%s)", envVarName)
 }
 
+// NeedsIPFamilySelection returns true when the container needs runtime IP selection
+// to pick the correct pod IP matching the configured IP family. This is needed on
+// dualstack Kubernetes clusters where status.podIP might not match the desired family.
+func NeedsIPFamilySelection(network cephv1.NetworkSpec) bool {
+	return network.IPFamily != "" && !network.DualStack && !network.IsHost()
+}
+
+// ipSelectionScript returns a POSIX shell snippet that selects the pod IP
+// matching the given IP family from the comma-separated ROOK_POD_IPS list.
+//
+// Example for IPv6 with ROOK_POD_IPS="10.0.0.1,fd00::1":
+//   - Iterates over each IP, matches *:* (contains colon → IPv6)
+//   - Skips 10.0.0.1, selects fd00::1
+//   - Exports ROOK_POD_IP=fd00::1
+//
+// Example for IPv4 with ROOK_POD_IPS="fd00::1,10.0.0.1":
+//   - Iterates over each IP, matches *.* (contains dot → IPv4)
+//   - Skips fd00::1, selects 10.0.0.1
+//   - Exports ROOK_POD_IP=10.0.0.1
+//
+// If no match is found, ROOK_POD_IP retains its original value from status.podIP.
+func ipSelectionScript(family cephv1.IPFamilyType) string {
+	pattern := "*.*" // IPv4
+	if family == cephv1.IPv6 {
+		pattern = "*:*"
+	}
+	return fmt.Sprintf(`IFS=,; for ip in $ROOK_POD_IPS; do case "$ip" in %s) ROOK_POD_IP="$ip"; break;; esac; done
+unset IFS; export ROOK_POD_IP
+`, pattern)
+}
+
+// WrapContainerForIPFamily wraps a container's command in a shell script that selects
+// the correct pod IP based on the configured IP family before exec-ing the daemon.
+// This is a no-op when IP family selection is not needed.
+func WrapContainerForIPFamily(container *v1.Container, spec *cephv1.ClusterSpec) {
+	if !NeedsIPFamilySelection(spec.Network) {
+		return
+	}
+
+	container.Env = append(container.Env,
+		k8sutil.PodIPsEnvVar("ROOK_POD_IPS"),
+	)
+
+	shellScript := ipSelectionScript(spec.Network.IPFamily) +
+		"exec " + strings.Join(container.Command, " ") + " " + strings.Join(container.Args, " ")
+	shellScript = strings.ReplaceAll(shellScript, "$(ROOK_POD_IP)", "$ROOK_POD_IP")
+	container.Command = []string{"/bin/sh", "-c"}
+	container.Args = []string{shellScript}
+}
+
 // DaemonEnvVars returns the container environment variables used by all Ceph daemons.
 func DaemonEnvVars(cephClusterSpec *cephv1.ClusterSpec) []v1.EnvVar {
 	networkEnv := ApplyNetworkEnv(cephClusterSpec)

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -256,6 +256,96 @@ func TestNetworkBindingFlags(t *testing.T) {
 	}
 }
 
+func TestNeedsIPFamilySelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		network cephv1.NetworkSpec
+		want    bool
+	}{
+		{"ipv6", cephv1.NetworkSpec{IPFamily: cephv1.IPv6}, true},
+		{"ipv4", cephv1.NetworkSpec{IPFamily: cephv1.IPv4}, true},
+		{"no family", cephv1.NetworkSpec{}, false},
+		{"dualstack", cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}, false},
+		{"host network", cephv1.NetworkSpec{IPFamily: cephv1.IPv6, HostNetwork: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NeedsIPFamilySelection(tt.network))
+		})
+	}
+}
+
+func TestWrapContainerForIPFamily(t *testing.T) {
+	t.Run("no-op when ipFamily is not set", func(t *testing.T) {
+		container := v1.Container{
+			Command: []string{"ceph-mon"},
+			Args:    []string{"--public-bind-addr=$(ROOK_POD_IP):3300"},
+		}
+		spec := &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{}}
+		WrapContainerForIPFamily(&container, spec)
+		assert.Equal(t, []string{"ceph-mon"}, container.Command)
+		assert.Equal(t, []string{"--public-bind-addr=$(ROOK_POD_IP):3300"}, container.Args)
+	})
+
+	t.Run("wraps for IPv6", func(t *testing.T) {
+		container := v1.Container{
+			Command: []string{"ceph-mon"},
+			Args:    []string{"--foreground", "--public-bind-addr=[$(ROOK_POD_IP)]:3300"},
+			Env:     []v1.EnvVar{{Name: "ROOK_POD_IP", Value: "test"}},
+		}
+		spec := &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6}}
+		WrapContainerForIPFamily(&container, spec)
+
+		assert.Equal(t, []string{"/bin/sh", "-c"}, container.Command)
+		assert.Len(t, container.Args, 1)
+		script := container.Args[0]
+		// Should contain IPv6 pattern
+		assert.Contains(t, script, "*:*")
+		// Should use shell expansion, not Kubernetes expansion
+		assert.Contains(t, script, "$ROOK_POD_IP")
+		assert.NotContains(t, script, "$(ROOK_POD_IP)")
+		// Should exec the original command
+		assert.Contains(t, script, "exec ceph-mon")
+		assert.Contains(t, script, "--foreground")
+		assert.Contains(t, script, "[$ROOK_POD_IP]:3300")
+		// Should have ROOK_POD_IPS env var
+		found := false
+		for _, env := range container.Env {
+			if env.Name == "ROOK_POD_IPS" {
+				assert.Equal(t, "status.podIPs", env.ValueFrom.FieldRef.FieldPath)
+				found = true
+			}
+		}
+		assert.True(t, found, "ROOK_POD_IPS env var should be present")
+	})
+
+	t.Run("wraps for IPv4", func(t *testing.T) {
+		container := v1.Container{
+			Command: []string{"ceph-mgr"},
+			Args:    []string{"--public-addr=$(ROOK_POD_IP)"},
+		}
+		spec := &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv4}}
+		WrapContainerForIPFamily(&container, spec)
+
+		assert.Equal(t, []string{"/bin/sh", "-c"}, container.Command)
+		script := container.Args[0]
+		assert.Contains(t, script, "*.*")
+		assert.Contains(t, script, "exec ceph-mgr")
+		assert.Contains(t, script, "--public-addr=$ROOK_POD_IP")
+		assert.NotContains(t, script, "$(ROOK_POD_IP)")
+	})
+
+	t.Run("no-op for dualstack", func(t *testing.T) {
+		container := v1.Container{
+			Command: []string{"ceph-mon"},
+			Args:    []string{"--public-bind-addr=$(ROOK_POD_IP)"},
+		}
+		spec := &cephv1.ClusterSpec{Network: cephv1.NetworkSpec{IPFamily: cephv1.IPv6, DualStack: true}}
+		WrapContainerForIPFamily(&container, spec)
+		assert.Equal(t, []string{"ceph-mon"}, container.Command)
+	})
+}
+
 func TestExtractMgrIP(t *testing.T) {
 	activeMgrRaw := "172.17.0.12:6801/2535462469"
 	ip := extractMgrIP(activeMgrRaw)

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -160,6 +160,8 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig, fsName string) v1
 		WorkingDir:    cephconfig.VarLogCephDir,
 	}
 
+	controller.WrapContainerForIPFamily(&container, c.clusterSpec)
+
 	return container
 }
 

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -76,6 +76,11 @@ func PodIPEnvVar(property string) v1.EnvVar {
 	return v1.EnvVar{Name: property, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}}
 }
 
+// PodIPsEnvVar returns an env var containing all pod IPs (comma-separated) from the downward API.
+func PodIPsEnvVar(property string) v1.EnvVar {
+	return v1.EnvVar{Name: property, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIPs"}}}
+}
+
 // NamespaceEnvVar namespace env var
 func NamespaceEnvVar() v1.EnvVar {
 	return v1.EnvVar{Name: PodNamespaceEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -223,6 +223,12 @@ func TestPodSpecPlacement(t *testing.T) {
 	testPodSpecPlacement(t, false, 1, 2, &p)
 }
 
+func TestPodIPsEnvVar(t *testing.T) {
+	env := PodIPsEnvVar("ROOK_POD_IPS")
+	assert.Equal(t, "ROOK_POD_IPS", env.Name)
+	assert.Equal(t, "status.podIPs", env.ValueFrom.FieldRef.FieldPath)
+}
+
 func TestIsMonScheduled(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)


### PR DESCRIPTION
On dualstack k8s clusters, status.podIP retrurn the first IP based on teh kubelet's --node-ip ordering. When ipFamily is set to Ipv6 but the first IP is IPv4 (or vice versa), ceph daemons bind to the wrong address family. This results in non-functional cluster.

This fix wraps mon, mgr and mds daemon containers in a shell script that selects the correct IP from teh status.podIPs before execing in the daemon. Shell scrip is required because the podIP is the only known to container runtine (assigned after scheduling) and k8s provide no downward API mechanism to select an IP by family. The script runs before daemon starts and overrides the Rook_POD_IP env variable with the IP matching the configured family.

OSD daemons are no affected becuase they don't use ROOK_POD_IP in their command-line arguments. OSD IP binding is controlled entirly by --ms-bind-ipv4 and -ms-bind-ipv6 flags, which are already set correctly based on the ipFamily. So only mon, mgr and mds are the affected daemons.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #17221


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
