### PR TITLE
toolbox: Wait for mon endpoints before writing them to config

### DIFF
--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -34,15 +34,13 @@ spec:
       {{- with .Values.toolbox.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      containers:
-        - name: rook-ceph-tools
+      initContainers:
+        - name: rook-ceph-tools-init
           image: {{ .Values.toolbox.image | default (printf "%s:%s" .Values.cephImage.repository .Values.cephImage.tag) }}
           command:
             - /bin/bash
             - -c
             - |
-              # Replicate the script from toolbox.sh inline so the ceph image
-              # can be run directly, instead of requiring the rook toolbox
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
@@ -76,6 +74,78 @@ spec:
                 fi
               }
 
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=${ROOK_CEPH_SECRET}
+              if [[ "$ceph_secret" == "" ]]; then
+                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > ${KEYRING_FILE}
+              [${ROOK_CEPH_USERNAME}]
+              key = ${ceph_secret}
+              EOF
+
+              # wait for mon endpoints to appear
+              until mon_endpoints=$(cat ${MON_CONFIG} | sed 's/[a-z0-9_-]\+=//g') && [ -n "${mon_endpoints}" ]; do
+                echo "waiting for mon endpoints to appear in ${MON_CONFIG}..."
+                sleep 5
+              done
+
+              # write the initial config file
+              write_endpoints
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
+      containers:
+        - name: rook-ceph-tools
+          image: {{ .Values.toolbox.image | default (printf "%s:%s" .Values.cephImage.repository .Values.cephImage.tag) }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
+
+              write_endpoints() {
+                endpoints=$(cat ${MON_CONFIG})
+
+                # filter out the mon names
+                # shellcheck disable=SC2001
+                mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$(date)
+                echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
+                  cat <<EOF > ${CEPH_CONFIG}
+              [global]
+              mon_host = ${mon_endpoints}
+
+              [client.admin]
+              keyring = ${KEYRING_FILE}
+              EOF
+
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
+              }
+
               # watch the endpoints config file and update if the mon endpoints ever change
               watch_endpoints() {
                 # get the timestamp for the target of the soft link
@@ -93,21 +163,6 @@ spec:
                   sleep 10
                 done
               }
-
-              # read the secret from an env var (for backward compatibility), or from the secret file
-              ceph_secret=${ROOK_CEPH_SECRET}
-              if [[ "$ceph_secret" == "" ]]; then
-                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
-              fi
-
-              # create the keyring file
-              cat <<EOF > ${KEYRING_FILE}
-              [${ROOK_CEPH_USERNAME}]
-              key = ${ceph_secret}
-              EOF
-
-              # write the initial config file
-              write_endpoints
 
               # continuously update the mon endpoints if they fail over
               watch_endpoints

--- a/deploy/examples/toolbox-operator-image.yaml
+++ b/deploy/examples/toolbox-operator-image.yaml
@@ -23,15 +23,13 @@ spec:
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: rook-ceph-default
-      containers:
-        - name: rook-ceph-tools-operator-image
+      initContainers:
+        - name: rook-ceph-tools-operator-image-init
           image: docker.io/rook/ceph:master
           command:
             - /bin/bash
             - -c
             - |
-              # Replicate the script from toolbox.sh inline so the ceph image
-              # can be run directly, instead of requiring the rook toolbox
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
@@ -65,6 +63,79 @@ spec:
                 fi
               }
 
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=${ROOK_CEPH_SECRET}
+              if [[ "$ceph_secret" == "" ]]; then
+                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > ${KEYRING_FILE}
+              [${ROOK_CEPH_USERNAME}]
+              key = ${ceph_secret}
+              EOF
+
+              # wait for mon endpoints to appear
+              until mon_endpoints=$(cat ${MON_CONFIG} | sed 's/[a-z0-9_-]\+=//g') && [ -n "${mon_endpoints}" ]; do
+                echo "waiting for mon endpoints to appear in ${MON_CONFIG}..."
+                sleep 5
+              done
+
+              # write the initial config file
+              write_endpoints
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
+      containers:
+        - name: rook-ceph-tools-operator-image
+          image: docker.io/rook/ceph:master
+          command:
+            - /bin/bash
+            - -c
+            - |
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
+
+              write_endpoints() {
+                endpoints=$(cat ${MON_CONFIG})
+
+                # filter out the mon names
+                # shellcheck disable=SC2001
+                mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$(date)
+                echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
+                  cat <<EOF > ${CEPH_CONFIG}
+              [global]
+              mon_host = ${mon_endpoints}
+
+              [client.admin]
+              keyring = ${KEYRING_FILE}
+              EOF
+
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
+              }
+
               # watch the endpoints config file and update if the mon endpoints ever change
               watch_endpoints() {
                 # get the timestamp for the target of the soft link
@@ -82,21 +153,6 @@ spec:
                   sleep 10
                 done
               }
-
-              # read the secret from an env var (for backward compatibility), or from the secret file
-              ceph_secret=${ROOK_CEPH_SECRET}
-              if [[ "$ceph_secret" == "" ]]; then
-                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
-              fi
-
-              # create the keyring file
-              cat <<EOF > ${KEYRING_FILE}
-              [${ROOK_CEPH_USERNAME}]
-              key = ${ceph_secret}
-              EOF
-
-              # write the initial config file
-              write_endpoints
 
               # continuously update the mon endpoints if they fail over
               watch_endpoints

--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -17,15 +17,13 @@ spec:
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: rook-ceph-default
-      containers:
-        - name: rook-ceph-tools
+      initContainers:
+        - name: rook-ceph-tools-init
           image: quay.io/ceph/ceph:v20
           command:
             - /bin/bash
             - -c
             - |
-              # Replicate the script from toolbox.sh inline so the ceph image
-              # can be run directly, instead of requiring the rook toolbox
               CEPH_CONFIG="/etc/ceph/ceph.conf"
               MON_CONFIG="/etc/rook/mon-endpoints"
               KEYRING_FILE="/etc/ceph/keyring"
@@ -59,6 +57,79 @@ spec:
                 fi
               }
 
+              # read the secret from an env var (for backward compatibility), or from the secret file
+              ceph_secret=${ROOK_CEPH_SECRET}
+              if [[ "$ceph_secret" == "" ]]; then
+                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
+              fi
+
+              # create the keyring file
+              cat <<EOF > ${KEYRING_FILE}
+              [${ROOK_CEPH_USERNAME}]
+              key = ${ceph_secret}
+              EOF
+
+              # wait for mon endpoints to appear
+              until mon_endpoints=$(cat ${MON_CONFIG} | sed 's/[a-z0-9_-]\+=//g') && [ -n "${mon_endpoints}" ]; do
+                echo "waiting for mon endpoints to appear in ${MON_CONFIG}..."
+                sleep 5
+              done
+
+              # write the initial config file
+              write_endpoints
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+              readOnly: true
+            - name: rook-config-override
+              mountPath: /etc/rook-config-override
+              readOnly: true
+      containers:
+        - name: rook-ceph-tools
+          image: quay.io/ceph/ceph:v20
+          command:
+            - /bin/bash
+            - -c
+            - |
+              CEPH_CONFIG="/etc/ceph/ceph.conf"
+              MON_CONFIG="/etc/rook/mon-endpoints"
+              KEYRING_FILE="/etc/ceph/keyring"
+              CONFIG_OVERRIDE="/etc/rook-config-override/config"
+
+              write_endpoints() {
+                endpoints=$(cat ${MON_CONFIG})
+
+                # filter out the mon names
+                # shellcheck disable=SC2001
+                mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')
+
+                DATE=$(date)
+                echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
+                  cat <<EOF > ${CEPH_CONFIG}
+              [global]
+              mon_host = ${mon_endpoints}
+
+              [client.admin]
+              keyring = ${KEYRING_FILE}
+              EOF
+
+                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
+                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
+                  echo "" >> ${CEPH_CONFIG}
+                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                fi
+              }
+
               # watch the endpoints config file and update if the mon endpoints ever change
               watch_endpoints() {
                 # get the timestamp for the target of the soft link
@@ -76,21 +147,6 @@ spec:
                   sleep 10
                 done
               }
-
-              # read the secret from an env var (for backward compatibility), or from the secret file
-              ceph_secret=${ROOK_CEPH_SECRET}
-              if [[ "$ceph_secret" == "" ]]; then
-                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
-              fi
-
-              # create the keyring file
-              cat <<EOF > ${KEYRING_FILE}
-              [${ROOK_CEPH_USERNAME}]
-              key = ${ceph_secret}
-              EOF
-
-              # write the initial config file
-              write_endpoints
 
               # continuously update the mon endpoints if they fail over
               watch_endpoints

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -77,7 +77,13 @@ cat <<EOF > ${KEYRING_FILE}
 key = ${ceph_secret}
 EOF
 
-# write the initial config file
+# wait for mon endpoints to appear
+until mon_endpoints=$(cat ${MON_CONFIG} | sed 's/[a-z0-9_-]\+=//g') && [ -n "${mon_endpoints}" ]; do
+  echo "waiting for mon endpoints to appear in ${MON_CONFIG}..."
+  sleep 5
+done
+
+# wait for endpoints to be available, then write the initial config file
 write_endpoints
 
 # continuously update the mon endpoints if they fail over


### PR DESCRIPTION
This adds a wait to toolbox.sh to ensure that mon endpoints exist in /etc/rook/mon-endpoints before writing them to
/etc/ceph/ceph.conf. There is currently a race condition exhibited with the rook-ceph-cluster Helm chart when the toolbox container image has already been pulled, where the toolbox pod can start too quickly and fail to obtain the mon endpoint configuration because the mon pods aren't running yet.

**Checklist:**

- [X ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [X ] Documentation has been updated, if necessary.
- [X ] Unit tests have been added, if necessary.
- [X ] Integration tests have been added, if necessary.
