### PR TITLE
osd: add cryptsetup resize for encrypted host based osds

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -16,3 +16,4 @@
 - Unused CRUSH rule cleanup: Rook now deletes unused CRUSH rules by default after the Ceph mgr starts. Set `ROOK_DELETE_UNUSED_CRUSH_RULES` to `false` in the operator config to disable this cleanup.
 - Declare stable the feature to concurrently reconcile multiple Ceph Clusters with the setting `ROOK_RECONCILE_CONCURRENT_CLUSTERS`.
 - Containers within a pod are now consistently reconciled by name instead of relying on the order in which they are declared.  This is a defensive measure against the declaration order changing due to manipulation by a mutating webhook.
+- OSD resize with encrypted host-based OSDs: When using `encryptedDevice: true` with host-based (non-PVC) OSDs, resizing the underlying disk now automatically expands encrypted OSDs.

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -140,6 +140,26 @@ if [[ "$CV_MODE" == "lvm" ]]; then
 	# activate osd
 	ceph-volume lvm activate --no-systemd "$OSD_STORE_FLAG" "$OSD_ID" "$OSD_UUID"
 
+	# For encrypted LVM OSDs, resize the full stack: PV → LV → LUKS.
+	# All operations are no-ops if the underlying device hasn't grown.
+	if [ "$ENCRYPTED" == "true" ]; then
+		VG_NAME=$(dirname "$DEVICE" | xargs basename)
+		pvresize "$(pvs --noheadings -o pv_name -S vg_name="$VG_NAME" 2>/dev/null | tr -d ' ')"
+		# With osd_per_device > 1, multiple LVs share the same VG. Absolute target
+		# (total/count) divides space equally and is a no-op on restarts.
+		OSD_COUNT=$(vgs --noheadings --nosuffix -o lv_count "$VG_NAME" 2>/dev/null | tr -d ' ')
+		TOTAL_EXTENTS=$(vgs --noheadings --nosuffix -o vg_extent_count "$VG_NAME" 2>/dev/null | tr -d ' ')
+		lvextend -l "$((TOTAL_EXTENTS / OSD_COUNT))" "$DEVICE" || true
+
+		DM_NAME=$(basename "$(readlink "$OSD_DATA_DIR/block")")
+		KEY_FILE=$(mktemp /tmp/.luks_key.XXXXXX)
+		trap "rm -f '$KEY_FILE'" EXIT
+		ceph --cluster ceph --name "$LOCKBOX_USER" \
+			--keyring "$LOCKBOX_KEYRING_FILE" \
+			config-key get "dm-crypt/osd/$OSD_UUID/luks" > "$KEY_FILE"
+		cryptsetup --verbose resize "$DM_NAME" --key-file "$KEY_FILE"
+	fi
+
 	# copy the tmpfs directory to a temporary directory
 	# this is needed because when the init container exits, the tmpfs goes away and its content with it
 	# this will result in the emptydir to be empty when accessed by the main osd container


### PR DESCRIPTION
when using encryptedDevice:true with host based (non pvc) osds, resizing the underlying disk and restarting the OSD didn't expand the OSD because the LUKS encryption layer was not resized.

This PR adds resize capabilities inside the activate container. Full device stack must be resized: PV → LV → LUKS

Steps:
1. Run pvresize and lvextend to grow the LVM layers.
2. Retrieve the LUKS key from the Ceph config-key store using the lockbox crednetials already available in the activate container
3. Pass the key explicitly to cryptsetup resize via --key-file.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #13262


Testing: 

**Note: Also tested with multiple OSDs per device.  If the disk is resized by 10 GB and there are two OSDs on each disk, then each OSD will will get 5GB each.** 

Before OSD resize (Notice OSD-1 on worker-2)

```
rook-ceph-osd-1-5c879447fc-4b5jg                             1/1     Running             0               13m     10.244.69.204    rook-dev-worker2   <none>           <none>
rook-ceph-osd-3-5689f46b46-qjzrz                             1/1     Running             0               13m     10.244.69.205    rook-dev-worker2   <none>           <none>
```

```

╭─    ~/Projects/rook-vagrant    main !12 ?1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────── ✔  kubernetes-admin@kubernetes ⎈  10:20:16 PM  ─╮
╰─ kubectl -n rook-ceph exec deploy/rook-ceph-operator -- ceph osd df --conf /var/lib/rook/rook-ceph/rook-ceph.config --keyring /var/lib/rook/rook-ceph/client.admin.keyring                                       ─╯
ID  CLASS  WEIGHT   REWEIGHT  SIZE     RAW USE  DATA     OMAP    META     AVAIL    %USE  VAR   PGS  STATUS
 2    hdd  0.01949   1.00000   20 GiB   27 MiB  888 KiB   1 KiB   26 MiB   20 GiB  0.13  1.09   17      up
 4    hdd  0.01949   1.00000   20 GiB   27 MiB  432 KiB   1 KiB   26 MiB   20 GiB  0.13  1.07   16      up
 0    hdd  0.01949   1.00000   30 GiB   28 MiB  884 KiB   4 KiB   27 MiB   30 GiB  0.09  0.74   18      up
 5    hdd  0.01949   1.00000   20 GiB   27 MiB  436 KiB   1 KiB   26 MiB   20 GiB  0.13  1.07   15      up
 1    hdd  0.01949   1.00000   20 GiB   27 MiB  436 KiB   1 KiB   26 MiB   20 GiB  0.13  1.07   15      up
 3    hdd  0.01949   1.00000   20 GiB   27 MiB  884 KiB   1 KiB   26 MiB   20 GiB  0.13  1.09   18      up
                       TOTAL  130 GiB  162 MiB  3.9 MiB  12 KiB  158 MiB  130 GiB  0.12
MIN/MAX VAR: 0.74/1.09  STDDEV: 0.02

```


```

 vagrant ssh rook-dev-worker2 -c "sudo lsblk -o NAME,TYPE,SIZE,FSTYPE | grep crypt"                                                                                                                              ─╯
  └─9pCR3s-LsUk-bd3e-zmLK-u75B-TgVL-NuMmDS                                                            crypt   20G
  └─k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS                                                            crypt   20G

```


After resizing the OSD disk and restarting the OSD-1 pod. 

```
kubectl logs -n rook-ceph rook-ceph-osd-1-5c879447fc-mxd8b -c activate                                                                                                                                          ─╯
+ OSD_ID=1
+ OSD_UUID=f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
+ OSD_STORE_FLAG=--bluestore
+ OSD_DATA_DIR=/var/lib/ceph/osd/ceph-1
+ KEYRING_FILE=/var/lib/ceph/osd/ceph-1/keyring
+ CV_MODE=lvm
+ DEVICE=/dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
+ ENCRYPTED=true
+ '[' true == true ']'
+ LOCKBOX_KEYRING_FILE=/var/lib/ceph/osd/ceph-1/lockbox.keyring
+ LOCKBOX_USER=client.osd-lockbox.f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
+ ceph --name client.admin auth get-or-create client.osd-lockbox.f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 mon 'allow command "config-key get" with key="dm-crypt/osd/f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0/luks"' --keyring /etc/ceph/admin-keyring-store/keyring
+ echo 'got latest cephx lockbox key for OSD successfully. updating on-disk key'
got latest cephx lockbox key for OSD successfully. updating on-disk key
+ mv /tmp/lockbox.keyring /var/lib/ceph/osd/ceph-1/lockbox.keyring
+ [[ lvm == \l\v\m ]]
++ mktemp -d
+ TMP_DIR=/tmp/tmp.qJ9G54nFKo
+ echo 'devices { filter = ["r|/dev/rbd.*|"] }'
+ ceph-volume lvm activate --no-systemd --bluestore 1 f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
--> Running ceph config-key get dm-crypt/osd/f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0/luks
Running command: /usr/bin/ceph --cluster ceph --name client.osd-lockbox.f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 --keyring /var/lib/ceph/osd/ceph-1/lockbox.keyring config-key get dm-crypt/osd/f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0/luks
Running command: /usr/sbin/cryptsetup --key-size 512 --key-file - --allow-discards luksOpen /dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
 stderr: Device k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS already exists.
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1
Running command: /usr/bin/ceph-bluestore-tool --cluster=ceph prime-osd-dir --dev /dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS --path /var/lib/ceph/osd/ceph-1 --no-mon-config
Running command: /usr/bin/ln -snf /dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS /var/lib/ceph/osd/ceph-1/block
Running command: /usr/bin/chown -h ceph:ceph /var/lib/ceph/osd/ceph-1/block
Running command: /usr/bin/chown -R ceph:ceph /dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1
--> ceph-volume lvm activate successful for osd ID: 1
+ '[' true == true ']'
++ lvs --noheadings -o vg_name /dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
++ tr -d ' '
+ VG_NAME=ceph-12a42479-c799-4dd5-af6b-04f55ecc909c
+ '[' -n ceph-12a42479-c799-4dd5-af6b-04f55ecc909c ']'
++ tr -d ' '
++ pvs --noheadings -o pv_name -S vg_name=ceph-12a42479-c799-4dd5-af6b-04f55ecc909c
Resizing PV: /dev/vdb
+ PV_NAME=/dev/vdb
+ '[' -n /dev/vdb ']'
+ echo 'Resizing PV: /dev/vdb'
+ pvresize /dev/vdb
  Physical volume "/dev/vdb" changed
  1 physical volume(s) resized or updated / 0 physical volume(s) not resized
Extending LV: /dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
+ echo 'Extending LV: /dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0'
+ lvextend -l +100%FREE /dev/ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0
  Size of logical volume ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 changed from <20.00 GiB (5119 extents) to <30.00 GiB (7679 extents).
  Udev is running and DM_DISABLE_UDEV environment variable is set. Bypassing udev, device-mapper library will manage device nodes in device directory.
  Logical volume ceph-12a42479-c799-4dd5-af6b-04f55ecc909c/osd-block-f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 successfully resized.
+ BLOCK_LINK=/var/lib/ceph/osd/ceph-1/block
+ '[' -L /var/lib/ceph/osd/ceph-1/block ']'
++ readlink -f /var/lib/ceph/osd/ceph-1/block
+ DM_PATH=/dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
+ [[ /dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS == /dev/mapper/* ]]
++ basename /dev/mapper/k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
+ DM_NAME=k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
+ '[' -n k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS ']'
+ echo 'Resizing encrypted device: k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS'
Resizing encrypted device: k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS
++ mktemp /tmp/.luks_key.XXXXXX
+ KEY_FILE=/tmp/.luks_key.Uwfi2g
+ trap 'rm -f '\''/tmp/.luks_key.Uwfi2g'\''' EXIT
+ ceph --cluster ceph --name client.osd-lockbox.f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0 --keyring /var/lib/ceph/osd/ceph-1/lockbox.keyring config-key get dm-crypt/osd/f6a61732-c8c9-4a2f-a5cc-af45a3cdbbc0/luks
+ cryptsetup --verbose resize k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS --key-file /tmp/.luks_key.Uwfi2g
No usable token is available.
Warning: keyslot operation could fail as it requires more than available memory.
Key slot 0 unlocked.
Command successful.
+ rm -f /tmp/.luks_key.Uwfi2g
+ cp --verbose --no-dereference /var/lib/ceph/osd/ceph-1/block /var/lib/ceph/osd/ceph-1/ceph_fsid /var/lib/ceph/osd/ceph-1/fsid /var/lib/ceph/osd/ceph-1/keyring /var/lib/ceph/osd/ceph-1/lockbox.keyring /var/lib/ceph/osd/ceph-1/ready /var/lib/ceph/osd/ceph-1/require_osd_release /var/lib/ceph/osd/ceph-1/type /var/lib/ceph/osd/ceph-1/whoami /tmp/tmp.qJ9G54nFKo/
'/var/lib/ceph/osd/ceph-1/block' -> '/tmp/tmp.qJ9G54nFKo/block'
'/var/lib/ceph/osd/ceph-1/ceph_fsid' -> '/tmp/tmp.qJ9G54nFKo/ceph_fsid'
'/var/lib/ceph/osd/ceph-1/fsid' -> '/tmp/tmp.qJ9G54nFKo/fsid'
'/var/lib/ceph/osd/ceph-1/keyring' -> '/tmp/tmp.qJ9G54nFKo/keyring'
'/var/lib/ceph/osd/ceph-1/lockbox.keyring' -> '/tmp/tmp.qJ9G54nFKo/lockbox.keyring'
'/var/lib/ceph/osd/ceph-1/ready' -> '/tmp/tmp.qJ9G54nFKo/ready'
'/var/lib/ceph/osd/ceph-1/require_osd_release' -> '/tmp/tmp.qJ9G54nFKo/require_osd_release'
'/var/lib/ceph/osd/ceph-1/type' -> '/tmp/tmp.qJ9G54nFKo/type'
'/var/lib/ceph/osd/ceph-1/whoami' -> '/tmp/tmp.qJ9G54nFKo/whoami'
+ umount /var/lib/ceph/osd/ceph-1
+ cp --verbose --no-dereference /tmp/tmp.qJ9G54nFKo/block /tmp/tmp.qJ9G54nFKo/ceph_fsid /tmp/tmp.qJ9G54nFKo/fsid /tmp/tmp.qJ9G54nFKo/keyring /tmp/tmp.qJ9G54nFKo/lockbox.keyring /tmp/tmp.qJ9G54nFKo/ready /tmp/tmp.qJ9G54nFKo/require_osd_release /tmp/tmp.qJ9G54nFKo/type /tmp/tmp.qJ9G54nFKo/whoami /var/lib/ceph/osd/ceph-1
'/tmp/tmp.qJ9G54nFKo/block' -> '/var/lib/ceph/osd/ceph-1/block'
'/tmp/tmp.qJ9G54nFKo/ceph_fsid' -> '/var/lib/ceph/osd/ceph-1/ceph_fsid'
'/tmp/tmp.qJ9G54nFKo/fsid' -> '/var/lib/ceph/osd/ceph-1/fsid'
'/tmp/tmp.qJ9G54nFKo/keyring' -> '/var/lib/ceph/osd/ceph-1/keyring'
'/tmp/tmp.qJ9G54nFKo/lockbox.keyring' -> '/var/lib/ceph/osd/ceph-1/lockbox.keyring'
'/tmp/tmp.qJ9G54nFKo/ready' -> '/var/lib/ceph/osd/ceph-1/ready'
'/tmp/tmp.qJ9G54nFKo/require_osd_release' -> '/var/lib/ceph/osd/ceph-1/require_osd_release'
'/tmp/tmp.qJ9G54nFKo/type' -> '/var/lib/ceph/osd/ceph-1/type'
'/tmp/tmp.qJ9G54nFKo/whoami' -> '/var/lib/ceph/osd/ceph-1/whoami'
+ chown --verbose --recursive ceph:ceph /var/lib/ceph/osd/ceph-1
changed ownership of '/var/lib/ceph/osd/ceph-1/ceph_fsid' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/keyring' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/lockbox.keyring' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/require_osd_release' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/block' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/fsid' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/whoami' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/ready' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1/type' from root:root to ceph:ceph
changed ownership of '/var/lib/ceph/osd/ceph-1' from root:root to ceph:ceph
+ rm --recursive --force /tmp/tmp.qJ9G54nFKo
+ rm -f /tmp/.luks_key.Uwfi2g 
```


```
─ kubectl -n rook-ceph exec deploy/rook-ceph-operator -- ceph osd df --conf /var/lib/rook/rook-ceph/rook-ceph.config --keyring /var/lib/rook/rook-ceph/client.admin.keyring                                       ─╯
ID  CLASS  WEIGHT   REWEIGHT  SIZE     RAW USE  DATA     OMAP    META     AVAIL    %USE  VAR   PGS  STATUS
 2    hdd  0.01949   1.00000   20 GiB   27 MiB  948 KiB   1 KiB   26 MiB   20 GiB  0.13  1.17   17      up
 4    hdd  0.01949   1.00000   20 GiB   27 MiB  492 KiB   1 KiB   26 MiB   20 GiB  0.13  1.15   16      up
 0    hdd  0.01949   1.00000   30 GiB   28 MiB  944 KiB   4 KiB   27 MiB   30 GiB  0.09  0.79   18      up
 5    hdd  0.01949   1.00000   20 GiB   27 MiB  496 KiB   1 KiB   26 MiB   20 GiB  0.13  1.15   15      up
 1    hdd  0.01949   1.00000   30 GiB   27 MiB  496 KiB   4 KiB   27 MiB   30 GiB  0.09  0.78   15      up
 3    hdd  0.01949   1.00000   20 GiB   27 MiB  944 KiB   1 KiB   26 MiB   20 GiB  0.13  1.17   18      up
                       TOTAL  140 GiB  162 MiB  4.2 MiB  15 KiB  158 MiB  140 GiB  0.11
MIN/MAX VAR: 0.78/1.17  STDDEV: 0.02
```

```
vagrant ssh rook-dev-worker2 -c "sudo lsblk -o NAME,TYPE,SIZE,FSTYPE | grep crypt"                                                                                                                              ─╯
  └─9pCR3s-LsUk-bd3e-zmLK-u75B-TgVL-NuMmDS                                                            crypt   20G
└─ceph--12a42479--c799--4dd5--af6b--04f55ecc909c-osd--block--f6a61732--c8c9--4a2f--a5cc--af45a3cdbbc0 lvm     30G crypto_LUKS
  └─k6Z5CO-lkQN-pQ01-Gqyj-xXeG-nGQl-wL6ROS                                                            crypt   30G ceph_bluestore
```



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
