### PR TITLE
csi: update ceph-csi image V3.17.0 and sidecars to latest

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -54,16 +54,16 @@ The following table lists the configurable parameters of the rook-operator chart
 | `containerSecurityContext` | Set the container security context for the operator | `{"capabilities":{"drop":["ALL"]},"runAsGroup":2016,"runAsNonRoot":true,"runAsUser":2016}` |
 | `crds.enabled` | Whether the helm chart should create and update the CRDs. If false, the CRDs must be managed independently with deploy/examples/crds.yaml. **WARNING** Only set during first deployment. If later disabled the cluster may be DESTROYED. If the CRDs are deleted in this case, see [the disaster recovery guide](https://rook.io/docs/rook/latest/Troubleshooting/disaster-recovery/#restoring-crds-after-deletion) to restore them. | `true` |
 | `csi.attacher.repository` | Kubernetes CSI Attacher image repository | `"registry.k8s.io/sig-storage/csi-attacher"` |
-| `csi.attacher.tag` | Attacher image tag | `"v4.11.0"` |
+| `csi.attacher.tag` | Attacher image tag | `"v4.12.0"` |
 | `csi.cephcsi.repository` | Ceph CSI image repository | `"quay.io/cephcsi/cephcsi"` |
-| `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.16.2"` |
+| `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.17.0"` |
 | `csi.csiAddons.repository` | CSIAddons sidecar image repository | `"quay.io/csiaddons/k8s-sidecar"` |
 | `csi.csiAddons.tag` | CSIAddons sidecar image tag | `"v0.14.0"` |
 | `csi.installCsiOperator` | When true, install the ceph-csi-operator subchart (see Chart.yaml `condition`). | `true` |
 | `csi.provisioner.repository` | Kubernetes CSI provisioner image repository | `"registry.k8s.io/sig-storage/csi-provisioner"` |
-| `csi.provisioner.tag` | Provisioner image tag | `"v6.1.1"` |
+| `csi.provisioner.tag` | Provisioner image tag | `"v6.2.0"` |
 | `csi.registrar.repository` | Kubernetes CSI registrar image repository | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` |
-| `csi.registrar.tag` | Registrar image tag | `"v2.16.0"` |
+| `csi.registrar.tag` | Registrar image tag | `"v2.17.0"` |
 | `csi.resizer.repository` | Kubernetes CSI resizer image repository | `"registry.k8s.io/sig-storage/csi-resizer"` |
 | `csi.resizer.tag` | Resizer image tag | `"v2.1.0"` |
 | `csi.serviceMonitor.enabled` | Enable ServiceMonitor for CSI metrics | `false` |

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -16,12 +16,12 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-csi-operator-image-set-c
 The default upstream images are included below, which can be customized to the desired images.
 
 ```yaml
-plugin: "quay.io/cephcsi/cephcsi:v3.16.2"
-provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.1.1"
-attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.11.0"
+plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
+provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.2.0"
+attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.12.0"
 resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
 snapshotter: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
-registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"
+registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"
 addons: "quay.io/csiaddons/k8s-sidecar:v0.14.0"
 ```
 

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -98,19 +98,19 @@ csi:
     # -- Ceph CSI image repository
     repository: quay.io/cephcsi/cephcsi
     # -- Ceph CSI image tag
-    tag: v3.16.2
+    tag: v3.17.0
 
   registrar:
     # -- Kubernetes CSI registrar image repository
     repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
     # -- Registrar image tag
-    tag: v2.16.0
+    tag: v2.17.0
 
   provisioner:
     # -- Kubernetes CSI provisioner image repository
     repository: registry.k8s.io/sig-storage/csi-provisioner
     # -- Provisioner image tag
-    tag: v6.1.1
+    tag: v6.2.0
 
   snapshotter:
     # -- Kubernetes CSI snapshotter image repository
@@ -122,7 +122,7 @@ csi:
     # -- Kubernetes CSI Attacher image repository
     repository: registry.k8s.io/sig-storage/csi-attacher
     # -- Attacher image tag
-    tag: v4.11.0
+    tag: v4.12.0
 
   resizer:
     # -- Kubernetes CSI resizer image repository

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -3,10 +3,10 @@ gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
 quay.io/ceph/ceph:v20.2.1
 quay.io/ceph/cosi:v0.1.4
 quay.io/cephcsi/ceph-csi-operator:v1.0.0
-quay.io/cephcsi/cephcsi:v3.16.2
+quay.io/cephcsi/cephcsi:v3.17.0
 quay.io/csiaddons/k8s-sidecar:v0.14.0
-registry.k8s.io/sig-storage/csi-attacher:v4.11.0
-registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
-registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+registry.k8s.io/sig-storage/csi-attacher:v4.12.0
+registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
 registry.k8s.io/sig-storage/csi-resizer:v2.1.0
 registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -105,12 +105,12 @@ metadata:
   name: rook-csi-operator-image-set-configmap
   namespace: rook-ceph # namespace:operator
 data:
-  provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.1.1"
-  attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.11.0"
+  provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.2.0"
+  attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.12.0"
   resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
   snapshotter: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
-  registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"
-  plugin: "quay.io/cephcsi/cephcsi:v3.16.2"
+  registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"
+  plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
   addons: "quay.io/csiaddons/k8s-sidecar:v0.14.0"
 ---
 # OperatorConfig defines the default settings for all CSI drivers.


### PR DESCRIPTION
Update ceph-csi to v3.17.0 and CSI sidecars:
- csi-provisioner v6.1.1 -> v6.2.0
- csi-attacher v4.11.0 -> v4.12.0
- csi-node-driver-registrar v2.16.0 -> v2.17.0

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
