### PR TITLE
object: add logger for AWS SDK v2 debug signing output

### DIFF
--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -29,8 +29,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithylogging "github.com/aws/smithy-go/logging"
 	"github.com/pkg/errors"
 )
+
+type rookLogger struct{}
+
+func (r rookLogger) Logf(classification smithylogging.Classification, format string, v ...interface{}) {
+	logger.Debugf(format, v...)
+}
 
 // Region for aws golang sdk
 const CephRegion = "us-east-1"
@@ -76,6 +83,9 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 		RetryMaxAttempts: 5,
 		RetryMode:        aws.RetryModeStandard,
 		ClientLogMode:    logMode,
+	}
+	if debug {
+		cfg.Logger = rookLogger{}
 	}
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.UsePathStyle = true


### PR DESCRIPTION
Wire a rookLogger adapter implementing smithy's Logger interface so that aws.LogSigning output is emitted through rook's capnslog when debug mode is enabled.


Test Procedure on private image `quay.io/oviner/rook:may27_3` on minikube:
```
1.Set DEBUG log level:
$ kubectl -n rook-ceph set env deployment/rook-ceph-operator ROOK_LOG_LEVEL=DEBUG
 
2.Create the CephObjectStore
$ kubectl apply -f deploy/examples/object-test.yaml
$ kubectl -n rook-ceph get cephobjectstore my-store
NAME       PHASE   ENDPOINT                                         SECUREENDPOINT   AGE
my-store   Ready   http://rook-ceph-rgw-my-store.rook-ceph.svc:80                    14m

3.Create the StorageClass + OBC:
$ kubectl apply -f deploy/examples/storageclass-bucket-delete.yaml
$ kubectl apply -f deploy/examples/object-bucket-claim-delete.yaml

4.Watch for signing logs:
$ kubectl -n rook-ceph logs -f deployment/rook-ceph-operator | grep -A 15 "CANONICAL STRING\|STRING TO SIGN\|Request Signature"
2026-05-27 16:27:22.548507 D | object-controller: Request Signature:
---[ CANONICAL STRING  ]-----------------------------
PUT
/ceph-bkt-3c7c7ddf-07f3-4800-9d2b-1aa8612949d7

accept-encoding:identity
amz-sdk-invocation-id:93efda17-ead5-4348-ac40-13801bc81c40
amz-sdk-request:attempt=1; max=5
host:rook-ceph-rgw-my-store.rook-ceph.svc
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20260527T162722Z

accept-encoding;amz-sdk-invocation-id;amz-sdk-request;host;x-amz-content-sha256;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
---[ STRING TO SIGN ]--------------------------------
AWS4-HMAC-SHA256
20260527T162722Z
20260527/us-east-1/s3/aws4_request
abab9d19ee6028d98613503a1bde4b08a65fa9da6115c1146457b6d76f90dfbf
---

```
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
