### PR TITLE
CI:  run integration test suites  on k8s v1.36

### DIFF
--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14"]  # test only on oldest supported k8s version
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -25,12 +25,33 @@ runs:
     - name: Install cri-dockerd
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        ARCH=$(go env GOARCH)
+       ARCH="$(dpkg --print-architecture)"   # amd64 / arm64
+        case "${ARCH}" in
+         amd64|arm64)
+           ;;
+         *)
+           echo "Unsupported arch: $ARCH"
+           exit 1
+           ;;
+        esac
+
+        TAG=v0.4.3
+        DEB_VERSION=0.4.3.3
+        PKG="cri-dockerd_${DEB_VERSION}-0.ubuntu-focal_${ARCH}.deb"
+        TMPDIR="$(mktemp -d)"
+        TMP_DEB="${TMPDIR}/${PKG}"
+        URL="https://github.com/Mirantis/cri-dockerd/releases/download/${TAG}/${PKG}"
         # --fail so an HTTP error page is not saved as the .deb (dpkg then fails on the
         # corrupt archive), and retry transient download errors
-        curl -fLO --retry 5 --retry-all-errors --retry-delay 10 https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
-        sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
-        rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
+        curl -fLO --retry 5 --retry-all-errors --retry-delay 10 -o "${TMP_DEB}" "${URL}"
+        # fail early with explicit diagnostics
+        ls -l "${TMPDIR}"
+        test -s "${TMP_DEB}" || { echo "Downloaded file missing/empty: ${TMP_DEB}"; exit 1; }
+        file "${TMP_DEB}" || true
+        dpkg-deb --info "${TMP_DEB}" >/dev/null
+        ls -lh "${TMP_DEB}"
+        sudo dpkg -i "${TMP_DEB}"
+        rm -f "${TMP_DEB}"
 
     - name: Setup Minikube
       uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
**Description:**

This adds testing of kubernetes v1.36 to the CI,
pecifically the latest patch release v1.36.1

ith this, rook now tests the latest patch releases of kubernetes
versions v1.31, v1.32, v1.34, and v1.36.

**Resolved issues:**

Resolves #17400
Resolves #17616 

This PR is based on prep PR #17742. 

Note: only together with PR #17742 , this will fully  resolve  #17616 .)


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
