### PR TITLE
CI: change some  minikube settings

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -37,7 +37,6 @@ runs:
         # longer supports older k8s version we lock to
         minikube-version: "1.38.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
-        driver: none
         container-runtime: containerd
         memory: 6g
         cpus: 2

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -38,7 +38,7 @@ runs:
         minikube-version: "1.38.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
         driver: none
-        container-runtime: docker
+        container-runtime: containerd
         memory: 6g
         cpus: 2
         addons: ingress


### PR DESCRIPTION
**Description:**

This is an attempt to fix various CI  errors seemingly  related to minikube aetup.

Specifically:

1. The container-runtime is changed from docker to cobntainerd to avoid issues with `kubectl exec` in k8s v1.36.
2. The use of the unsupported `none`driver is removed
This PR is split out of #17623 .  






**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
