### PR TITLE
ci: do not use the unsupported none driver for minikube

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -22,13 +22,17 @@ runs:
       with:
         go-version: "1.26"
 
-    - name: Install cri-dockerd
+    - name: Install cri-dockerd and libvirt/kvm
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         ARCH=$(go env GOARCH)
         curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
         sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
         rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
+        sudo apt-get update
+        sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+
+
 
     - name: Setup Minikube
       uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
@@ -37,7 +41,7 @@ runs:
         # longer supports older k8s version we lock to
         minikube-version: "1.38.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
-        driver: none
+        driver: kvm2
         container-runtime: docker
         memory: 6g
         cpus: 2


### PR DESCRIPTION
The use of the unsupported 'none' driver for minikube was causing issues in the CI.

This change removes the configuration for driver none and
configures the kvm2 driver instead - best for a linux host.

This has been split out of PR #17624 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
