### PR TITLE
object: remove dead EjectPrincipals methods and duplicate AllowedActi…

### DIFF
--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -104,7 +104,6 @@ var AllowedActions = []action{
 	PutBucketTagging,
 	PutBucketVersioning,
 	PutBucketWebsite,
-	PutBucketVersioning,
 	PutLifecycleConfiguration,
 	PutObject,
 	PutObjectAcl,
@@ -225,15 +224,6 @@ func (bp *BucketPolicy) DropPolicyStatements(sid ...string) *BucketPolicy {
 	return bp
 }
 
-func (bp *BucketPolicy) EjectPrincipals(users ...string) *BucketPolicy {
-	statements := bp.Statement
-	for _, s := range statements {
-		s.EjectPrincipals(users...)
-	}
-	bp.Statement = statements
-	return bp
-}
-
 // NewPolicyStatement generates a new PolicyStatement. PolicyStatement methods are designed to
 // be chain called with dot notation to allow for easy configuration at creation.  This is preferable
 // to a long parameter list.
@@ -308,18 +298,6 @@ func (ps *PolicyStatement) Denies() *PolicyStatement {
 func (ps *PolicyStatement) Actions(actions ...action) *PolicyStatement {
 	ps.Action = actions
 	return ps
-}
-
-func (ps *PolicyStatement) EjectPrincipals(users ...string) {
-	principals := ps.Principal[awsPrinciple]
-	for _, u := range users {
-		for j, v := range principals {
-			if u == v {
-				principals = append(principals[:j], principals[:j+1]...)
-			}
-		}
-	}
-	ps.Principal[awsPrinciple] = principals
 }
 
 // //////////////


### PR DESCRIPTION
…ons entry

Remove (*BucketPolicy).EjectPrincipals and (*PolicyStatement).EjectPrincipals, which had no callers outside policy.go. Also drop the duplicate PutBucketVersioning entry in AllowedActions.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
