### PR TITLE
object: preserve other users' statements in OBC policy updates

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -186,7 +186,8 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 
 	// check and make sure the bucket exists
 	log.NamedInfo(nsName, logger, "Checking for existing bucket %q", p.bucketName)
-	if exists, _, err := p.bucketExists(p.bucketName); !exists {
+	exists, owner, err := p.bucketExists(p.bucketName)
+	if !exists {
 		return nil, errors.Wrapf(err, "bucket %s does not exist", p.bucketName)
 	}
 
@@ -205,7 +206,18 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 		}
 	}
 
-	err = p.setS3Agent()
+	// the bucket-level operations below (policy, lifecycle) are only permitted
+	// for the bucket owner; the OBC user has no access to the bucket until the
+	// policy statement built below is applied. composeObjectBucket() still
+	// returns the OBC user's credentials set above.
+	ownerUser, err := p.adminOpsClient.GetUser(p.clusterInfo.Context, admin.User{ID: owner})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get owner %q of bucket %q", owner, p.bucketName)
+	}
+	if len(ownerUser.Keys) == 0 {
+		return nil, errors.Errorf("owner %q of bucket %q has no access keys", owner, p.bucketName)
+	}
+	err = p.setS3AgentWithCreds(ownerUser.Keys[0].AccessKey, ownerUser.Keys[0].SecretKey)
 	if err != nil {
 		return nil, err
 	}
@@ -223,14 +235,12 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 
 	// generate the bucket policy if it isn't managed by the user
 
-	// if the policy does not exist, we'll create a new and append the statement to it
+	// fetch the existing policy so statements for other users are preserved; a new policy is created if none exists
 	policy, err := p.s3Agent.GetBucketPolicy(p.clusterInfo.Context, p.bucketName)
 	if err != nil {
 		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) {
-			if apiErr.ErrorCode() != "NoSuchBucketPolicy" {
-				return nil, err
-			}
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "NoSuchBucketPolicy" {
+			return nil, err
 		}
 	}
 
@@ -241,11 +251,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 		ForSubResources(p.bucketName).
 		Allows().
 		Actions(object.AllowedActions...)
-	if policy == nil {
-		policy = object.NewBucketPolicy(*statement)
-	} else {
-		policy = policy.ModifyBucketPolicy(*statement)
-	}
+	policy = replaceUserStatement(policy, statement)
 	out, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
 
 	log.NamedInfo(nsName, logger, "PutBucketPolicy output: %v", out)
@@ -343,11 +349,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 				ForSubResources(p.bucketName).
 				Denies().
 				Actions(object.AllowedActions...)
-			if policy == nil {
-				policy = object.NewBucketPolicy(*statement)
-			} else {
-				policy = policy.ModifyBucketPolicy(*statement)
-			}
+			policy = replaceUserStatement(policy, statement)
 			out, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
 			log.NamedInfo(nsName, logger, "PutBucketPolicy output: %v", out)
 			if err != nil {
@@ -360,9 +362,17 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 		// drop policy if present
 		if policy != nil {
 			policy = policy.DropPolicyStatements(p.cephUserName)
-			_, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
-			if err != nil {
-				return err
+			if len(policy.Statement) == 0 {
+				// rather than putting a policy with no statements, remove the policy
+				_, err := p.s3Agent.Client.DeleteBucketPolicy(p.clusterInfo.Context, &s3.DeleteBucketPolicyInput{Bucket: &p.bucketName})
+				if err != nil {
+					return err
+				}
+			} else {
+				_, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
+				if err != nil {
+					return err
+				}
 			}
 			log.NamedInfo(nsName, logger, "principal %q ejected from bucket %q policy", p.cephUserName, p.bucketName)
 		}
@@ -375,6 +385,17 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 	}
 
 	return nil
+}
+
+// replaceUserStatement returns the bucket policy with the given statement
+// replacing any existing statement with the same SID. Statements for other
+// principals (e.g. other OBCs sharing a brownfield bucket) are preserved.
+func replaceUserStatement(policy *object.BucketPolicy, statement *object.PolicyStatement) *object.BucketPolicy {
+	if policy == nil {
+		return object.NewBucketPolicy(*statement)
+	}
+	policy = policy.DropPolicyStatements(statement.Sid)
+	return policy.ModifyBucketPolicy(append(policy.Statement, *statement)...)
 }
 
 // Return the OB struct with minimal fields filled in.
@@ -765,6 +786,15 @@ func (p *Provisioner) setBucketPolicy(bucket *bucket) error {
 	additionalConfig := bucket.additionalConfig
 	ctx := context.TODO()
 
+	// When the OBC does not define an explicit bucket policy, policy management
+	// is left to Grant/Revoke: each OBC owns the statement keyed by its ceph user
+	// (the statement SID) and preserves statements that belong to other OBCs
+	// sharing the bucket. Deleting the whole policy here would clobber those
+	// statements, so there is nothing for setBucketPolicy to do in that case.
+	if additionalConfig.bucketPolicy == nil {
+		return nil
+	}
+
 	svc := p.s3Agent.Client
 	var livePolicy *string
 
@@ -789,21 +819,12 @@ func (p *Provisioner) setBucketPolicy(bucket *bucket) error {
 	}
 
 	log.NamedDebug(nsName, logger, "Policy for bucket %q has changed. diff:%s", p.bucketName, diff)
-	if additionalConfig.bucketPolicy == nil {
-		_, err = svc.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
-			Bucket: &p.bucketName,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete policy for bucket %q", p.bucketName)
-		}
-	} else {
-		_, err = svc.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
-			Bucket: &p.bucketName,
-			Policy: additionalConfig.bucketPolicy,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to set policy for bucket %q", p.bucketName)
-		}
+	_, err = svc.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: &p.bucketName,
+		Policy: additionalConfig.bucketPolicy,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to set policy for bucket %q", p.bucketName)
 	}
 
 	return nil
@@ -945,7 +966,13 @@ func (p *Provisioner) setAdminOpsAPIClient() error {
 }
 
 func (p *Provisioner) setS3Agent() error {
+	return p.setS3AgentWithCreds(p.accessKeyID, p.secretAccessKey)
+}
+
+// setS3AgentWithCreds sets the provisioner's S3 agent using the given
+// credentials instead of the ones stored on the receiver.
+func (p *Provisioner) setS3AgentWithCreds(accessKeyID, secretAccessKey string) error {
 	var err error
-	p.s3Agent, err = object.NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint(), logger.LevelAt(capnslog.DEBUG), p.tlsCert, p.insecureTLS, nil)
+	p.s3Agent, err = object.NewS3Agent(accessKeyID, secretAccessKey, p.getObjectStoreEndpoint(), logger.LevelAt(capnslog.DEBUG), p.tlsCert, p.insecureTLS, nil)
 	return err
 }

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -617,3 +617,29 @@ func numberOfCallsWithValue(substr string, strs []string) int {
 	}
 	return count
 }
+
+func TestReplaceUserStatement(t *testing.T) {
+	t.Run("nil policy creates a new policy with the statement", func(t *testing.T) {
+		statement := object.NewPolicyStatement().WithSID("user-a").ForPrincipals("user-a").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		policy := replaceUserStatement(nil, statement)
+		assert.Equal(t, []object.PolicyStatement{*statement}, policy.Statement)
+	})
+
+	t.Run("preserves statements for other users", func(t *testing.T) {
+		stmtA := object.NewPolicyStatement().WithSID("user-a").ForPrincipals("user-a").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		stmtB := object.NewPolicyStatement().WithSID("user-b").ForPrincipals("user-b").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		stmtC := object.NewPolicyStatement().WithSID("user-c").ForPrincipals("user-c").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		policy := object.NewBucketPolicy(*stmtA, *stmtB)
+		policy = replaceUserStatement(policy, stmtC)
+		assert.Equal(t, []object.PolicyStatement{*stmtA, *stmtB, *stmtC}, policy.Statement)
+	})
+
+	t.Run("replaces an existing statement with the same SID", func(t *testing.T) {
+		stmtAOld := object.NewPolicyStatement().WithSID("user-a").ForPrincipals("user-a").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		stmtB := object.NewPolicyStatement().WithSID("user-b").ForPrincipals("user-b").ForResources("bkt").ForSubResources("bkt").Allows().Actions(object.AllowedActions...)
+		stmtANew := object.NewPolicyStatement().WithSID("user-a").ForPrincipals("user-a").ForResources("bkt").ForSubResources("bkt").Denies().Actions(object.AllowedActions...)
+		policy := object.NewBucketPolicy(*stmtAOld, *stmtB)
+		policy = replaceUserStatement(policy, stmtANew)
+		assert.Equal(t, []object.PolicyStatement{*stmtB, *stmtANew}, policy.Statement)
+	})
+}

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -45,6 +45,15 @@ func (b *BucketOperation) DeleteBucketStorageClass(namespace string, storeName s
 	return err
 }
 
+func (b *BucketOperation) CreateBucketStorageClassBrownfield(namespace string, storeName string, storageClassName string, reclaimPolicy string, bucketName string) error {
+	return b.k8sh.ResourceOperation("create", b.manifests.GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName))
+}
+
+func (b *BucketOperation) DeleteBucketStorageClassBrownfield(namespace string, storeName string, storageClassName string, reclaimPolicy string, bucketName string) error {
+	err := b.k8sh.ResourceOperation("delete", b.manifests.GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName))
+	return err
+}
+
 func (b *BucketOperation) CreateObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
 	return b.k8sh.ResourceOperation("create", b.manifests.GetOBC(obcName, storageClassName, bucketName, maxObject, createBucket))
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -50,6 +50,7 @@ type CephManifests interface {
 	GetObjectStore(name string, replicaCount, port int, tlsEnable bool, swiftAndKeystone bool) string
 	GetObjectStoreUser(name, displayName, store, usercaps, maxsize string, maxbuckets, maxobjects int) string
 	GetBucketStorageClass(storeName, storageClassName, reclaimPolicy string) string
+	GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName string) string
 	GetOBC(obcName, storageClassName, bucketName string, maxObject string, createBucket bool) string
 	GetBucketTopic(topicName string, storeName string, httpEndpointService string) string
 	GetClient(name string, caps map[string]string) string
@@ -564,6 +565,21 @@ reclaimPolicy: ` + reclaimPolicy + `
 parameters:
     objectStoreName: ` + storeName + `
     objectStoreNamespace: ` + m.settings.Namespace
+}
+
+// GetBucketStorageClassBrownfield returns the manifest to create a storage class that
+// grants OBCs access to an existing (brownfield) bucket via the bucketName parameter.
+func (m *CephManifestsMaster) GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName string) string {
+	return `apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: ` + storageClassName + `
+provisioner: ` + m.settings.Namespace + `.ceph.rook.io/bucket
+reclaimPolicy: ` + reclaimPolicy + `
+parameters:
+    objectStoreName: ` + storeName + `
+    objectStoreNamespace: ` + m.settings.Namespace + `
+    bucketName: ` + bucketName
 }
 
 // GetOBC returns the manifest to create object bucket claim

--- a/tests/framework/installer/ceph_manifests_previous.go
+++ b/tests/framework/installer/ceph_manifests_previous.go
@@ -152,6 +152,11 @@ func (m *CephManifestsPreviousVersion) GetBucketStorageClass(storeName, storageC
 	return m.latest.GetBucketStorageClass(storeName, storageClassName, reclaimPolicy)
 }
 
+// GetBucketStorageClassBrownfield returns the manifest to create a brownfield bucket storage class
+func (m *CephManifestsPreviousVersion) GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName string) string {
+	return m.latest.GetBucketStorageClassBrownfield(storeName, storageClassName, reclaimPolicy, bucketName)
+}
+
 // GetOBC returns the manifest to create object bucket claim
 func (m *CephManifestsPreviousVersion) GetOBC(claimName, storageClassName, objectBucketName, maxObject string, varBucketName bool) string {
 	return m.latest.GetOBC(claimName, storageClassName, objectBucketName, maxObject, varBucketName)

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -1007,6 +1007,136 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		})
 	})
 
+	t.Run("two obcs sharing a brownfield bucket keep both user policy statements", func(t *testing.T) {
+		seedBucket := "brownfield-policy-test"
+		seedObcName := "brownfield-seed"
+		brownfieldSC := bucketStorageClassName + "-brownfield"
+		var s3client *rgw.S3Agent
+
+		// the helpers take the subtest's own *testing.T so a failure aborts just
+		// that subtest instead of failing the parent from a child goroutine
+		waitOBCBound := func(t *testing.T, name string) {
+			bound := utils.Retry(20, 2*time.Second, "OBC is Bound", func() bool {
+				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
+			})
+			require.True(t, bound)
+		}
+		waitOBCAbsent := func(t *testing.T, name string) {
+			absent := utils.Retry(20, 2*time.Second, "OBC is absent", func() bool {
+				_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+				return k8serrors.IsNotFound(err)
+			})
+			require.True(t, absent)
+		}
+		// cephUserForOBC returns the ceph user backing an OBC, which is also the SID of its policy statement.
+		cephUserForOBC := func(t *testing.T, name string) string {
+			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+			require.NoError(t, err)
+			ob, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obc.Spec.ObjectBucketName, metav1.GetOptions{})
+			require.NoError(t, err)
+			return ob.Spec.AdditionalState["cephUser"]
+		}
+		policySIDs := func(t *testing.T) []string {
+			require.NotNil(t, s3client, "s3 client is not initialized; did the seed subtest fail?")
+			policy, err := s3client.GetBucketPolicy(ctx, seedBucket)
+			require.NoError(t, err)
+			sids := make([]string, 0, len(policy.Statement))
+			for _, stmt := range policy.Statement {
+				sids = append(sids, stmt.Sid)
+			}
+			return sids
+		}
+		createBrownfieldOBC := func(t *testing.T, name string) {
+			newObc := v1alpha1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					BucketName:       seedBucket,
+					StorageClassName: brownfieldSC,
+				},
+			}
+			_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Create(ctx, &newObc, metav1.CreateOptions{})
+			require.NoError(t, err)
+			waitOBCBound(t, name)
+		}
+
+		t.Run("seed the shared bucket and brownfield storage class", func(t *testing.T) {
+			seedObc := v1alpha1.ObjectBucketClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: seedObcName, Namespace: namespace},
+				Spec: v1alpha1.ObjectBucketClaimSpec{
+					BucketName:       seedBucket,
+					StorageClassName: bucketStorageClassName,
+				},
+			}
+			_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Create(ctx, &seedObc, metav1.CreateOptions{})
+			require.NoError(t, err)
+			waitOBCBound(t, seedObcName)
+
+			cobErr := helper.BucketClient.CreateBucketStorageClassBrownfield(namespace, storeName, brownfieldSC, "Delete", seedBucket)
+			require.NoError(t, cobErr)
+
+			// the seed user owns the bucket, so its creds can read the bucket policy
+			secret, err := k8sh.Clientset.CoreV1().Secrets(namespace).Get(ctx, seedObcName, metav1.GetOptions{})
+			require.NoError(t, err)
+			labelSelector := "rgw=" + storeName
+			services, err := k8sh.Clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			require.NoError(t, err)
+			require.Len(t, services.Items, 1)
+			s3endpoint := services.Items[0].Spec.ClusterIP + ":80"
+			s3client, err = rgw.NewS3Agent(string(secret.Data["AWS_ACCESS_KEY_ID"]), string(secret.Data["AWS_SECRET_ACCESS_KEY"]), s3endpoint, true, nil, objectStore.Spec.IsTLSEnabled(), nil)
+			require.NoError(t, err)
+		})
+
+		var cephUserA, cephUserB string
+		t.Run("first obc adds its statement", func(t *testing.T) {
+			createBrownfieldOBC(t, "brownfield-obc-a")
+			cephUserA = cephUserForOBC(t, "brownfield-obc-a")
+			assert.Contains(t, policySIDs(t), cephUserA)
+		})
+
+		t.Run("second obc preserves the first obc statement", func(t *testing.T) {
+			require.NotEmpty(t, cephUserA, "the first obc subtest did not complete")
+			createBrownfieldOBC(t, "brownfield-obc-b")
+			cephUserB = cephUserForOBC(t, "brownfield-obc-b")
+			sids := policySIDs(t)
+			assert.Contains(t, sids, cephUserA)
+			assert.Contains(t, sids, cephUserB)
+			assert.Len(t, sids, 2)
+		})
+
+		t.Run("revoking the second obc keeps the first obc statement", func(t *testing.T) {
+			require.NotEmpty(t, cephUserB, "the second obc subtest did not complete")
+			err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Delete(ctx, "brownfield-obc-b", metav1.DeleteOptions{})
+			require.NoError(t, err)
+			waitOBCAbsent(t, "brownfield-obc-b")
+			sids := policySIDs(t)
+			assert.Contains(t, sids, cephUserA)
+			assert.NotContains(t, sids, cephUserB)
+		})
+
+		t.Run("cleanup", func(t *testing.T) {
+			// tolerate OBCs missing here so that an earlier subtest failure does
+			// not cascade into misleading cleanup errors
+			err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Delete(ctx, "brownfield-obc-a", metav1.DeleteOptions{})
+			if !k8serrors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+			waitOBCAbsent(t, "brownfield-obc-a")
+
+			dscErr := helper.BucketClient.DeleteBucketStorageClassBrownfield(namespace, storeName, brownfieldSC, "Delete", seedBucket)
+			assert.NoError(t, dscErr)
+
+			err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Delete(ctx, seedObcName, metav1.DeleteOptions{})
+			if !k8serrors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+			waitOBCAbsent(t, seedObcName)
+		})
+	})
+
 	t.Run("Regression check: OBC does not revert to Pending phase", func(t *testing.T) {
 		// A bug exists in older versions of lib-bucket-provisioner that will revert a bucket and claim
 		// back to "Pending" phase after being created and initially "Bound" by looping infinitely in


### PR DESCRIPTION
`Grant` and owner-`Revoke` pass a single statement to the now-clobbering `ModifyBucketPolicy` (#17643), dropping other users' statements on a shared brownfield bucket. Fixes the call sites to build the full statement set; adds integration coverage for two OBCs sharing a brownfield bucket.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.