### PR TITLE
nvmeof: pin NVMeoF gateway image to quay.io/ceph/nvmeof:1.5.27

### DIFF
--- a/deploy/examples/nvmeof-test.yaml
+++ b/deploy/examples/nvmeof-test.yaml
@@ -6,7 +6,7 @@ metadata:
   name: nvmeof
   namespace: rook-ceph # namespace:cluster
 spec:
-  image: quay.io/ceph/nvmeof:1.5
+  image: quay.io/ceph/nvmeof:1.5.27
   pool: nvmeof
   group: group-a
   instances: 1


### PR DESCRIPTION
Pin the default NVMeoF gateway image to quay.io/ceph/nvmeof:1.5.27 to work around a keyring parsing regression in the latest 1.5 floating tag that causes gateway pods to fail with "Malformed input" errors during startupi.

Fixes: #17646 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
