### PR TITLE
csi: csi-addons should be disabled by default

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -210,7 +210,7 @@ spec:
     enableMetadata: true
     generateOMapInfo: false
     fsGroupPolicy: File
-    deployCsiAddons: true
+    deployCsiAddons: false
     cephFsClientType: kernel
     nodePlugin:
       priorityClassName: "system-node-critical"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -130,7 +130,7 @@ spec:
     enableMetadata: true
     generateOMapInfo: false
     fsGroupPolicy: File
-    deployCsiAddons: true
+    deployCsiAddons: false
     cephFsClientType: kernel
     nodePlugin:
       priorityClassName: "system-node-critical"

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -306,7 +306,8 @@ function remove_cluster_prerequisites() {
 
 function deploy_manifest_with_local_build() {
   if [[ "$1" == "deploy/examples/operator.yaml" || "$1" == "operator.yaml" ]]; then
-     sed -i "s|replicas: 2|replicas: 1|g" $1
+    sed -i "s|deployCsiAddons: false|deployCsiAddons: true|g" $1
+    sed -i "s|replicas: 2|replicas: 1|g" $1
   fi
   if [[ "$USE_LOCAL_BUILD" != "false" ]]; then
     sed -i "s|image: docker.io/rook/ceph:.*|image: docker.io/rook/ceph:local-build|g" $1


### PR DESCRIPTION
having csi-addons enabled by default is causing random pod restart on non-openshift cluster. Let's disable it by default.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17662 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
