### PR TITLE
docs: add rook compatible ceph csi driver values

### DIFF
--- a/Documentation/Helm-Charts/csi-drivers-chart.md
+++ b/Documentation/Helm-Charts/csi-drivers-chart.md
@@ -16,9 +16,13 @@ The `helm install` command deploys the drivers in the default configuration from
 
 Ceph-CSI publishes the drivers chart from the `ceph-csi-operator` Helm repository.
 
+!!! important
+    Install this chart with the recommended values.yaml. The drivers will fail if only configured with the chart defaults.
+
 ```console
 helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
-helm install ceph-csi-drivers --namespace rook-ceph ceph-csi-operator/ceph-csi-drivers
+helm install ceph-csi-drivers --namespace rook-ceph ceph-csi-operator/ceph-csi-drivers \
+  -f https://raw.githubusercontent.com/rook/rook/master/deploy/charts/rook-ceph/ceph-csi-drivers/values.yaml
 ```
 
 ## Custom settings

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -119,10 +119,14 @@ See the default settings applied by Rook in [values.yaml](https://github.com/roo
 Install or upgrade the [`ceph-csi-drivers`](../Helm-Charts/csi-drivers-chart.md) chart,
 to configure the CSI driver.
 
-!!! important
-    In previous releases, CSI settings were customized in the `rook-ceph` chart. Now, settings
-    must be customized in the [CSI Drivers Chart config](https://github.com/ceph/ceph-csi-operator/blob/main/docs/helm-charts/drivers-chart.md#configuration).
+**Important points** to ensure CSI mounts continue working after upgrades:
 
+1. This `ceph-csi-drivers` chart must be installed, otherwise the CSI driver will be in a
+    failed state due to missing service accounts.
+2. A recommended `values.yaml` is provided for Rook-compatible defaults in the drivers chart doc linked above.
+    This is critical for setting the proper driver names with the rook operator namespace as a prefix.
+3. In previous releases, CSI settings were customized in the `rook-ceph` chart.
+    Now see the [CSI Drivers Chart config](https://github.com/ceph/ceph-csi-operator/blob/main/docs/helm-charts/drivers-chart.md#configuration) for customization.
 
 ### `rook-ceph-cluster` Chart
 

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -1,0 +1,32 @@
+# Rook-compatible default values for the ceph-csi-drivers Helm chart.
+#
+# Use these values when installing or upgrading the ceph-csi-drivers chart
+# alongside the rook-ceph operator chart. The driver names must match the
+# provisioner names used by Rook (e.g. in StorageClasses and VolumeSnapshotClasses).
+#
+# If the Rook operator is installed in a namespace other than rook-ceph, replace
+# "rook-ceph" in the driver names below with your operator namespace.
+
+operatorConfig:
+  namespace: rook-ceph # namespace:operator
+  driverSpecDefaults:
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    nodePlugin:
+      priorityClassName: system-node-critical
+    controllerPlugin:
+      priorityClassName: system-cluster-critical
+
+drivers:
+  rbd:
+    enabled: true
+    name: rook-ceph.rbd.csi.ceph.com
+  cephfs:
+    enabled: true
+    name: rook-ceph.cephfs.csi.ceph.com
+  nfs:
+    enabled: false
+    name: rook-ceph.nfs.csi.ceph.com
+  nvmeof:
+    enabled: false
+    name: rook-ceph.nvmeof.csi.ceph.com

--- a/deploy/examples/csi/nvmeof/storageclass.yaml
+++ b/deploy/examples/csi/nvmeof/storageclass.yaml
@@ -2,6 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ceph-nvmeof
+provisioner: rook-ceph.nvmeof.csi.ceph.com # csi-provisioner-name
 parameters:
   clusterID: rook-ceph
   pool: nvmeof
@@ -27,7 +28,6 @@ parameters:
   csi.storage.k8s.io/node-expand-secret-namespace: rook-ceph
   imageFormat: "2"
   imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
-provisioner: rook-ceph.nvmeof.csi.ceph.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true


### PR DESCRIPTION
adding rook compatible Ceph-Csi driver values.yaml file making sure, upgrading to 1.20 doesn't break
when csi-driver is moved to admin.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17651 #17644 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
