### PR TITLE
mgr: remove unused IsModuleInSpec function

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -580,17 +580,6 @@ func (c *Cluster) EnableServiceMonitor() error {
 	return nil
 }
 
-// IsModuleInSpec returns whether a module is present in the CephCluster manager spec
-func IsModuleInSpec(modules []cephv1.Module, moduleName string) bool {
-	for _, v := range modules {
-		if v.Name == moduleName {
-			return true
-		}
-	}
-
-	return false
-}
-
 // ApplyMonitoringLabels function adds the name of the resource that manages
 // cephcluster, as a label on the ceph metrics
 func applyMonitoringLabels(c *Cluster, serviceMonitor *monitoringv1.ServiceMonitor) {


### PR DESCRIPTION
## Description of your changes

`IsModuleInSpec` in `pkg/operator/ceph/cluster/mgr/mgr.go` is dead code: it has no callers anywhere in the repository (verified with `golang.org/x/tools/cmd/deadcode` and a repo-wide grep — only the declaration itself matched). This removes it.

No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
