### PR TITLE
operator: remove dead code from the operator tree

### DIFF
--- a/pkg/operator/ceph/controller/label.go
+++ b/pkg/operator/ceph/controller/label.go
@@ -64,18 +64,6 @@ func AddCephVersionLabelToDeployment(cephVersion version.CephVersion, d *apps.De
 	addCephVersionLabel(cephVersion, d.Labels)
 }
 
-// AddCephVersionLabelToDaemonSet adds a label reporting the Ceph version which Rook has detected is
-// running in the DaemonSet's pods.
-func AddCephVersionLabelToDaemonSet(cephVersion version.CephVersion, d *apps.DaemonSet) {
-	if d == nil {
-		return
-	}
-	if d.Labels == nil {
-		d.Labels = map[string]string{}
-	}
-	addCephVersionLabel(cephVersion, d.Labels)
-}
-
 // AddCephVersionLabelToJob adds a label reporting the Ceph version which Rook has detected is
 // running in the Job's pods.
 func AddCephVersionLabelToJob(cephVersion version.CephVersion, j *batch.Job) {

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -173,9 +173,8 @@ func (o *Operator) startCRDManager(context context.Context, mgrErrorCh chan erro
 
 	// options to pass to the controllers
 	controllerOpts := &controllerconfig.Context{
-		ClusterdContext:   o.context,
-		ReconcileCanaries: &controllerconfig.LockingBool{},
-		OpManagerContext:  context,
+		ClusterdContext:  o.context,
+		OpManagerContext: context,
 	}
 
 	// Add the registered controllers to the manager (entrypoint for controllers)

--- a/pkg/operator/ceph/csi/config.go
+++ b/pkg/operator/ceph/csi/config.go
@@ -36,7 +36,6 @@ import (
 
 var (
 	CephFSDriverName string
-	NFSDriverName    string
 	RBDDriverName    string
 
 	ConfigName = "rook-ceph-csi-config"
@@ -50,7 +49,6 @@ const (
 
 	rbdDriverSuffix    = "rbd.csi.ceph.com"
 	cephFSDriverSuffix = "cephfs.csi.ceph.com"
-	nfsDriverSuffix    = "nfs.csi.ceph.com"
 )
 
 func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Client, clusterInfo *cephclient.ClusterInfo, cephBlockPoolRadosNamespaceName, clusterID string) error {

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -164,7 +164,6 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 	driverPrefix := fmt.Sprintf("%s.", r.opConfig.OperatorNamespace)
 	CephFSDriverName = driverPrefix + cephFSDriverSuffix
 	RBDDriverName = driverPrefix + rbdDriverSuffix
-	NFSDriverName = driverPrefix + nfsDriverSuffix
 
 	// See if there is a CephCluster
 	cephClusters := &cephv1.CephClusterList{}

--- a/pkg/operator/ceph/disruption/controllerconfig/context.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/context.go
@@ -18,34 +18,12 @@ package controllerconfig
 
 import (
 	"context"
-	"sync"
 
 	"github.com/rook/rook/pkg/clusterd"
 )
 
 // Context passed to the controller when associating it with the manager.
 type Context struct {
-	ClusterdContext   *clusterd.Context
-	ReconcileCanaries *LockingBool
-	OpManagerContext  context.Context
-}
-
-// LockingBool is a bool coupled with a sync.Mutex
-type LockingBool struct {
-	value bool
-	mux   sync.Mutex
-}
-
-// Get bool
-func (b *LockingBool) Get() bool {
-	b.mux.Lock()
-	defer b.mux.Unlock()
-	return b.value
-}
-
-// Update bool
-func (b *LockingBool) Update(newValue bool) {
-	b.mux.Lock()
-	defer b.mux.Unlock()
-	b.value = newValue
+	ClusterdContext  *clusterd.Context
+	OpManagerContext context.Context
 }


### PR DESCRIPTION
## Description of your changes

Dead-code removal across the operator tree. None of the removed symbols had any callers or readers anywhere in the repository, tests included (verified with `deadcode`, `staticcheck U1000`, repo-wide grep, and an exported-symbol audit):

**`pkg/operator/ceph/disruption/controllerconfig` + `cr_manager.go`:**
- The `ReconcileCanaries` field of `controllerconfig.Context` was assigned once but never read, so the `LockingBool` type backing it and its `Get`/`Update` methods were dead. Removed the field, type, methods, initializer, and the now-unused `sync` import.

**`pkg/operator/ceph/csi`:**
- `NFSDriverName` was assigned once in the CSI controller reconcile but never read. Removed the variable, its assignment, and the `nfsDriverSuffix` const that only existed to feed it.

**`pkg/operator/ceph/controller`:**
- `AddCephVersionLabelToDaemonSet` had no callers; rook applies ceph version labels to Deployments, Jobs, and object metas, but never to DaemonSets. The shared `addCephVersionLabel` helper remains in use by the live siblings.

`go build`, `go vet`, and `gofmt` are clean. No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.