### PR TITLE
test: remove unused label verification helpers

### DIFF
--- a/pkg/operator/ceph/test/spec.go
+++ b/pkg/operator/ceph/test/spec.go
@@ -19,56 +19,11 @@ package test
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
-	e "github.com/pkg/errors"
-	"github.com/rook/rook/pkg/operator/ceph/controller"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 )
-
-func checkLabel(key, value string, labels map[string]string) error {
-	v, ok := labels[key]
-	if !ok {
-		return e.Errorf("label not present: expected={%s: %s}", key, value)
-	}
-	if v != value {
-		return e.Errorf("label mismatch: expected={%s: %s} present={%s: %s}", key, value, key, v)
-	}
-	return nil
-}
-
-func combineErrors(errors ...error) error {
-	errText := ""
-	failure := false
-	for _, e := range errors {
-		if e != nil {
-			failure = true
-			errText = fmt.Sprintf("%v: %s", e, errText) // Will result in string ending in ": "
-		}
-	}
-	if failure {
-		errText = strings.TrimRight(errText, ": ") // Remove ": " from end
-		return e.Errorf("%s", errText)
-	}
-	return nil
-}
-
-// VerifyAppLabels returns a descriptive error if app labels are not present or not as expected.
-func VerifyAppLabels(appName, namespace string, labels map[string]string) error {
-	errA := checkLabel("app", appName, labels)
-	errB := checkLabel("rook_cluster", namespace, labels)
-	return combineErrors(errA, errB)
-}
-
-// VerifyPodLabels returns a descriptive error if pod labels are not present or not as expected.
-func VerifyPodLabels(appName, namespace, daemonType, daemonID string, labels map[string]string) error {
-	errA := VerifyAppLabels(appName, namespace, labels)
-	errB := checkLabel(controller.DaemonIDLabel, daemonID, labels)
-	errC := checkLabel(daemonType, daemonID, labels)
-	return combineErrors(errA, errB, errC)
-}
 
 // AssertLabelsContainCephRequirements asserts that the labels under test contain the labels
 // which all Ceph pods should have. This can be used with labels for Kubernetes Deployments,


### PR DESCRIPTION
## Description of your changes

A dead cluster of label-verification helpers in `pkg/operator/ceph/test/spec.go`:

- `VerifyPodLabels` had **no callers** anywhere in the repo.
- It was the only caller of `VerifyAppLabels`,
- which was the only caller of the unexported `checkLabel` and `combineErrors`.

This removes all four functions and the imports that become unused as a result
(`strings`, `github.com/pkg/errors`, and `pkg/operator/ceph/controller`).
`AssertLabelsContainCephRequirements` in the same file is still used and is
left untouched.

Verified with `grep`, `deadcode`, and `staticcheck`; `go build` and `go vet`
pass. No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
