### PR TITLE
docs: Helm instructions to install drivers in another namespace

### DIFF
--- a/Documentation/Helm-Charts/csi-drivers-chart.md
+++ b/Documentation/Helm-Charts/csi-drivers-chart.md
@@ -16,13 +16,15 @@ The `helm install` command deploys the drivers in the default configuration from
 
 Ceph-CSI publishes the drivers chart from the `ceph-csi-operator` Helm repository.
 
-!!! important
-    Install this chart with the recommended values.yaml. The drivers will fail if only configured with the chart defaults.
+**IMPORTANT**
+
+1. Install this chart with the recommended values.yaml. The drivers will fail if only configured with the chart defaults.
+2. If installing in another namespace, replace all instances of `rook-ceph` in the values.yaml with the required namespace.
 
 ```console
 helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
 helm install ceph-csi-drivers --namespace rook-ceph ceph-csi-operator/ceph-csi-drivers \
-  -f https://raw.githubusercontent.com/rook/rook/master/deploy/charts/rook-ceph/ceph-csi-drivers/values.yaml
+  -f https://raw.githubusercontent.com/rook/rook/master/deploy/charts/ceph-csi-drivers/values.yaml
 ```
 
 ## Custom settings

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -20,13 +20,13 @@ operatorConfig:
 drivers:
   rbd:
     enabled: true
-    name: rook-ceph.rbd.csi.ceph.com
+    name: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
   cephfs:
     enabled: true
-    name: rook-ceph.cephfs.csi.ceph.com
+    name: rook-ceph.cephfs.csi.ceph.com # csi-provisioner-name
   nfs:
     enabled: false
-    name: rook-ceph.nfs.csi.ceph.com
+    name: rook-ceph.nfs.csi.ceph.com # csi-provisioner-name
   nvmeof:
     enabled: false
-    name: rook-ceph.nvmeof.csi.ceph.com
+    name: rook-ceph.nvmeof.csi.ceph.com # csi-provisioner-name


### PR DESCRIPTION
The helm values need to be updated if installing the drivers chart in a namespace other than rook-ceph.
This is a follow-up from the discussion here: https://github.com/rook/rook/pull/17665/files#r3363008626

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
