### PR TITLE
osd: remove unused updateQueue.Clear method

### DIFF
--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -313,11 +313,6 @@ func (q *updateQueue) Exists(osdID int) bool {
 	return false
 }
 
-// Clear deletes all entries inside the queue
-func (q *updateQueue) Clear() {
-	q.q = q.q[:0]
-}
-
 // Remove removes the items from the queue if they exist.
 func (q *updateQueue) Remove(osdIDs []int) {
 	shouldRemove := func(rid int) bool {


### PR DESCRIPTION
## Description of your changes

The `Clear` method on the unexported `updateQueue` type in
`pkg/operator/ceph/cluster/osd/update.go` had no callers anywhere in the
repository. The queue is emptied via `Remove`/`Pop` in practice. This removes the
dead method.

Verified with `grep`, `deadcode`, and `staticcheck`. `go build` and `go vet` pass.
No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.