### PR TITLE
mon: update how hostname was set for drbd

### DIFF
--- a/pkg/operator/ceph/cluster/mon/template/floating-mon-drbd-deployment.yaml
+++ b/pkg/operator/ceph/cluster/mon/template/floating-mon-drbd-deployment.yaml
@@ -112,15 +112,18 @@ spec:
           hostPath:
             path: {{ .DRBD_DIR_PATH }}
             type: Directory
-        - name: host-root
-          hostPath:
-            path: /
       initContainers:
         - name: drbd-init
           image: {{ .DRBD_UTILS_IMAGE }}
           imagePullPolicy: {{ .IMAGE_PULL_POLICY }}
           securityContext:
             privileged: true
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           command:
             - sh
             - -c
@@ -130,11 +133,10 @@ spec:
                 echo "Unmounting stale mount at {{ .CONTAINER_DATA_DIR }}..."
                 umount {{ .CONTAINER_DATA_DIR }}
               fi
-              REAL_HOSTNAME=$(cat /host/etc/hostname)
-              echo "Setting hostname to: $REAL_HOSTNAME"
-              echo "$REAL_HOSTNAME" > /proc/sys/kernel/hostname
-              echo "Hostname after change:"
-              uname -n
+              echo "Current hostname: $(uname -n)"
+              echo "Setting hostname to $HOSTNAME"
+              echo "$HOSTNAME" > /proc/sys/kernel/hostname
+              echo "New hostname: $(uname -n)"
               echo "Promoting DRBD resource to Primary..."
               drbdadm primary {{ .DRBD_RESOURCE_NAME }} --config-file {{ .DRBD_CONF_PATH }}
               echo "DRBD init steps completed"
@@ -145,9 +147,6 @@ spec:
               mountPath: {{ .DRBD_CONF_PATH }}
             - name: drbd-dir
               mountPath: {{ .DRBD_DIR_PATH }}
-            - name: host-root
-              mountPath: /host
-              readOnly: true
         - name: chown-container-data-dir
           image: {{ .CEPH_IMAGE }}
           imagePullPolicy: {{ .IMAGE_PULL_POLICY }}
@@ -539,15 +538,20 @@ spec:
           imagePullPolicy: {{ .IMAGE_PULL_POLICY }}
           securityContext:
             privileged: true
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           command:
             - sh
             - -c
             - |
-              REAL_HOSTNAME=$(cat /host/etc/hostname)
-              echo "Setting hostname to: $REAL_HOSTNAME"
-              echo "$REAL_HOSTNAME" > /proc/sys/kernel/hostname
-              echo "Hostname after change:"
-              uname -n
+              echo "Current hostname: $(uname -n)"
+              echo "Setting hostname to $HOSTNAME"
+              echo "$HOSTNAME" > /proc/sys/kernel/hostname
+              echo "New hostname: $(uname -n)"
               sleep infinity
           volumeMounts:
             - name: dev
@@ -556,9 +560,6 @@ spec:
               mountPath: {{ .DRBD_CONF_PATH }}
             - name: drbd-dir
               mountPath: {{ .DRBD_DIR_PATH }}
-            - name: host-root
-              mountPath: /host
-              readOnly: true
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
currently, drbd hostname was ready using command
but now the change we use kubernetes built-in api
to read hostname from `spec.nodeName`.`

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17273


**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
