### PR TITLE
external: update the external cluster to make use of csi op

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster/consumer-import.md
+++ b/Documentation/CRDs/Cluster/external-cluster/consumer-import.md
@@ -17,15 +17,23 @@ helm repo add rook-release https://charts.rook.io/release
 helm install --create-namespace --namespace $clusterNamespace rook-ceph rook-release/rook-ceph -f values.yaml
 helm install --create-namespace --namespace $clusterNamespace rook-ceph-cluster \
 --set operatorNamespace=$operatorNamespace rook-release/rook-ceph-cluster -f values-external.yaml
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
+helm install ceph-csi-drivers --namespace rook-ceph ceph-csi-operator/ceph-csi-drivers \
+  -f https://raw.githubusercontent.com/rook/rook/master/deploy/charts/ceph-csi-drivers/values.yaml
 ```
 
 ### Manifest Installation
 
 If not installing with Helm, here are the steps to install with manifests.
 
-1. Deploy Rook, create [common.yaml](https://github.com/rook/rook/blob/master/deploy/examples/common.yaml), [crds.yaml](https://github.com/rook/rook/blob/master/deploy/examples/crds.yaml), [csi-operator.yaml](https://github.com/rook/rook/blob/master/deploy/examples/csi-operator.yaml) and [operator.yaml](https://github.com/rook/rook/blob/master/deploy/examples/operator.yaml) manifests.
+Deploy Rook:
 
-2. Create [common-external.yaml](https://github.com/rook/rook/blob/master/deploy/examples/external/common-external.yaml) and [cluster-external.yaml](https://github.com/rook/rook/blob/master/deploy/examples/external/cluster-external.yaml)
+```console
+$ git clone --single-branch --branch master https://github.com/rook/rook.git
+cd rook/deploy/examples
+kubectl create -f crds.yaml -f common.yaml -f csi-operator.yaml
+kubectl create -f operator.yaml -f common-external.yaml -f cluster-external.yaml
+```
 
 ## Import the Provider Data
 

--- a/Documentation/CRDs/Cluster/external-cluster/provider-export.md
+++ b/Documentation/CRDs/Cluster/external-cluster/provider-export.md
@@ -4,7 +4,7 @@ In order to configure an external Ceph cluster with Rook, we need to extract som
 
 ## 1. Create all users and keys
 
-Run the python script [create-external-cluster-resources.py](https://github.com/rook/rook/blob/master/deploy/examples/external/create-external-cluster-resources.py) in the provider Ceph cluster cephadm shell, to have access to create the necessary users and keys.
+Run the python script [create-external-cluster-resources.py](https://github.com/rook/rook/blob/master/deploy/examples/create-external-cluster-resources.py) in the provider Ceph cluster cephadm shell, to have access to create the necessary users and keys.
 
 ```console
 python3 create-external-cluster-resources.py --rbd-data-pool-name <pool_name> --cephfs-filesystem-name <filesystem-name> --rgw-endpoint  <rgw-endpoint> --namespace <namespace> --format bash

--- a/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-configuration.md
@@ -49,7 +49,8 @@ sed -i.bak \
   common.yaml operator.yaml csi-operator.yaml cluster.yaml # add other files or change these as desired for your config
 
 # You need to use `apply` for all Ceph clusters after the first if you have only one Operator
-kubectl apply -f crds.yaml -f common.yaml -f operator.yaml -f csi-operator.yaml -f cluster.yaml # add other files as desired for yourconfig
+kubectl apply -f crds.yaml -f common.yaml -f csi-operator.yaml
+kubectl apply -f operator.yaml -f cluster.yaml # add other files as desired for yourconfig
 ```
 
 Also see the CSI driver

--- a/build/release/set-release-ver.sh
+++ b/build/release/set-release-ver.sh
@@ -17,6 +17,8 @@ SED="${scriptdir}/../sed-in-place"
 FILES_DOCS=(
  Documentation/Getting-Started/quickstart.md
  Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+ Documentation/CRDs/Cluster/external-cluster/consumer-import.md
+ Documentation/Helm-Charts/csi-drivers-chart.md
 )
 FILES_CHARTS=(
  deploy/charts/rook-ceph/values.yaml

--- a/deploy/examples/cluster-external-management.yaml
+++ b/deploy/examples/cluster-external-management.yaml
@@ -2,8 +2,8 @@
 # Define the settings for the rook-ceph-external cluster with common settings for a production cluster.
 
 # For example, if Rook is not managing any existing cluster in the 'rook-ceph' namespace do:
-#   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
-#   kubectl create -f cluster-external.yaml
+#   kubectl create -f crds.yaml -f common.yaml -f csi-operator.yaml
+#   kubectl create -f operator.yaml -f cluster-external.yaml
 
 # If there is already a cluster managed by Rook in 'rook-ceph' then run:
 #   kubectl create -f common-external.yaml -f cluster-external-management.yaml

--- a/deploy/examples/cluster-external.yaml
+++ b/deploy/examples/cluster-external.yaml
@@ -2,8 +2,8 @@
 # Define the settings for the rook-ceph-external cluster with common settings for a production cluster.
 
 # For example, if Rook is not managing any existing cluster in the 'rook-ceph' namespace do:
-#   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
-#   kubectl create -f cluster-external.yaml
+#   kubectl create -f crds.yaml -f common.yaml -f csi-operator.yaml
+#   kubectl create -f operator.yaml -f cluster-external.yaml
 
 # If there is already a cluster managed by Rook in 'rook-ceph' then do:
 #   kubectl create -f common-external.yaml

--- a/deploy/examples/external/cluster-external.yaml
+++ b/deploy/examples/external/cluster-external.yaml
@@ -1,7 +1,7 @@
 #################################################################################################################
 # If Rook is not managing any existing cluster in the 'rook-ceph' namespace do:
-#   kubectl create -f ../../examples/crds.yaml -f ../../examples/common.yaml -f ../../examples/operator.yaml
-#   kubectl create -f common-external.yaml -f cluster-external.yaml
+#   kubectl create -f ../../examples/crds.yaml -f ../../examples/common.yaml -f ../../examples/csi-operator.yaml
+#   kubectl create -f ../../examples/operator.yaml -f common-external.yaml -f cluster-external.yaml
 #
 # If there is already a cluster managed by Rook in 'rook-ceph' then do:
 #   kubectl create -f common-external.yaml


### PR DESCRIPTION
updated the external cluster doc, and helm and manifest install to make use of csi operator as it is the default offering now

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
