### PR TITLE
ci: require TestCephObjectSuiteTLS checks for release-1.20 automerge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -241,7 +241,7 @@ pull_request_rules:
       - "check-success=TestCephHelmSuite (v3.18.3, v1.35.5)"
       - "check-success=TestCephMultiClusterDeploySuite (v1.35.5)"
       - "check-success=TestCephObjectSuite (v1.31.14)"
-      - "check-success=TestCephObjectSuite (v1.35.5)"
+      - "check-success=TestCephObjectSuiteTLS (v1.35.5)"
       - "check-success=TestCephSmokeSuite (v1.31.14)"
       - "check-success=TestCephSmokeSuite (v1.35.5)"
       - "check-success=TestCephUpgradeSuite (v1.31.14)"


### PR DESCRIPTION
**Description:**

Follow-up to #17695, which split the `CephObjectSuite` into separate TLS and non-TLS jobs. The non-TLS job kept the `TestCephObjectSuite` name, so its required check is unchanged, but the new `TestCephObjectSuiteTLS` job produces new status checks that the `release-1.20` automerge rule must also require — otherwise a backport PR could automerge with the TLS variant failing or still running.

> [!IMPORTANT]
> **Do not merge until #17695 has been backported to `release-1.20`.** Until that backport lands, `release-1.20` still runs the unsplit workflow, which never produces the `TestCephObjectSuiteTLS` checks — merging this first would stall automerge for every `release-1.20` backport PR.

Older release branches (1.17–1.19) are untouched, as the job split will not be backported to them.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
