### PR TITLE
test: wait out rgw quota sync in old quota checks

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -311,7 +311,10 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, poErr)
 			logger.Infof("Testing the max object limit")
-			quotaEnforced := utils.Retry(30, 2*time.Second, "user quota enforced", func() bool {
+			// rgw enforces user quotas from cached stats that sync on
+			// rgw_user_quota_bucket_sync_interval (default 180s), so the wait
+			// must exceed that interval or this check flakes on slow runners
+			quotaEnforced := utils.Retry(120, 2*time.Second, "user quota enforced", func() bool {
 				_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 				if err != nil {
 					return true
@@ -333,7 +336,8 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			logger.Infof("Testing the updated object limit")
 			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 			assert.NoError(t, poErr)
-			quotaEnforced := utils.Retry(30, 2*time.Second, "updated user quota enforced", func() bool {
+			// see the sync-interval comment on "user quota enforced" above
+			quotaEnforced := utils.Retry(120, 2*time.Second, "updated user quota enforced", func() bool {
 				_, putErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
 				if putErr != nil {
 					return true


### PR DESCRIPTION
**Flake-isolation experiment (1 of 3, split from #17704):** #17704 bundles three object-suite stability fixes and passed 5 consecutive full-matrix runs, but we don't know which fix (or combination) is actually required. This PR carries only the quota-wait extension; siblings #17708 and #17709 carry the other two commits. Each PR's objectsuite jobs will be restarted until 5 consecutive successful runs, with pre-suite infra failures (minikube, etc.) not counted, and 2 successive genuine object-suite failures ending the experiment for that PR.

**The fix:** the `user_quota_enforcement` and `update_user_quota_limits` subtests waited 60s for rgw to start rejecting over-quota writes, but rgw enforces user quotas from cached stats that sync on `rgw_user_quota_bucket_sync_interval` (default 180s). The wait was structurally shorter than the interval it can depend on, so the checks flaked on slow CI runners. Extend both waits to 240s; the retry returns on the first rejected write, so passing runs are unaffected.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
