### PR TITLE
test: run object suite store with a single rgw instance

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -163,7 +163,12 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	}
 
 	logger.Infof("Running on Rook Cluster %s", namespace)
-	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 3, tlsEnable, swiftAndKeystone)
+	// a single gateway makes quota enforcement deterministic: rgw quota checks
+	// run against per-instance cached stats, and with multiple gateways an
+	// instance can be blind to writes served by its peers for up to
+	// rgw_user_quota_bucket_sync_interval; multi-instance deployment is still
+	// covered by the keystone suite
+	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 1, tlsEnable, swiftAndKeystone)
 
 	// Canary test: verify all *_pool fields in zone.json are covered by Rook's zonePoolNSSuffix map.
 	// This catches new RGW pool fields added in newer Ceph versions that Rook doesn't yet handle,


### PR DESCRIPTION
rgw quota checks run against per-instance cached stats kept current by
local per-op deltas; the durable user stats object only catches up on
rgw_user_quota_bucket_sync_interval (180s), and a peer instance only
reloads it on the rgw_bucket_quota_ttl refresh cycle. With 3 gateways
behind the service, an S3 reconnect mid-test can land on an instance
that is blind to the objects already written, letting over-quota writes
pass until those clocks line up. A single gateway serves all writes
from one accurate cache, so enforcement is immediate and deterministic.

Multi-instance rgw deployment remains covered by the keystone suite,
and this matches the notification, COSI, and sharedstore fixtures that
already run one instance.