### PR TITLE
object: generate URL-safe realm access keys

### DIFF
--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -291,18 +291,22 @@ func (r *ReconcileObjectRealm) createRealmKeys(realm *cephv1.CephObjectRealm) (r
 		return reconcile.Result{}, nil
 	}
 
-	// the realm's secret key and access key are randomly generated and then encoded to base64
+	// The realm's secret key and access key are randomly generated and then encoded to base64.
+	// The encoded values are used verbatim as the S3 keys of the realm's system user, so the
+	// encoding alphabet must be URL-safe: an access key containing '/' breaks AWS SigV4
+	// credential scope parsing ("<access-key>/<date>/<region>/...") and makes
+	// "radosgw-admin realm pull" against this realm fail with "(22) Invalid argument".
 	accessKey, err := mgr.GeneratePassword(accessKeyLength, mgr.AccessKey)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "access key failed to generate")
 	}
-	accessKey = base64.StdEncoding.EncodeToString([]byte(accessKey))
+	accessKey = base64.RawURLEncoding.EncodeToString([]byte(accessKey))
 
 	secretKey, err := mgr.GeneratePassword(secretKeyLength, mgr.DefaultKey)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to generate secret key")
 	}
-	secretKey = base64.StdEncoding.EncodeToString([]byte(secretKey))
+	secretKey = base64.RawURLEncoding.EncodeToString([]byte(secretKey))
 
 	log.NamedDebug(nsName, logger, "creating secrets for new realm %q", realm.Name)
 

--- a/pkg/operator/ceph/object/realm/controller_test.go
+++ b/pkg/operator/ceph/object/realm/controller_test.go
@@ -19,6 +19,7 @@ package realm
 
 import (
 	"context"
+	"regexp"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -301,6 +303,30 @@ func TestReconcileObjectRealm_createRealmKeys(t *testing.T) {
 				assert.Contains(t, secret.Data, "access-key")
 				assert.Contains(t, secret.Data, "secret-key")
 			})
+		}
+	})
+
+	t.Run("generated keys are URL-safe", func(t *testing.T) {
+		// the access key is embedded in the '/'-delimited SigV4 credential scope, so a '/'
+		// anywhere in it makes "radosgw-admin realm pull" fail with "(22) Invalid argument"
+		urlSafe := regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+		for i := 0; i < 100; i++ {
+			r := ReconcileObjectRealm{
+				context: &clusterd.Context{
+					Clientset: k8sfake.NewClientset(),
+				},
+				scheme:   scheme,
+				recorder: events.NewFakeRecorder(50),
+			}
+
+			res, err := r.createRealmKeys(realm)
+			require.NoError(t, err)
+			assert.True(t, res.IsZero())
+
+			secret, err := r.context.Clientset.CoreV1().Secrets(ns).Get(ctx, realmName+"-keys", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Regexp(t, urlSafe, string(secret.Data["access-key"]))
+			assert.Regexp(t, urlSafe, string(secret.Data["secret-key"]))
 		}
 	})
 


### PR DESCRIPTION
## Description of your changes

The realm system user's access and secret keys are generated by `GeneratePassword()` and then wrapped in `base64.StdEncoding`. `GeneratePassword()` deliberately excludes `/` from the access key character set, but the StdEncoding wrap reintroduces it: its alphabet contains `/` and `+`, and the 14-character input always produces a trailing `=`. The encoded string is the literal access key used in S3 requests.

An access key containing `/` breaks AWS SigV4 credential scope parsing (`<access-key>/<date>/<region>/<service>/aws4_request` is split on `/`), so `radosgw-admin realm pull` against the realm endpoint fails permanently with `request failed: (22) Invalid argument` (HTTP 400), and a CephObjectRealm pulling that realm can never reconcile.

This is the dominant cause of the "deploy second cluster rook" failures in the `rgw-multisite-testing` canary job. Every sampled failing run had a generated access key containing `/` and looped on EINVAL for the entire 600s wait window, e.g.:

- [run 27291886912](https://github.com/rook/rook/actions/runs/27291886912) (master push): `--access-key=bUc/M25DYHRLJTNfdnw=`, 65 failed pull attempts over 10 minutes
- [run 27226448401](https://github.com/rook/rook/actions/runs/27226448401): `--access-key=Y1g6UCdXa1w/JT9caTQ=`
- [run 27291914960](https://github.com/rook/rook/actions/runs/27291914960): `--access-key=XGhqY11rVn0/QmFcaz0=`

while runs with slash-free keys pulled the realm successfully.

Fix: encode both keys with `base64.RawURLEncoding` instead, whose alphabet (`A-Za-z0-9-_`, unpadded) is safe in credential scopes, URLs, and shell arguments. Only newly created realm secrets are affected; the reconciler does not modify existing secrets.

Marked do-not-merge while CI reliability of the multisite canary job is being validated together with the companion CI PR.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.