### PR TITLE
test: extend quota waits and bound notification checks

### DIFF
--- a/tests/framework/clients/notification.go
+++ b/tests/framework/clients/notification.go
@@ -60,16 +60,84 @@ func (t *NotificationOperation) CheckNotificationCR(notificationName string) boo
 	return true
 }
 
-func (t *NotificationOperation) CheckNotificationFromHTTPEndPoint(appLabel, eventName, fileName string) (bool, error) {
-	// wait for the notification to reach http-server
-	time.Sleep(5 * time.Second)
-	selectorName := "--selector=" + appLabel
-	l, err := t.k8sh.Kubectl("logs", selectorName, "--tail", "5")
+const (
+	notificationWaitAttempts = 12
+	notificationWaitInterval = 5 * time.Second
+)
+
+// notificationRecords returns the http server log lines emitted strictly
+// after since. The endpoint pod is shared by every scenario in the suite
+// (including the other TLS pass), so an unbounded sample can match stale
+// records; --timestamps gives per-line runtime stamps for a precise client
+// side boundary, while --since-time only prefilters at second granularity.
+func (t *NotificationOperation) notificationRecords(appLabel string, since time.Time) ([]string, error) {
+	l, err := t.k8sh.Kubectl("logs",
+		"--selector="+appLabel,
+		"--timestamps",
+		"--since-time="+since.Add(-2*time.Second).UTC().Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+
+	var records []string
+	for _, line := range strings.Split(l, "\n") {
+		stamp, record, found := strings.Cut(line, " ")
+		if !found {
+			continue
+		}
+		when, err := time.Parse(time.RFC3339Nano, stamp)
+		if err != nil {
+			continue
+		}
+		if when.After(since) {
+			records = append(records, record)
+		}
+	}
+	return records, nil
+}
+
+// recordMatches reports whether a single record line carries both eventName
+// and fileName. Records are single-line JSON; matching the concatenated log
+// would let two unrelated records satisfy the substrings independently.
+func recordMatches(records []string, eventName, fileName string) bool {
+	for _, record := range records {
+		if strings.Contains(record, eventName) && strings.Contains(record, fileName) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckNotificationFromHTTPEndPoint polls the http endpoint logs for an
+// eventName/fileName record emitted after since, for up to a minute —
+// delivery lags well past a single fixed sleep on loaded CI runners.
+func (t *NotificationOperation) CheckNotificationFromHTTPEndPoint(appLabel, eventName, fileName string, since time.Time) (bool, error) {
+	var lastErr error
+	for i := 0; i < notificationWaitAttempts; i++ {
+		// wait for the notification to reach http-server
+		time.Sleep(notificationWaitInterval)
+		records, err := t.notificationRecords(appLabel, since)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		lastErr = nil
+		if recordMatches(records, eventName, fileName) {
+			return true, nil
+		}
+	}
+	return false, lastErr
+}
+
+// CheckNotificationAbsentFromHTTPEndPoint reports whether no eventName/
+// fileName record was emitted after since: one settle interval, then a
+// single sample. Callers pair it with a positive check that already proved
+// delivery works, so polling longer would only slow the suite down.
+func (t *NotificationOperation) CheckNotificationAbsentFromHTTPEndPoint(appLabel, eventName, fileName string, since time.Time) (bool, error) {
+	time.Sleep(notificationWaitInterval)
+	records, err := t.notificationRecords(appLabel, since)
 	if err != nil {
 		return false, err
 	}
-	if strings.Contains(l, eventName) && strings.Contains(l, fileName) {
-		return true, nil
-	}
-	return false, nil
+	return !recordMatches(records, eventName, fileName), nil
 }

--- a/tests/integration/ceph_bucket_notification_test.go
+++ b/tests/integration/ceph_bucket_notification_test.go
@@ -129,33 +129,35 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		assert.Nil(t, err)
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
+		putTime := time.Now()
 		t.Run("put object", func(t *testing.T) {
 			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey1, contentType)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for put bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1)
+			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1, putTime)
 			assert.True(t, notificationReceived)
 			assert.Nil(t, err)
 			// negative test case to confirm didn't receive any delete event notification
-			notificationReceived, err = helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1, putTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 
+		deleteTime := time.Now()
 		t.Run("delete objects", func(t *testing.T) {
 			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for delete bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1)
+			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1, deleteTime)
 			assert.True(t, notificationReceived)
 			assert.Nil(t, err)
 			// negative test case to confirm didn't receive any put event notification
-			notificationReceived, err = helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, putEvent, ObjectKey1, deleteTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 	})
@@ -229,25 +231,27 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		assert.Nil(t, err)
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
+		putTime := time.Now()
 		t.Run("put object", func(t *testing.T) {
 			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for put bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey2)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, putEvent, ObjectKey2, putTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 
+		deleteTime := time.Now()
 		t.Run("delete objects", func(t *testing.T) {
 			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for delete bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey2)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey2, deleteTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 	})

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -311,7 +311,10 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, poErr)
 			logger.Infof("Testing the max object limit")
-			quotaEnforced := utils.Retry(30, 2*time.Second, "user quota enforced", func() bool {
+			// rgw enforces user quotas from cached stats that sync on
+			// rgw_user_quota_bucket_sync_interval (default 180s), so the wait
+			// must exceed that interval or this check flakes on slow runners
+			quotaEnforced := utils.Retry(120, 2*time.Second, "user quota enforced", func() bool {
 				_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 				if err != nil {
 					return true
@@ -333,7 +336,8 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			logger.Infof("Testing the updated object limit")
 			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 			assert.NoError(t, poErr)
-			quotaEnforced := utils.Retry(30, 2*time.Second, "updated user quota enforced", func() bool {
+			// see the sync-interval comment on "user quota enforced" above
+			quotaEnforced := utils.Retry(120, 2*time.Second, "updated user quota enforced", func() bool {
 				_, putErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
 				if putErr != nil {
 					return true


### PR DESCRIPTION
**Flake-isolation experiment (4 of 4, split from #17704):** combination leg carrying the #17707 quota-wait extension AND the #17709 notification-check rework — i.e. everything from #17704 *except* the single-rgw-instance change — to measure whether those two together are any more reliable than each alone. Same base commit as the other legs (05d2c251f) for a controlled comparison, and the same protocol: restart the objectsuite jobs until 5 consecutive successful runs; pre-suite infra failures (minikube, etc.) are not counted; 2 successive genuine object-suite failures end the experiment for this PR.

Context from the completed legs: #17708 (single rgw instance only) passed 5/5 with zero suite failures; #17707 (waits only) retired with 3 quota-subtest failures, each exhausting the full 240s window; #17709 (notification only) retired with 4 quota-subtest failures at the baseline window and zero notification-check failures.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.