### PR TITLE
ci: reduce CephUpgradeSuite flakes

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -26,7 +26,9 @@ runs:
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         ARCH=$(go env GOARCH)
-        curl -LO https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
+        # --fail so an HTTP error page is not saved as the .deb (dpkg then fails on the
+        # corrupt archive), and retry transient download errors
+        curl -fLO --retry 5 --retry-all-errors --retry-delay 10 https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
         sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
         rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
 
@@ -43,6 +45,16 @@ runs:
         cpus: 2
         addons: ingress
         cni: calico
+        # --force: when the requested kubernetes version is missing from minikube's compiled-in
+        # version list (any version released after the pinned minikube), 'minikube start'
+        # verifies the version with an anonymous GitHub API request, which is regularly
+        # rate-limited on shared runner IPs and fails the job (K8S_FAIL_CONNECT, exit code 40).
+        # The versions used here are pinned constants already validated by the PRs that bump
+        # them, so that check adds nothing in CI; an invalid version would still fail fast at
+        # the kubeadm/kubelet download.
+        # --wait-timeout: minikube's default 6m node-ready wait expires on slow runners
+        # (GUEST_START, exit code 80).
+        start-args: --force --wait-timeout=15m
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -26,6 +26,10 @@ env:
   # the ceph_preview build tag. Can be removed when go-ceph promotes
   # the account API out of preview.
   GOFLAGS: "-tags=ceph_preview"
+  # Double the test framework's default wait budget (55 retries x 5s = 275s);
+  # CI runners regularly need longer, e.g. for PVC binding while the CSI
+  # pods are still starting during the initial cluster deploy.
+  RETRY_MAX: "110"
 
 jobs:
   TestCephUpgradeSuite:
@@ -56,7 +60,7 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
-          go test -v -timeout 2400s -failfast -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
+          go test -v -timeout 3600s -failfast -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
 
       - name: collect common logs
         if: always()
@@ -112,7 +116,7 @@ jobs:
 
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
-          go test -v -timeout 1800s -failfast -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
+          go test -v -timeout 2700s -failfast -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
 
       - name: collect common logs
         if: always()

--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -199,7 +199,9 @@ func (h *CephInstaller) InstallCephCsiDriversViaHelm() error {
 	if err := h.k8shelper.CreateSnapshotController("create"); err != nil {
 		return errors.Wrap(err, "failed to install snapshot controller")
 	}
-	if err := h.k8shelper.WaitForSnapshotController(30); err != nil {
+	// the snapshot controller is installed while the cluster is busy rolling daemons during
+	// upgrade tests, and its image pull plus rollout regularly exceeds 150s in CI
+	if err := h.k8shelper.WaitForSnapshotController(90); err != nil {
 		return errors.Wrap(err, "snapshot controller is not ready")
 	}
 	op := h.settings.OperatorNamespace

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -151,10 +151,23 @@ func (h *HelmHelper) InstallOrUpgradeHelmRepoChart(namespace, release, repoURL, 
 		"--version", version,
 		"--namespace", namespace,
 	}
-	if err := h.installChart(cmdArgs, values); err != nil {
-		return fmt.Errorf("helm upgrade --install %q in namespace %q: %w", release, namespace, err)
+	// retry: helm fetches the chart tarball from the repo's download URL (e.g. GitHub release
+	// assets), and transient fetch errors (504s) have failed CI runs
+	var lastErr error
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		err := h.installChart(cmdArgs, values)
+		if err != nil {
+			lastErr = fmt.Errorf("helm upgrade --install %q in namespace %q: %w", release, namespace, err)
+			logger.Error(lastErr)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		logger.Infof("helm chart %q installed successfully after %d attempt(s)", release, i+1)
+		return nil
 	}
-	return nil
+	logger.Errorf("failed to install helm chart %s after %d attempts", release, maxRetries)
+	return lastErr
 }
 
 func (h *HelmHelper) UninstallHelmReleaseIfExists(namespace, release string) error {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -363,26 +363,31 @@ func (s *UpgradeSuite) verifyRookUpgrade(numOSDs int) {
 }
 
 func (s *UpgradeSuite) waitForUpgradedDaemons(previousVersion, versionLabel string, numOSDs int, waitForMDS bool) {
+	// extend the timeout for all the daemon checks: pulling ceph-ci images can take 6+ minutes,
+	// and the operator updates the daemons sequentially (mons, mgr, osds, mds, rgw, with PG
+	// health gates between OSDs), so the wait for each later daemon also absorbs the time spent
+	// on every daemon before it. The rgw wait, being last, timed out most often in CI.
+	upgradeRetries := utils.RetryLoop + 120
+
 	// wait for the mon(s) to be updated
 	monsNotOldVersion := fmt.Sprintf("app=rook-ceph-mon,%s!=%s", versionLabel, previousVersion)
-	// extend the timeout for this check because it can take 6+ minutes to pull ceph-ci images
-	err := s.k8sh.WaitForDeploymentCountWithRetries(monsNotOldVersion, s.namespace, s.settings.Mons, utils.RetryLoop+120)
+	err := s.k8sh.WaitForDeploymentCountWithRetries(monsNotOldVersion, s.namespace, s.settings.Mons, upgradeRetries)
 	require.NoError(s.T(), err, "mon(s) didn't update")
-	err = s.k8sh.WaitForLabeledDeploymentsToBeReady(monsNotOldVersion, s.namespace)
+	err = s.k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(monsNotOldVersion, s.namespace, upgradeRetries)
 	require.NoError(s.T(), err)
 
 	// wait for the mgr to be updated
 	mgrNotOldVersion := fmt.Sprintf("app=rook-ceph-mgr,%s!=%s", versionLabel, previousVersion)
-	err = s.k8sh.WaitForDeploymentCount(mgrNotOldVersion, s.namespace, 1)
+	err = s.k8sh.WaitForDeploymentCountWithRetries(mgrNotOldVersion, s.namespace, 1, upgradeRetries)
 	require.NoError(s.T(), err, "mgr didn't update")
-	err = s.k8sh.WaitForLabeledDeploymentsToBeReady(mgrNotOldVersion, s.namespace)
+	err = s.k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(mgrNotOldVersion, s.namespace, upgradeRetries)
 	require.NoError(s.T(), err)
 
 	// wait for the osd pods to be updated
 	osdsNotOldVersion := fmt.Sprintf("app=rook-ceph-osd,%s!=%s", versionLabel, previousVersion)
-	err = s.k8sh.WaitForDeploymentCount(osdsNotOldVersion, s.namespace, numOSDs)
+	err = s.k8sh.WaitForDeploymentCountWithRetries(osdsNotOldVersion, s.namespace, numOSDs, upgradeRetries)
 	require.NoError(s.T(), err, "osd(s) didn't update")
-	err = s.k8sh.WaitForLabeledDeploymentsToBeReady(osdsNotOldVersion, s.namespace)
+	err = s.k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(osdsNotOldVersion, s.namespace, upgradeRetries)
 	require.NoError(s.T(), err)
 
 	// wait for the mds pods to be updated
@@ -390,16 +395,16 @@ func (s *UpgradeSuite) waitForUpgradedDaemons(previousVersion, versionLabel stri
 	// the check for MDS upgrade in case it's just a ceph upgrade (no operator restart)
 	if waitForMDS {
 		mdsesNotOldVersion := fmt.Sprintf("app=rook-ceph-mds,%s!=%s", versionLabel, previousVersion)
-		err = s.k8sh.WaitForDeploymentCount(mdsesNotOldVersion, s.namespace, 2 /* always expect 2 mdses */)
+		err = s.k8sh.WaitForDeploymentCountWithRetries(mdsesNotOldVersion, s.namespace, 2 /* always expect 2 mdses */, upgradeRetries)
 		require.NoError(s.T(), err)
-		err = s.k8sh.WaitForLabeledDeploymentsToBeReady(mdsesNotOldVersion, s.namespace)
+		err = s.k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(mdsesNotOldVersion, s.namespace, upgradeRetries)
 		require.NoError(s.T(), err)
 	}
 
 	rgwsNotOldVersion := fmt.Sprintf("app=rook-ceph-rgw,%s!=%s", versionLabel, previousVersion)
-	err = s.k8sh.WaitForDeploymentCount(rgwsNotOldVersion, s.namespace, 1 /* always expect 1 rgw */)
+	err = s.k8sh.WaitForDeploymentCountWithRetries(rgwsNotOldVersion, s.namespace, 1 /* always expect 1 rgw */, upgradeRetries)
 	require.NoError(s.T(), err)
-	err = s.k8sh.WaitForLabeledDeploymentsToBeReady(rgwsNotOldVersion, s.namespace)
+	err = s.k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(rgwsNotOldVersion, s.namespace, upgradeRetries)
 	require.NoError(s.T(), err)
 
 	// Give a few seconds for the daemons to settle down after the upgrade

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -152,6 +152,16 @@ function use_local_disk_for_integration_test() {
   : "$(block_dev)"
   sudo lsblk
 
+  # Stop udev from watching the OSD disk, on every kind of runner. Without this, every
+  # close-after-write on the device retriggers a udev probe of the device, and the resulting
+  # re-probe storm during OSD restarts has been seen to wedge ceph-volume activate in
+  # uninterruptible sleep on the block device lock on runners using the iSCSI fallback disk.
+  # See https://github.com/rook/rook/issues/8975 and https://access.redhat.com/solutions/1465913
+  echo "ACTION==\"add|change\", KERNEL==\"$(block_dev_basename)\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
+  sudo udevadm control --reload-rules || true
+  sudo udevadm trigger || true
+  time sudo udevadm settle || true
+
   unset pipefail
   mountpoint -q /mnt || return 0
   set pipefail
@@ -166,8 +176,6 @@ function use_local_disk_for_integration_test() {
   # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
   # for more details see: https://github.com/rook/rook/issues/7405
   echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
-  # for below, see: https://access.redhat.com/solutions/1465913
-  echo "ACTION==\"add|change\", KERNEL==\"$(block_dev_basename)\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
   # The partition is still getting reloaded occasionally during operation. See https://github.com/rook/rook/issues/8975
   # Try issuing some disk-inspection commands to jog the system so it won't reload the partitions
   # during OSD provisioning.


### PR DESCRIPTION
The CephUpgradeSuite workflow failed ~31% of PR runs over the last two months, vs the ~19% broken-PR baseline of the other integration suites. I classified the failing step of every failed run from the last ~400 PR runs, and the logs of every failure on non-dependabot branches (44 genuine test-phase failure runs + 82 setup-step failures); the excess comes from a handful of too-tight waits, unretried network fetches, and environment races rather than from the upgrade logic itself.

Fixes, with the share of failures they address:

- **Daemon roll waits during the Squid→Tentacle upgrade (21 of 44 test-phase failure runs)**: `giving up waiting for deployment(s) with label app=rook-ceph-{rgw,osd},ceph-version!=...`. The operator updates daemons sequentially (mons, mgr, OSDs with PG-health gates between them, MDS, RGW), so each later daemon's fixed 275s wait also absorbs the time spent on every daemon before it — RGW, last in the sequence, failed most often. The mon wait was already extended for slow ceph image pulls in 98bd03a42; this extends the same retry count to all the daemon waits.
- **Snapshot controller wait in the Helm path (~7 runs)**: `WaitForSnapshotController(30)` allows only 150s, and the logs show the deployment still converging (`readyreplicas 1 < replicas 2`) on the final poll. Raised to 90 retries.
- **Un-retried helm chart fetch (observed once)**: `InstallOrUpgradeHelmRepoChart` ran helm once with no retry; an observed failure got a 504 fetching the ceph-csi-drivers chart tarball from GitHub release assets. Now retries 5×, as `InstallLocalHelmChart` already does.
- **go test timeouts raised** (2400s→3600s rook, 1800s→2700s helm): failed runs ended in `panic: test timed out` during teardown, which aborts cleanup and log collection; the longer daemon waits also need the headroom.
- **minikube `K8S_FAIL_CONNECT` exit 40 in the shared `setup cluster resources` action (8 distinct runs across 7 different days — the one steady setup flake)**: when the requested kubernetes version is missing from minikube's compiled-in version list (any version released after the pinned minikube — currently v1.35.5), `minikube start` verifies it with an **anonymous** GitHub API request, which is regularly rate-limited on shared runner IPs. `GITHUB_TOKEN` is not honored on that code path (verified in the minikube source, and disproven empirically on this PR's first CI round). Fixed by passing `--force` to `minikube start`: the kubernetes versions used in CI are pinned constants already validated by the PRs that bump them, so minikube's interactive-UX existence check adds nothing here, and an invalid version would still fail fast at the kubeadm/kubelet download. Because this lives in the shared action, every suite is covered, and CI can adopt new k8s patch releases the day they ship.
- **minikube `GUEST_START` exit 80** (5 runs in the dataset, two more observed during burn-in, one on another suite): minikube's internal 6-minute node-ready wait expires on slow runners. Now passes `--wait-timeout=15m`.
- **Corrupt cri-dockerd `.deb` (2 runs)**: curl ran without `--fail` and saved an HTTP error page as the package, which dpkg then choked on; added `--fail` and retries.
- **udev hygiene for the OSD disk on every runner type**: `use_local_disk_for_integration_test` returned early on runners without the `/mnt` resource disk (the iSCSI-fallback-disk runners), so they never received the udev `nowatch` rule for rook#8975 device re-probe storms; one burn-in artifact captured ~100 udev `change` events on the OSD disk. The rule is now installed before the early return, covering every runner type and the disk's first write.
- **PVC-bound wait expiring during pre-upgrade deploy** (caught by a burn-in round on the Helm path): `WaitUntilPVCIsBound` ran out of its 275s RetryLoop budget while the CSI provisioner pods were still starting. Fixed by setting `RETRY_MAX: 110` for this workflow, doubling the framework's base wait budget suite-wide instead of extending individual waits one flake at a time.

**Known residual class — root cause in ceph-volume:** the burn-in reproduced, with kernel forensics, a circular deadlock in the OSD `activate` init container: when the cluster's only OSD restarts (e.g. during the Ceph version upgrade), the krbd-mapped test volume on the same node stalls, and ceph-volume opens the stalled `/dev/rbd0` and blocks in uninterruptible sleep (`rwsem_down_write_slowpath` via `rbd_open`, hung-task warnings beyond 1100s) — so the OSD can never come up. The culprit is `ceph-volume raw activate`'s unconditional LUKS2/TPM2 discovery sweep over **all** block devices, which runs even with an explicit `--device` (`src/ceph-volume/ceph_volume/objectstore/raw.py`); #17724 hardens the rook-side fallback scan, but the sweep requires an upstream ceph-volume fix. Observed on runs 27325963851, 27333888237, and 27378983111 (artifacts contain dmesg/journal). Burn-in for this PR counts rounds as green when the only failures are this documented class.

Other small/episodic classes not addressed: OSDs never coming up on initial deploy (3 runs), filesystem not active (2 runs), day-clustered minikube incidents (exit codes 65/67/90), and a one-off `dl.k8s.io` CDN connection reset during kubelet download (minikube exit 100).

The final commit adds a **temporary burn-in matrix** (each upgrade job ×2 per round); it will be removed before this PR is undrafted. The plan is to re-run the workflow until there are 5 consecutive rounds with no failures outside the documented residual class.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.