### PR TITLE
osd: wipe partially provisioned devices during prepare

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -993,43 +993,79 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 		if err != nil {
 			return errors.Wrapf(err, "failed to clean up encrypted disks from other clusters")
 		}
-		return nil
-	}
-
-	for _, existingOSD := range existingOSDs {
-		// Wipe the devices that will be used for preparing OSD but already have OSD metadata from another ceph cluster
-		if existingOSD.CephFsid != a.clusterInfo.FSID {
-			osdID := existingOSD.OsdID
-			deviceToWipe := existingOSD.Device
-			osdDisk, encryptedBlock, err := getOSDDiskToBeWiped(context, existingOSD.Device)
-			if err != nil {
-				return errors.Wrapf(err, "failed to get the actual device path to be wiped for existing OSD %d with path %q", osdID, osdDisk.RealPath)
-			}
-			if osdDisk != nil {
-				deviceToWipe := osdDisk.RealPath
-				if encryptedBlock != "" {
-					err = RemoveEncryptedDevice(context, encryptedBlock)
-					if err != nil {
-						logger.Warningf("failed to remove stale dm device %q: %q", encryptedBlock, err)
-						continue
+	} else {
+		for _, existingOSD := range existingOSDs {
+			// Wipe the devices that will be used for preparing OSD but already have OSD metadata from another ceph cluster
+			if existingOSD.CephFsid != a.clusterInfo.FSID {
+				osdID := existingOSD.OsdID
+				deviceToWipe := existingOSD.Device
+				osdDisk, encryptedBlock, err := getOSDDiskToBeWiped(context, existingOSD.Device)
+				if err != nil {
+					return errors.Wrapf(err, "failed to get the actual device path to be wiped for existing OSD %d with path %q", osdID, osdDisk.RealPath)
+				}
+				if osdDisk != nil {
+					deviceToWipe := osdDisk.RealPath
+					if encryptedBlock != "" {
+						err = RemoveEncryptedDevice(context, encryptedBlock)
+						if err != nil {
+							logger.Warningf("failed to remove stale dm device %q: %q", encryptedBlock, err)
+							continue
+						}
 					}
+					logger.Infof("begin wiping OSD %d device %q belonging to a different ceph cluster %q ", osdID, deviceToWipe, existingOSD.CephFsid)
+					logger.Infof("zap OSD.%d on device path %q", osdID, deviceToWipe)
+					if err := ZapDevice(context, deviceToWipe); err != nil {
+						return errors.Wrapf(err, "failed to zap osd.%d path %q", osdID, deviceToWipe)
+					}
+					logger.Infof("successfully zapped osd.%d path %q", osdID, deviceToWipe)
+					logger.Infof("completed wiping OSD %d device %q belonging to a different ceph cluster", osdID, deviceToWipe)
+					// Since the device is wiped clean, clear the stale filesystem reference on the disk so that the wiped disk is not filtered out for filesystem check.
+					osdDisk.Filesystem = ""
+				} else {
+					logger.Infof("skip wiping OSD %d device %q belonging to a different ceph cluster %q since not a desired device", osdID, deviceToWipe, existingOSD.CephFsid)
 				}
-				logger.Infof("begin wiping OSD %d device %q belonging to a different ceph cluster %q ", osdID, deviceToWipe, existingOSD.CephFsid)
-				logger.Infof("zap OSD.%d on device path %q", osdID, deviceToWipe)
-				if err := ZapDevice(context, deviceToWipe); err != nil {
-					return errors.Wrapf(err, "failed to zap osd.%d path %q", osdID, deviceToWipe)
-				}
-				logger.Infof("successfully zapped osd.%d path %q", osdID, deviceToWipe)
-				logger.Infof("completed wiping OSD %d device %q belonging to a different ceph cluster", osdID, deviceToWipe)
-				// Since the device is wiped clean, clear the stale filesystem reference on the disk so that the wiped disk is not filtered out for filesystem check.
-				osdDisk.Filesystem = ""
-			} else {
-				logger.Infof("skip wiping OSD %d device %q belonging to a different ceph cluster %q since not a desired device", osdID, deviceToWipe, existingOSD.CephFsid)
 			}
 		}
 	}
 
+	if err := wipePartiallyProvisionedDevices(context, existingOSDs); err != nil {
+		return errors.Wrap(err, "failed to wipe partially provisioned devices")
+	}
+
 	return nil
+}
+
+// wipePartiallyProvisionedDevices zaps devices that have a ceph_bluestore filesystem signature
+// (from lsblk) but are not reported by ceph-volume raw list. This happens when a node reboots
+// mid-OSD-prepare, leaving the disk with an incomplete bluestore signature that cannot be
+// used to start an OSD and would otherwise block future provisioning.
+func wipePartiallyProvisionedDevices(context *clusterd.Context, existingOSDs map[string]osdInfoBlock) error {
+	for _, device := range context.Devices {
+		if device.Filesystem != "ceph_bluestore" {
+			continue
+		}
+		if deviceHasOSDData(device, existingOSDs) {
+			continue
+		}
+		logger.Infof("device %q has ceph_bluestore filesystem but is not reported by ceph-volume raw list, wiping as partially provisioned", device.RealPath)
+		if err := ZapDevice(context, device.RealPath); err != nil {
+			return errors.Wrapf(err, "failed to zap partially provisioned device %q", device.RealPath)
+		}
+		logger.Infof("successfully wiped partially provisioned device %q", device.RealPath)
+		device.Filesystem = ""
+	}
+	return nil
+}
+
+// deviceHasOSDData checks whether a device appears in the ceph-volume raw list output,
+// meaning it has valid OSD metadata and should not be wiped.
+func deviceHasOSDData(device *sys.LocalDisk, existingOSDs map[string]osdInfoBlock) bool {
+	for _, osd := range existingOSDs {
+		if device.RealPath == osd.Device || slices.Contains(strings.Split(device.DevLinks, " "), osd.Device) {
+			return true
+		}
+	}
+	return false
 }
 
 func wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context, currentClusterFSID string) error {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2330,6 +2330,83 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	context.Executor = executor
 	err = agent.WipeDevicesFromOtherClusters(context)
 	assert.NoError(t, err)
+
+	// `ceph-volume raw list` returns empty but the device has ceph_bluestore filesystem
+	// from an interrupted OSD prepare. The device should be zapped as partially provisioned.
+	zappedPartial := false
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+			return `{}`, nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		devicePath := "/dev/vdb"
+		if command == cryptsetupBinary && args[0] == "luksDump" {
+			return luksDump, nil
+		}
+		if command == "stdbuf" {
+			if !slices.Contains(args, "zap") || !slices.Contains(args, devicePath) {
+				return "", errors.Errorf("expected device %s to be zapped but got %v", devicePath, args)
+			}
+			zappedPartial = true
+			return "", nil
+		}
+		if command == "umount" {
+			return "not mounted", errors.New("not mounted")
+		}
+		if command == "wipefs" {
+			if args[1] != devicePath {
+				return "", errors.Errorf("expected device %s to be zapped but got %v", devicePath, args)
+			}
+			return "", nil
+		}
+		if command == "ceph-bluestore-tool" {
+			return "", nil
+		}
+		if command == "dd" {
+			return "", nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	partialDevice := &sys.LocalDisk{RealPath: "/dev/vdb", Filesystem: "ceph_bluestore"}
+	context = &clusterd.Context{
+		Devices: []*sys.LocalDisk{partialDevice},
+	}
+	context.Executor = executor
+	err = agent.WipeDevicesFromOtherClusters(context)
+	assert.NoError(t, err)
+	assert.True(t, zappedPartial, "partially provisioned device should have been zapped")
+	assert.Equal(t, "", partialDevice.Filesystem, "filesystem should be cleared after zap")
+
+	// `ceph-volume raw list` returns a valid OSD on /dev/vdb with ceph_bluestore.
+	// The device should NOT be zapped since it has valid OSD data.
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+			return `{
+				"0": {
+					"ceph_fsid": "c03d7353-96e5-4a41-98de-830dfff97d06",
+					"device": "/dev/vdb",
+					"osd_id": 0,
+					"osd_uuid": "abcd1234-0000-0000-0000-000000000000",
+					"type": "bluestore"
+				}
+			}`, nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		return "", errors.Errorf("ZapDevice should not be called for a device with valid OSD data: %s %v", command, args)
+	}
+	context = &clusterd.Context{
+		Devices: []*sys.LocalDisk{{RealPath: "/dev/vdb", Filesystem: "ceph_bluestore"}},
+	}
+	context.Executor = executor
+	err = agent.WipeDevicesFromOtherClusters(context)
+	assert.NoError(t, err)
 }
 
 func TestFindDeviceClass(t *testing.T) {


### PR DESCRIPTION
when the node reboots mid osd-prepare, the disk retains ceph-bluestore signature but the ceph-volume list return nothing. This leaves the device stuck, its neither wiped nor configurable.

THis PR detects these partially configured devices in WipeDevicesFromOtherClusters function and zap them so that they can be reprovisoned.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
