### PR TITLE
csi: check for operator chart label for ownership

### DIFF
--- a/pkg/operator/ceph/csi/operator_config.go
+++ b/pkg/operator/ceph/csi/operator_config.go
@@ -36,11 +36,24 @@ const (
 	cephCsiHelmDriversReleaseName = "ceph-csi-drivers"
 )
 
-func setHelmLabels(objMeta *metav1.ObjectMeta, clusterMeta metav1.ObjectMeta, releaseName, releaseNamespace string) {
-	// Skip helm annotations/labels if the cluster is not managed by Helm.
-	if _, ok := clusterMeta.Annotations["meta.helm.sh/release-name"]; !ok {
+func (r *ReconcileCSI) setHelmLabels(objMeta *metav1.ObjectMeta, clusterMeta metav1.ObjectMeta, releaseName, releaseNamespace string) {
+	deployment, err := r.context.Clientset.AppsV1().Deployments(r.opConfig.OperatorNamespace).Get(r.opManagerContext, "rook-ceph-operator", metav1.GetOptions{})
+	if err != nil {
+		logger.Warningf("failed to get rook-ceph-operator deployment. %v", err)
+	}
+
+	rookHelmReleaseName := false
+	if deployment != nil {
+		_, rookHelmReleaseName = deployment.Annotations["meta.helm.sh/release-name"]
+	}
+
+	_, clusterHelmReleaseName := clusterMeta.Annotations["meta.helm.sh/release-name"]
+
+	// Skip helm annotations/labels if the cluster or rook-ceph-operator is not managed by Helm.
+	if !rookHelmReleaseName && !clusterHelmReleaseName {
 		return
 	}
+
 	if objMeta.Labels == nil {
 		objMeta.Labels = map[string]string{}
 	}
@@ -70,7 +83,7 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			opConfig.Spec = spec
-			setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
+			r.setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, opConfig)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create ceph-CSI operator operator config CR %q", opConfig.Name)
@@ -83,7 +96,7 @@ func (r *ReconcileCSI) createOrUpdateOperatorConfig(cluster cephv1.CephCluster) 
 	}
 
 	opConfig.Spec = spec
-	setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
+	r.setHelmLabels(&opConfig.ObjectMeta, cluster.ObjectMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, opConfig)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update ceph-CSI operator operator config CR %q", opConfig.Name)
@@ -179,7 +192,7 @@ func (r *ReconcileCSI) createImageSetConfigmap(clusterMeta metav1.ObjectMeta) (s
 	err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: cm.Name, Namespace: r.opConfig.OperatorNamespace}, cm)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
+			r.setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, cm)
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to create imageSet cm  %q for ceph-CSI operator-config CR %q", cm.Name, opConfigCRName)
@@ -192,7 +205,7 @@ func (r *ReconcileCSI) createImageSetConfigmap(clusterMeta metav1.ObjectMeta) (s
 	}
 
 	cm.Data = data
-	setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
+	r.setHelmLabels(&cm.ObjectMeta, clusterMeta, operatorHelmReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, cm)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to updated imageSet cm  %q ceph-CSI operator-config CR %q", cm.Name, opConfigCRName)

--- a/pkg/operator/ceph/csi/operator_config_test.go
+++ b/pkg/operator/ceph/csi/operator_config_test.go
@@ -18,6 +18,7 @@ package csi
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
@@ -25,9 +26,11 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
+	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	testop "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apifake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +38,81 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestReconcileCSI_helmLabels(t *testing.T) {
+	const ns = "test"
+	tests := []struct {
+		name, opRelease, clusterRelease string
+		expectHelm                      bool
+	}{
+		{"rook operator helm chart only", operatorHelmReleaseName, "", true},
+		{"ceph cluster helm chart only", "", "my-ceph-cluster", true},
+		{"rook operator and ceph cluster helm charts", operatorHelmReleaseName, "my-ceph-cluster", true},
+		{"no helm charts", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := testop.New(t, 1)
+			opAnnots := map[string]string{}
+			if tt.opRelease != "" {
+				opAnnots["meta.helm.sh/release-name"] = tt.opRelease
+			}
+			_, err := clientset.AppsV1().Deployments(ns).Create(context.TODO(), &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "rook-ceph-operator", Namespace: ns, Annotations: opAnnots},
+			}, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			cluster := &cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "testCluster", Namespace: ns},
+				Spec: cephv1.ClusterSpec{CSI: cephv1.CSIDriverSpec{
+					ReadAffinity: cephv1.ReadAffinitySpec{Enabled: true, CrushLocationLabels: []string{"kubernetes.io/hostname"}},
+				}},
+			}
+			if tt.clusterRelease != "" {
+				cluster.Annotations = map[string]string{"meta.helm.sh/release-name": tt.clusterRelease}
+			}
+
+			s := scheme.Scheme
+			s.AddKnownTypes(cephv1.SchemeGroupVersion, &csiopv1.OperatorConfig{}, &csiopv1.Driver{}, &cephv1.CephCluster{}, &v1.ConfigMap{})
+			r := &ReconcileCSI{
+				context: &clusterd.Context{
+					Clientset:           clientset,
+					RookClientset:       rookclient.NewSimpleClientset(),
+					ApiExtensionsClient: apifake.NewClientset(),
+				},
+				opManagerContext: context.TODO(),
+				opConfig:         opcontroller.OperatorConfig{OperatorNamespace: ns},
+				client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(cluster).Build(),
+			}
+			assert.NoError(t, r.setParams())
+			assert.NoError(t, r.createOrUpdateOperatorConfig(*cluster))
+
+			c := clienttest.CreateTestClusterInfo(3)
+			c.Namespace = ns
+			assert.NoError(t, r.createOrUpdateDriverResources(*cluster, c))
+
+			check := func(meta *metav1.ObjectMeta, release string) {
+				if !tt.expectHelm {
+					assert.NotContains(t, meta.Labels, "app.kubernetes.io/managed-by")
+					return
+				}
+				assert.Equal(t, release, meta.Annotations["meta.helm.sh/release-name"])
+			}
+
+			opConfig := &csiopv1.OperatorConfig{}
+			assert.NoError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: opConfigCRName, Namespace: ns}, opConfig))
+			check(&opConfig.ObjectMeta, cephCsiHelmDriversReleaseName)
+
+			cm := &v1.ConfigMap{}
+			assert.NoError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: "rook-csi-operator-image-set-configmap", Namespace: ns}, cm))
+			check(&cm.ObjectMeta, operatorHelmReleaseName)
+
+			driver := &csiopv1.Driver{}
+			assert.NoError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s.rbd.csi.ceph.com", ns), Namespace: ns}, driver))
+			check(&driver.ObjectMeta, cephCsiHelmDriversReleaseName)
+		})
+	}
+}
 
 func TestReconcileCSI_createOrUpdateOperatorConfig(t *testing.T) {
 	ns := "test"

--- a/pkg/operator/ceph/csi/operator_driver.go
+++ b/pkg/operator/ceph/csi/operator_driver.go
@@ -229,7 +229,7 @@ func (r ReconcileCSI) createOrUpdateDriverResource(clusterInfo *cephclient.Clust
 	err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: driverResource.Name, Namespace: r.opConfig.OperatorNamespace}, driverResource)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
+			r.setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 			err = r.client.Create(r.opManagerContext, driverResource)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create CSI-operator driver CR %q", driverResource.Name)
@@ -242,7 +242,7 @@ func (r ReconcileCSI) createOrUpdateDriverResource(clusterInfo *cephclient.Clust
 	}
 
 	driverResource.Spec = spec
-	setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
+	r.setHelmLabels(&driverResource.ObjectMeta, clusterMeta, cephCsiHelmDriversReleaseName, r.opConfig.OperatorNamespace)
 	err = r.client.Update(r.opManagerContext, driverResource)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update CSI-operator driver CR %q", driverResource.Name)


### PR DESCRIPTION
adding check if operator is installed via helm with existing cluster chart check so that if some users install only operator chart and not the cluster chart we are still able to transfer the ownership of old yaml based csi resource to new helm based csi.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17696


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
