### PR TITLE
ci: fix toolbox exec race in validate_cluster.sh

### DIFF
--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -32,7 +32,12 @@ fi
 #############
 # FUNCTIONS #
 #############
-EXEC_COMMAND="kubectl -n rook-ceph exec $(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}') -- ceph --connect-timeout 10"
+# Wait for the toolbox to be ready before the per-daemon wait budgets start, and exec through
+# the deployment so every call resolves a currently-ready pod instead of a name captured once
+# (a pod whose container is still creating, or that has been replaced, fails every exec with
+# "container not found").
+kubectl -n rook-ceph rollout status deploy/rook-ceph-tools --timeout=120s
+EXEC_COMMAND="kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph --connect-timeout 10"
 
 function wait_for_daemon() {
   timeout=90
@@ -51,21 +56,15 @@ function wait_for_daemon() {
 }
 
 function test_demo_mon {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq quorum")
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq quorum"
 }
 
 function test_demo_mgr {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'mgr:'")
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'mgr:'"
 }
 
 function test_demo_osd {
-  # shellcheck disable=SC2046
-  ret_val=$(wait_for_daemon "$EXEC_COMMAND -s | grep -sq \"$OSD_COUNT osds: $OSD_COUNT up.*, $OSD_COUNT in.*\"")
-  # debug info for an intermittent failure
-  echo "Return value = $ret_val"
-  return $ret_val
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq \"$OSD_COUNT osds: $OSD_COUNT up.*, $OSD_COUNT in.*\""
 }
 
 function test_demo_rgw {
@@ -82,23 +81,19 @@ function test_demo_mds {
   # NOTE: metadata server always takes up to 5 sec to run
   # so we first check if the pools exit, from that we assume that
   # the process will start. We stop waiting after 10 seconds.
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND osd dump | grep -sq cephfs && $EXEC_COMMAND -s | grep -sq up")
+  wait_for_daemon "$EXEC_COMMAND osd dump | grep -sq cephfs && $EXEC_COMMAND -s | grep -sq up"
 }
 
 function test_demo_rbd_mirror {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'rbd-mirror:'")
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'rbd-mirror:'"
 }
 
 function test_demo_fs_mirror {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'cephfs-mirror:'")
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'cephfs-mirror:'"
 }
 
 function test_demo_pool {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq '11 pools'")
+  wait_for_daemon "$EXEC_COMMAND -s | grep -sq '11 pools'"
 }
 
 function test_csi {


### PR DESCRIPTION
## Description of your changes

`validate_cluster.sh` builds its ceph exec command around a toolbox **pod name captured once at script start**, with no readiness wait. When the toolbox container is still being created (or the pod has been replaced), every check fails with `error: Internal error occurred: unable to upgrade connection: container not found ("rook-ceph-tools")` for the entire wait window, and the mon quorum check times out without ever observing the actual cluster state.

This is the signature of every sampled `wait for ceph cluster 1 to be ready` flake on master pushes between 2026-03-10 and 2026-04-24 (e.g. [multi-cluster-mirroring run](https://github.com/rook/rook/actions/runs/24907957622): 95 consecutive container-not-found errors filling the whole window); the main `canary` job's `wait for ceph to be ready` failures in the same window share the script. The race is load-dependent and remains latent.

A second, compounding bug: the `test_demo_*` functions use `return $(wait_for_daemon ...)`. The command substitution runs `wait_for_daemon` in a subshell and captures its stdout, so the `current status:` + `ceph -s` diagnostics printed on timeout are never displayed — instead the captured text becomes the argument of `return`, which fails with `return: numeric argument required` and aborts the script with a misleading exit code 2 (visible verbatim in the run linked above).

Changes:

- Wait for the toolbox deployment rollout (120s) before the per-daemon wait budgets start, and exec through `deploy/rook-ceph-tools` so every call resolves a currently-ready pod — matching how `collect-logs.sh` and `github-action-helper.sh` already invoke the toolbox. (`rollout status` rather than `kubectl wait -l ...`, which errors instantly on a momentarily-empty selector.)
- Call `wait_for_daemon` directly in all `test_demo_*` functions so its exit status propagates and its timeout diagnostics actually print. The osd variant's captured `Return value` debug echo had the same problem and is removed.

No behavior change on the success path. Marked do-not-merge pending observation across CI runs.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.