### PR TITLE
osd: do not scan rbd devices in raw activate fallback

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -205,7 +205,18 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 	cat "$OSD_LIST"
 
 	if ! find_device < "$OSD_LIST"; then
-		ceph-volume raw list > "$OSD_LIST"
+		# The disk may have been renamed, so scan disks to find the right one. Build the
+		# scan list explicitly instead of letting a bare 'ceph-volume raw list' scan every
+		# block device: opening an rbd device can block in uninterruptible sleep while this
+		# OSD is down (the same deadlock the lvm filter above prevents for lvm-mode OSDs).
+		# Skip rbd, nbd, and drbd (network-backed devices that can hang when their backing
+		# storage is unavailable) and zram (volatile RAM); Rook never provisions OSDs on any
+		# of these. loop devices are intentionally kept, since OSDs on loop devices are
+		# supported for CI and local testing.
+		SCAN_DEVICES="$(lsblk --noheadings --paths --list --output NAME,TYPE | awk '$2 == "disk" || $2 == "part" {print $1}' | grep -vE '^/dev/(rbd|nbd|zram|drbd)' || true)"
+		[[ -z "$SCAN_DEVICES" ]] && { echo "no devices to scan for OSD $OSD_ID" ; exit 1 ; }
+		# shellcheck disable=SC2086 # word splitting of the device list is intended
+		ceph-volume raw list $SCAN_DEVICES > "$OSD_LIST"
 		cat "$OSD_LIST"
 
 		DEVICE="$(find_device < "$OSD_LIST")"


### PR DESCRIPTION
**What this PR does (scope honestly narrowed after burn-in):** hardens the device-rename fallback in the raw-mode OSD `activate` init container. When the configured device path doesn't match, the script previously ran a bare `ceph-volume raw list`, which enumerates **every** block device and opens each one to read bluestore labels. Opening a krbd device whose backing cluster is unhealthy blocks in **uninterruptible sleep**, and when that device's I/O depends on the OSD being activated, activation deadlocks. The fallback now builds its scan list explicitly with lsblk (disks and partitions), excludes `rbd|nbd|loop|zram|drbd`, and fails fast if the filtered list is empty. Excluding these is safe because Rook never provisions OSDs on those device types — device discovery explicitly skips rbd devices (`pkg/clusterd/disk.go`) — so the fallback can never legitimately need to find an OSD on them.

**What this PR does NOT fix — the full deadlock, which needs an upstream ceph-volume change:** this PR's own burn-in reproduced the deadlock with the fallback fix in place ([run 27378983111](https://github.com/rook/rook/actions/runs/27378983111), same kernel signature as [27325963851](https://github.com/rook/rook/actions/runs/27325963851) and [27333888237](https://github.com/rook/rook/actions/runs/27333888237)). Root cause in the ceph-volume source: `raw activate` runs an **unconditional LUKS2/TPM2 discovery sweep over all block devices** (`src/ceph-volume/ceph_volume/objectstore/raw.py`, `activate()`: `for d in disk.lsblk_all(...)` → `CephLuks2(device).is_ceph_encrypted` opens and reads every device) — **even when given an explicit `--device`**. No script-side argument can prevent that sweep from opening a stalled `/dev/rbd0`:

```
task:ceph-volume     state:D
Call Trace:
 rwsem_down_write_slowpath+0x28c/0x4f0
 ? rbd_open+0x4f/0x70 [rbd]
 down_write+0x47/0x60
 blkdev_llseek+0x34/0x70
```

Fixing that sweep requires an upstream ceph-volume change; until fixed ceph images ship, the deadlock remains a documented residual CI class (tracked in #17714, whose burn-in counts it as such). This change still stands on its own: it makes the Rook-controlled scan safe regardless of ceph version, mirroring the lvm-mode branch's existing rbd filter.

**Scope notes:** this changes only what the activate container *scans* during the rename fallback. End-user LVM on RBD volumes is unaffected (the lvm filter is scoped to the activate container's own `/etc/lvm`, not the host). PVC-based OSDs (including RBD-backed PVCs) activate via the stable per-claim bridge path and don't rely on this fallback.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.