### PR TITLE
core: remove dead code from pkg/daemon and pkg/util

### DIFF
--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -34,21 +34,6 @@ type AuthListEntry struct {
 	Entity string `json:"entity"`
 }
 
-// AuthGetOrCreate will either get or create a user with the given capabilities.  The keyring for the
-// user will be written to the given keyring path.
-func AuthGetOrCreate(context *clusterd.Context, clusterInfo *ClusterInfo, name, keyringPath string, caps []string) error {
-	logger.Infof("getting or creating ceph auth %q", name)
-	args := append([]string{"auth", "get-or-create", name, "-o", keyringPath}, caps...)
-	cmd := NewCephCommand(context, clusterInfo, args)
-	cmd.JsonOutput = false
-	_, err := cmd.Run()
-	if err != nil {
-		return errors.Wrapf(err, "failed to auth get-or-create for %s", name)
-	}
-
-	return nil
-}
-
 // AuthGetKey gets the key for the given user.
 func AuthGetKey(context *clusterd.Context, clusterInfo *ClusterInfo, name string) (string, error) {
 	logger.Infof("getting ceph auth key %q", name)

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -249,15 +249,6 @@ func (c *CephToolCommand) RunWithTimeout(timeout time.Duration) ([]byte, error) 
 	return c.run()
 }
 
-// ExecuteRBDCommandWithTimeout executes the 'rbd' command with a timeout of 1
-// minute. This method is left as a special case in which the caller has fully
-// configured its arguments. It is future work to integrate this case into the
-// generalization.
-func ExecuteRBDCommandWithTimeout(context *clusterd.Context, args []string) (string, error) {
-	output, err := context.Executor.ExecuteCommandWithTimeout(exec.CephCommandsTimeout, RBDTool, args...)
-	return output, err
-}
-
 func ExecuteCephCommandWithRetry(
 	cmd func() (string, []byte, error),
 	retries int,

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -278,16 +278,6 @@ func activeRanksSuccess(upCount, desiredRanks int, moreIsOkay bool) bool {
 	return upCount == desiredRanks
 }
 
-// MarkFilesystemAsDown marks a Ceph filesystem as down.
-func MarkFilesystemAsDown(context *clusterd.Context, clusterInfo *ClusterInfo, fsName string) error {
-	args := []string{"fs", "set", fsName, "cluster_down", "true"}
-	_, err := NewCephCommand(context, clusterInfo, args).Run()
-	if err != nil {
-		return errors.Wrapf(err, "failed to set file system %s to cluster_down", fsName)
-	}
-	return nil
-}
-
 // failMDS instructs Ceph to fail an mds daemon.
 func failMDS(context *clusterd.Context, clusterInfo *ClusterInfo, gid int) error {
 	args := []string{"mds", "fail", strconv.Itoa(gid)}

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -50,16 +50,6 @@ type OSDNodeUsage struct {
 	Pgs         json.Number `json:"pgs"`
 }
 
-type OSDPerfStats struct {
-	PerfInfo []struct {
-		ID    json.Number `json:"id"`
-		Stats struct {
-			CommitLatency json.Number `json:"commit_latency_ms"`
-			ApplyLatency  json.Number `json:"apply_latency_ms"`
-		} `json:"perf_stats"`
-	} `json:"osd_perf_infos"`
-}
-
 type OSDDump struct {
 	OSDs []struct {
 		OSD json.Number `json:"osd"`

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -200,21 +200,6 @@ func IsClusterClean(context *clusterd.Context, clusterInfo *ClusterInfo, pgHealt
 	return msg, true, nil
 }
 
-// IsClusterCleanError returns an error indicating if the cluster is fully clean yet (i.e., all placement
-// groups are in the active+clean state). It returns nil if the cluster is clean.
-// Using IsClusterClean is recommended if you want to differentiate between a failure of the status query and
-// an unclean cluster.
-func IsClusterCleanError(context *clusterd.Context, clusterInfo *ClusterInfo, pgHealthyRegex string) error {
-	msg, clean, err := IsClusterClean(context, clusterInfo, pgHealthyRegex)
-	if err != nil {
-		return err
-	}
-	if !clean {
-		return errors.New(msg)
-	}
-	return nil
-}
-
 func isClusterClean(status CephStatus, pgHealthyRegex *regexp.Regexp) (string, bool) {
 	if status.PgMap.NumPgs == 0 {
 		// there are no PGs yet, that still counts as clean

--- a/pkg/daemon/multus/config.go
+++ b/pkg/daemon/multus/config.go
@@ -239,10 +239,6 @@ func (c *ValidationTestConfig) Validate() error {
 	return nil
 }
 
-func NewSharedStorageAndWorkerNodesValidationTestConfig() *ValidationTestConfig {
-	return NewDefaultValidationTestConfig()
-}
-
 const (
 	DedicatedStorageNodeType = "storage-nodes"
 	DedicatedWorkerNodeType  = "worker-nodes"

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -17,29 +17,14 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "util")
-
-func WriteFile(filePath string, contentBuffer bytes.Buffer) error {
-	dir := filepath.Dir(filePath)
-	if err := os.MkdirAll(dir, 0o744); err != nil {
-		return fmt.Errorf("failed to create config file directory at %s: %+v", dir, err)
-	}
-	if err := os.WriteFile(filePath, contentBuffer.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to write config file to %s: %+v", filePath, err)
-	}
-
-	return nil
-}
 
 func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	contents, err := os.ReadFile(filepath.Clean(path))
@@ -49,16 +34,6 @@ func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	}
 
 	logger.Infof("Config file %s:\n%s", path, string(contents))
-}
-
-// PathToProjectRoot returns the path to the root of the rook repo on the current host.
-// This is primarily useful for tests.
-func PathToProjectRoot() string {
-	_, path, _, _ := runtime.Caller(0) // get path to current file (<root>/pkg/util/file.go)
-	util := filepath.Dir(path)         // <root>/pkg/util
-	pkg := filepath.Dir(util)          // <root>/pkg
-	root := filepath.Dir(pkg)          // <root>
-	return root
 }
 
 // CreateTempFile creates a temporary file with content passed as an argument


### PR DESCRIPTION
## Description of your changes

Dead-code removal across `pkg/daemon` and `pkg/util`. None of the removed symbols had any callers or references anywhere in the repository, tests included (verified with `deadcode`, `staticcheck U1000`, repo-wide grep, and an exported-symbol audit):

**`pkg/daemon/ceph/client`:**
- `auth.go`: `AuthGetOrCreate`
- `command.go`: `ExecuteRBDCommandWithTimeout`
- `filesystem.go`: `MarkFilesystemAsDown`
- `status.go`: `IsClusterCleanError` (`IsClusterClean` itself remains in use)
- `osd.go`: `OSDPerfStats` type (unmarshal target whose consumer was removed long ago)

**`pkg/util`:**
- `file.go`: `WriteFile` (superseded by direct `os.WriteFile` usage), `PathToProjectRoot`, and the now-unused `bytes`/`fmt`/`runtime` imports

**`pkg/daemon/multus`:**
- `config.go`: `NewSharedStorageAndWorkerNodesValidationTestConfig`, a wrapper that simply returned `NewDefaultValidationTestConfig()`; all sibling constructors remain in use by the multus validation CLI

This PR supersedes #17728 and #17729, which are closed in its favor. `go build`, `go vet`, `go test`, and `gofmt` are clean. No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.