### PR TITLE
core: remove unused file helpers from pkg/util

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -17,29 +17,14 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "util")
-
-func WriteFile(filePath string, contentBuffer bytes.Buffer) error {
-	dir := filepath.Dir(filePath)
-	if err := os.MkdirAll(dir, 0o744); err != nil {
-		return fmt.Errorf("failed to create config file directory at %s: %+v", dir, err)
-	}
-	if err := os.WriteFile(filePath, contentBuffer.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to write config file to %s: %+v", filePath, err)
-	}
-
-	return nil
-}
 
 func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	contents, err := os.ReadFile(filepath.Clean(path))
@@ -49,16 +34,6 @@ func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	}
 
 	logger.Infof("Config file %s:\n%s", path, string(contents))
-}
-
-// PathToProjectRoot returns the path to the root of the rook repo on the current host.
-// This is primarily useful for tests.
-func PathToProjectRoot() string {
-	_, path, _, _ := runtime.Caller(0) // get path to current file (<root>/pkg/util/file.go)
-	util := filepath.Dir(path)         // <root>/pkg/util
-	pkg := filepath.Dir(util)          // <root>/pkg
-	root := filepath.Dir(pkg)          // <root>
-	return root
 }
 
 // CreateTempFile creates a temporary file with content passed as an argument


### PR DESCRIPTION
## Description of your changes

`WriteFile` and `PathToProjectRoot` in `pkg/util/file.go` had no callers anywhere in the repository, tests included (verified with `deadcode`, `staticcheck U1000`, and repo-wide grep). `WriteFile` has long been superseded by direct `os.WriteFile` usage. The now-unused `bytes`, `fmt`, and `runtime` imports are dropped; the file's remaining helpers (`WriteFileToLog`, `CreateTempFile`) are still in use.

`go build`, `go vet`, `go test`, and `gofmt` are clean. No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.