### PR TITLE
multus: remove unused validation test config constructor

### DIFF
--- a/pkg/daemon/multus/config.go
+++ b/pkg/daemon/multus/config.go
@@ -239,10 +239,6 @@ func (c *ValidationTestConfig) Validate() error {
 	return nil
 }
 
-func NewSharedStorageAndWorkerNodesValidationTestConfig() *ValidationTestConfig {
-	return NewDefaultValidationTestConfig()
-}
-
 const (
 	DedicatedStorageNodeType = "storage-nodes"
 	DedicatedWorkerNodeType  = "worker-nodes"


### PR DESCRIPTION
## Description of your changes

`NewSharedStorageAndWorkerNodesValidationTestConfig` in `pkg/daemon/multus/config.go` was a wrapper that simply returned `NewDefaultValidationTestConfig()` and had no callers anywhere in the repository, tests included (verified with `deadcode` and repo-wide grep). The sibling constructors are all referenced by the multus validation CLI and remain.

`go build`, `go vet`, `go test`, and `gofmt` are clean. No behavior change.

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.