### PR TITLE
test: retry keystone setup applies until webhooks are ready

### DIFF
--- a/tests/integration/ceph_base_keystone_test.go
+++ b/tests/integration/ceph_base_keystone_test.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
@@ -114,27 +115,27 @@ func InstallKeystoneInTestCluster(shelper *utils.K8sHelper, namespace string) er
 		return err
 	}
 
-	if err := shelper.ResourceOperation("apply", keystoneApiClusterIssuer(namespace)); err != nil {
+	if err := applyWithWebhookRetry(shelper, keystoneApiClusterIssuer(namespace), "ClusterIssuer"); err != nil {
 		logger.Errorf("Could not apply ClusterIssuer in namespace %s: %s", namespace, err)
 		return err
 	}
 
-	if err := shelper.ResourceOperation("apply", keystoneApiCaCertificate(namespace)); err != nil {
+	if err := applyWithWebhookRetry(shelper, keystoneApiCaCertificate(namespace), "CA Certificate"); err != nil {
 		logger.Errorf("Could not apply ClusterIssuer CA Certificate in namespace %s: %s", namespace, err)
 		return err
 	}
 
-	if err := shelper.ResourceOperation("apply", keystoneApiCaIssuer(namespace)); err != nil {
+	if err := applyWithWebhookRetry(shelper, keystoneApiCaIssuer(namespace), "CA Issuer"); err != nil {
 		logger.Errorf("Could not install CA Issuer in namespace %s: %s", namespace, err)
 		return err
 	}
 
-	if err := shelper.ResourceOperation("apply", keystoneApiCertificate(namespace)); err != nil {
+	if err := applyWithWebhookRetry(shelper, keystoneApiCertificate(namespace), "Certificate"); err != nil {
 		logger.Errorf("Could not create Certificate (request) in namespace %s", namespace)
 		return err
 	}
 
-	if err := shelper.ResourceOperation("apply", trustManagerBundle(namespace)); err != nil {
+	if err := applyWithWebhookRetry(shelper, trustManagerBundle(namespace), "trust-manager Bundle"); err != nil {
 		logger.Errorf("Could not create CA Certificate Bundle in namespace %s", namespace)
 		return err
 	}
@@ -317,6 +318,23 @@ func installHelmChart(helmHelper *utils.HelmHelper, namespace string, chartName 
 	}
 
 	return nil
+}
+
+// applyWithWebhookRetry retries a kubectl apply of a resource that is
+// validated by the cert-manager or trust-manager webhook. helm --wait returns
+// once the webhook deployments report ready, but the webhook service
+// endpoints may not be reachable from the apiserver yet, failing the apply
+// with "failed calling webhook ... connection refused".
+func applyWithWebhookRetry(shelper *utils.K8sHelper, manifest, description string) error {
+	var err error
+	// nolint:gosec // G115 no overflow in test
+	if utils.Retry(uint16(utils.RetryLoop), utils.RetryInterval*time.Second, "apply "+description, func() bool {
+		err = shelper.ResourceOperation("apply", manifest)
+		return err == nil
+	}) {
+		return nil
+	}
+	return err
 }
 
 func keystoneApiCaIssuer(namespace string) string {


### PR DESCRIPTION
**Flake-isolation experiment:** `TestCephKeystoneAuthSuite` is currently flaking with the suite failing before any test runs. This PR carries a targeted fix and will have its keystone jobs restarted until 5 consecutive successful runs, with unrelated pre-suite infra failures (minikube, etc.) not counted.

**The failure:** `InstallKeystoneInTestCluster` installs cert-manager and trust-manager via `helm --wait`, then immediately applies `ClusterIssuer`/`Certificate`/`Issuer`/`Bundle` resources. `helm --wait` returns when the webhook deployments report ready, but the webhook *service endpoints* may not be reachable from the apiserver yet, so the first apply is rejected:

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred:
failed calling webhook "trust.cert-manager.io": failed to call webhook:
Post "https://trust-manager.cert-manager.svc:443/validate-trust-cert-manager-io-v1alpha1-bundle?timeout=5s":
dial tcp 10.108.145.116:443: connect: connection refused
```

SetupSuite then continues with keystone never installed, and every test fails waiting 400s for RGW pods, burning ~12 minutes per failed job.

This signature accounts for 8 of the 13 failed keystone jobs sampled from the last two weeks (the rest are unrelated infra or genuine PR breakage), including runs on branches that cannot have caused it: master ([26603019298](https://github.com/rook/rook/actions/runs/26603019298)), dependabot GitHub Actions bumps ([27138432214](https://github.com/rook/rook/actions/runs/27138432214), [27138406446](https://github.com/rook/rook/actions/runs/27138406446)), and a mergify backport ([27358846748](https://github.com/rook/rook/actions/runs/27358846748)).

**The fix:** retry the webhook-validated applies until the webhook accepts connections, instead of failing the suite on the first attempt.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
