### PR TITLE
ci: harden CephSmokeSuite against CSI cold-start and teardown flakes

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -300,6 +300,28 @@ func (h *CephInstaller) waitForCluster() error {
 		}
 	}
 
+	// The CSI operator creates the driver deployments asynchronously, so they
+	// may still be pulling images when the ceph daemons are already up. If a
+	// PVC is created before the provisioner is ready, the first provisioning
+	// attempt fails and the external-provisioner sidecar backs off
+	// exponentially, delaying the volume creation by several minutes.
+	drivers := []string{"rbd", "cephfs"}
+	if h.settings.TestNFSCSI {
+		drivers = append(drivers, "nfs")
+	}
+	for _, driver := range drivers {
+		// Look up the deployment by name: the csi-operator does not set labels
+		// on the deployment object itself, only on its pod template. Wait for a
+		// single ready replica: the ctrlplugin runs two replicas with pod
+		// anti-affinity, so only one can be scheduled on a single-node CI
+		// cluster, and the provisioner sidecars use leader election so one
+		// ready replica is enough to provision volumes.
+		name := fmt.Sprintf("%s.%s.csi.ceph.com-ctrlplugin", h.settings.OperatorNamespace, driver)
+		if err := h.k8shelper.WaitForDeploymentReadyReplicas(name, h.settings.OperatorNamespace, 1, 2*utils.RetryLoop); err != nil {
+			return err
+		}
+	}
+
 	logger.Infof("Rook Cluster started")
 	if !h.settings.SkipOSDCreation {
 		return h.k8shelper.WaitForLabeledPodsToRun("app=rook-ceph-osd", h.settings.Namespace)

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -186,6 +186,25 @@ func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, e
 }
 
 func getManifestFromURL(url string) (string, error) {
+	var lastErr error
+	// retry the download since fetches from raw.githubusercontent.com fail
+	// transiently in CI
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			time.Sleep(5 * time.Second)
+		}
+		manifest, err := downloadManifest(url)
+		if err != nil {
+			logger.Warningf("failed to get manifest, will retry. %v", err)
+			lastErr = err
+			continue
+		}
+		return manifest, nil
+	}
+	return "", lastErr
+}
+
+func downloadManifest(url string) (string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -195,6 +214,9 @@ func getManifestFromURL(url string) (string, error) {
 		return "", errors.Wrapf(err, "failed to get manifest from url %s", url)
 	}
 	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", errors.Errorf("failed to get manifest from url %s. status: %s", url, res.Status)
+	}
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to read manifest from url %s", url)

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1551,6 +1551,23 @@ func (k8sh *K8sHelper) WaitForLabeledDeploymentsToBeReady(label, namespace strin
 	return k8sh.WaitForLabeledDeploymentsToBeReadyWithRetries(label, namespace, RetryLoop)
 }
 
+// WaitForDeploymentReadyReplicas waits for the named deployment to have at least minReady ready
+// replicas. Retry the number of times given.
+func (k8sh *K8sHelper) WaitForDeploymentReadyReplicas(name, namespace string, minReady int32, retries int) error {
+	ctx := context.TODO()
+	for i := 0; i < retries; i++ {
+		d, err := k8sh.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err == nil && d.Status.ReadyReplicas >= minReady {
+			logger.Infof("deployment %q in namespace %q has %d ready replicas", name, namespace, d.Status.ReadyReplicas)
+			return nil
+		}
+		logger.Infof("waiting for deployment %q in namespace %q to have %d ready replicas. ready=%d/%d, err=%v",
+			name, namespace, minReady, d.Status.ReadyReplicas, d.Status.Replicas, err)
+		time.Sleep(RetryInterval * time.Second)
+	}
+	return fmt.Errorf("giving up waiting for deployment %q in namespace %q to have %d ready replicas", name, namespace, minReady)
+}
+
 // WaitForLabeledDeploymentsToBeReadyWithRetries waits for all deployments matching the given label
 // selector to be fully ready. Retry the number of times given.
 func (k8sh *K8sHelper) WaitForLabeledDeploymentsToBeReadyWithRetries(label, namespace string, retries int) error {

--- a/tests/framework/utils/snapshot.go
+++ b/tests/framework/utils/snapshot.go
@@ -62,6 +62,21 @@ func (k8sh *K8sHelper) CheckSnapshotISReadyToUse(name, namespace string, retries
 	return false, fmt.Errorf("giving up waiting for %q snapshot in namespace %q", name, namespace)
 }
 
+// kubectlWithURLRetry runs kubectl with a manifest URL argument, retrying on
+// failure since fetching manifests from raw.githubusercontent.com fails
+// transiently in CI.
+func (k8sh *K8sHelper) kubectlWithURLRetry(args ...string) error {
+	var err error
+	for i := 0; i < 5; i++ {
+		if _, err = k8sh.Kubectl(args...); err == nil {
+			return nil
+		}
+		logger.Warningf("failed to run kubectl %v, will retry. %v", args, err)
+		time.Sleep(5 * time.Second)
+	}
+	return err
+}
+
 // snapshotController creates/applies or deletes the snapshotcontroller and required RBAC
 func (k8sh *K8sHelper) snapshotController(action string) error {
 	controllerURL := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, controllerPath)
@@ -78,11 +93,7 @@ func (k8sh *K8sHelper) snapshotController(action string) error {
 	}
 
 	rbac := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, rbacPath)
-	_, err = k8sh.Kubectl(action, "-f", rbac)
-	if err != nil {
-		return err
-	}
-	return nil
+	return k8sh.kubectlWithURLRetry(action, "-f", rbac)
 }
 
 // WaitForSnapshotController check snapshotcontroller is ready within given
@@ -130,39 +141,19 @@ func (k8sh *K8sHelper) snapshotCRD(action string) error {
 		}
 		return a
 	}
-	snapshotClassCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, snapshotClassCRDPath)
-	_, err := k8sh.Kubectl(args(snapshotClassCRD)...)
-	if err != nil {
-		return err
+	crdPaths := []string{
+		snapshotClassCRDPath,
+		volumeSnapshotContentsCRDPath,
+		volumeSnapshotCRDPath,
+		volumeGroupSnapshotClassCRDPath,
+		volumeGroupSnapshotContentsCRDPath,
+		volumeGroupSnapshotCRDPath,
 	}
-
-	snapshotContentsCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeSnapshotContentsCRDPath)
-	_, err = k8sh.Kubectl(args(snapshotContentsCRD)...)
-	if err != nil {
-		return err
-	}
-
-	snapshotCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeSnapshotCRDPath)
-	_, err = k8sh.Kubectl(args(snapshotCRD)...)
-	if err != nil {
-		return err
-	}
-	vgsClassCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeGroupSnapshotClassCRDPath)
-	_, err = k8sh.Kubectl(args(vgsClassCRD)...)
-	if err != nil {
-		return err
-	}
-
-	vgsContentsCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeGroupSnapshotContentsCRDPath)
-	_, err = k8sh.Kubectl(args(vgsContentsCRD)...)
-	if err != nil {
-		return err
-	}
-
-	vgsCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeGroupSnapshotCRDPath)
-	_, err = k8sh.Kubectl(args(vgsCRD)...)
-	if err != nil {
-		return err
+	for _, crdPath := range crdPaths {
+		crdURL := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, crdPath)
+		if err := k8sh.kubectlWithURLRetry(args(crdURL)...); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/tests/integration/ceph_base_block_test.go
+++ b/tests/integration/ceph_base_block_test.go
@@ -144,7 +144,8 @@ func blockCSISnapshotTest(helper *clients.TestClient, k8sh *utils.K8sHelper, s *
 		require.NoError(s.T(), err)
 	}()
 	logger.Infof("check snapshot controller is running")
-	err = k8sh.WaitForSnapshotController(15)
+	// the snapshot-controller image pull can take a few minutes in CI
+	err = k8sh.WaitForSnapshotController(90)
 	require.NoError(s.T(), err)
 	// create snapshot class
 	snapshotDeletePolicy := "Delete"
@@ -533,16 +534,28 @@ func blockTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, s *
 // periodically checking if block image count has changed to expected value
 // When creating pvc in k8s platform, it may take some time for the block Image to be bounded
 func retryBlockImageCountCheck(helper *clients.TestClient, clusterInfo *client.ClusterInfo, expectedImageCount int) error {
-	for i := 0; i < utils.RetryLoop; i++ {
+	// Allow twice the usual retry budget: if the first provisioning attempt fails
+	// (e.g. the pool is not created yet), the external-provisioner sidecar backs
+	// off exponentially and its next attempt can be several minutes out.
+	var lastErr error
+	for i := 0; i < 2*utils.RetryLoop; i++ {
 		blockImages, err := helper.BlockClient.ListAllImages(clusterInfo)
 		if err != nil {
-			return err
+			// Listing images can fail transiently while the pool is still being
+			// created, so keep retrying instead of aborting the check.
+			logger.Warningf("failed to list block images, will retry. %v", err)
+			lastErr = err
+		} else {
+			if expectedImageCount == len(blockImages) {
+				return nil
+			}
+			logger.Infof("Waiting for block image count to reach %d. current=%d. %+v", expectedImageCount, len(blockImages), blockImages)
+			lastErr = nil
 		}
-		if expectedImageCount == len(blockImages) {
-			return nil
-		}
-		logger.Infof("Waiting for block image count to reach %d. current=%d. %+v", expectedImageCount, len(blockImages), blockImages)
 		time.Sleep(time.Second * utils.RetryInterval)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("timed out waiting for image count to reach %d. last error: %v", expectedImageCount, lastErr)
 	}
 	return fmt.Errorf("timed out waiting for image count to reach %d", expectedImageCount)
 }

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -151,7 +151,8 @@ func fileSystemCSISnapshotTest(helper *clients.TestClient, k8sh *utils.K8sHelper
 		require.NoError(s.T(), err)
 	}()
 	logger.Infof("check snapshot controller is running")
-	err = k8sh.WaitForSnapshotController(15)
+	// the snapshot-controller image pull can take a few minutes in CI
+	err = k8sh.WaitForSnapshotController(90)
 	require.NoError(s.T(), err)
 	// create snapshot class
 	snapshotDeletePolicy := "Delete"

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -199,7 +199,9 @@ func deleteObjectStore(t *testing.T, k8sh *utils.K8sHelper, namespace, storeName
 func assertObjectStoreDeletion(t *testing.T, k8sh *utils.K8sHelper, namespace, storeName string) {
 	store := &cephv1.CephObjectStore{}
 	i := 0
-	retry := 10
+	// The operator may take a while to set the deletion condition when the
+	// reconcile queue is busy with the other resources the suite created.
+	retry := utils.RetryLoop
 	sleepTime := 3 * time.Second
 	for i = 0; i < retry; i++ {
 		storeStr, err := k8sh.GetResource("-n", namespace, "CephObjectStore", storeName, "-o", "json")
@@ -229,10 +231,14 @@ func assertObjectStoreDeletion(t *testing.T, k8sh *utils.K8sHelper, namespace, s
 		logger.Infof("waiting 3 more seconds for CephObjectStore %q to be unblocked by dependents", storeName)
 		time.Sleep(sleepTime)
 	}
-	assert.NotEqual(t, retry, i)
+	// require, not assert: if the deletion condition never showed up, the
+	// condition lookups below would dereference a nil condition and panic,
+	// aborting the whole suite without teardown.
+	require.NotEqual(t, retry, i, "timed out waiting for CephObjectStore %q deletion condition", storeName)
 	assert.Equal(t, cephv1.ConditionDeleting, store.Status.Phase) // phase == "Deleting"
 	// verify deletion is NOT blocked b/c object has dependents
 	cond := cephv1.FindStatusCondition(store.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
+	require.NotNil(t, cond)
 	assert.Equal(t, v1.ConditionFalse, cond.Status)
 	assert.Equal(t, cephv1.ObjectHasNoDependentsReason, cond.Reason)
 


### PR DESCRIPTION
This PR hardens `TestCephSmokeSuite` against the flake classes found by analyzing the last ~1000 runs (2026-04-07 to 2026-06-11) of `integration-test-smoke-suite.yaml`. Excluding genuinely-broken development branches and dependabot `go.mod.check` drift, the dominant smoke-specific failure classes on healthy branches were:

1. **`timed out waiting for image count to reach 1` in `TestBlockStorage_SmokeTest` (12 runs)** — the largest class. Failure artifacts show two mechanisms, both converging on the same outcome:
   - The csi-operator creates the driver deployments asynchronously, and the rbd ctrlplugin pod can still be pulling images when the test starts. The first `CreateVolume` lands on a just-started provisioner and fails with `failed to fetch monitor list using clusterID (smoke-ns)` (csi config not visible to the driver yet). The external-provisioner sidecar then backs off exponentially; in run 25901058637 the second provisioning attempt landed at 05:10:16 — **two seconds after** the test wait expired at 05:10:14.
   - The first attempts fail with `pool not found: pool (replicapool) not found in Ceph cluster` when provisioning races CephBlockPool reconciliation (run 25180004552), with the same backoff consequence. That run also shows `rbd ls` failing transiently (`exit status 124`) while pool PGs were being created, which `retryBlockImageCountCheck` treated as an immediate test failure instead of retrying.

   Fixes: wait for the drivers' ctrlplugin deployments to have a ready replica at the end of cluster install for all suites (looked up by deployment name since the csi-operator sets no labels on the deployment object, and waiting for a single ready replica since the two anti-affine replicas cannot both schedule on a single-node CI cluster); make `retryBlockImageCountCheck` retry on transient listing errors; and double its budget so one full provisioner backoff cycle fits inside the wait. The wait applies to all suites unconditionally; the vestigial `EnableCsiOperator` setting it would otherwise have been gated on (the csi-operator is installed unconditionally, so the setting is consumed nowhere) is removed separately in #17743.

2. **`delete_object_store` assertion panic (run 27333887722)** — when the CephObjectStore deletion condition did not appear within the 10×3s window, `assertObjectStoreDeletion` recorded the failure with `assert` and then dereferenced the nil condition: SIGSEGV, aborting the whole test binary with no teardown or operator log collection. Fixes: `require` for the timeout, nil-check before dereference, and the standard retry budget for the window.

3. **NFS/file snapshot infra fetch flakes (2 runs)** — `kubectl create -f https://raw.githubusercontent.com/...` for the external-snapshotter CRDs/controller has no retry, and `getManifestFromURL` neither retried nor checked the HTTP status (an error page could be piped to kubectl as a manifest). A 75s `WaitForSnapshotController` budget also raced the snapshot-controller image pull. Fixes: retry URL-based kubectl calls and manifest downloads, fail on non-200, bump the wait to 450s in the block and file tests.

Setup-phase classes seen in the same analysis are intentionally **not** addressed here: minikube `K8S_FAIL_CONNECT` GitHub rate-limiting and cri-dockerd `.deb` corruption are fixed by the shared-action changes in #17714, and the helm `empty index.yaml` cache class has a maintainer branch in flight.

**Burn-in results:** with a temporary commit doubling the smoke matrix (4 jobs/round, since dropped), the smoke workflow passed **5 consecutive rounds (20/20 jobs green)** on run 27392166168 attempts 1–5. After making the readiness wait unconditional for all suites, the smoke workflow passed **another 5 consecutive rounds (10/10 jobs green)** on run 27426714739 attempts 1–5, and all integration suites (helm, upgrade, object, multi-cluster, keystone, canary) were green on the final head, including the suites that newly gained the wait.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
