### PR TITLE
osd: verify freshly prepared devices appear in raw list results

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -177,6 +178,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	}
 
 	// Check if the PVC is an LVM block device (certain StorageClass do this)
+	var preparedRawDevices []string
 	if a.pvcBacked {
 		for _, device := range devices.Entries {
 			dev := device.Config.Name
@@ -190,7 +192,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			return nil, errors.Wrap(err, "failed to initialize devices on PVC")
 		}
 	} else {
-		err = a.initializeDevices(context, devices)
+		preparedRawDevices, err = a.initializeDevices(context, devices)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to initialize osd")
 		}
@@ -216,9 +218,81 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
+
+	// "ceph-volume raw list" without a device argument can miss freshly prepared OSDs
+	// (transiently right after mkfs, or persistently on Ceph versions where the listing of all
+	// devices is broken while listing a specific device still works). Without this check the
+	// prepare job would silently report fewer OSDs than it just prepared and the operator would
+	// never create the missing OSD deployments.
+	if !isEncrypted {
+		rawOsds, err = ensurePreparedDevicesListed(context, a.clusterInfo, rawOsds, preparedRawDevices, a.devices)
+		if err != nil {
+			return nil, err
+		}
+	}
 	osds = appendOSDInfo(osds, rawOsds)
 
 	return osds, err
+}
+
+// Number of attempts and delay between them when a freshly prepared device is missing from the
+// "ceph-volume raw list" results. The interval is a variable so unit tests can shorten it.
+const rawListMissingDeviceRetries = 5
+
+var rawListMissingDeviceRetryInterval = 3 * time.Second
+
+// ensurePreparedDevicesListed verifies that every device that was just prepared in raw mode is
+// represented in the OSD list reported by "ceph-volume raw list". Any prepared device missing
+// from the results is listed individually ("ceph-volume raw list <device>"), with retries to
+// ride out udev settling right after the OSD was created. If a prepared device still yields no
+// OSD, an error is returned so the prepare job fails loudly instead of silently under-reporting
+// the OSDs on the node.
+func ensurePreparedDevicesListed(context *clusterd.Context, clusterInfo *client.ClusterInfo, osds []oposd.OSDInfo, preparedDevices []string, devices []DesiredDevice) ([]oposd.OSDInfo, error) {
+	for _, device := range preparedDevices {
+		if deviceInOSDInfoList(device, osds) {
+			continue
+		}
+
+		recovered := false
+		for attempt := 1; attempt <= rawListMissingDeviceRetries; attempt++ {
+			logger.Warningf("prepared device %q is missing from the ceph-volume raw list results, listing the device individually (attempt %d/%d)", device, attempt, rawListMissingDeviceRetries)
+			deviceOsds, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, device, "", "", false, false, devices)
+			if err != nil {
+				logger.Warningf("failed to list raw OSD on device %q. %v", device, err)
+			} else if len(deviceOsds) > 0 {
+				osds = appendOSDInfo(osds, deviceOsds)
+				recovered = true
+				break
+			}
+			time.Sleep(rawListMissingDeviceRetryInterval)
+		}
+		if !recovered {
+			return nil, errors.Errorf("an OSD was prepared on device %q, but ceph-volume does not report it after %d attempts", device, rawListMissingDeviceRetries)
+		}
+	}
+
+	return osds, nil
+}
+
+// deviceInOSDInfoList returns true if the given device path is the block path of one of the
+// given OSDs. Paths are compared after symlink resolution since ceph-volume may report a device
+// through a different alias (e.g. /dev/sdb1 configured as /dev/disk/by-id/...-part1).
+func deviceInOSDInfoList(device string, osds []oposd.OSDInfo) bool {
+	resolve := func(path string) string {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return resolved
+		}
+		return path
+	}
+
+	resolvedDevice := resolve(device)
+	for _, osd := range osds {
+		if osd.BlockPath == device || resolve(osd.BlockPath) == resolvedDevice {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *DeviceOsdMapping, lvBackedPV bool) (string, string, string, error) {
@@ -475,18 +549,20 @@ func lvmModeAllowed(device *DeviceOsdIDEntry, storeConfig *config.StoreConfig) b
 	return true
 }
 
-func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceOsdMapping) error {
+// initializeDevices prepares the given devices with ceph-volume and returns the paths of the
+// devices that were newly prepared in raw mode.
+func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceOsdMapping) ([]string, error) {
 	// Should we allow ceph-volume raw mode?
 	allowRawMode, err := a.allowRawMode(context)
 	if err != nil {
-		return errors.Wrap(err, "failed to determine which ceph-volume mode to use")
+		return nil, errors.Wrap(err, "failed to determine which ceph-volume mode to use")
 	}
 
 	// If not raw mode we must execute a few LVM prerequisites
 	if !allowRawMode {
 		err = lvmPreReq(context)
 		if err != nil {
-			return errors.Wrap(err, "failed to run lvm prerequisites")
+			return nil, errors.Wrap(err, "failed to run lvm prerequisites")
 		}
 	}
 
@@ -518,26 +594,29 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		}
 	}
 
-	err = a.initializeDevicesRawMode(context, rawDevices)
+	preparedRawDevices, err := a.initializeDevicesRawMode(context, rawDevices)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = a.initializeDevicesLVMMode(context, lvmDevices)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return preparedRawDevices, nil
 }
 
-func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *DeviceOsdMapping) error {
+// initializeDevicesRawMode prepares the given devices with "ceph-volume raw prepare" and returns
+// the paths of the devices that were newly prepared.
+func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *DeviceOsdMapping) ([]string, error) {
 	baseCommand := "stdbuf"
 	cephVolumeMode := "raw"
 	storeFlag := a.storeConfig.GetStoreFlag()
 
 	baseArgs := []string{"-oL", cephVolumeCmd, cephVolumeMode, "prepare", storeFlag}
 
+	var preparedDevices []string
 	for name, device := range devices.Entries {
 		deviceArg := path.Join("/dev", name)
 		if device.Data == -1 {
@@ -573,15 +652,16 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 				}
 
 				// Return failure
-				return errors.Wrapf(err, "failed to run ceph-volume raw command. %s", op) // fail return here as validation provided by ceph-volume
+				return nil, errors.Wrapf(err, "failed to run ceph-volume raw command. %s", op) // fail return here as validation provided by ceph-volume
 			}
 			logger.Infof("%v", op)
+			preparedDevices = append(preparedDevices, deviceArg)
 		} else {
 			logger.Infof("skipping device %q with osd %d already configured", deviceArg, device.Data)
 		}
 	}
 
-	return nil
+	return preparedDevices, nil
 }
 
 func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *DeviceOsdMapping) error {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -579,6 +579,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "sgdisk" {
 				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
 			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
 		deviceClassSet := false
@@ -588,16 +591,6 @@ func TestConfigureCVDevices(t *testing.T) {
 				assert.Equal(t, "myclass", args[8])
 				deviceClassSet = true
 				return "", nil
-			}
-			return "", errors.Errorf("unknown command %s %s", command, args)
-		}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
-			if args[0] == "auth" && args[1] == "get-or-create-key" {
-				return "{\"key\":\"mysecurekey\"}", nil
-			}
-			if args[1] == "ceph-volume" && args[2] == "--log-path" && args[3] == "/tmp/ceph-log" {
-				return `{}`, nil
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
@@ -612,9 +605,10 @@ func TestConfigureCVDevices(t *testing.T) {
 				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
 			},
 		}
-		_, err := agent.configureCVDevices(context, devices)
+		deviceOSDs, err := agent.configureCVDevices(context, devices)
 		assert.Nil(t, err)
 		assert.True(t, deviceClassSet)
+		assert.Len(t, deviceOSDs, 1)
 	}
 
 	{
@@ -669,6 +663,107 @@ func TestConfigureCVDevices(t *testing.T) {
 		_, err := agent.configureCVDevices(context, devices)
 		assert.Nil(t, err)
 		assert.True(t, deviceClassSet)
+	}
+
+	{
+		// "ceph-volume raw list" without a device argument can miss freshly prepared OSDs.
+		// The freshly prepared device must be listed individually and the OSD must be returned.
+		t.Log("Test case for a raw mode OSD missing from the ceph-volume raw list results")
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
+			if command == "lsblk" && (args[0] == "/dev/vdb1") {
+				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="part" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
+			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" && args[6] == "/dev/vdb1" {
+				// listing the specific device finds the OSD
+				return cephVolumeRawPartitionTestResult, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
+				// listing all devices misses the freshly prepared OSD
+				return `{}`, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
+			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" {
+				return "", nil
+			}
+			if command == "cryptsetup" && args[0] == "luksDump" {
+				return "", errors.Errorf("%s is not a valid LUKS device", args[1])
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		clusterInfo := &cephclient.ClusterInfo{
+			FSID:    clusterFSID,
+			Context: context.TODO(),
+		}
+		context := &clusterd.Context{Executor: executor, ConfigDir: cephConfigDir}
+		agent := &OsdAgent{clusterInfo: clusterInfo, nodeName: nodeName, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+		devices := &DeviceOsdMapping{
+			Entries: map[string]*DeviceOsdIDEntry{
+				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
+			},
+		}
+		deviceOSDs, err := agent.configureCVDevices(context, devices)
+		assert.Nil(t, err)
+		assert.Len(t, deviceOSDs, 1)
+		assert.Equal(t, "/dev/vdb1", deviceOSDs[0].BlockPath)
+	}
+
+	{
+		// If a freshly prepared device cannot be listed at all, the prepare job must fail
+		// instead of silently reporting fewer OSDs than were prepared.
+		t.Log("Test case for a raw mode OSD missing from all ceph-volume raw list results")
+		origRetryInterval := rawListMissingDeviceRetryInterval
+		rawListMissingDeviceRetryInterval = 0
+		defer func() { rawListMissingDeviceRetryInterval = origRetryInterval }()
+
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
+				return `{}`, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
+			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" {
+				return "", nil
+			}
+			if command == "cryptsetup" && args[0] == "luksDump" {
+				return "", errors.Errorf("%s is not a valid LUKS device", args[1])
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		clusterInfo := &cephclient.ClusterInfo{
+			FSID:    clusterFSID,
+			Context: context.TODO(),
+		}
+		context := &clusterd.Context{Executor: executor, ConfigDir: cephConfigDir}
+		agent := &OsdAgent{clusterInfo: clusterInfo, nodeName: nodeName, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+		devices := &DeviceOsdMapping{
+			Entries: map[string]*DeviceOsdIDEntry{
+				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
+			},
+		}
+		_, err := agent.configureCVDevices(context, devices)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ceph-volume does not report it")
 	}
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix. Addresses sporadic canary CI failures and relates to #17716.

**What is this PR about? / Why do we need it?**

`ceph-volume raw list` without a device argument can miss OSDs that were just prepared — transiently right after mkfs while udev is still settling, or persistently on Ceph versions where listing all devices is broken while listing a specific device still works (see #17716 for Ceph v20.2.1). The prepare job trusted the listing blindly: it silently reported fewer OSDs than it had just prepared, the operator never created the missing OSD deployments, and the cluster sat with OSDs registered in the osdmap but no daemons running.

Two recent canary job failures on master show exactly this (prepare logs show 2 successful `ceph-volume raw prepare` calls immediately followed by `raw list` reporting 0 or 1 OSDs, and `wait for ceph to be ready` then times out with OSDs `in` but never `up`):
- run 27149222715 (2026-06-08): `raw list` returned `{}` after both devices were prepared
- run 24675046082 (2026-04-20): `raw list` returned only 1 of 2 prepared devices

This PR makes the prepare job verify that every device prepared in raw mode is represented in the listing results. Any missing device is listed individually (`ceph-volume raw list <device>`) with retries, and the prepare job fails loudly if an OSD it prepared cannot be listed at all.

This is opened as an experimental draft to burn in against the canary CI job; the target is 5 consecutive green runs.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
