### PR TITLE
ci: make canary rgw endpoint validation retry until clean

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -221,12 +221,15 @@ jobs:
         run: |
           rgw_endpoint=$(kubectl get service -n rook-ceph -l rgw=store-a |  awk '/rgw/ {print $3":80"}')
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+          # create-external-cluster-resources.py exits 0 even when validation fails (e.g. RGW
+          # not responding yet), reporting the failure only on stderr, so an exit-code check
+          # alone cannot detect it: retry until the script exits 0 with no stderr output
           # pass the valid rgw-endpoint of same ceph cluster
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 120 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt && [ ! -s output.txt ]; do sleep 5 && echo 'waiting for the rgw endpoint to be validated'; done" || { echo "rgw endpoint validation failed, last stderr:"; cat output.txt; exit 1; }
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
           # pass the invalid rgw-endpoint of different ceph cluster
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint 10.108.96.128:80 --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint 10.108.96.128:80 --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
           if [ -s output.txt ]; then
             echo "script run completed with stderr error after passing the wrong rgw-endpoint: $output"
             rm -f output.txt
@@ -236,11 +239,11 @@ jobs:
             exit 1
           fi
           # pass the valid rgw-endpoint of same ceph cluster with --rgw-tls-cert-path
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-tls-cert-path my-cert --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 120 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-tls-cert-path my-cert --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt && [ ! -s output.txt ]; do sleep 5 && echo 'waiting for the rgw endpoint to be validated'; done" || { echo "rgw endpoint validation failed, last stderr:"; cat output.txt; exit 1; }
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
           # pass the valid rgw-endpoint of same ceph cluster with --rgw-skip-tls
-          timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-skip-tls true --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt; do sleep 1 && echo 'waiting for the rgw endpoint to be validated'; done"
+          timeout 120 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-endpoint $rgw_endpoint --rgw-skip-tls true --rgw-zone-name store-a --rgw-zonegroup-name store-a --rgw-realm-name store-a 2> output.txt && [ ! -s output.txt ]; do sleep 5 && echo 'waiting for the rgw endpoint to be validated'; done" || { echo "rgw endpoint validation failed, last stderr:"; cat output.txt; exit 1; }
           tests/scripts/github-action-helper.sh check_empty_file output.txt
           rm -f output.txt
 

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -1432,10 +1432,12 @@ class RadosJSON:
         request_url = base_url + urlencode(params)
 
         try:
+            # requests.get without a timeout could hang forever on an unresponsive endpoint
             r = requests.get(
                 request_url,
                 auth=S3Auth(access_key, secret_key, rgw_endpoint),
                 verify=verify,
+                timeout=30,
             )
         except requests.exceptions.Timeout:
             sys.stderr.write(


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

CI flake fix.

**What is this PR about? / Why do we need it?**

The canary job's `validate-rgw-endpoint` step sporadically fails with exit code 124 and no diagnostics (master runs 27227164039 on 2026-06-09 and 25740788017 on 2026-05-12). Two compounding problems:

1. Each validation loop had a 15 second umbrella timeout, but a single attempt of `create-external-cluster-resources.py` can exceed that when the RGW is slow to respond right after the object store was created — in part because the admin-ops API request had no HTTP timeout at all, so one slow request could eat the whole budget.
2. Validation failures are written to stderr while the script exits 0, so the `until` loop never actually retried them — the loop only retried hard crashes.

This PR bounds the admin-ops API request in the script (`external:` commit), and makes the workflow loops retry until the script succeeds with no stderr output, with a generous timeout and stderr printed when validation does not succeed in time (`ci:` commit).

This is opened as an experimental draft to burn in against the canary CI job; the target is 5 consecutive green runs.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
