### PR TITLE
test: add quota burn-in instrumentation

### DIFF
--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -35,6 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version: ["v1.31.14"]  # test only on oldest supported k8s version
+        iteration: [1, 2, 3]  # burn-in: parallel samples of the same job
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -70,7 +71,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: ceph-object-suite-artifact-${{ matrix.kubernetes-version }}
+          name: ceph-object-suite-artifact-${{ matrix.kubernetes-version }}-${{ matrix.iteration }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
       - name: consider (post-job) debugging
@@ -85,6 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version: ["v1.35.5"]  # test only on latest supported k8s version
+        iteration: [1, 2, 3]  # burn-in: parallel samples of the same job
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -120,7 +122,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: ceph-object-suite-tls-artifact-${{ matrix.kubernetes-version }}
+          name: ceph-object-suite-tls-artifact-${{ matrix.kubernetes-version }}-${{ matrix.iteration }}
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
       - name: consider (post-job) debugging

--- a/tests/framework/clients/notification.go
+++ b/tests/framework/clients/notification.go
@@ -60,16 +60,84 @@ func (t *NotificationOperation) CheckNotificationCR(notificationName string) boo
 	return true
 }
 
-func (t *NotificationOperation) CheckNotificationFromHTTPEndPoint(appLabel, eventName, fileName string) (bool, error) {
-	// wait for the notification to reach http-server
-	time.Sleep(5 * time.Second)
-	selectorName := "--selector=" + appLabel
-	l, err := t.k8sh.Kubectl("logs", selectorName, "--tail", "5")
+const (
+	notificationWaitAttempts = 12
+	notificationWaitInterval = 5 * time.Second
+)
+
+// notificationRecords returns the http server log lines emitted strictly
+// after since. The endpoint pod is shared by every scenario in the suite
+// (including the other TLS pass), so an unbounded sample can match stale
+// records; --timestamps gives per-line runtime stamps for a precise client
+// side boundary, while --since-time only prefilters at second granularity.
+func (t *NotificationOperation) notificationRecords(appLabel string, since time.Time) ([]string, error) {
+	l, err := t.k8sh.Kubectl("logs",
+		"--selector="+appLabel,
+		"--timestamps",
+		"--since-time="+since.Add(-2*time.Second).UTC().Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+
+	var records []string
+	for _, line := range strings.Split(l, "\n") {
+		stamp, record, found := strings.Cut(line, " ")
+		if !found {
+			continue
+		}
+		when, err := time.Parse(time.RFC3339Nano, stamp)
+		if err != nil {
+			continue
+		}
+		if when.After(since) {
+			records = append(records, record)
+		}
+	}
+	return records, nil
+}
+
+// recordMatches reports whether a single record line carries both eventName
+// and fileName. Records are single-line JSON; matching the concatenated log
+// would let two unrelated records satisfy the substrings independently.
+func recordMatches(records []string, eventName, fileName string) bool {
+	for _, record := range records {
+		if strings.Contains(record, eventName) && strings.Contains(record, fileName) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckNotificationFromHTTPEndPoint polls the http endpoint logs for an
+// eventName/fileName record emitted after since, for up to a minute —
+// delivery lags well past a single fixed sleep on loaded CI runners.
+func (t *NotificationOperation) CheckNotificationFromHTTPEndPoint(appLabel, eventName, fileName string, since time.Time) (bool, error) {
+	var lastErr error
+	for i := 0; i < notificationWaitAttempts; i++ {
+		// wait for the notification to reach http-server
+		time.Sleep(notificationWaitInterval)
+		records, err := t.notificationRecords(appLabel, since)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		lastErr = nil
+		if recordMatches(records, eventName, fileName) {
+			return true, nil
+		}
+	}
+	return false, lastErr
+}
+
+// CheckNotificationAbsentFromHTTPEndPoint reports whether no eventName/
+// fileName record was emitted after since: one settle interval, then a
+// single sample. Callers pair it with a positive check that already proved
+// delivery works, so polling longer would only slow the suite down.
+func (t *NotificationOperation) CheckNotificationAbsentFromHTTPEndPoint(appLabel, eventName, fileName string, since time.Time) (bool, error) {
+	time.Sleep(notificationWaitInterval)
+	records, err := t.notificationRecords(appLabel, since)
 	if err != nil {
 		return false, err
 	}
-	if strings.Contains(l, eventName) && strings.Contains(l, fileName) {
-		return true, nil
-	}
-	return false, nil
+	return !recordMatches(records, eventName, fileName), nil
 }

--- a/tests/integration/ceph_bucket_notification_test.go
+++ b/tests/integration/ceph_bucket_notification_test.go
@@ -129,33 +129,35 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		assert.Nil(t, err)
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
+		putTime := time.Now()
 		t.Run("put object", func(t *testing.T) {
 			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey1, contentType)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for put bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1)
+			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1, putTime)
 			assert.True(t, notificationReceived)
 			assert.Nil(t, err)
 			// negative test case to confirm didn't receive any delete event notification
-			notificationReceived, err = helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1, putTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 
+		deleteTime := time.Now()
 		t.Run("delete objects", func(t *testing.T) {
 			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for delete bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1)
+			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey1, deleteTime)
 			assert.True(t, notificationReceived)
 			assert.Nil(t, err)
 			// negative test case to confirm didn't receive any put event notification
-			notificationReceived, err = helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey1)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, putEvent, ObjectKey1, deleteTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 	})
@@ -229,25 +231,27 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		assert.Nil(t, err)
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
+		putTime := time.Now()
 		t.Run("put object", func(t *testing.T) {
 			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for put bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, putEvent, ObjectKey2)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, putEvent, ObjectKey2, putTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 
+		deleteTime := time.Now()
 		t.Run("delete objects", func(t *testing.T) {
 			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 
 		t.Run("check for delete bucket notification", func(t *testing.T) {
-			notificationReceived, err := helper.NotificationClient.CheckNotificationFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey2)
-			assert.False(t, notificationReceived)
+			notificationAbsent, err := helper.NotificationClient.CheckNotificationAbsentFromHTTPEndPoint(appLabel, deleteEvent, ObjectKey2, deleteTime)
+			assert.True(t, notificationAbsent)
 			assert.Nil(t, err)
 		})
 	})

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -55,6 +55,11 @@ import (
 const (
 	objectStoreServicePrefixUniq = "rook-ceph-rgw-"
 	objectStoreTLSName           = "tls-test-store"
+
+	// burnInQuotaOnly trims the suite to the user-quota path (store create ->
+	// OBC -> quota subtests) on a minimal cluster, for burn-in sampling of the
+	// quota flake rate. Do-not-merge instrumentation; see the PR description.
+	burnInQuotaOnly = true
 )
 
 var objectStoreServicePrefix = "rook-ceph-rgw-"
@@ -98,7 +103,7 @@ func (s *ObjectSuite) SetupSuite() {
 		StorageClassName:        installer.StorageClassName(),
 		UseHelm:                 false,
 		UsePVC:                  installer.UsePVC(),
-		Mons:                    3,
+		Mons:                    1, // burn-in: minimal cluster, see burnInQuotaOnly
 		SkipOSDCreation:         false,
 		UseCrashPruner:          true,
 		EnableVolumeReplication: false,
@@ -193,16 +198,22 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	})
 
 	// test that a second object store can be created (and deleted) while the first exists
-	s.T().Run("run a second object store", func(t *testing.T) {
-		otherStoreName := "other-" + storeName
-		// The lite e2e test is perfect, as it only creates a cluster, checks that it is healthy,
-		// and then deletes it.
-		deleteStore := true
-		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
-	})
+	if !burnInQuotaOnly {
+		s.T().Run("run a second object store", func(t *testing.T) {
+			otherStoreName := "other-" + storeName
+			// The lite e2e test is perfect, as it only creates a cluster, checks that it is healthy,
+			// and then deletes it.
+			deleteStore := true
+			runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
+		})
+	}
 
 	// now test operation of the first object store
 	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
+
+	if burnInQuotaOnly {
+		return
+	}
 
 	// The namespaced test packages below all skip when TLS is enabled, so only set up the
 	// shared store when it will actually be used.
@@ -359,6 +370,10 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			logger.Info("Objects deleted on bucket successfully")
 		})
 	})
+
+	if burnInQuotaOnly {
+		return
+	}
 
 	// this test deviates from the others in this package in that it does not
 	// rely on kubectl and uses the k8s api directly

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -311,7 +311,10 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, poErr)
 			logger.Infof("Testing the max object limit")
-			quotaEnforced := utils.Retry(30, 2*time.Second, "user quota enforced", func() bool {
+			// rgw enforces user quotas from cached stats that sync on
+			// rgw_user_quota_bucket_sync_interval (default 180s), so the wait
+			// must exceed that interval or this check flakes on slow runners
+			quotaEnforced := utils.Retry(120, 2*time.Second, "user quota enforced", func() bool {
 				_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 				if err != nil {
 					return true
@@ -333,7 +336,8 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			logger.Infof("Testing the updated object limit")
 			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
 			assert.NoError(t, poErr)
-			quotaEnforced := utils.Retry(30, 2*time.Second, "updated user quota enforced", func() bool {
+			// see the sync-interval comment on "user quota enforced" above
+			quotaEnforced := utils.Retry(120, 2*time.Second, "updated user quota enforced", func() bool {
 				_, putErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
 				if putErr != nil {
 					return true


### PR DESCRIPTION
**Burn-in instrumentation for #17713 — will be closed when sampling completes. Do not merge or review.**

Samples the user-quota flake rate under #17713's exact configuration (240s quota waits, 3 rgw instances, notification rework present but quota-irrelevant since those tests run later). On top of #17713's two commits, one instrumentation commit: trims the suite to the store → OBC → user-quota path on a 1-mon cluster, and adds a 3-way `iteration` matrix to both objectsuite jobs, so each workflow run produces **6 independent quota-path samples in ~30 minutes** instead of 2 in ~45.

Protocol: rerun the workflow until **30 clean job-samples** accumulate (95% upper bound ≈ 10% per-job flake rate via rule of three) or the first genuine quota failure (which immediately concludes "insufficient" — the prior pooled rate for this configuration is 3 failures / 10 attempts from #17707+#17713). Jobs failing before the suite runs ("setup cluster resources" etc.) are rerun and not counted.

Context: #17708 (single rgw instance) passed 5/5 attempts and is the mechanism-removing fix; this PR measures whether #17713's probabilistic mitigation is sufficient on its own.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.