### PR TITLE
CI: test k8s v1.34 instead of v1.33 for  rook releases

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.33.12", "1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.33.12", "1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.33.12", "1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -145,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.33.12", "1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.33.12", "1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
**Description:**

Rook supports six versions of kubernetes but we only want to spend CI
resources for testing four of them.

In order to align with this commitment, this change lets rook run
integration test suites on kubernetes v1.34 instead of v1.33 for release
testing.
    
As a result, the latest patch releases of kubernetes v1.31, v1.32,
v1.34, and v1.35 are tested for rook releases.

In addition, k8s version specification is made more systematic to
use the pattern  v1.3X.Y instead of 1.3X.Y.



This is a preparation for adding testing of k8s v1.36 to the mix.
See PR #17623. 


 


**Issue resolved by this Pull Request:**
This PR was intended to resolve issue  #17616. 

Note that this issue will only be fully resolved when k8s v1.36 is tested as well (See PR #17623).


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
