### PR TITLE
ci: remove unused EnableCsiOperator test setting

### DIFF
--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -52,7 +52,6 @@ type TestCephSettings struct {
 	RookVersion                 string
 	CephVersion                 cephv1.CephVersionSpec
 	KubernetesVersion           string
-	EnableCsiOperator           bool
 	ClusterConcurrency          int
 }
 

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -71,7 +71,6 @@ func (h *HelmSuite) SetupSuite() {
 		ConnectionsEncrypted: true,
 		RookVersion:          installer.LocalBuildTag,
 		CephVersion:          installer.SquidVersion,
-		EnableCsiOperator:    true,
 	}
 	h.settings.ApplyEnvVars()
 	h.installer, h.k8shelper = StartTestCluster(h.T, h.settings)

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -94,7 +94,6 @@ func (s *SmokeSuite) SetupSuite() {
 		ChangeHostName:          true,
 		RookVersion:             installer.LocalBuildTag,
 		CephVersion:             installer.ReturnCephVersion(),
-		EnableCsiOperator:       true,
 	}
 	s.settings.ApplyEnvVars()
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -90,7 +90,6 @@ func (s *UpgradeSuite) baseSetup(useHelm bool, initialRookVersion string, initia
 		SkipClusterCleanup:          true,
 		RookVersion:                 initialRookVersion,
 		CephVersion:                 initialCephVersion,
-		EnableCsiOperator:           true,
 	}
 
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)


### PR DESCRIPTION
Split out of #17732 to stand alone.

The `EnableCsiOperator` field in `TestCephSettings` is vestigial: the CSI operator is installed unconditionally by the integration test installer (`InstallCSIOperator()` runs for every suite with no gate), so the setting no longer selects between CSI management modes, and it is consumed nowhere in the test framework. Three suites (smoke, helm, upgrade) set it to `true` with no effect; the other four leave it unset.

This is a pure dead-code removal with no behavioral change. (#17732 separately adds a CSI driver readiness wait that applies to all suites.)

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
