### PR TITLE
ci: run CephMgrSuite on its nightly schedule

### DIFF
--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   TestCephMgrSuite:
     runs-on: ubuntu-22.04
-    if: "contains(github.event.pull_request.labels.*.name, 'run-mgr-suite')"
+    if: "github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-mgr-suite')"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `Integration test CephMgrSuite` workflow declares a daily `schedule` trigger, but its only job is gated on `if: contains(github.event.pull_request.labels.*.name, 'run-mgr-suite')`. On a `schedule` event there is no pull request, so the condition is always false — the nightly cron has been running zero jobs. This allows scheduled runs to execute the suite by adding `github.event_name == 'schedule'` to the condition.

Alternative for maintainers: if nightly mgr coverage is not wanted, drop the `schedule:` trigger instead. Opened as a **draft / do-not-merge** to surface the contradiction for a decision.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
