### PR TITLE
ci: drop ignored github-token inputs from composite action calls

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -2081,7 +2081,6 @@ jobs:
         with:
           ibm-instance-id: ${{ secrets.IBM_INSTANCE_ID }}
           ibm-service-api-key: ${{ secrets.IBM_SERVICE_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-name: ${{ github.job }}-${{ matrix.ceph-image }}
           ceph-image: ${{ matrix.ceph-image }}
           kubernetes-version: ${{ matrix.kubernetes-version }}

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -87,7 +87,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephSmokeSuite
@@ -127,7 +126,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephSmokeSuite
@@ -167,7 +165,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephSmokeSuite
@@ -207,7 +204,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephObjectSuite (without TLS)
@@ -247,7 +243,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephObjectSuiteTLS
@@ -287,7 +282,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephUpgradeSuite
@@ -327,7 +321,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: "v1.35.5"
 
       - name: TestCephUpgradeSuite

--- a/.github/workflows/integration-test-keystone-auth-suite.yaml
+++ b/.github/workflows/integration-test-keystone-auth-suite.yaml
@@ -55,7 +55,6 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           kubernetes-version: ${{ matrix.kubernetes-version }}
 
       - name: TestCephKeystoneAuthSuite


### PR DESCRIPTION
Several workflows pass a `github-token` input to composite actions that do not declare it, so the input is silently ignored and the runner emits a warning. This removes the dead input from every such call:

- `integration-test-setup-cluster-resources` (declares only `kubernetes-version`): 7 calls in `daily-nightly-jobs.yml` + 1 in `integration-test-keystone-auth-suite.yaml`
- `encryption-pvc-kms-ibm-kp` (declares only its IBM / artifact / ceph / k8s inputs): 1 call in `canary-integration-test.yml`

If a token is ever genuinely needed by one of these actions, it should be declared as an input and consumed inside the action rather than passed and dropped.

`daily-nightly-jobs.yml` and `integration-test-keystone-auth-suite.yaml` also appear in the in-flight k8s-version PRs (e.g. #17406); this change is independent (different lines). Opened as a **draft / do-not-merge**.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
