### PR TITLE
ci: include kubernetes version in canary artifact names

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -452,7 +452,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -538,7 +538,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -597,7 +597,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -657,7 +657,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -723,7 +723,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -783,7 +783,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -848,7 +848,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -960,7 +960,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1020,7 +1020,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1091,7 +1091,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1195,7 +1195,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1257,7 +1257,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1329,7 +1329,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1426,7 +1426,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1503,7 +1503,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1568,7 +1568,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -1858,7 +1858,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
           additional-namespace: rook-ceph-secondary
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
@@ -1968,7 +1968,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
           additional-namespace: rook-ceph-secondary
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
@@ -2038,7 +2038,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
         with:
@@ -2071,7 +2071,7 @@ jobs:
         with:
           ibm-instance-id: ${{ secrets.IBM_INSTANCE_ID }}
           ibm-service-api-key: ${{ secrets.IBM_SERVICE_API_KEY }}
-          artifact-name: ${{ github.job }}-${{ matrix.ceph-image }}
+          artifact-name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
           ceph-image: ${{ matrix.ceph-image }}
           kubernetes-version: ${{ matrix.kubernetes-version }}
 
@@ -2164,7 +2164,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
           additional-namespace: kube-system
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug
@@ -2230,7 +2230,7 @@ jobs:
         if: always()
         uses: ./.github/workflows/collect-logs
         with:
-          name: ${{ github.job }}-${{ matrix.ceph-image }}
+          name: ${{ github.job }}-${{ matrix.ceph-image }}-${{ matrix.kubernetes-version }}
 
       - name: consider (post-job) debugging
         uses: ./.github/workflows/upterm_debug


### PR DESCRIPTION
Canary jobs upload their logs under an artifact named `${{ github.job }}-${{ matrix.ceph-image }}`, but the job matrix also varies `kubernetes-version`. `actions/upload-artifact` (v4+) fails the run on a duplicate artifact name, so as soon as a job's matrix exercises more than one Kubernetes version the canary fails. This appends the Kubernetes version so every matrix cell produces a unique name — 22 artifact names across the file, including the `artifact-name:` handed to the `encryption-pvc-kms-ibm-kp` action.

The `collect-logs` composite already sanitizes `:` and `/` in names, so the `vX.Y.Z` suffix is safe.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
