### PR TITLE
ci: drop redundant per-step shell overrides in canary tests

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1893,12 +1893,10 @@ jobs:
         run: tests/scripts/github-action-helper.sh replace_ceph_image  "deploy/examples/cluster-test.yaml" "${{ matrix.ceph-image }}"
 
       - name: install additional deps for object testing
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           sudo apt-get install -y s3cmd
 
       - name: use local disk into two partitions
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
           tests/scripts/github-action-helper.sh use_local_disk
@@ -1906,7 +1904,6 @@ jobs:
           sudo lsblk
 
       - name: deploy first cluster rook
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh deploy_first_rook_cluster
           kubectl create -f deploy/examples/object-multisite-test.yaml
@@ -1914,7 +1911,6 @@ jobs:
           tests/scripts/github-action-helper.sh wait_for cephobjectstore multisite-store rook-ceph 600
 
       - name: prep second cluster pull realm config
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           cd deploy/examples/
           IP_ADDR=$(kubectl -n rook-ceph get svc rook-ceph-rgw-multisite-store -o jsonpath="{.spec.clusterIP}")
@@ -1925,7 +1921,6 @@ jobs:
           sed -i 's/WVY1MFIxeExkbG84U3pKdlRseEZXVGR3T3k1U1dUSS9KaTFoUVE9PQ==/'"$BASE64_SECRET_KEY"'/g' object-multisite-pull-realm-test.yaml
 
       - name: deploy second cluster rook
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh deploy_second_rook_cluster
           kubectl create -f deploy/examples/object-multisite-pull-realm-test.yaml
@@ -1933,7 +1928,6 @@ jobs:
           tests/scripts/github-action-helper.sh wait_for cephobjectstore zone-b-multisite-store rook-ceph-secondary 600
 
       - name: wait for both ceph clusters to be ready
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh wait_for cephcluster my-cluster rook-ceph
           tests/scripts/github-action-helper.sh wait_for cephcluster my-cluster rook-ceph-secondary
@@ -1943,18 +1937,15 @@ jobs:
           kubectl -n rook-ceph-secondary wait --for=condition=Ready pod -l rook_object_store=zone-b-multisite-store --timeout=300s
 
       - name: wait for multisite sync to be established
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh wait_for_multisite_sync_established
 
       - name: write an object to one cluster, read from the other
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh test_multisite_object_replication
 
       # if this test fails, it could mean the RGW `period get` or `period update` output has changed
       - name: RGW configuration period should be committed on first reconcile and not be committed on second reconcile
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           ns_name_primary_object_store='"rook-ceph/multisite-store"' # double quotes intended
           ns_name_secondary_object_store='"rook-ceph-secondary/zone-b-multisite-store"' # double quotes intended
@@ -1970,7 +1961,6 @@ jobs:
 
       - name: dump multisite diagnostics on failure
         if: failure()
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           tests/scripts/github-action-helper.sh dump_multisite_diagnostics
 
@@ -2223,7 +2213,6 @@ jobs:
           tests/scripts/github-action-helper.sh wait_for cephcluster my-cluster rook-ceph 240
 
       - name: create CephBlockPool(s), CephObjectZone, and CephObjectStore(s)
-        shell: bash --noprofile --norc -eo pipefail -x {0}
         run: |
           kubectl create -f deploy/examples/object-separate-pools-test.yaml
           kubectl create -f deploy/examples/two-object-one-zone-test.yaml


### PR DESCRIPTION
The workflow sets `defaults.run.shell` to `bash --noprofile --norc -eo pipefail -x {0}`, yet several steps in the `rgw-multisite-testing` and `two-object-one-zone` jobs re-declare that identical shell. The per-step overrides are redundant — the workflow default already applies to every `run` step. This removes the 9 duplicate lines with no behavior change.

`rgw-multisite-testing` is also touched by in-flight PR #17711 (different lines), trivial to sequence. Opened as a **draft / do-not-merge**.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
