### PR TITLE
ci: require explicit ceph_images input for canary workflow

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ceph_images:
         description: "JSON list of Ceph images for creating Ceph cluster"
-        default: '["quay.io/ceph/ceph:v20"]'
+        required: true
         type: string
       kubernetes-version:
         description: kubernetes version to use for the workflow


### PR DESCRIPTION
The reusable canary workflow's `ceph_images` input declares a default (`["quay.io/ceph/ceph:v20"]`) that is never used: both callers always pass an explicit list — `canary-integration-suite.yml` passes `["quay.io/ceph/ceph:v19"]` and `daily-nightly-jobs.yml` passes the full five-image list. A stale, unused default is a drift hazard: a new caller could silently test the wrong image. This drops the default and marks the input `required: true` so callers must choose deliberately. The `kubernetes-version` input's default is intentionally left as-is, since callers do rely on it.

Aside (not addressed here): the `nvmeof-protocol` job hardcodes `ceph-image: ["quay.io/ceph/ceph:v20"]` instead of consuming this input — a separate cleanup. Opened as a **draft / do-not-merge**.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
