### PR TITLE
ci: lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint configuration.
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  # Composite actions live under .github/workflows/<name>/action.{yml,yaml}.
+  # actionlint only understands workflow files, so it mis-parses these as
+  # workflows ("jobs"/"on" section missing, unexpected "runs"/"inputs" keys).
+  # It cannot lint composite action definitions, so ignore them entirely.
+  "**/action.{yml,yaml}":
+    ignore:
+      - ".*"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,40 @@
+name: actionlint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - master
+      - release-*
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "Makefile"
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+
+      - name: run actionlint
+        run: make lint.workflows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: build rook
         run: |
-          GOPATH=$(go env GOPATH) make clean && make -j$nproc BUILD_CONTAINER_IMAGE=false build
+          GOPATH=$(go env GOPATH) make clean && make -j"$nproc" BUILD_CONTAINER_IMAGE=false build
 
       - name: validate build
         run: tests/scripts/validate_modified_files.sh build
@@ -48,7 +48,7 @@ jobs:
         run: tests/scripts/validate_modified_files.sh codegen
 
       - name: run mod check
-        run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check
+        run: GOPATH=$(go env GOPATH) make -j"$(nproc)" mod.check
 
       - name: validate modcheck
         run: tests/scripts/validate_modified_files.sh modcheck

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph mgr dump -f json|jq --raw-output .active_addr|grep -Eosq \"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\" ; do sleep 1 && echo 'waiting for the manager IP to be available'; done"
-          mgr_raw=$(kubectl -n rook-ceph exec $toolbox -- ceph mgr dump -f json|jq --raw-output .active_addr)
+          mgr_raw=$(kubectl -n rook-ceph exec "$toolbox" -- ceph mgr dump -f json|jq --raw-output .active_addr)
           timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- curl --silent --show-error ${mgr_raw%%:*}:9283; do echo 'waiting for mgr prometheus exporter to be ready' && sleep 1; done"
 
       - name: test osd.0 auth recovery from keyring file
@@ -82,12 +82,12 @@ jobs:
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           osd_id=0
           osd_pod=$(kubectl get pod -l app=rook-ceph-osd,osd=$osd_id -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          if [ $osd_pod ]; then
+          if [ "$osd_pod" ]; then
             timeout 15 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph auth del osd.$osd_id ; do sleep 1 && echo 'waiting for osd auth to be deleted'; done";
-            kubectl -n rook-ceph delete pod $osd_pod;
+            kubectl -n rook-ceph delete pod "$osd_pod";
             timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph auth get osd.$osd_id ; do sleep 1 && echo 'waiting for osd auth to be recovered'; done";
             osd_pod=$(kubectl get pod -l app=rook-ceph-osd,osd=$osd_id -n rook-ceph -o jsonpath='{.items[*].metadata.name}');
-            kubectl -n rook-ceph wait --for=condition=Ready pod/$osd_pod --timeout=120s;
+            kubectl -n rook-ceph wait --for=condition=Ready pod/"$osd_pod" --timeout=120s;
           else
             echo "osd $osd_id not found, skipping test";
           fi
@@ -95,20 +95,20 @@ jobs:
       - name: test external script create-external-cluster-resources.py
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- mkdir -p /etc/ceph/test-data
-          kubectl -n rook-ceph cp tests/external-cluster/ceph-status-out $toolbox:/etc/ceph/test-data/
-          kubectl -n rook-ceph cp tests/external-cluster/external-config.ini $toolbox:/etc/ceph/
-          kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources.py $toolbox:/etc/ceph
-          kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources-tests.py $toolbox:/etc/ceph
+          kubectl -n rook-ceph exec "$toolbox" -- mkdir -p /etc/ceph/test-data
+          kubectl -n rook-ceph cp tests/external-cluster/ceph-status-out "$toolbox":/etc/ceph/test-data/
+          kubectl -n rook-ceph cp tests/external-cluster/external-config.ini "$toolbox":/etc/ceph/
+          kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources.py "$toolbox":/etc/ceph
+          kubectl -n rook-ceph cp deploy/examples/create-external-cluster-resources-tests.py "$toolbox":/etc/ceph
           timeout 10 sh -c "until kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool; do echo 'waiting for script to succeed' && sleep 1; done"
           # print existing client auth
-          kubectl -n rook-ceph exec $toolbox -- ceph auth ls
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth ls
 
       - name: test re-running of external script should result in same output
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool | tee output1.txt
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool | tee output2.txt
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool | tee output1.txt
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool | tee output2.txt
           if cmp output1.txt output2.txt; then
             echo "files have same output"
             rm output1.txt
@@ -123,58 +123,58 @@ jobs:
       - name: dry run external script create-external-cluster-resources.py
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool --dry-run
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool --dry-run
 
       - name: test external script create-external-cluster-resources.py if users already exist with different caps
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # update client.csi-rbd-provisioner.1 csi user caps
           # print client.csi-rbd-provisioner.1 user before update
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
-          kubectl -n rook-ceph exec $toolbox -- ceph auth caps client.csi-rbd-provisioner.1 mon 'profile rbd, allow command "osd ls"' osd 'profile rbd' mgr 'allow rw'
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth get client.csi-rbd-provisioner.1
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth caps client.csi-rbd-provisioner.1 mon 'profile rbd, allow command "osd ls"' osd 'profile rbd' mgr 'allow rw'
           # print client.csi-rbd-provisioner.1 user after update
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth get client.csi-rbd-provisioner.1
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool
           # print client.csi-rbd-provisioner.1 user after running script
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-provisioner.1
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth get client.csi-rbd-provisioner.1
 
       - name: run external script create-external-cluster-resources.py unit tests
         run: |
-          kubectl -n rook-ceph exec $(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[0].metadata.name}') -- python3 -m unittest /etc/ceph/create-external-cluster-resources-tests.py
+          kubectl -n rook-ceph exec "$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[0].metadata.name}')" -- python3 -m unittest /etc/ceph/create-external-cluster-resources-tests.py
 
       - name: wait for the subvolumegroup to be created
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
+          timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q group-a; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
 
       - name: test subvolumegroup validation
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # pass the correct subvolumegroup and cephfs_filesystem flag name
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group group-a --cephfs-filesystem-name myfs
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group group-a --cephfs-filesystem-name myfs
           # pass the subvolumegroup name which doesn't exist
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group false-test-subvolume-group
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --subvolume-group false-test-subvolume-group
 
       - name: dry run test skip monitoring endpoint
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool --dry-run --skip-monitoring-endpoint
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name=replicapool --dry-run --skip-monitoring-endpoint
 
       - name: test of rados namespace
         run: |
           kubectl create -f deploy/examples/radosnamespace.yaml
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q "namespace-a"; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
+          timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- rbd namespace ls replicapool --format=json|jq .[0].name|grep -q namespace-a; do sleep 1 && echo 'waiting for the rados namespace to be created'; done"
           kubectl delete -f deploy/examples/radosnamespace.yaml
 
       - name: test rados namespace validation
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosnamespace1
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosnamespace1
+          kubectl -n rook-ceph exec "$toolbox" -- rbd namespace create replicapool/radosnamespace1
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosnamespace1
            # test the rados namespace which not exit for replicapool(false testing)
-          if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace false-test-namespace); then
+          if output=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace false-test-namespace); then
             echo "unexpectedly succeeded after passing the wrong rados namespace: $output"
             exit 1
           else
@@ -184,38 +184,38 @@ jobs:
       - name: test external script with restricted_auth_permission flag and without having cephfs_filesystem flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
 
       - name: test external script with restricted_auth_permission flag and with --cluster-name legacy flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cluster-name rookstorage --restricted-auth-permission true
 
       - name: test external script with restricted_auth_permission flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage --restricted-auth-permission true
 
       - name: test the upgrade flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # print existing client auth
-          kubectl -n rook-ceph exec $toolbox -- ceph auth ls
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth ls
           # update the existing non-restricted client auth with the new ones
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade
           # print upgraded client auth
-          kubectl -n rook-ceph exec $toolbox -- ceph auth ls
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth ls
 
       - name: test the upgrade flag for restricted auth user
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # print existing client auth
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
           # restricted auth user need to provide --rbd-data-pool-name,
           #  --k8s-cluster-name and --run-as-user flag while upgrading
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --upgrade --rbd-data-pool-name replicapool --k8s-cluster-name rookstorage  --run-as-user client.csi-rbd-node-rookstorage-replicapool
           # print upgraded client auth
-          kubectl -n rook-ceph exec $toolbox -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
+          kubectl -n rook-ceph exec "$toolbox" -- ceph auth get client.csi-rbd-node-rookstorage-replicapool
 
       - name: validate-rgw-endpoint
         run: |
@@ -248,11 +248,11 @@ jobs:
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # create realm
-          kubectl -n rook-ceph exec $toolbox -- radosgw-admin realm create --rgw-realm=realm1
+          kubectl -n rook-ceph exec "$toolbox" -- radosgw-admin realm create --rgw-realm=realm1
           # pass correct realm
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-realm-name realm1
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-realm-name realm1
           # pass wrong realm
-          if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-realm-name realm3); then
+          if output=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rgw-realm-name realm3); then
             echo "script run completed with stderr error after passing the wrong realm: $output"
           else
             echo "script failed because wrong realm was passed"
@@ -277,15 +277,15 @@ jobs:
           kubectl wait --for='jsonpath={.status.phase}=Ready' Cephblockpool/replica1c -nrook-ceph
 
           # pass correct flags
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools replica1a,replica1b,replica1c --topology-failure-domain-label hostname --topology-failure-domain-values minikube,minikube-m02,minikube-m03
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools replica1a,replica1b,replica1c --topology-failure-domain-label hostname --topology-failure-domain-values minikube,minikube-m02,minikube-m03
           # pass the pool which is not exists
-          if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools ab,cd,ef --topology-failure-domain-label hostname --topology-failure-domain-values minikube,minikube-m02,minikube-m03); then
+          if output=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools ab,cd,ef --topology-failure-domain-label hostname --topology-failure-domain-values minikube,minikube-m02,minikube-m03); then
             echo "script run completed with stderr error after passing the wrong pools: $output"
           else
             echo "script failed because wrong pools doesn't exist"
           fi
           # dont pass all topology flags
-          if output=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools replica1a,replica1b,replica1c --topology-failure-domain-values minikube,minikube-m02,minikube-m03); then
+          if output=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --topology-pools replica1a,replica1b,replica1c --topology-failure-domain-values minikube,minikube-m02,minikube-m03); then
             echo "script run completed with stderr error after passing the wrong flags: $output"
           else
             echo "script failed because topology-failure-domain-label is missing"
@@ -294,17 +294,17 @@ jobs:
       - name: test enable v2 mon port
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --v2-port-enable
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --v2-port-enable
 
       - name: test config file flag
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # create `radosNamespace2` rados-namespace for `replicapool` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosnamespace2
+          kubectl -n rook-ceph exec "$toolbox" -- rbd namespace create replicapool/radosnamespace2
 
           # validate `--rados-namespace`, config file value is radosnamespace2, cli arg flag is set to radosnamespace1 and no default is set
           # command line arg should be used
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosnamespace1 --config-file /etc/ceph/external-config.ini
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosnamespace1 --config-file /etc/ceph/external-config.ini
 
           # validate the `rbd-data-pool-name`,config value set to replicapoolconfig, command line arg is not set and no default
           # config value should be used
@@ -312,23 +312,23 @@ jobs:
           kubectl create -f deploy/examples/pool-test.yaml
           kubectl wait --for='jsonpath={.status.phase}=Ready' Cephblockpool/replicapoolconfig -nrook-ceph
           # create `radosNamespace2` rados-namespace for `replicapoolconfig` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapoolconfig/radosnamespace2
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --config-file /etc/ceph/external-config.ini
+          kubectl -n rook-ceph exec "$toolbox" -- rbd namespace create replicapoolconfig/radosnamespace2
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --config-file /etc/ceph/external-config.ini
 
           # validate the default `format`` flag, config file value is not set and no cmd line argument is set and default value is `Json``,
           # default value should be used
-          kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --config-file /etc/ceph/external-config.ini
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --config-file /etc/ceph/external-config.ini
 
       - name: test key rotation with --cephx-key-rotate
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          output1=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs)
+          output1=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs)
 
           # check if it create a csi rbd, cephfs Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node.1 client.csi-rbd-provisioner.1 client.csi-cephfs-node.1 client.csi-cephfs-provisioner.1 client.healthchecker.1
 
           # rotate the key
-          output2=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs --cephx-key-rotate rotate)
+          output2=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs --cephx-key-rotate rotate)
 
           # check if it create a csi rbd, cephfs and Healthchecker rotated keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node.2 client.csi-rbd-provisioner.2 client.csi-cephfs-node.2 client.csi-cephfs-provisioner.2 client.healthchecker.2
@@ -342,7 +342,7 @@ jobs:
           fi
 
           # revert the key
-          output3=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs --cephx-key-rotate revert)
+          output3=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs --cephx-key-rotate revert)
           # check if it revert the key, it should be same as output1
           if [ "$output1" == "$output3" ]; then
             echo "csi rbd and cephfs key reverted successfully"
@@ -352,7 +352,7 @@ jobs:
           fi
 
           # if --cephx-key-rotate is not set provide the latest key
-          output4=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs)
+          output4=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --cephfs-filesystem-name myfs)
           if [ "$output2" == "$output4" ]; then
             echo "csi rbd and cephfs key uses latest generation"
           else
@@ -365,19 +365,19 @@ jobs:
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
           # create tenant1 and verify
           # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/rn1
-          output1=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true)
+          kubectl -n rook-ceph exec "$toolbox" -- rbd namespace create replicapool/rn1
+          output1=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true)
 
           # check if it create a csi rbd, cephfs and  Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn1 client.csi-rbd-provisioner-rookstorage-replicapool-rn1 client.csi-cephfs-provisioner-rookstorage-myfs client.csi-cephfs-node-rookstorage-myfs client.healthchecker
 
           # rotate tenant1 and verify
-          output2=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate)
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate
           # check if it create rotated csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn1.1 client.csi-rbd-provisioner-rookstorage-replicapool-rn1.1 client.csi-cephfs-provisioner-rookstorage-myfs.1 client.csi-cephfs-node-rookstorage-myfs.1 client.healthchecker.1
 
           # revert tenant1 and verify
-          output3=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate revert)
+          output3=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate revert)
           # check if it create a revert csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn1 client.csi-rbd-provisioner-rookstorage-replicapool-rn1 client.csi-cephfs-provisioner-rookstorage-myfs client.csi-cephfs-node-rookstorage-myfs client.healthchecker
 
@@ -391,19 +391,19 @@ jobs:
 
           # create tenant2 and verify
           # create `radosNamespace2` rados-namespace for `replicapool` rbd data-pool
-          kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/rn2
-          output4=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true)
+          kubectl -n rook-ceph exec "$toolbox" -- rbd namespace create replicapool/rn2
+          output4=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true)
 
           # check if it create a csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn2 client.csi-rbd-provisioner-rookstorage-replicapool-rn2 client.csi-cephfs-provisioner-rookstorage-myfs client.csi-cephfs-node-rookstorage-myfs client.healthchecker
 
           # rotate tenant2 and verify
-          output5=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate)
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate
           # check if it create rotated csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn2.1 client.csi-rbd-provisioner-rookstorage-replicapool-rn2.1 client.csi-cephfs-provisioner-rookstorage-myfs.1 client.csi-cephfs-node-rookstorage-myfs.1 client.healthchecker.1
 
           # rotate tenant1 (again) and verify
-          output6=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate)
+          kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn1 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate rotate
           # check if it create rotated csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn1.2 client.csi-rbd-provisioner-rookstorage-replicapool-rn1.2 client.csi-cephfs-provisioner-rookstorage-myfs.2 client.csi-cephfs-node-rookstorage-myfs.2 client.healthchecker.2
 
@@ -412,7 +412,7 @@ jobs:
           tests/scripts/github-action-helper.sh check_keys_not_exists client.csi-rbd-node-rookstorage-replicapool-rn2.2 client.csi-rbd-provisioner-rookstorage-replicapool-rn2.2
 
           # revert tenant2 and verify
-          output7=$(kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate revert)
+          output7=$(kubectl -n rook-ceph exec "$toolbox" -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace rn2 --cephfs-filesystem-name myfs --k8s-cluster-name rookstorage --restricted-auth-permission true --cephx-key-rotate revert)
           # check if it create a reverted csi rbd, cephfs and Healthchecker keys
           tests/scripts/github-action-helper.sh check_keys_exists client.csi-rbd-node-rookstorage-replicapool-rn2 client.csi-rbd-provisioner-rookstorage-replicapool-rn2 client.csi-cephfs-provisioner-rookstorage-myfs client.csi-cephfs-node-rookstorage-myfs client.healthchecker
 
@@ -442,11 +442,11 @@ jobs:
           sed -i 's|rook/ceph:.*|rook/ceph:local-build|' deploy/examples/osd-purge.yaml
           kubectl -n rook-ceph create -f deploy/examples/osd-purge.yaml
           toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          kubectl -n rook-ceph exec $toolbox -- ceph status
+          kubectl -n rook-ceph exec "$toolbox" -- ceph status
           # wait until osd.1 is removed from the osd tree
           timeout 120 sh -c "while kubectl -n rook-ceph exec $toolbox -- ceph osd tree|grep -qE 'osd.1'; do echo 'waiting for ceph osd 1 to be purged'; sleep 1; done"
-          kubectl -n rook-ceph exec $toolbox -- ceph status
-          kubectl -n rook-ceph exec $toolbox -- ceph osd tree
+          kubectl -n rook-ceph exec "$toolbox" -- ceph status
+          kubectl -n rook-ceph exec "$toolbox" -- ceph osd tree
 
       - name: collect common logs
         if: always()
@@ -491,7 +491,8 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: prepare loop devices for osds
@@ -525,8 +526,8 @@ jobs:
       - name: check s5cmd version in the toolbox image
         run: |
           toolbox=$(kubectl get pod -l app=rook-ceph-tools-operator-image -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-          s5cmd_version="$(kubectl -n rook-ceph exec ${toolbox} -- /usr/local/bin/s5cmd version)"
-          echo ${s5cmd_version} | grep -q "^v2.3.0"  || {
+          s5cmd_version="$(kubectl -n rook-ceph exec "${toolbox}" -- /usr/local/bin/s5cmd version)"
+          echo "${s5cmd_version}" | grep -q "^v2.3.0"  || {
              echo " Error: the version of s5cmd version in the  toolbox is not the expected v2.3.0 but ${s5cmd_version}"
              exit 1
           }
@@ -576,7 +577,8 @@ jobs:
       - name: use local disk as OSD
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: deploy cluster
@@ -635,7 +637,8 @@ jobs:
 
       - name: use local disk as OSD metadata partition
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --bluestore-type block.db --osd-count 1
 
@@ -695,7 +698,8 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -703,7 +707,7 @@ jobs:
         run: |
           dd if=/dev/zero of=test-rook.img bs=1 count=0 seek=10G
           # If we use metadata device, both data devices and metadata devices should be logical volumes or raw devices
-          tests/scripts/github-action-helper.sh create_LV_on_disk $(sudo losetup --find --show test-rook.img)
+          tests/scripts/github-action-helper.sh create_LV_on_disk "$(sudo losetup --find --show test-rook.img)"
 
       - name: deploy cluster
         run: |
@@ -761,7 +765,8 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
@@ -821,14 +826,16 @@ jobs:
 
       - name: use local disk as OSD
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --wipe-only
 
       - name: create LV on disk
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          tests/scripts/github-action-helper.sh create_LV_on_disk "$BLOCK"
 
       - name: deploy cluster
         run: |
@@ -892,7 +899,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/loopDevicePV.sh 1
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
@@ -920,14 +928,16 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh delete_cluster
           lsblk
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          sudo head --bytes=60 ${BLOCK}1
-          sudo head --bytes=60 ${BLOCK}2
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          sudo head --bytes=60 "${BLOCK}1"
+          sudo head --bytes=60 "${BLOCK}2"
           sudo head --bytes=60 /dev/loop1
 
       - name: recreate cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/loopDevicePV.sh 1
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
@@ -951,9 +961,10 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh delete_cluster
           lsblk
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          sudo head --bytes=60 ${BLOCK}1
-          sudo head --bytes=60 ${BLOCK}2
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          sudo head --bytes=60 "${BLOCK}1"
+          sudo head --bytes=60 "${BLOCK}2"
           sudo head --bytes=60 /dev/loop1
 
       - name: collect common logs
@@ -1082,9 +1093,10 @@ jobs:
       - name: teardown cluster with cleanup policy
         run: |
           tests/scripts/github-action-helper.sh delete_cluster
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          sudo head --bytes=60 ${BLOCK}1
-          sudo head --bytes=60 ${BLOCK}2
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          sudo head --bytes=60 "${BLOCK}1"
+          sudo head --bytes=60 "${BLOCK}2"
           sudo lsblk
 
       - name: collect common logs
@@ -1131,7 +1143,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
@@ -1155,14 +1168,16 @@ jobs:
       - name: teardown cluster with cleanup policy
         run: |
           tests/scripts/github-action-helper.sh delete_cluster
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          sudo head --bytes=60 ${BLOCK}1
-          sudo head --bytes=60 ${BLOCK}2
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          sudo head --bytes=60 "${BLOCK}1"
+          sudo head --bytes=60 "${BLOCK}2"
           sudo lsblk
 
       - name: recreate cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
@@ -1186,9 +1201,10 @@ jobs:
       - name: teardown cluster with cleanup policy
         run: |
           tests/scripts/github-action-helper.sh delete_cluster
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          sudo head --bytes=60 ${BLOCK}1
-          sudo head --bytes=60 ${BLOCK}2
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          sudo head --bytes=60 "${BLOCK}1"
+          sudo head --bytes=60 "${BLOCK}2"
           sudo lsblk
 
       - name: collect common logs
@@ -1369,7 +1385,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
@@ -1466,7 +1483,8 @@ jobs:
 
       - name: create cluster prerequisites
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/localPathPV.sh "$BLOCK"
           tests/scripts/github-action-helper.sh create_cluster_prerequisites
 
@@ -1544,8 +1562,9 @@ jobs:
 
       - name: create LV on disk
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          tests/scripts/github-action-helper.sh create_LV_on_disk $BLOCK
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
+          tests/scripts/github-action-helper.sh create_LV_on_disk "$BLOCK"
           tests/scripts/localPathPV.sh /dev/test-rook-vg/test-rook-lv
 
       - name: deploy cluster
@@ -1604,7 +1623,8 @@ jobs:
       - name: use local disk into two partitions
         run: |
           tests/scripts/github-action-helper.sh use_local_disk
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 6
           sudo lsblk
 
@@ -1637,7 +1657,8 @@ jobs:
           yq w -i pool-test.yaml spec.mirroring.enabled true
           yq w -i pool-test.yaml spec.mirroring.mode image
           kubectl create -f pool-test.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool replicapool -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool to be created on cluster 1" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool replicapool -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool to be created on cluster 1" && sleep 1; done'
 
       - name: create ec pool on cluster 1
         run: |
@@ -1645,14 +1666,16 @@ jobs:
           yq w -i pool-ec.yaml spec.failureDomain osd
           yq w -i pool-ec.yaml metadata.name ecpool
           kubectl create -f pool-ec.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool ecpool -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool ecpool to be created on cluster 1" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool ecpool -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool ecpool to be created on cluster 1" && sleep 1; done'
 
       - name: create replicated mirrored pool 2 on cluster 1
         run: |
           cd deploy/examples/
           yq w -i pool-test.yaml metadata.name replicapool2
           kubectl create -f pool-test.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool replicapool2 -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool2 to be created on cluster 1" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph get cephblockpool replicapool2 -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool2 to be created on cluster 1" && sleep 1; done'
           yq w -i pool-test.yaml metadata.name replicapool
 
       - name: create replicated mirrored pool on cluster 2
@@ -1660,21 +1683,24 @@ jobs:
           cd deploy/examples/
           yq w -i pool-test.yaml metadata.namespace rook-ceph-secondary
           kubectl create -f pool-test.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool to be created on cluster 2" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool to be created on cluster 2" && sleep 1; done'
 
       - name: create ec-pool pool on cluster 2
         run: |
           cd deploy/examples/
           yq w -i pool-ec.yaml metadata.namespace rook-ceph-secondary
           kubectl create -f pool-ec.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool ecpool -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool ecpool to be created on cluster 2" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool ecpool -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool ecpool to be created on cluster 2" && sleep 1; done'
 
       - name: create replicated mirrored pool 2 on cluster 2
         run: |
           cd deploy/examples/
           yq w -i pool-test.yaml metadata.name replicapool2
           kubectl create -f pool-test.yaml
-          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool2 -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool2 to be created on cluster 2" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 180 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool2 -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for pool replicapool2 to be created on cluster 2" && sleep 1; done'
 
       - name: create images in the pools
         run: |
@@ -1715,22 +1741,27 @@ jobs:
       - name: verify image has been mirrored for replicapool
         run: |
           # let's wait a bit for the image to be present
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
           timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -ge 1 ]; do echo "waiting for image to be mirrored in pool replicapool" && sleep 1; done'
 
       - name: verify image has been mirrored for ec
         run: |
           # let's wait a bit for the image to be present
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
           timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c ec-test-image)" -eq 1 ]; do echo "waiting for image to be mirrored in ecpool replicapool" && sleep 1; done'
 
       - name: verify image has been mirrored for replicapool2
         run: |
           # let's wait a bit for the image to be present
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
           timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool2 ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored in pool replicapool2" && sleep 1; done'
 
       - name: display cephblockpool and image status
         run: |
-          timeout 80 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool -o jsonpath='{.status.mirroringStatus.summary.daemon_health}'|grep -c OK)" -eq 1 ]; do echo "waiting for mirroring status to be updated in replicapool" && sleep 1; done'
-          timeout 80 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool2 -o jsonpath='{.status.mirroringStatus.summary.daemon_health}'|grep -c OK)" -eq 1 ]; do echo "waiting for mirroring status to be updated in replicapool2" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 80 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool -o jsonpath="{.status.mirroringStatus.summary.daemon_health}"|grep -c OK)" -eq 1 ]; do echo "waiting for mirroring status to be updated in replicapool" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 80 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephblockpool replicapool2 -o jsonpath="{.status.mirroringStatus.summary.daemon_health}"|grep -c OK)" -eq 1 ]; do echo "waiting for mirroring status to be updated in replicapool2" && sleep 1; done'
           kubectl -n rook-ceph-secondary get cephblockpool replicapool -o yaml
           kubectl -n rook-ceph-secondary get cephblockpool replicapool2 -o yaml
           kubectl -n rook-ceph-secondary get cephblockpool ecpool -o yaml
@@ -1749,7 +1780,8 @@ jobs:
 
       - name: wait for rook-ceph-csi-mapping-config to be updated with cluster ID
         run: |
-          timeout 60 sh -c 'until [ "$(kubectl get cm -n rook-ceph rook-ceph-csi-mapping-config  -o jsonpath='{.data.csi-mapping-config-json}' | grep -c "rook-ceph-secondary")" -eq 1 ]; do echo "waiting for rook-ceph-csi-mapping-config to be created with cluster ID mappings" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 60 sh -c 'until [ "$(kubectl get cm -n rook-ceph rook-ceph-csi-mapping-config  -o jsonpath="{.data.csi-mapping-config-json}" | grep -c "rook-ceph-secondary")" -eq 1 ]; do echo "waiting for rook-ceph-csi-mapping-config to be created with cluster ID mappings" && sleep 1; done'
 
       - name: create replicated mirrored filesystem on cluster 1
         run: |
@@ -1767,11 +1799,13 @@ jobs:
 
       - name: wait for filesystem on cluster 1
         run: |
-          timeout 300 sh -c 'until [ "$(kubectl -n rook-ceph get cephfilesystem myfs -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for filesystem to be created" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 300 sh -c 'until [ "$(kubectl -n rook-ceph get cephfilesystem myfs -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for filesystem to be created" && sleep 1; done'
 
       - name: wait for filesystem on cluster 2
         run: |
-          timeout 300 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephfilesystem myfs -o jsonpath='{.status.phase}'|grep -c "Ready")" -eq 1 ]; do echo "waiting for filesystem to be created" && sleep 1; done'
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
+          timeout 300 sh -c 'until [ "$(kubectl -n rook-ceph-secondary get cephfilesystem myfs -o jsonpath="{.status.phase}"|grep -c "Ready")" -eq 1 ]; do echo "waiting for filesystem to be created" && sleep 1; done'
 
       - name: copy filesystem mirror peer secret from the secondary cluster to the primary one
         run: |
@@ -1786,15 +1820,18 @@ jobs:
 
       - name: verify fs mirroring is working
         run: |
+          # shellcheck disable=SC2016 # $(...) is evaluated by the inner 'sh -c', not the outer shell
           timeout 45 sh -c 'until [ "$(kubectl -n rook-ceph exec -t deploy/rook-ceph-fs-mirror -- ls -1 /var/run/ceph/|grep -c asok)" -gt 3 ]; do echo "waiting for connection to peer" && sleep 1; done'
           sockets=$(kubectl -n rook-ceph exec -t deploy/rook-ceph-fs-mirror -- ls -1 /var/run/ceph/)
-          status=$(for socket in $sockets; do minikube kubectl -- -n rook-ceph exec -t deploy/rook-ceph-fs-mirror -- ceph --admin-daemon /var/run/ceph/$socket help|awk -F ":" '/get filesystem mirror status/ {print $1}'; done)
+          # shellcheck disable=SC2086 # word splitting of $sockets into separate socket paths is intentional
+          status=$(for socket in $sockets; do minikube kubectl -- -n rook-ceph exec -t deploy/rook-ceph-fs-mirror -- ceph --admin-daemon "/var/run/ceph/$socket" help|awk -F ":" '/get filesystem mirror status/ {print $1}'; done)
           if [ "${#status}" -lt 1 ]; then echo "peer addition failed" && exit 1; fi
 
       - name: display cephfilesystem and fs mirror daemon status
         run: |
           kubectl -n rook-ceph get cephfilesystem myfs -o yaml
           # the check is not super ideal since 'mirroring_failed' is only displayed when there is a failure but not when it's working...
+          # shellcheck disable=SC2016 # $(...) and the jq filter are evaluated by the inner 'sh -c', not the outer shell
           timeout 60 sh -c 'while [ "$(kubectl exec -n rook-ceph deploy/rook-ceph-tools -t -- ceph fs snapshot mirror daemon status|jq -r '.[0].filesystems[0]'|grep -c "mirroring_failed")" -eq 1 ]; do echo "waiting for filesystem to be mirrored" && sleep 1; done'
 
       - name: Create subvolume on primary cluster
@@ -1831,6 +1868,7 @@ jobs:
       - name: Get the peer and verify the peer synchronization status that snaps have synced on secondary cluster
         run: |
           exec_fs_mirror='kubectl -n rook-ceph exec deploy/rook-ceph-fs-mirror --'
+          # shellcheck disable=SC2034 # mirror_daemon is consumed by the verification below, which is currently commented out
           mirror_daemon=$($exec_fs_mirror ls /var/run/ceph/ | grep "fs-mirror" | head -n 1)
           # timeout 45 bash -x <<EOF
           #   while
@@ -1898,7 +1936,8 @@ jobs:
 
       - name: use local disk into two partitions
         run: |
-          export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           tests/scripts/github-action-helper.sh use_local_disk
           tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 6
           sudo lsblk
@@ -1914,7 +1953,7 @@ jobs:
         run: |
           cd deploy/examples/
           IP_ADDR=$(kubectl -n rook-ceph get svc rook-ceph-rgw-multisite-store -o jsonpath="{.spec.clusterIP}")
-          yq w -i -d1 object-multisite-pull-realm-test.yaml spec.pull.endpoint http://${IP_ADDR}:80
+          yq w -i -d1 object-multisite-pull-realm-test.yaml spec.pull.endpoint "http://${IP_ADDR}:80"
           BASE64_ACCESS_KEY=$(kubectl -n rook-ceph get secrets realm-a-keys -o jsonpath="{.data.access-key}")
           BASE64_SECRET_KEY=$(kubectl -n rook-ceph get secrets realm-a-keys -o jsonpath="{.data.secret-key}")
           sed -i 's/VzFjNFltMVdWRTFJWWxZelZWQT0=/'"$BASE64_ACCESS_KEY"'/g' object-multisite-pull-realm-test.yaml
@@ -2018,7 +2057,8 @@ jobs:
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "deploy/examples/operator.yaml"
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "deploy/examples/csi/nvmeof/driver.yaml"
 
-          export BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           yq w -i -d0 deploy/examples/cluster-test.yaml spec.storage.deviceFilter "${BLOCK}"
           kubectl create -f deploy/examples/cluster-test.yaml
           tests/scripts/github-action-helper.sh deploy_toolbox
@@ -2130,7 +2170,8 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build deploy/examples/operator.yaml
           tests/scripts/github-action-helper.sh deploy_manifest_with_local_build "deploy/examples/csi/nfs/driver.yaml"
-          export BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          BLOCK="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+          export BLOCK
           yq write -i deploy/examples/cluster-multus-test.yaml "spec.storage.deviceFilter" "${BLOCK}"
           kubectl create -f deploy/examples/cluster-multus-test.yaml
 

--- a/.github/workflows/collect-logs/action.yaml
+++ b/.github/workflows/collect-logs/action.yaml
@@ -21,7 +21,7 @@ runs:
         no_slash="${no_colon////-}"
         # echo to $GITHUB_OUTPUT doesn't work in composite steps:
         # https://github.com/actions/runner/issues/2009#issuecomment-1793565031
-        echo "ARTIFACT_NAME=${no_slash}" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=${no_slash}" >> "$GITHUB_ENV"
 
     - name: collect common logs
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -91,7 +91,8 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="squid-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -130,7 +131,8 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="tentacle-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -169,7 +171,8 @@ jobs:
 
       - name: TestCephSmokeSuite
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=main go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -208,7 +211,8 @@ jobs:
 
       - name: TestCephObjectSuite (without TLS)
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=main go test -v -timeout 1800s -failfast -run CephObjectSuite/TestWithoutTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -247,7 +251,8 @@ jobs:
 
       - name: TestCephObjectSuiteTLS
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=main go test -v -timeout 1800s -failfast -run CephObjectSuite/TestWithTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -286,7 +291,8 @@ jobs:
 
       - name: TestCephUpgradeSuite
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToSquidDevel github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -325,7 +331,8 @@ jobs:
 
       - name: TestCephUpgradeSuite
         run: |
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToTentacleDevel github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           make generate-docs-crds
           DIFF_ON_DOCS=$(git diff --ignore-matching-lines='on git commit')
-          if [ ! -z "$DIFF_ON_DOCS" ]; then
+          if [ -n "$DIFF_ON_DOCS" ]; then
           echo "Please run 'make generate-docs-crds' locally, commit the updated crds docs, and push the change"
           fi
           git diff --ignore-matching-lines='on git commit' --exit-code

--- a/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
+++ b/.github/workflows/encryption-pvc-kms-ibm-kp/action.yml
@@ -46,7 +46,8 @@ runs:
     - name: create cluster prerequisites
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
-        export BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+        BLOCK="/dev/$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
+        export BLOCK
         tests/scripts/localPathPV.sh "$BLOCK"
         tests/scripts/github-action-helper.sh create_cluster_prerequisites
 

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -65,7 +65,8 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           tests/scripts/github-action-helper.sh create_helm_tag
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephHelmSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-keystone-auth-suite.yaml
+++ b/.github/workflows/integration-test-keystone-auth-suite.yaml
@@ -60,7 +60,8 @@ jobs:
       - name: TestCephKeystoneAuthSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          DEVICE_FILTER=$(lsblk|awk '/14G/ || /64G/ {print $1}'| head -1)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 3600s -failfast -run CephKeystoneAuthSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: TestCephMgrSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 1800s -failfast -run CephMgrSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: TestCephObjectSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite/TestWithoutTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -105,7 +106,8 @@ jobs:
       - name: TestCephObjectSuiteTLS
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite/TestWithTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -28,9 +28,9 @@ runs:
         ARCH=$(go env GOARCH)
         # --fail so an HTTP error page is not saved as the .deb (dpkg then fails on the
         # corrupt archive), and retry transient download errors
-        curl -fLO --retry 5 --retry-all-errors --retry-delay 10 https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
-        sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
-        rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb
+        curl -fLO --retry 5 --retry-all-errors --retry-delay 10 https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.21/cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
+        sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
+        rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_"${ARCH}".deb
 
     - name: Setup Minikube
       uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: TestCephSmokeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -59,7 +59,8 @@ jobs:
       - name: TestCephUpgradeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 3600s -failfast -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -115,7 +116,8 @@ jobs:
           tests/scripts/github-action-helper.sh create_helm_tag
 
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 2700s -failfast -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -43,7 +43,8 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           tests/scripts/github-action-helper.sh create_helm_tag
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephHelmSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -122,7 +123,8 @@ jobs:
       - name: TestCephSmokeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -160,7 +162,8 @@ jobs:
       - name: TestCephUpgradeSuite
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 2400s -run CephUpgradeSuite/TestUpgradeRook github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -199,7 +202,8 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh create_helm_tag
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           go test -v -timeout 1800s -run CephUpgradeSuite/TestUpgradeHelm github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -237,7 +241,8 @@ jobs:
       - name: TestCephObjectSuite (without TLS)
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite/TestWithoutTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs
@@ -275,7 +280,8 @@ jobs:
       - name: TestCephObjectSuiteTLS
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
-          export DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          DEVICE_FILTER=$(tests/scripts/github-action-helper.sh find_extra_block_dev)
+          export DEVICE_FILTER
           SKIP_CLEANUP_POLICY=false go test -v -timeout 2400s -failfast -run CephObjectSuite/TestWithTLS github.com/rook/rook/tests/integration
 
       - name: collect common logs

--- a/.github/workflows/mod-check.yml
+++ b/.github/workflows/mod-check.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: "1.26"
 
       - name: run mod check
-        run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check
+        run: GOPATH=$(go env GOPATH) make -j"$(nproc)" mod.check
 
       - name: validate modcheck
         run: tests/scripts/validate_modified_files.sh modcheck

--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -72,8 +72,8 @@ jobs:
       # creating custom env var
       - name: set env
         run: |
-          echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-          echo "GITHUB_REF"=${GITHUB_REF} >> $GITHUB_ENV
+          echo "BRANCH_NAME=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+          echo "GITHUB_REF=${GITHUB_REF}" >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/tmate_debug/action.yml
+++ b/.github/workflows/tmate_debug/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         # Enable tmate only in the Rook fork, where the USE_TMATE secret is set in the repo, or if the action is re-run
         if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ -n "${{ inputs.use-tmate }}" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
-          echo ENABLE_TMATE=1 >> $GITHUB_ENV
+          echo ENABLE_TMATE=1 >> "$GITHUB_ENV"
         fi
 
     - name: set up tmate session

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -52,10 +52,11 @@ jobs:
 
       - name: run unit tests
         run: |
-          export ROOK_UNIT_JQ_PATH="$(which jq)"
+          ROOK_UNIT_JQ_PATH="$(which jq)"
+          export ROOK_UNIT_JQ_PATH
           # AZURE_EXTENSION_DIR is set in GH action runners and affects Azure KMS unit tests; unset it
           unset AZURE_EXTENSION_DIR
-          GOPATH=$(go env GOPATH) make -j $(nproc) test | tee output.txt
+          GOPATH=$(go env GOPATH) make -j"$(nproc)" test | tee output.txt
 
       - name: check mds liveness probe script ran successfully
         run: |

--- a/.github/workflows/upterm_debug/action.yml
+++ b/.github/workflows/upterm_debug/action.yml
@@ -13,7 +13,7 @@ runs:
       run: |
         # Enable upterm only in the main Rook repo, where the USE_TMATE secret is set in the repo, or if the action is re-run
         if [ "$GITHUB_REPOSITORY_OWNER" = "rook" ] || [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
-          echo ENABLE_UPTERM=1 >> $GITHUB_ENV
+          echo ENABLE_UPTERM=1 >> "$GITHUB_ENV"
         fi
 
     - name: set up upterm session


### PR DESCRIPTION
Workflow files are not statically checked today, so defects such as undeclared composite-action inputs or expression/matrix mistakes only surface at run time (for example, the ignored `github-token` inputs fixed in a sibling PR). This adds an `actionlint` job that lints the workflows on pull requests touching `.github/**` and on pushes to the protected branches.

Draft caveats for maintainers:

- actionlint is installed via `go install ...@latest` here for simplicity; it should be pinned before merge (a version tag, or a SHA-pinned action such as `rhysd/actionlint` or `reviewdog/action-actionlint`) to match the repo's action-pinning policy.
- A follow-up could wire it into `make lint` (e.g. `lint.quick`) and add zizmor (https://github.com/woodruffw/zizmor) for workflow security checks.

Opened as a **draft / do-not-merge**.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
