### PR TITLE
helm: add enabled flag to toggle storage types.

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -62,16 +62,22 @@ The following table lists the configurable parameters of the rook-operator chart
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `cephBlockPools` | A list of CephBlockPool configurations to deploy | See [below](#ceph-block-pools) |
+| `cephBlockPools.enabled` | Whether to create CephBlockPools | `true` |
+| `cephBlockPools.pools` | List of CephBlockPool configurations | See [below](#ceph-block-pools) |
 | `cephBlockPoolsVolumeSnapshotClass` | Settings for the block pool snapshot class | See [RBD Snapshots](../Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md#rbd-snapshots) |
 | `cephClusterMetadata.annotations` |  | `{}` |
 | `cephClusterMetadata.labels` |  | `{}` |
 | `cephClusterSpec` | Cluster configuration. | See [below](#ceph-cluster-spec) |
 | `cephFileSystemVolumeSnapshotClass` | Settings for the filesystem snapshot class | See [CephFS Snapshots](../Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md#cephfs-snapshots) |
 | `cephFileSystems` | A list of CephFileSystem configurations to deploy | See [below](#ceph-file-systems) |
+| `cephFileSystems.enabled` | Whether to create CephFileSystems | `true` |
+| `cephFileSystems.filesystems` | List of CephFileSystem configurations | See [below](#ceph-file-systems) |
 | `cephImage.allowUnsupported` |  | `false` |
 | `cephImage.repository` |  | `"quay.io/ceph/ceph"` |
 | `cephImage.tag` |  | `"v20.2.1"` |
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
+| `cephObjectStores.enabled` | Whether to create CephObjectStores | `true` |
+| `cephObjectStores.objectstores` | List of CephObjectStore configurations | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |
 | `csiDriverNamePrefix` | CSI driver name prefix for cephfs, rbd and nfs. | `namespace name where rook-ceph operator is deployed` |

--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -1,5 +1,13 @@
 {{- $root := . -}}
-{{- range $blockpool := .Values.cephBlockPools }}
+{{- $pools := list }}
+{{- if kindIs "map" .Values.cephBlockPools }}
+  {{- if .Values.cephBlockPools.enabled }}
+    {{- $pools = .Values.cephBlockPools.pools }}
+  {{- end }}
+{{- else }}
+  {{- $pools = .Values.cephBlockPools }}
+{{- end }}
+{{- range $blockpool := $pools }}
 ---
 kind: CephBlockPool
 apiVersion: ceph.rook.io/v1

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -1,5 +1,13 @@
 {{- $root := . -}}
-{{- range $filesystem := .Values.cephFileSystems }}
+{{- $filesystems := list }}
+{{- if kindIs "map" .Values.cephFileSystems }}
+  {{- if .Values.cephFileSystems.enabled }}
+    {{- $filesystems = .Values.cephFileSystems.filesystems }}
+  {{- end }}
+{{- else }}
+  {{- $filesystems = .Values.cephFileSystems }}
+{{- end }}
+{{- range $filesystem := $filesystems }}
 ---
 kind: CephFilesystemSubVolumeGroup
 apiVersion: ceph.rook.io/v1

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-httproute.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-httproute.yaml
@@ -1,4 +1,12 @@
-{{- range .Values.cephObjectStores -}}
+{{- $objectstores := list }}
+{{- if kindIs "map" .Values.cephObjectStores }}
+  {{- if .Values.cephObjectStores.enabled }}
+    {{- $objectstores = .Values.cephObjectStores.objectstores }}
+  {{- end }}
+{{- else }}
+  {{- $objectstores = .Values.cephObjectStores }}
+{{- end }}
+{{- range $objectstores -}}
 {{- if (. | dig "route" "enabled" false) }}
 ---
 kind: HTTPRoute

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore-ingress.yaml
@@ -1,4 +1,12 @@
-{{- range .Values.cephObjectStores -}}
+{{- $objectstores := list }}
+{{- if kindIs "map" .Values.cephObjectStores }}
+  {{- if .Values.cephObjectStores.enabled }}
+    {{- $objectstores = .Values.cephObjectStores.objectstores }}
+  {{- end }}
+{{- else }}
+  {{- $objectstores = .Values.cephObjectStores }}
+{{- end }}
+{{- range $objectstores -}}
 {{- if (. | dig "ingress" "enabled" false) }}
 ---
 kind: Ingress

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -1,5 +1,13 @@
 {{- $root := . -}}
-{{- range $objectstore := .Values.cephObjectStores }}
+{{- $objectstores := list }}
+{{- if kindIs "map" .Values.cephObjectStores }}
+  {{- if .Values.cephObjectStores.enabled }}
+    {{- $objectstores = .Values.cephObjectStores.objectstores }}
+  {{- end }}
+{{- else }}
+  {{- $objectstores = .Values.cephObjectStores }}
+{{- end }}
+{{- range $objectstore := $objectstores }}
 ---
 kind: CephObjectStore
 apiVersion: ceph.rook.io/v1

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -478,122 +478,132 @@ route:
 # -- A list of CephBlockPool configurations to deploy
 # @default -- See [below](#ceph-block-pools)
 cephBlockPools:
-  - name: ceph-blockpool
-    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
-    spec:
-      failureDomain: host
-      replicated:
-        size: 3
-      # Enables collecting RBD per-image IO statistics by enabling dynamic OSD performance counters. Defaults to false.
-      # For reference: https://docs.ceph.com/docs/latest/mgr/prometheus/#rbd-io-statistics
-      # enableRBDStats: true
-    storageClass:
-      enabled: true
-      name: ceph-block
-      annotations: {}
-      labels: {}
-      isDefault: true
-      reclaimPolicy: Delete
-      allowVolumeExpansion: true
-      volumeBindingMode: "Immediate"
-      mountOptions: []
-      # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
-      allowedTopologies: []
-      #        - matchLabelExpressions:
-      #            - key: rook-ceph-role
-      #              values:
-      #                - storage-node
-      # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md#provision-storage for available configuration
-      parameters:
-        # (optional) mapOptions is a comma-separated list of map options.
-        # For krbd options refer
-        # https://docs.ceph.com/docs/latest/man/8/rbd/#kernel-rbd-krbd-options
-        # For nbd options refer
-        # https://docs.ceph.com/docs/latest/man/8/rbd-nbd/#options
-        # mapOptions: lock_on_read,queue_depth=1024
+  # -- Whether to create CephBlockPools
+  enabled: true
+  # -- List of CephBlockPool configurations
+  # @default -- See [below](#ceph-block-pools)
+  pools:
+    - name: ceph-blockpool
+      # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
+      spec:
+        failureDomain: host
+        replicated:
+          size: 3
+        # Enables collecting RBD per-image IO statistics by enabling dynamic OSD performance counters. Defaults to false.
+        # For reference: https://docs.ceph.com/docs/latest/mgr/prometheus/#rbd-io-statistics
+        # enableRBDStats: true
+      storageClass:
+        enabled: true
+        name: ceph-block
+        annotations: {}
+        labels: {}
+        isDefault: true
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: "Immediate"
+        mountOptions: []
+        # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
+        allowedTopologies: []
+        #        - matchLabelExpressions:
+        #            - key: rook-ceph-role
+        #              values:
+        #                - storage-node
+        # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md#provision-storage for available configuration
+        parameters:
+          # (optional) mapOptions is a comma-separated list of map options.
+          # For krbd options refer
+          # https://docs.ceph.com/docs/latest/man/8/rbd/#kernel-rbd-krbd-options
+          # For nbd options refer
+          # https://docs.ceph.com/docs/latest/man/8/rbd-nbd/#options
+          # mapOptions: lock_on_read,queue_depth=1024
 
-        # (optional) unmapOptions is a comma-separated list of unmap options.
-        # For krbd options refer
-        # https://docs.ceph.com/docs/latest/man/8/rbd/#kernel-rbd-krbd-options
-        # For nbd options refer
-        # https://docs.ceph.com/docs/latest/man/8/rbd-nbd/#options
-        # unmapOptions: force
+          # (optional) unmapOptions is a comma-separated list of unmap options.
+          # For krbd options refer
+          # https://docs.ceph.com/docs/latest/man/8/rbd/#kernel-rbd-krbd-options
+          # For nbd options refer
+          # https://docs.ceph.com/docs/latest/man/8/rbd-nbd/#options
+          # unmapOptions: force
 
-        # RBD image format. Defaults to "2".
-        imageFormat: "2"
+          # RBD image format. Defaults to "2".
+          imageFormat: "2"
 
-        # RBD image features, equivalent to OR'd bitfield value: 63
-        # Available for imageFormat: "2". Older releases of CSI RBD
-        # support only the `layering` feature. The Linux kernel (KRBD) supports the
-        # full feature complement as of 5.4
-        imageFeatures: layering
+          # RBD image features, equivalent to OR'd bitfield value: 63
+          # Available for imageFormat: "2". Older releases of CSI RBD
+          # support only the `layering` feature. The Linux kernel (KRBD) supports the
+          # full feature complement as of 5.4
+          imageFeatures: layering
 
-        # These secrets contain Ceph admin credentials.
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-        # Specify the filesystem type of the volume. If not specified, csi-provisioner
-        # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
-        # in hyperconverged settings where the volume is mounted on the same node as the osds.
-        csi.storage.k8s.io/fstype: ext4
+          # These secrets contain Ceph admin credentials.
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+          # Specify the filesystem type of the volume. If not specified, csi-provisioner
+          # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+          # in hyperconverged settings where the volume is mounted on the same node as the osds.
+          csi.storage.k8s.io/fstype: ext4
 
 # -- A list of CephFileSystem configurations to deploy
 # @default -- See [below](#ceph-file-systems)
 cephFileSystems:
-  - name: ceph-filesystem
-    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#filesystem-settings for available configuration
-    spec:
-      metadataPool:
-        replicated:
-          size: 3
-      dataPools:
-        - failureDomain: host
+  # -- Whether to create CephFileSystems
+  enabled: true
+  # -- List of CephFileSystem configurations
+  # @default -- See [below](#ceph-file-systems)
+  filesystems:
+    - name: ceph-filesystem
+      # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#filesystem-settings for available configuration
+      spec:
+        metadataPool:
           replicated:
             size: 3
-          # Optional and highly recommended, 'data0' by default, see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#pools
-          name: data0
-      metadataServer:
-        activeCount: 1
-        activeStandby: true
-        resources:
-          limits:
-            memory: "4Gi"
-          requests:
-            cpu: "1000m"
-            memory: "4Gi"
-        priorityClassName: system-cluster-critical
-    storageClass:
-      enabled: true
-      isDefault: false
-      name: ceph-filesystem
-      # (Optional) specify a data pool to use, must be the name of one of the data pools above, 'data0' by default
-      pool: data0
-      reclaimPolicy: Delete
-      allowVolumeExpansion: true
-      volumeBindingMode: "Immediate"
-      annotations: {}
-      labels: {}
-      mountOptions: []
-      # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md#provision-storage for available configuration
-      parameters:
-        # The secrets contain Ceph admin credentials.
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
-        csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-        # Specify the filesystem type of the volume. If not specified, csi-provisioner
-        # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
-        # in hyperconverged settings where the volume is mounted on the same node as the osds.
-        csi.storage.k8s.io/fstype: ext4
+        dataPools:
+          - failureDomain: host
+            replicated:
+              size: 3
+            # Optional and highly recommended, 'data0' by default, see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#pools
+            name: data0
+        metadataServer:
+          activeCount: 1
+          activeStandby: true
+          resources:
+            limits:
+              memory: "4Gi"
+            requests:
+              cpu: "1000m"
+              memory: "4Gi"
+          priorityClassName: system-cluster-critical
+      storageClass:
+        enabled: true
+        isDefault: false
+        name: ceph-filesystem
+        # (Optional) specify a data pool to use, must be the name of one of the data pools above, 'data0' by default
+        pool: data0
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: "Immediate"
+        annotations: {}
+        labels: {}
+        mountOptions: []
+        # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage.md#provision-storage for available configuration
+        parameters:
+          # The secrets contain Ceph admin credentials.
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+          # Specify the filesystem type of the volume. If not specified, csi-provisioner
+          # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+          # in hyperconverged settings where the volume is mounted on the same node as the osds.
+          csi.storage.k8s.io/fstype: ext4
 
 # -- Settings for the filesystem snapshot class
 # @default -- See [CephFS Snapshots](../Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md#cephfs-snapshots)
@@ -622,82 +632,87 @@ cephBlockPoolsVolumeSnapshotClass:
 # -- A list of CephObjectStore configurations to deploy
 # @default -- See [below](#ceph-object-stores)
 cephObjectStores:
-  - name: ceph-objectstore
-    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md#object-store-settings for available configuration
-    spec:
-      metadataPool:
-        failureDomain: host
-        replicated:
-          size: 3
-      dataPool:
-        failureDomain: host
-        erasureCoded:
-          dataChunks: 2
-          codingChunks: 1
+  # -- Whether to create CephObjectStores
+  enabled: true
+  # -- List of CephObjectStore configurations
+  # @default -- See [below](#ceph-object-stores)
+  objectstores:
+    - name: ceph-objectstore
+      # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md#object-store-settings for available configuration
+      spec:
+        metadataPool:
+          failureDomain: host
+          replicated:
+            size: 3
+        dataPool:
+          failureDomain: host
+          erasureCoded:
+            dataChunks: 2
+            codingChunks: 1
+          parameters:
+            bulk: "true"
+        preservePoolsOnDelete: true
+        gateway:
+          port: 80
+          resources:
+            limits:
+              memory: "2Gi"
+            requests:
+              cpu: "1000m"
+              memory: "1Gi"
+          # securePort: 443
+          # sslCertificateRef:
+          instances: 1
+          priorityClassName: system-cluster-critical
+          # opsLogSidecar:
+          #   resources:
+          #     limits:
+          #       memory: "100Mi"
+          #     requests:
+          #       cpu: "100m"
+          #       memory: "40Mi"
+      storageClass:
+        enabled: true
+        name: ceph-bucket
+        reclaimPolicy: Delete
+        volumeBindingMode: "Immediate"
+        annotations: {}
+        labels: {}
+        # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md#storageclass for available configuration
         parameters:
-          bulk: "true"
-      preservePoolsOnDelete: true
-      gateway:
-        port: 80
-        resources:
-          limits:
-            memory: "2Gi"
-          requests:
-            cpu: "1000m"
-            memory: "1Gi"
-        # securePort: 443
-        # sslCertificateRef:
-        instances: 1
-        priorityClassName: system-cluster-critical
-        # opsLogSidecar:
-        #   resources:
-        #     limits:
-        #       memory: "100Mi"
-        #     requests:
-        #       cpu: "100m"
-        #       memory: "40Mi"
-    storageClass:
-      enabled: true
-      name: ceph-bucket
-      reclaimPolicy: Delete
-      volumeBindingMode: "Immediate"
-      annotations: {}
-      labels: {}
-      # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md#storageclass for available configuration
-      parameters:
-        # note: objectStoreNamespace and objectStoreName are configured by the chart
-        region: us-east-1
-    ingress:
-      # Enable an ingress for the ceph-objectstore
-      enabled: false
-      # The ingress port by default will be the object store's "securePort" (if set), or the gateway "port".
-      # To override those defaults, set this ingress port to the desired port.
-      # port: 80
-      # annotations: {}
-      # host:
-      #   name: objectstore.example.com
-      #   path: /
-      #   pathType: Prefix
-      # tls:
-      # - hosts:
-      #     - objectstore.example.com
-      #   secretName: ceph-objectstore-tls
-      # ingressClassName: nginx
-    route:
-      # Enable an ingress for the ceph-objectstore
-      enabled: false
-      # The ingress port by default will be the object store's "securePort" (if set), or the gateway "port".
-      # To override those defaults, set this ingress port to the desired port.
-      # port: 80
-      # annotations: {}
-      # host:
-      #   name: objectstore.example.com
-      #   path: /
-      #   pathType: PathPrefix
-      # parentRefs:
-      #   - name: internal
-      #     namespace: kube-system
-      #     sectionName: https
+          # note: objectStoreNamespace and objectStoreName are configured by the chart
+          region: us-east-1
+      ingress:
+        # Enable an ingress for the ceph-objectstore
+        enabled: false
+        # The ingress port by default will be the object store's "securePort" (if set), or the gateway "port".
+        # To override those defaults, set this ingress port to the desired port.
+        # port: 80
+        # annotations: {}
+        # host:
+        #   name: objectstore.example.com
+        #   path: /
+        #   pathType: Prefix
+        # tls:
+        # - hosts:
+        #     - objectstore.example.com
+        #   secretName: ceph-objectstore-tls
+        # ingressClassName: nginx
+      route:
+        # Enable an ingress for the ceph-objectstore
+        enabled: false
+        # The ingress port by default will be the object store's "securePort" (if set), or the gateway "port".
+        # To override those defaults, set this ingress port to the desired port.
+        # port: 80
+        # annotations: {}
+        # host:
+        #   name: objectstore.example.com
+        #   path: /
+        #   pathType: PathPrefix
+        # parentRefs:
+        #   - name: internal
+        #     namespace: kube-system
+        #     sectionName: https
 ## cephECBlockPools are disabled by default, please remove the comments and set desired values to enable it
 ## For erasure coded a replicated metadata pool is required.
 ## https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded


### PR DESCRIPTION
Adds an enabled flag to cephBlockPools, cephFileSystems, and cephObjectStores in the rook-ceph-cluster Helm chart. This allows users to selectively deploy only the storage types they need.

Changes
Added enabled: true (default) to each storage type in values.yaml
Updated templates to check the enabled flag before rendering resources
Restructured values to use nested lists (pools, filesystems, objectstores)

Usage

      # Deploy only block storage
      cephBlockPools:
        enabled: true
      cephFileSystems:
        enabled: false
      cephObjectStores:
        enabled: false

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #17753 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
