### PR TITLE
design: rgw: add tenant and defaultPlacement fields to CephObjectStoreUser

### DIFF
--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -4,12 +4,23 @@
 
 ## Summary
 
-This document proposes extending the `CephObjectStoreUser` CRD with two new spec fields:
+This document proposes extending the `CephObjectStoreUser` CRD with four new spec fields:
 
 - `tenant` — assigns the RGW user to a named RGW tenant, enabling bucket name isolation across tenants.
 - `defaultPlacement` — sets the user's default bucket placement target, controlling which data/metadata pools newly created buckets land in.
+- `defaultStorageClass` — sets the user's default storage class for objects, applied on top of `defaultPlacement`.
+- `defaultPlacementTags` — sets storage class placement tags associated with the user's default placement.
 
-Both fields already exist in the underlying `admin.User` struct in `go-ceph`; this work wires them into the Rook controller and API.
+All four fields already exist in the underlying `admin.User` struct in `go-ceph`; this work wires them into the Rook controller and API.
+
+### Why tenant and placement are covered in the same document
+
+`tenant`, `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` are unrelated in what they do in RGW, but they're proposed together here because they:
+
+- are all optional additions to the exact same CRD field (`ObjectStoreUserSpec`), reviewed against the same schema and the same immutability/mutability rules,
+- share the same controller entry points (`generateUserConfig`, `isUserSync`, `createOrUpdateCephUser`), so a reviewer needs to see how they compose in that code regardless of which section of the doc they came from,
+
+Splitting placement into its own document would not change the schema or the controller logic — it would only move prose. We've kept them together so the field interactions (e.g. `defaultStorageClass` requiring `defaultPlacement`, all three being independent of `tenant`) are visible in one place instead of cross-referenced across two documents.
 
 ## Motivation
 
@@ -23,21 +34,32 @@ tenantA$user1 → s3://photos
 tenantB$user1 → s3://photos
 ```
 
-Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW tenant. Operators who need per-tenant user isolation must manage RGW users manually outside of Rook, forgoing the benefits of the operator (secret rotation, lifecycle management, status conditions).
+Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW
+tenant. Operators who need per-tenant user isolation must manage RGW users
+manually outside of Rook, forgoing the benefits of the operator (secret
+rotation, lifecycle management, status conditions).
 
 ### Placement Targeting
 
-`CephObjectStore.spec.sharedPools.poolPlacements` already allows defining named placement targets (each backed by distinct metadata/data pools). However, the `CephObjectStoreUser` controller has no way to assign a user's `default-placement`, meaning all users default to the store-wide default placement. For multi-tier storage scenarios (hot/cold pools, per-tenant pools), operators need per-user placement control.
+`CephObjectStore.spec.sharedPools.poolPlacements` already allows defining named
+placement targets (each backed by distinct metadata/data pools). However, the
+`CephObjectStoreUser` controller has no way to assign a user's
+`default-placement`, meaning all users default to the store-wide default
+placement.
 
 ## Goals
 
 - Add `spec.tenant` to `CephObjectStoreUser` to set the `Tenant` field on the RGW Admin Ops API `User` struct at user creation.
 - Add `spec.defaultPlacement` to `CephObjectStoreUser` to set `DefaultPlacement` on the user via `CreateUser`/`ModifyUser` in the RGW Admin Ops API.
+- Add `spec.defaultStorageClass` to `CephObjectStoreUser` to set `DefaultStorageClass` on the user, embedded into the placement rule sent to RGW
+- Add `spec.defaultPlacementTags` to `CephObjectStoreUser` to set `PlacementTags` on the user via `CreateUser`/`ModifyUser`, now that go-ceph supports it upstream (merged in [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)).
 - Validate `defaultPlacement` against the named placements defined in the referenced `CephObjectStore`.
+- Require `defaultPlacement` to be set whenever `defaultStorageClass` is set, since RGW cannot apply a storage class without a placement target.
 - Treat `tenant` as immutable (changing tenant requires user deletion and recreation in RGW).
-- Treat `defaultPlacement` as mutable (can be updated via `ModifyUser`).
-- Both fields are independent of each other: `defaultPlacement` may be set without `tenant`, and vice versa.
-- Preserve backward compatibility: both fields are optional, existing resources are unaffected.
+- Treat `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` as mutable (can be updated via `ModifyUser`).
+- Explicitly reconcile removal of `defaultPlacement`/`defaultStorageClass`/`defaultPlacementTags` back to Ceph's defaults rather than leaving the RGW-side value stale (see [Unset/Removal Behavior](#unsetremoval-behavior)).
+- All four fields are independent of `tenant`: `defaultPlacement`/`defaultStorageClass`/`defaultPlacementTags` may be set without `tenant`, and vice versa.
+- Preserve backward compatibility: all new fields are optional, existing resources are unaffected.
 
 
 ## Background
@@ -57,14 +79,15 @@ radosgw-admin user info --uid="user1" --tenant="tenantA"
 The `go-ceph` `admin.User` struct already models this:
 ```go
 type User struct {
-    ID              string `json:"user_id" url:"uid"`
-    Tenant          string `url:"tenant"`           // ← passed as URL param only, not in JSON response
-    DefaultPlacement string `json:"default_placement" url:"default-placement"`
+    ID                  string   `json:"user_id" url:"uid"`
+    Tenant              string   `url:"tenant"`                                          // ← passed as URL param only, not in JSON response
+    DefaultPlacement    string   `json:"default_placement" url:"default-placement"`
+    DefaultStorageClass string   `json:"default_storage_class" url:"default-storage-class"`
+    PlacementTags       []string `json:"placement_tags" url:"placement-tags"`             // ← support merged upstream in ceph/go-ceph#1290
     // ...
 }
 ```
 
-**Note**: `Tenant` is URL-parameter-only (no `json` tag) in go-ceph, meaning it is passed in API requests but not present in JSON responses. The controller must store the tenant from spec, not from API responses.
 
 ### Interaction with `AccountRef`
 
@@ -74,7 +97,11 @@ type User struct {
 
 ### `ObjectStoreUserSpec` (`pkg/apis/ceph.rook.io/v1/types.go`)
 
+`defaultPlacement` and `defaultStorageClass` are added as flat, top-level `*string` fields directly on `ObjectStoreUserSpec`, named to match the `go-ceph` `admin.User` fields exactly (`DefaultPlacement`, `DefaultStorageClass`), rather than being wrapped in a nested `ObjectStoreUserPlacementSpec` struct. This mirrors the pattern already established by PR [#17260](https://github.com/rook/rook/pull/17260), which added `DefaultStorageClass` as a flat field on the same spec — introducing a nested struct here would create two incompatible shapes for closely related fields on the same object.
+
 ```go
+// ObjectStoreUserSpec represent the spec of an Objectstoreuser
+// +kubebuilder:validation:XValidation:message="defaultStorageClass requires defaultPlacement",rule="!has(self.defaultStorageClass) || has(self.defaultPlacement)"
 type ObjectStoreUserSpec struct {
     Store        string `json:"store,omitempty"`
     DisplayName  string `json:"displayName,omitempty"`
@@ -90,33 +117,66 @@ type ObjectStoreUserSpec struct {
     // +kubebuilder:validation:MaxLength=255
     Tenant string `json:"tenant,omitempty"`
 
-    // Placement controls the user's default bucket placement target and storage class tags.
-    // May be set independently of tenant.
+    // DefaultPlacement overrides the default pool placement for buckets created by
+    // this user. Must match one of the entries in the referenced CephObjectStore's
+    // spec.sharedPools.poolPlacements[].name. If not provided, the zone group's
+    // default placement target is used.
     // +optional
-    // +nullable
-    Placement *ObjectStoreUserPlacementSpec `json:"placement,omitempty"`
-}
+    // +kubebuilder:validation:MinLength=0
+    // +kubebuilder:validation:MaxLength=2048
+    DefaultPlacement *string `json:"defaultPlacement,omitempty"`
 
-// ObjectStoreUserPlacementSpec sets the user's default placement target and storage class tags.
-type ObjectStoreUserPlacementSpec struct {
-    // ID names the placement target for new buckets created by this user.
-    // Must match one of the entries in the referenced CephObjectStore's
-    // spec.sharedPools.poolPlacements[].name.
+    // DefaultStorageClass overrides the default storage class for objects created by
+    // this user. Requires DefaultPlacement to be set. If not provided, the default
+    // `STANDARD` storage class is used.
     // +optional
-    // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._/-]+$`
-    // +kubebuilder:validation:MaxLength=255
-    ID string `json:"id,omitempty"`
+    // +kubebuilder:validation:MinLength=0
+    // +kubebuilder:validation:MaxLength=2048
+    DefaultStorageClass *string `json:"defaultStorageClass,omitempty"`
 
-    // Tags is a list of storage class tags to associate with this user's default placement.
+    // DefaultPlacementTags is a list of storage class tags to associate with this
+    // user's default placement.
     // +optional
     // +listType=atomic
-    Tags []string `json:"tags,omitempty"`
+    // +kubebuilder:validation:MinItems=1
+    // +kubebuilder:validation:MaxItems=64
+    DefaultPlacementTags []string `json:"defaultPlacementTags,omitempty"`
 }
 ```
 
 Maps to `go-ceph` `admin.User` fields:
-- `Placement.ID` → `DefaultPlacement` (URL param `default-placement`)
-- `Placement.Tags` → `PlacementTags` (JSON `placement_tags`)
+- `DefaultPlacement` → `DefaultPlacement` (URL param `default-placement`, embeds storage class — see below)
+- `DefaultStorageClass` → `DefaultStorageClass` (URL param `default-storage-class`, informational only — see below)
+- `DefaultPlacementTags` → `PlacementTags` (URL param `placement-tags`, JSON `placement_tags`)
+
+**`PlacementTags` was previously out of scope** because go-ceph did not yet support it and PR #17260 does not implement it. That gap has since closed: [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290) added `PlacementTags` support to the admin ops client and merged upstream on 2026-07-09. This design now includes it as a flat `DefaultPlacementTags []string` field, following the same flat, go-ceph-aligned naming as the other fields. Rook's `go.mod` currently points at a fork (`github.com/ideepika/go-ceph`) pending an official tagged go-ceph release that includes this change; that pin must be replaced with a released version before this can merge.
+
+### Unset/Removal Behavior
+
+Ceph RGW's `ModifyUser` semantics do not treat an absent field as "no change" —
+the field's zero value is sent, and RGW acts on it:
+
+- If `defaultPlacement` is set and later removed from the spec, the controller
+  must issue a `ModifyUser` call with an explicit empty `default-placement`,
+  which reverts the user to the zone group's default placement target. Simply
+  omitting the field from a subsequent reconcile is not sufficient — go-ceph's
+  `ModifyUser` sends whatever value is present on the `admin.User` struct
+  passed to it, so a removed spec field must be explicitly reconciled by the
+  controller (e.g. by constructing the request with `DefaultPlacement: ""`),
+  not just left unset in Go.
+
+- If both are removed together, the controller reverts to sending an empty
+  `default-placement`, which implicitly also clears any storage class override.
+- If `defaultPlacementTags` is set and later removed, the controller must send
+  an empty `placement-tags` list, clearing the tags on the live RGW user rather
+  than leaving the last-applied tags in place.
+
+This mirrors the enforcement mechanism already used for `tenant`'s
+immutability: the desired end-state is expressed declaratively in the spec, and
+the controller is responsible for issuing whatever explicit RGW admin API call
+is needed to converge live state to it, including reverting fields to their
+Ceph-side defaults on removal — not merely for what to send when a field is
+populated.
 
 ### Example CR
 
@@ -130,10 +190,10 @@ spec:
   store: my-store
   displayName: "Tenant A User 1"
   tenant: tenantA
-  placement:
-    id: hot-tier
-    tags:
-      - tenant_a_tag
+  defaultPlacement: hot-tier
+  defaultStorageClass: STANDARD_IA
+  defaultPlacementTags:
+    - tenant-a
 ```
 
 ## S3 Client Configuration for Tenanted Users
@@ -147,24 +207,47 @@ aws_access_key_id     = <AccessKey from rook-ceph-object-user-my-store-user1>
 aws_secret_access_key = <SecretKey from rook-ceph-object-user-my-store-user1>
 ```
 
-Bucket names, however, are only unique within a tenant namespace. Two users in different tenants may each own a bucket named `photos` without conflict. From the client's perspective, each accesses their own `photos` bucket using their respective credentials; RGW routes requests to the correct tenant namespace internally.
+### Intra-tenant access (primary use case)
 
-Cross-tenant access to another tenant's bucket is not possible via standard S3 path/virtual-host addressing — RGW resolves the bucket to the owner's tenant based on the credentials used. Bucket policies and ACLs apply within the same tenant; cross-tenant sharing is out of scope for this feature.
+Users within the same tenant access their buckets using standard S3 virtual-host-style URLs with no changes:
 
-No changes to existing user documentation are required for the S3 endpoint or credential format.
+```
+my-bucket.s3.ceph.io   ← works normally for same-tenant users
+```
+
+RGW resolves the bucket to the correct tenant namespace based on the credentials used. No DNS changes or special endpoint configuration are required for this feature's primary use case.
+
+### Cross-tenant access (out of scope, deprecated upstream)
+
+Cross-tenant bucket access via path-style requests using the `tenant:bucket`
+notation (e.g. `s3.ceph.io/tenantA:my-bucket/`) is a Ceph extension to the S3
+protocol. As noted in the Ceph Tentacle release notes, this feature is
+deprecated and scheduled for removal.
+
+> S3 API support for cross-tenant names such as `Bucket='tenant:bucketname'`
+
+Virtual-host-style cross-tenant access (`tenantA:my-bucket.s3.ceph.io`) is not
+possible because `:` is not valid in DNS names.
+
+**Cross-tenant bucket sharing is explicitly out of scope for this feature.**
+Users who need to share buckets across tenant boundaries should be placed in
+the same tenant namespace. This aligns with Ceph's upstream direction of
+removing cross-tenant path-style access.
 
 ## Immutability
 
-`tenant` is immutable because RGW does not support moving a user between tenants; the only path is deletion and recreation. Attempting to change `tenant` on an existing `CephObjectStoreUser` would silently create a second user in the new tenant while leaving the original orphaned.
+`tenant` is immutable because RGW does not support moving a user between
+tenants; the only path is deletion and recreation. Attempting to change
+`tenant` on an existing `CephObjectStoreUser` would silently create a second
+user in the new tenant while leaving the original orphaned.
 
-**Enforcement mechanism**: CEL `XValidation` rule on the spec field (same pattern as `accountRef`):
-```go
-// +kubebuilder:validation:XValidation:message="tenant is immutable",rule="self == oldSelf"
-```
 
-This gives a clear admission webhook error on any attempted change.
-
-`defaultPlacement` is mutable — RGW supports changing a user's default placement at any time; it only affects future bucket creation, not existing buckets.
+`defaultPlacement` and `defaultStorageClass` are mutable — RGW supports
+changing a user's default placement and storage class at any time; changes only
+affect future bucket/object creation, not existing buckets/objects. As
+described in [Unset/Removal Behavior](#unsetremoval-behavior), mutability also
+covers the removal case: the controller must actively drive RGW back to its own
+defaults rather than treating an unset field as a no-op.
 
 ## Interaction with `AccountRef`
 
@@ -173,9 +256,3 @@ This gives a clear admission webhook error on any attempted change.
 - `userConfig.AccountID` is set from `spec.accountRef`
 
 No conflict; `admin.User` has both fields.
-
-## Upgrade and Backward Compatibility
-
-- Both new fields are `omitempty`; existing `CephObjectStoreUser` resources without these fields continue to work unchanged.
-- No migration of existing RGW users is required or performed.
-- The CRD schema is additive only.

--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -31,11 +31,12 @@ Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW tenan
 
 ## Goals
 
-- Add `spec.tenant` to `CephObjectStoreUser` to pass `--tenant` to radosgw-admin at user creation.
-- Add `spec.defaultPlacement` to `CephObjectStoreUser` to pass `--placement-id` / set `default_placement` on modify.
+- Add `spec.tenant` to `CephObjectStoreUser` to set the `Tenant` field on the RGW Admin Ops API `User` struct at user creation.
+- Add `spec.defaultPlacement` to `CephObjectStoreUser` to set `DefaultPlacement` on the user via `CreateUser`/`ModifyUser` in the RGW Admin Ops API.
 - Validate `defaultPlacement` against the named placements defined in the referenced `CephObjectStore`.
 - Treat `tenant` as immutable (changing tenant requires user deletion and recreation in RGW).
 - Treat `defaultPlacement` as mutable (can be updated via `ModifyUser`).
+- Both fields are independent of each other: `defaultPlacement` may be set without `tenant`, and vice versa.
 - Preserve backward compatibility: both fields are optional, existing resources are unaffected.
 
 
@@ -89,15 +90,33 @@ type ObjectStoreUserSpec struct {
     // +kubebuilder:validation:MaxLength=255
     Tenant string `json:"tenant,omitempty"`
 
-    // DefaultPlacement names the placement target for new buckets created by this user.
+    // Placement controls the user's default bucket placement target and storage class tags.
+    // May be set independently of tenant.
+    // +optional
+    // +nullable
+    Placement *ObjectStoreUserPlacementSpec `json:"placement,omitempty"`
+}
+
+// ObjectStoreUserPlacementSpec sets the user's default placement target and storage class tags.
+type ObjectStoreUserPlacementSpec struct {
+    // ID names the placement target for new buckets created by this user.
     // Must match one of the entries in the referenced CephObjectStore's
     // spec.sharedPools.poolPlacements[].name.
     // +optional
     // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._/-]+$`
     // +kubebuilder:validation:MaxLength=255
-    DefaultPlacement string `json:"defaultPlacement,omitempty"`
+    ID string `json:"id,omitempty"`
+
+    // Tags is a list of storage class tags to associate with this user's default placement.
+    // +optional
+    // +listType=atomic
+    Tags []string `json:"tags,omitempty"`
 }
 ```
+
+Maps to `go-ceph` `admin.User` fields:
+- `Placement.ID` → `DefaultPlacement` (URL param `default-placement`)
+- `Placement.Tags` → `PlacementTags` (JSON `placement_tags`)
 
 ### Example CR
 
@@ -111,8 +130,28 @@ spec:
   store: my-store
   displayName: "Tenant A User 1"
   tenant: tenantA
-  defaultPlacement: hot-tier
+  placement:
+    id: hot-tier
+    tags:
+      - tenant_a_tag
 ```
+
+## S3 Client Configuration for Tenanted Users
+
+RGW exposes tenanted users to S3 clients through their access key / secret key pair — the S3 client itself requires no special modification. Credentials stored in the Rook-managed Kubernetes Secret are functionally identical regardless of whether the user belongs to a tenant.
+
+```yaml
+# AWS CLI profile for a tenanted user — identical to a non-tenanted user
+[profile tenantA-user1]
+aws_access_key_id     = <AccessKey from rook-ceph-object-user-my-store-user1>
+aws_secret_access_key = <SecretKey from rook-ceph-object-user-my-store-user1>
+```
+
+Bucket names, however, are only unique within a tenant namespace. Two users in different tenants may each own a bucket named `photos` without conflict. From the client's perspective, each accesses their own `photos` bucket using their respective credentials; RGW routes requests to the correct tenant namespace internally.
+
+Cross-tenant access to another tenant's bucket is not possible via standard S3 path/virtual-host addressing — RGW resolves the bucket to the owner's tenant based on the credentials used. Bucket policies and ACLs apply within the same tenant; cross-tenant sharing is out of scope for this feature.
+
+No changes to existing user documentation are required for the S3 endpoint or credential format.
 
 ## Immutability
 

--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -1,0 +1,142 @@
+# RGW User Multitenancy and Default Placement Targeting in CephObjectStoreUser
+
+- **Issue**: https://github.com/rook/rook/issues/17274
+
+## Summary
+
+This document proposes extending the `CephObjectStoreUser` CRD with two new spec fields:
+
+- `tenant` — assigns the RGW user to a named RGW tenant, enabling bucket name isolation across tenants.
+- `defaultPlacement` — sets the user's default bucket placement target, controlling which data/metadata pools newly created buckets land in.
+
+Both fields already exist in the underlying `admin.User` struct in `go-ceph`; this work wires them into the Rook controller and API.
+
+## Motivation
+
+### Tenant Isolation
+
+Ceph RGW supports a multitenancy model where users live in named tenants. Users in different tenants can own buckets with the same name without collision:
+
+```
+# Two separate objects, no conflict
+tenantA$user1 → s3://photos
+tenantB$user1 → s3://photos
+```
+
+Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW tenant. Operators who need per-tenant user isolation must manage RGW users manually outside of Rook, forgoing the benefits of the operator (secret rotation, lifecycle management, status conditions).
+
+### Placement Targeting
+
+`CephObjectStore.spec.sharedPools.poolPlacements` already allows defining named placement targets (each backed by distinct metadata/data pools). However, the `CephObjectStoreUser` controller has no way to assign a user's `default-placement`, meaning all users default to the store-wide default placement. For multi-tier storage scenarios (hot/cold pools, per-tenant pools), operators need per-user placement control.
+
+## Goals
+
+- Add `spec.tenant` to `CephObjectStoreUser` to pass `--tenant` to radosgw-admin at user creation.
+- Add `spec.defaultPlacement` to `CephObjectStoreUser` to pass `--placement-id` / set `default_placement` on modify.
+- Validate `defaultPlacement` against the named placements defined in the referenced `CephObjectStore`.
+- Treat `tenant` as immutable (changing tenant requires user deletion and recreation in RGW).
+- Treat `defaultPlacement` as mutable (can be updated via `ModifyUser`).
+- Preserve backward compatibility: both fields are optional, existing resources are unaffected.
+
+
+## Background
+
+### RGW Tenant User ID Format
+
+When a user is created in a tenant, RGW stores and returns the user as `$tenant$uid` internally, but the external UID (passed to the API) is just `uid`. When querying or deleting a tenanted user, the RGW Admin Ops API accepts a `Tenant` field alongside `ID` rather than a combined string.
+
+Equivalently via CLI:
+```bash
+radosgw-admin user create --uid="user1" --tenant="tenantA" --display-name="User 1"
+# effective UID internally: tenantA$user1
+
+radosgw-admin user info --uid="user1" --tenant="tenantA"
+```
+
+The `go-ceph` `admin.User` struct already models this:
+```go
+type User struct {
+    ID              string `json:"user_id" url:"uid"`
+    Tenant          string `url:"tenant"`           // ← passed as URL param only, not in JSON response
+    DefaultPlacement string `json:"default_placement" url:"default-placement"`
+    // ...
+}
+```
+
+**Note**: `Tenant` is URL-parameter-only (no `json` tag) in go-ceph, meaning it is passed in API requests but not present in JSON responses. The controller must store the tenant from spec, not from API responses.
+
+### Interaction with `AccountRef`
+
+`AccountRef` (added in a recent release) also links users to an RGW account and is already marked immutable. Users with `accountRef` set are account-member users. Tenant assignment and account membership are orthogonal in RGW—a user can belong to both a tenant and an account.
+
+## Proposed API Changes
+
+### `ObjectStoreUserSpec` (`pkg/apis/ceph.rook.io/v1/types.go`)
+
+```go
+type ObjectStoreUserSpec struct {
+    Store        string `json:"store,omitempty"`
+    DisplayName  string `json:"displayName,omitempty"`
+    // ... existing fields ...
+
+    // Tenant is the RGW tenant this user belongs to.
+    // Users in different tenants can have buckets with the same name without conflict.
+    // When set, the effective user ID in RGW becomes "<tenant>$<name>".
+    // This field is immutable after creation.
+    // +optional
+    // +kubebuilder:validation:XValidation:message="tenant is immutable",rule="self == oldSelf"
+    // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+$`
+    // +kubebuilder:validation:MaxLength=255
+    Tenant string `json:"tenant,omitempty"`
+
+    // DefaultPlacement names the placement target for new buckets created by this user.
+    // Must match one of the entries in the referenced CephObjectStore's
+    // spec.sharedPools.poolPlacements[].name.
+    // +optional
+    // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._/-]+$`
+    // +kubebuilder:validation:MaxLength=255
+    DefaultPlacement string `json:"defaultPlacement,omitempty"`
+}
+```
+
+### Example CR
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: user1
+  namespace: rook-ceph
+spec:
+  store: my-store
+  displayName: "Tenant A User 1"
+  tenant: tenantA
+  defaultPlacement: hot-tier
+```
+
+## Immutability
+
+`tenant` is immutable because RGW does not support moving a user between tenants; the only path is deletion and recreation. Attempting to change `tenant` on an existing `CephObjectStoreUser` would silently create a second user in the new tenant while leaving the original orphaned.
+
+**Enforcement mechanism**: CEL `XValidation` rule on the spec field (same pattern as `accountRef`):
+```go
+// +kubebuilder:validation:XValidation:message="tenant is immutable",rule="self == oldSelf"
+```
+
+This gives a clear admission webhook error on any attempted change.
+
+`defaultPlacement` is mutable — RGW supports changing a user's default placement at any time; it only affects future bucket creation, not existing buckets.
+
+## Interaction with `AccountRef`
+
+`tenant` and `accountRef` are orthogonal. Both can be set simultaneously. When both are set:
+- `userConfig.Tenant` is set from `spec.tenant`
+- `userConfig.AccountID` is set from `spec.accountRef`
+
+No conflict; `admin.User` has both fields.
+
+## Upgrade and Backward Compatibility
+
+- Both new fields are `omitempty`; existing `CephObjectStoreUser` resources without these fields continue to work unchanged.
+- No migration of existing RGW users is required or performed.
+- The CRD schema is additive only.

--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -1,0 +1,423 @@
+# RGW User Multitenancy and Default Placement Targeting in CephObjectStoreUser
+
+- **Issue**: https://github.com/rook/rook/issues/17274
+
+## Summary
+
+This document proposes extending the `CephObjectStoreUser` CRD with four new spec fields:
+
+- `tenant` — assigns the RGW user to a named RGW tenant, enabling bucket name isolation across tenants.
+- `defaultPlacement` — sets the user's default bucket placement target, controlling which data/metadata pools newly created buckets land in.
+- `defaultStorageClass` — sets the user's default storage class for objects, applied on top of `defaultPlacement`.
+- `defaultPlacementTags` — restricts which zonegroup placement targets the user may create buckets in, based on tags carried by those targets.
+
+All four fields already exist in the underlying `admin.User` struct in `go-ceph`; this work wires them into the Rook controller and API.
+
+### Why tenant and placement are covered in the same document
+
+`tenant`, `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` are unrelated in what they do in RGW, but they're proposed together here because they:
+
+- are all optional additions to the exact same CRD field (`ObjectStoreUserSpec`), reviewed against the same schema and the same immutability/mutability rules,
+- share the same controller entry points (`generateUserConfig`, `isUserSync`, `createOrUpdateCephUser`), so a reviewer needs to see how they compose in that code regardless of which section of the doc they came from,
+
+Splitting placement into its own document would not change the schema or the controller logic — it would only move prose. We've kept them together so the field interactions (e.g. `defaultStorageClass` requiring `defaultPlacement`, all three being independent of `tenant`) are visible in one place instead of cross-referenced across two documents.
+
+## Motivation
+
+### Tenant Isolation
+
+Ceph RGW supports a multitenancy model where users live in named tenants. Users in different tenants can own buckets with the same name without collision:
+
+```
+# Two separate objects, no conflict
+tenantA$user1 → s3://photos
+tenantB$user1 → s3://photos
+```
+
+Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW
+tenant. Operators who need per-tenant user isolation must manage RGW users
+manually outside of Rook, forgoing the benefits of the operator (secret
+rotation, lifecycle management, status conditions).
+
+### Placement Targeting
+
+`CephObjectStore.spec.sharedPools.poolPlacements` already allows defining named
+placement targets (each backed by distinct metadata/data pools). However, the
+`CephObjectStoreUser` controller has no way to assign a user's
+`default-placement`, meaning all users default to the store-wide default
+placement.
+
+## Goals
+
+- Add `spec.tenant` to `CephObjectStoreUser` to set the `Tenant` field on the RGW Admin Ops API `User` struct at user creation.
+- Add `spec.defaultPlacement` to `CephObjectStoreUser` to set `DefaultPlacement` on the user via `CreateUser`/`ModifyUser` in the RGW Admin Ops API.
+- Add `spec.defaultStorageClass` to `CephObjectStoreUser` to set `DefaultStorageClass` on the user, embedded into the placement rule sent to RGW
+- Add `spec.defaultPlacementTags` to `CephObjectStoreUser` to set `PlacementTags` on the user via `CreateUser`/`ModifyUser`, now that go-ceph supports it upstream (merged in [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)).
+- Leave `defaultPlacement` validation to RGW: the serving RGW validates it
+  against the live zonegroup on every create/modify and rejects unknown
+  targets with `EINVAL`; the operator surfaces that failure in the CR status.
+  (Validating against the referenced `CephObjectStore`'s `spec.sharedPools`
+  would be wrong for zone-backed stores, whose placements live on
+  `CephObjectZone`, and impossible for external stores.)
+- Require `defaultPlacement` to be set whenever `defaultStorageClass` is set, since RGW cannot apply a storage class without a placement target.
+- Treat `tenant` as immutable (changing tenant requires user deletion and recreation in RGW).
+- Treat `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` as changeable but not removable: they can be updated to a different value via `ModifyUser`, but cannot be unset once set, because RGW provides no way to clear them (see [Unset/Removal Behavior](#unsetremoval-behavior)). This caveat is enforced by CEL and documented for users; lifting it depends on upstream RGW and go-ceph fixes.
+- All four fields are independent of `tenant`: `defaultPlacement`/`defaultStorageClass`/`defaultPlacementTags` may be set without `tenant`, and vice versa.
+- Preserve backward compatibility: all new fields are optional, existing resources are unaffected.
+
+
+## Background
+
+### RGW Tenant User ID Format
+
+When a user is created in a tenant, the user's identity everywhere in RGW is the combined form `<tenant>$<uid>`. Every Admin Ops operation resolves the `uid` parameter through this form (`rgw_user::from_str` splits on `$`); a bare `uid` addresses the user in the default (empty) tenant.
+
+The Admin Ops API accepts a separate `tenant` parameter **only on user create**. User info, modify, and remove have no tenant parameter — on those operations a tenant can only be expressed inside the combined `uid`. go-ceph mirrors this: `admin.User.Tenant` is transmitted by `CreateUser` only and silently dropped by `GetUser`/`ModifyUser`/`RemoveUser`, whose URL-parameter whitelists exclude `tenant`.
+
+The controller therefore uses the combined `<tenant>$<name>` string as the user ID for **every** Admin Ops call, create included, and never relies on the go-ceph `Tenant` struct field. Addressing a tenanted user by bare `uid` would silently resolve to the same-named user in the default tenant: reconciliation would adopt (and CR deletion would delete) an unrelated user, or wedge in a CreateUser/UserAlreadyExists loop when none exists. As a backstop, the reconcile fails with an explicit error if the live user's tenant does not match `spec.tenant`, rather than adopting a user from another tenant.
+
+Equivalently via CLI:
+```bash
+radosgw-admin user create --uid="tenantA$user1" --display-name="User 1"
+
+radosgw-admin user info --uid="tenantA$user1"
+```
+
+The `go-ceph` `admin.User` struct models all four fields. Released support
+arrived in two steps: v0.40.0 (Rook's current pin) transmits
+`default-placement` and `default-storage-class` on both `CreateUser` and
+`ModifyUser`; v0.41.0 (released 2026-08-11) adds `placement-tags`
+([ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)):
+
+```go
+// go-ceph v0.41.0 (released)
+type User struct {
+    ID                  string   `json:"user_id" url:"uid"`
+    Tenant              string   `url:"tenant"`  // ← URL param on user create only
+    DefaultPlacement    string   `json:"default_placement" url:"default-placement"`
+    DefaultStorageClass string   `json:"default_storage_class" url:"default-storage-class"`
+    PlacementTags       []string `json:"placement_tags" url:"placement-tags"`
+    // ...
+}
+```
+
+Implementing `spec.defaultPlacementTags` therefore requires only a `go.mod`
+bump to go-ceph v0.41.0 — no fork and no unreleased dependency. See
+[Setting the storage class](#setting-the-storage-class) for how the two
+placement parameters are applied on the wire.
+
+
+### Interaction with `AccountRef`
+
+`AccountRef` (added in a recent release) also links users to an RGW account and is already marked immutable. Users with `accountRef` set are account-member users. RGW itself allows a tenanted account member as long as the member's tenant equals the account's own tenant, but Rook's `CephObjectStoreAccount` cannot create a tenanted account today — see [Interaction with `AccountRef`](#interaction-with-accountref-1) for why this design rejects the combination at admission rather than exposing an always-failing configuration.
+
+## Proposed API Changes
+
+### `ObjectStoreUserSpec` (`pkg/apis/ceph.rook.io/v1/types.go`)
+
+`defaultPlacement` and `defaultStorageClass` are added as flat, top-level `*string` fields directly on `ObjectStoreUserSpec`, named to match the `go-ceph` `admin.User` fields exactly (`DefaultPlacement`, `DefaultStorageClass`), rather than being wrapped in a nested `ObjectStoreUserPlacementSpec` struct. This mirrors the pattern already established by PR [#17260](https://github.com/rook/rook/pull/17260), which added `DefaultStorageClass` as a flat field on the same spec — introducing a nested struct here would create two incompatible shapes for closely related fields on the same object.
+
+A nested `spec.placement` struct would make the `defaultStorageClass` requires `defaultPlacement` coupling structurally visible, which is the strongest argument for it. The flat layout expresses the same constraint with a CEL rule instead, which produces a specific, actionable error message at admission and does not require users to learn a second nesting level for what is, on the RGW side, three sibling attributes of one user. The coupling is also not total — `defaultPlacement` and `defaultPlacementTags` are each usable on their own — so a wrapper struct would group fields more tightly than their actual semantics warrant.
+
+```go
+// ObjectStoreUserSpec represent the spec of an Objectstoreuser
+// +kubebuilder:validation:XValidation:message="defaultStorageClass requires defaultPlacement",rule="!has(self.defaultStorageClass) || has(self.defaultPlacement)"
+// +kubebuilder:validation:XValidation:message="defaultPlacement cannot be unset once set; RGW does not support clearing a user's default placement",rule="!has(oldSelf.defaultPlacement) || has(self.defaultPlacement)"
+// +kubebuilder:validation:XValidation:message="defaultStorageClass cannot be unset once set; RGW does not support clearing a user's default storage class",rule="!has(oldSelf.defaultStorageClass) || has(self.defaultStorageClass)"
+// +kubebuilder:validation:XValidation:message="defaultPlacementTags cannot be unset once set; RGW does not support clearing a user's placement tags",rule="!has(oldSelf.defaultPlacementTags) || has(self.defaultPlacementTags)"
+// +kubebuilder:validation:XValidation:message="tenant is immutable",rule="has(oldSelf.tenant) == has(self.tenant) && (!has(self.tenant) || self.tenant == oldSelf.tenant)"
+type ObjectStoreUserSpec struct {
+    Store        string `json:"store,omitempty"`
+    DisplayName  string `json:"displayName,omitempty"`
+    // ... existing fields ...
+
+    // Tenant is the RGW tenant this user belongs to.
+    // Users in different tenants can have buckets with the same name without conflict.
+    // When set, the effective user ID in RGW becomes "<tenant>$<name>".
+    // This field is immutable after creation.
+    // +optional
+    // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
+    // +kubebuilder:validation:MaxLength=255
+    Tenant string `json:"tenant,omitempty"`
+
+    // DefaultPlacement overrides the default pool placement for buckets created by
+    // this user. It must name a placement target known to the zonegroup serving
+    // the referenced object store; RGW validates this on every create and modify
+    // and rejects unknown targets. If not provided, the zone group's
+    // default placement target is used.
+    // This field cannot be unset once set — see "Unset/Removal Behavior".
+    // +optional
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:MaxLength=2048
+    // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+$`
+    DefaultPlacement *string `json:"defaultPlacement,omitempty"`
+
+    // DefaultStorageClass overrides the default storage class for objects created by
+    // this user. Requires DefaultPlacement to be set. If not provided, the default
+    // `STANDARD` storage class is used.
+    // This field cannot be unset once set — see "Unset/Removal Behavior".
+    // +optional
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:MaxLength=2048
+    DefaultStorageClass *string `json:"defaultStorageClass,omitempty"`
+
+    // DefaultPlacementTags restricts which placement targets this user may
+    // create buckets in: if a zonegroup placement target carries tags, RGW
+    // allows bucket creation there only when one of the user's placement
+    // tags matches. Targets without tags remain usable by every user. The
+    // tags are not storage-class related and are not scoped to DefaultPlacement.
+    // This field cannot be unset once set — see "Unset/Removal Behavior".
+    // +optional
+    // +listType=atomic
+    // +kubebuilder:validation:MinItems=1
+    // +kubebuilder:validation:MaxItems=64
+    DefaultPlacementTags []string `json:"defaultPlacementTags,omitempty"`
+}
+```
+
+Maps to `go-ceph` `admin.User` fields:
+- `DefaultPlacement` → `DefaultPlacement` (URL param `default-placement`)
+- `DefaultStorageClass` → `DefaultStorageClass` (URL param `default-storage-class`)
+- `DefaultPlacementTags` → `PlacementTags` (URL param `placement-tags`, JSON `placement_tags`)
+
+### Setting the storage class
+
+RGW stores a user's default placement as a single `rgw_placement_rule` value
+with two members, `name` and `storage_class` (`src/rgw/rgw_placement_types.h`),
+but it does not present that value as one field on either side of the admin ops
+API:
+
+- **Reading**, the two members are split across two JSON keys —
+  `"default_placement"` and `"default_storage_class"` in `RGWUserInfo::dump`
+  (`src/rgw/rgw_common.cc`). On squid and tentacle the raw `storage_class`
+  member is dumped, so a user that has never had one set reports
+  `"default_storage_class": ""`; only on main (v21) does `get_storage_class()`
+  canonicalize it to `STANDARD`. The controller treats `""` and `STANDARD`
+  as equivalent when comparing desired and live state.
+- **Writing**, the wire encoding differs by Ceph version, and the controller
+  selects it internally by `cephver` so the CRD contract is identical on
+  every supported release:
+  - **Tentacle (v20) and later** ([ceph#57985](https://github.com/ceph/ceph/pull/57985),
+    [tracker 66439](https://tracker.ceph.com/issues/66439), never backported
+    to squid): two separate URL params, and RGW composes the rule itself —
+    `target_rule.name = default_placement_str`, then
+    `target_rule.storage_class = default_storage_class_str` if non-empty
+    (`RGWOp_User_Modify::execute`).
+  - **Squid (v19)**: `default-storage-class` is never parsed; the handler
+    builds the rule with `target_rule.from_str(default_placement_str)`, which
+    splits on the first `/`. On squid only, the controller composes
+    `<placement>/<storage-class>` into the `default-placement` parameter — an
+    internal, explicitly temporary encoding, removed when squid leaves Rook's
+    support window.
+
+  Both encodings produce the identical `rgw_placement_rule` on the user, are
+  validated by the same server-side `valid_placement` check (an unknown
+  placement or storage class fails with `EINVAL` on both), and are reported
+  back identically by user info — so reconcile comparisons, status, and the
+  CRD contract are version-blind. Unit tests assert the exact wire fields
+  `generateUserConfig` produces for each version.
+
+The `<placement>/<storage-class>` form that appears elsewhere in Ceph is the
+*serialized* representation of that struct — `rgw_placement_rule::to_str()`
+emits it for on-disk encoding, and `from_str()` splits it back apart on decode.
+It is not the admin ops wire format. **Packing a storage class into
+`spec.defaultPlacement` (e.g. `hot-tier/STANDARD_IA`) is therefore not
+supported, and this design disallows it.** On Tentacle and later, RGW assigns
+the parameter to `target_rule.name` verbatim without splitting on `/`, and then
+validates it with
+`RGWZoneParams::valid_placement`, which does a `placement_pools.find(rule.name)`
+lookup (`src/rgw/rgw_zone.h`). A packed string will not match any configured
+placement target, so the request is rejected with `EINVAL`. The no-`/`
+pattern on `spec.defaultPlacement` additionally rejects a packed value at
+admission, before it ever reaches RGW.
+
+So the two Rook fields map one-to-one onto the two URL params, and the operator
+sends them separately. Users never see or construct the `/`-joined form. The
+reason this needed clarifying is historical: because released `go-ceph` cannot
+send `default-storage-class` at all (see [Background](#rgw-tenant-user-id-format)),
+packing looked like the only available route to set a storage class — as hit in
+[#17260](https://github.com/rook/rook/pull/17260). Fixing it in `go-ceph` is the
+correct layer, which is what [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)
+does; hiding the joined string from Rook's API is deliberate, since it is an
+RGW-internal encoding detail rather than something users should have to know.
+
+**`PlacementTags` availability and scope:** [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290) added placement-tags support to the admin ops client and is included in released go-ceph v0.41.0, so this field only needs a `go.mod` bump — no fork. One caveat belongs on record: placement tags act only against zonegroup placement targets that themselves carry tags, and Rook's `PoolPlacementSpec` (on both `CephObjectStore` and `CephObjectZone`) has no `tags` field today. In a fully Rook-managed topology this knob therefore has no effect until targets are tagged out-of-band (`radosgw-admin zonegroup placement modify --tags ...`, which Rook's zonegroup reconcile preserves) or a `PoolPlacementSpec.tags` counterpart lands as follow-up work; deployments with externally managed zonegroups can use it as-is.
+
+### Unset/Removal Behavior
+
+Rook's long-term direction for typed APIs is that unset means disabled: removing
+a field from the spec should drive the resource back to its default, the same
+way a native Kubernetes API behaves. RGW cannot express that today for these
+three fields. The admin ops user-modify handler acts on `default-placement`,
+`default-storage-class`, and `placement-tags` only when the submitted value is
+non-empty (`if (!default_placement_str.empty())` in
+`src/rgw/driver/rados/rgw_rest_user.cc`, `RGWOp_User_Modify::execute` — the same
+guard is present on squid, tentacle, and main), so an explicitly empty value is
+silently ignored rather than treated as a clear. `radosgw-admin` gates the same
+way (`if (!placement_id.empty())` / `if (!tags.empty())` in
+`src/rgw/radosgw-admin/radosgw-admin.cc`), so this is a property of RGW itself
+and not of the admin ops REST layer. Booleans on the same handler (`suspended`, `system`,
+`account-root`) do support this, via an `s->info.args.exists(...)` check that
+distinguishes "parameter absent" from "parameter present and empty" — the
+placement parameters simply have not adopted that idiom. The client side has the
+same gap independently: released `go-ceph` never transmits empty values for
+these parameters, so the clear is not expressible from Rook even once RGW
+accepts it. Two upstream issues track closing this —
+[tracker.ceph.com#79090](https://tracker.ceph.com/issues/79090) (extend the
+`exists()` idiom to the placement parameters) and
+[ceph/go-ceph#1307](https://github.com/ceph/go-ceph/issues/1307) (send
+explicitly empty values). Until both land in versions Rook can require, there is
+no working pathway for "revert on field removal."
+
+**Caveat for the initial implementation:** `defaultPlacement`,
+`defaultStorageClass`, and `defaultPlacementTags` may be set and may be changed
+to another value, but cannot be unset once set. Rather than accept a removal and
+silently leave stale state on the RGW user, the CRD rejects the removal outright
+with the CEL transition rules shown above, so the failure is a clear, immediate
+validation error instead of drift the user cannot see. `MinLength=1` on the
+string fields closes the obvious workaround of setting the field to `""`, which
+would pass the CEL check and then be ignored by RGW. Users who need to return a
+user to the zone group's default placement must delete and recreate the
+`CephObjectStoreUser`. This caveat must be stated in the user-facing CRD
+documentation as well as in the field's Go doc comment. When the upstream fixes
+are released, the CEL rules can be relaxed and the controller taught to send the
+explicit clear, moving these fields to the unset-means-disabled behavior we
+want; because that change only removes a restriction, it is backward compatible.
+Whether to additionally mark these fields experimental for the first release is
+left to code/doc review.
+
+### Example CR
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: user1
+  namespace: rook-ceph
+spec:
+  store: my-store
+  displayName: "Tenant A User 1"
+  tenant: tenantA
+  defaultPlacement: hot-tier
+  defaultStorageClass: STANDARD_IA
+  defaultPlacementTags:
+    - tenant-a
+```
+
+## Status
+
+The controller echoes applied state into the CR status after a successful
+reconcile: the effective `default_placement` and `default_storage_class`
+read back from user info (current Ceph releases report an unset storage
+class as `""`; the controller treats `""` and `STANDARD` as equivalent).
+A placement or storage class rejected by RGW's server-side validation
+fails the reconcile and surfaces the RGW error in the CR status; this is
+the intended validation UX. A tenant mismatch between spec and the live
+user is likewise a surfaced reconcile error, never a silent adoption.
+
+## Multisite
+
+RGW user metadata — including `default_placement` and
+`default_storage_class` — is realm-scoped and replicates to every zone via
+metadata sync. Placement *targets*, however, are zonegroup-scoped, and
+their pools are zone-local. Consequences this design accepts:
+
+- Validation happens at apply time, by the RGW serving the referenced
+  object store, against **its** zonegroup only.
+- In a realm with multiple zonegroups (or independently managed zone
+  specs), a user's synced `default_placement` may name a target that does
+  not exist in a peer zonegroup. Bucket creation there fails with
+  `InvalidLocationConstraint` at the S3 layer; Rook does not detect this.
+  Deployments using per-user placement across zonegroups should define the
+  same placement target names in every zonegroup of the realm.
+- Rook does not re-validate user placements when zonegroup placement
+  targets change after the fact.
+
+Zone-backed stores (`spec.zone.name` set) and external-mode stores are
+fully supported: because validation is RGW-side, no rook CR needs to carry
+the placement list.
+
+## S3 Client Configuration for Tenanted Users
+
+RGW exposes tenanted users to S3 clients through their access key / secret key pair — the S3 client itself requires no special modification. Credentials stored in the Rook-managed Kubernetes Secret are functionally identical regardless of whether the user belongs to a tenant.
+
+```yaml
+# AWS CLI profile for a tenanted user — identical to a non-tenanted user
+[profile tenantA-user1]
+aws_access_key_id     = <AccessKey from rook-ceph-object-user-my-store-user1>
+aws_secret_access_key = <SecretKey from rook-ceph-object-user-my-store-user1>
+```
+
+### Intra-tenant access (primary use case)
+
+Users within the same tenant access their buckets using standard S3 virtual-host-style URLs with no changes:
+
+```
+my-bucket.s3.ceph.io   ← works normally for same-tenant users
+```
+
+RGW resolves the bucket to the correct tenant namespace based on the credentials used. No DNS changes or special endpoint configuration are required for this feature's primary use case.
+
+### Cross-tenant access (out of scope, deprecated upstream)
+
+Cross-tenant bucket access via path-style requests using the `tenant:bucket`
+notation (e.g. `s3.ceph.io/tenantA:my-bucket/`) is a Ceph extension to the S3
+protocol. As noted in the Ceph Tentacle release notes, this feature is
+deprecated and scheduled for removal.
+
+> S3 API support for cross-tenant names such as `Bucket='tenant:bucketname'`
+
+Virtual-host-style cross-tenant access (`tenantA:my-bucket.s3.ceph.io`) is not
+possible because `:` is not valid in DNS names.
+
+**Cross-tenant bucket sharing is explicitly out of scope for this feature.**
+Users who need to share buckets across tenant boundaries should be placed in
+the same tenant namespace. This aligns with Ceph's upstream direction of
+removing cross-tenant path-style access.
+
+## Compatibility and rollback
+
+All fields are optional; CRs created by older Rook are unaffected, and the
+new schema invalidates no stored object.
+
+Rolling back to a Rook release that predates `spec.tenant` while tenanted
+CRs exist is **destructive**: the older operator addresses the user by
+bare name, fails to find the tenanted user, creates an untenanted user
+with the same name, and repoints the CR's Secret at it — orphaning the
+tenanted user and its buckets. Before downgrading, tenanted
+`CephObjectStoreUser` CRs must be removed (or the operator scaled down).
+This warning ships in the release notes. The placement fields carry no
+such hazard: an older operator simply leaves the live values in place.
+
+## Immutability
+
+`tenant` is immutable because RGW does not support moving a user between
+tenants; the only path is deletion and recreation. Attempting to change
+`tenant` on an existing `CephObjectStoreUser` would silently create a second
+user in the new tenant while leaving the original orphaned.
+
+
+`defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` are
+mutable — RGW supports changing a user's default placement, storage class, and
+placement tags at any time; changes only affect future bucket/object creation,
+not existing buckets/objects. Removal is the exception: as described in
+[Unset/Removal Behavior](#unsetremoval-behavior), RGW offers no way to clear
+these values, so the CRD rejects an update that unsets a previously set field.
+This is a caveat of the initial implementation, not the intended end state.
+
+## Interaction with `AccountRef`
+
+RGW requires an account member's tenant to equal the account's tenant
+(`validate_account_tenant`, enforced at user create and modify). Rook's
+`CephObjectStoreAccount` cannot currently create tenanted accounts, so
+every expressible `tenant` + `accountRef` combination would fail at RGW
+with `EINVAL` on a doubly-immutable field pair, permanently wedging the
+CR. The spec therefore rejects the combination at admission:
+
+```go
+// +kubebuilder:validation:XValidation:message="tenant cannot be combined with accountRef (CephObjectStoreAccount does not support tenants)",rule="!(has(self.tenant) && has(self.accountRef))"
+```
+
+Supporting tenanted account members later requires a tenant field on
+`CephObjectStoreAccount` (go-ceph already transmits one on account
+create/modify) and lifting this rule — a backward-compatible relaxation.

--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -392,13 +392,16 @@ already transmits one) and is listed under [Future work](#future-work).
   tagged placement target when one of the user's tags matches. It is
   deferred because (a) its enabling half, tags on zonegroup placement
   targets, has no Rook API (`PoolPlacementSpec` would need a `tags` field);
-  (b) client support exists only in unreleased go-ceph
-  ([go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)); and (c) tags
-  cannot be cleared through the admin ops API once set
+  (b) client support requires a `go.mod` bump — Rook currently pins go-ceph
+  v0.40.0, which predates `PlacementTags` support
+  ([go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290), merged
+  2026-07-09 and released in go-ceph v0.41.0 on 2026-08-11 — the dependency
+  itself is released, only Rook's pin is behind); and (c) tags cannot be
+  cleared through the admin ops API once set
   ([tracker 79090](https://tracker.ceph.com/issues/79090)). When revisited:
   the field is named `placementTags` (it is not scoped to the default
-  placement), ships together with `PoolPlacementSpec.tags`, and gates on a
-  released go-ceph.
+  placement), ships together with `PoolPlacementSpec.tags`, and gates on
+  bumping Rook's go-ceph pin to v0.41.0+.
 - **Revert-on-removal** for the placement fields, once
   [tracker 79090](https://tracker.ceph.com/issues/79090) and
   [go-ceph#1307](https://github.com/ceph/go-ceph/issues/1307) are in Rook's

--- a/design/ceph/rgw-user-multitenancy-and-placement.md
+++ b/design/ceph/rgw-user-multitenancy-and-placement.md
@@ -4,29 +4,37 @@
 
 ## Summary
 
-This document proposes extending the `CephObjectStoreUser` CRD with four new spec fields:
+This document proposes extending the `CephObjectStoreUser` CRD with three new
+optional spec fields:
 
-- `tenant` — assigns the RGW user to a named RGW tenant, enabling bucket name isolation across tenants.
-- `defaultPlacement` — sets the user's default bucket placement target, controlling which data/metadata pools newly created buckets land in.
-- `defaultStorageClass` — sets the user's default storage class for objects, applied on top of `defaultPlacement`.
-- `defaultPlacementTags` — restricts which zonegroup placement targets the user may create buckets in, based on tags carried by those targets.
+- `tenant` — assigns the RGW user to a named tenant, enabling bucket name
+  isolation across tenants.
+- `defaultPlacement` — sets the user's default bucket placement target,
+  controlling which data/metadata pools newly created buckets land in.
+- `defaultStorageClass` — sets the user's default storage class for objects,
+  applied on top of `defaultPlacement`.
 
-All four fields already exist in the underlying `admin.User` struct in `go-ceph`; this work wires them into the Rook controller and API.
+A fourth field, `placementTags`, is deferred to follow-up work (see
+[Future work](#future-work)).
 
 ### Why tenant and placement are covered in the same document
 
-`tenant`, `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` are unrelated in what they do in RGW, but they're proposed together here because they:
-
-- are all optional additions to the exact same CRD field (`ObjectStoreUserSpec`), reviewed against the same schema and the same immutability/mutability rules,
-- share the same controller entry points (`generateUserConfig`, `isUserSync`, `createOrUpdateCephUser`), so a reviewer needs to see how they compose in that code regardless of which section of the doc they came from,
-
-Splitting placement into its own document would not change the schema or the controller logic — it would only move prose. We've kept them together so the field interactions (e.g. `defaultStorageClass` requiring `defaultPlacement`, all three being independent of `tenant`) are visible in one place instead of cross-referenced across two documents.
+`tenant` and the placement fields are unrelated in what they do in RGW, but
+they are proposed together because they are optional additions to the same
+CRD spec (`ObjectStoreUserSpec`), reviewed against the same schema and
+immutability rules, and share the same controller entry points
+(`generateUserConfig`, `isUserSync`, `createOrUpdateCephUser`). Keeping them
+together makes the field interactions (e.g. `defaultStorageClass` requiring
+`defaultPlacement`, the placement fields being independent of `tenant`)
+visible in one place.
 
 ## Motivation
 
 ### Tenant Isolation
 
-Ceph RGW supports a multitenancy model where users live in named tenants. Users in different tenants can own buckets with the same name without collision:
+Ceph RGW supports a multitenancy model where users live in named tenants.
+Users in different tenants can own buckets with the same name without
+collision:
 
 ```
 # Two separate objects, no conflict
@@ -37,7 +45,7 @@ tenantB$user1 → s3://photos
 Rook currently has no mechanism to place a `CephObjectStoreUser` in an RGW
 tenant. Operators who need per-tenant user isolation must manage RGW users
 manually outside of Rook, forgoing the benefits of the operator (secret
-rotation, lifecycle management, status conditions).
+rotation, lifecycle management, status reporting).
 
 ### Placement Targeting
 
@@ -49,242 +57,203 @@ placement.
 
 ## Goals
 
-- Add `spec.tenant` to `CephObjectStoreUser` to set the `Tenant` field on the RGW Admin Ops API `User` struct at user creation.
-- Add `spec.defaultPlacement` to `CephObjectStoreUser` to set `DefaultPlacement` on the user via `CreateUser`/`ModifyUser` in the RGW Admin Ops API.
-- Add `spec.defaultStorageClass` to `CephObjectStoreUser` to set `DefaultStorageClass` on the user, embedded into the placement rule sent to RGW
-- Add `spec.defaultPlacementTags` to `CephObjectStoreUser` to set `PlacementTags` on the user via `CreateUser`/`ModifyUser`, now that go-ceph supports it upstream (merged in [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)).
-- Leave `defaultPlacement` validation to RGW: the serving RGW validates it
-  against the live zonegroup on every create/modify and rejects unknown
-  targets with `EINVAL`; the operator surfaces that failure in the CR status.
-  (Validating against the referenced `CephObjectStore`'s `spec.sharedPools`
-  would be wrong for zone-backed stores, whose placements live on
-  `CephObjectZone`, and impossible for external stores.)
-- Require `defaultPlacement` to be set whenever `defaultStorageClass` is set, since RGW cannot apply a storage class without a placement target.
-- Treat `tenant` as immutable (changing tenant requires user deletion and recreation in RGW).
-- Treat `defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` as changeable but not removable: they can be updated to a different value via `ModifyUser`, but cannot be unset once set, because RGW provides no way to clear them (see [Unset/Removal Behavior](#unsetremoval-behavior)). This caveat is enforced by CEL and documented for users; lifting it depends on upstream RGW and go-ceph fixes.
-- All four fields are independent of `tenant`: `defaultPlacement`/`defaultStorageClass`/`defaultPlacementTags` may be set without `tenant`, and vice versa.
-- Preserve backward compatibility: all new fields are optional, existing resources are unaffected.
+- Add `spec.tenant` to `CephObjectStoreUser`. The controller addresses the
+  RGW user by its combined identity `<tenant>$<name>` in every Admin Ops
+  call (see [RGW Tenant User ID Format](#rgw-tenant-user-id-format)).
+- Add `spec.defaultPlacement` and `spec.defaultStorageClass`, applied via
+  `CreateUser`/`ModifyUser` in the RGW Admin Ops API.
+- Require `defaultPlacement` to be set whenever `defaultStorageClass` is
+  set, since RGW cannot apply a storage class without a placement target.
+- Treat `tenant` as immutable (RGW does not support moving a user between
+  tenants; `radosgw-admin user rename` rejects tenant changes).
+- Treat `defaultPlacement` and `defaultStorageClass` as mutable.
+- Leave placement validation to RGW: the serving RGW validates
+  `default-placement` against the live zonegroup on every create/modify and
+  rejects unknown targets with `EINVAL`. The operator surfaces that failure
+  in the CR status instead of duplicating the check against a rook CR (which
+  would be wrong for zone-backed and external stores, where the store CR
+  does not carry the placement list).
+- Treat an absent placement field as **unmanaged**: the controller neither
+  writes nor reconciles it (see
+  [Field removal](#field-removal-unmanaged-semantics)).
+- CR behavior is identical on every supported Ceph version (see
+  [Ceph version invariance](#ceph-version-invariance)).
+- Preserve backward compatibility: all new fields are optional; existing
+  resources and pre-existing RGW users are unaffected.
 
+## Ceph version invariance
+
+The CRD contract MUST NOT vary with the cluster's Ceph version: the same
+spec produces the same RGW state, the same errors, and the same status on
+every supported release. RGW Admin Ops API differences are absorbed inside
+the controller, never exposed as version-conditional CRD behavior, and
+nothing in the CRD schema, godoc, or user documentation references Ceph
+versions.
+
+This is not hypothetical for these fields. Squid's admin ops API applies a
+user's storage class only when it is embedded in the placement rule
+(`<placement>/<storage-class>`) and ignores the separate
+`default-storage-class` parameter; Tentacle (via
+[ceph#57985](https://github.com/ceph/ceph/pull/57985),
+[tracker 66439](https://tracker.ceph.com/issues/66439), not backported)
+takes `default-placement` verbatim and honors the separate parameter — the
+embedded form fails with `EINVAL` there. The controller therefore selects
+the wire encoding by `cephver`:
+
+| cluster Ceph | wire encoding for `defaultStorageClass` |
+|---|---|
+| Squid (v19) | embedded: `default-placement=<placement>/<class>` |
+| Tentacle (v20) and later | separate: `default-placement=<placement>` + `default-storage-class=<class>` |
+
+Both encodings produce the identical `rgw_placement_rule` on the user, are
+validated by the same server-side `valid_placement` check, and are reported
+back identically by user info — so `isUserSync` and status are
+version-blind. The embedded form is an explicitly temporary path, retired
+when Squid leaves the support window. Unit tests assert the exact wire
+fields `generateUserConfig` produces for both versions; the integration
+suites exercise whichever arm matches their Ceph image.
+
+The same rule constrains future changes: a capability absent from older
+Ceph (e.g. clearing a user's placement, once
+[tracker 79090](https://tracker.ceph.com/issues/79090) lands) may only
+change CR semantics once rook's minimum supported Ceph includes it — never
+behind a runtime version gate.
 
 ## Background
 
 ### RGW Tenant User ID Format
 
-When a user is created in a tenant, the user's identity everywhere in RGW is the combined form `<tenant>$<uid>`. Every Admin Ops operation resolves the `uid` parameter through this form (`rgw_user::from_str` splits on `$`); a bare `uid` addresses the user in the default (empty) tenant.
+When a user is created in a tenant, the user's identity everywhere in RGW is
+the combined form `<tenant>$<uid>`. Every RGW Admin Ops operation resolves
+the `uid` parameter through this form (`rgw_user::from_str` splits on `$`);
+a bare `uid` addresses the user in the default (empty) tenant.
 
-The Admin Ops API accepts a separate `tenant` parameter **only on user create**. User info, modify, and remove have no tenant parameter — on those operations a tenant can only be expressed inside the combined `uid`. go-ceph mirrors this: `admin.User.Tenant` is transmitted by `CreateUser` only and silently dropped by `GetUser`/`ModifyUser`/`RemoveUser`, whose URL-parameter whitelists exclude `tenant`.
+The Admin Ops API accepts a separate `tenant` parameter **only on user
+create**. User info, modify, and remove have no tenant parameter — on those
+operations a tenant can only be expressed inside the combined `uid`. go-ceph
+mirrors this: `admin.User.Tenant` is transmitted by `CreateUser` only and
+silently dropped by `GetUser`/`ModifyUser`/`RemoveUser`.
 
-The controller therefore uses the combined `<tenant>$<name>` string as the user ID for **every** Admin Ops call, create included, and never relies on the go-ceph `Tenant` struct field. Addressing a tenanted user by bare `uid` would silently resolve to the same-named user in the default tenant: reconciliation would adopt (and CR deletion would delete) an unrelated user, or wedge in a CreateUser/UserAlreadyExists loop when none exists. As a backstop, the reconcile fails with an explicit error if the live user's tenant does not match `spec.tenant`, rather than adopting a user from another tenant.
+The controller therefore uses the combined `<tenant>$<name>` string as the
+user ID for **every** Admin Ops call, create included, and never relies on
+the go-ceph `Tenant` struct field. This is essential for correctness, not
+style: addressing a tenanted user by bare `uid` silently resolves to the
+same-named user in the default tenant — reconciliation would adopt (and CR
+deletion would delete) an unrelated user.
+
+As a safety backstop, the reconcile fails with an explicit error if the live
+user's tenant does not match `spec.tenant`, rather than adopting a user
+from another tenant.
 
 Equivalently via CLI:
+
 ```bash
 radosgw-admin user create --uid="tenantA$user1" --display-name="User 1"
-
 radosgw-admin user info --uid="tenantA$user1"
 ```
-
-The `go-ceph` `admin.User` struct models all four fields. Released support
-arrived in two steps: v0.40.0 (Rook's current pin) transmits
-`default-placement` and `default-storage-class` on both `CreateUser` and
-`ModifyUser`; v0.41.0 (released 2026-08-11) adds `placement-tags`
-([ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)):
-
-```go
-// go-ceph v0.41.0 (released)
-type User struct {
-    ID                  string   `json:"user_id" url:"uid"`
-    Tenant              string   `url:"tenant"`  // ← URL param on user create only
-    DefaultPlacement    string   `json:"default_placement" url:"default-placement"`
-    DefaultStorageClass string   `json:"default_storage_class" url:"default-storage-class"`
-    PlacementTags       []string `json:"placement_tags" url:"placement-tags"`
-    // ...
-}
-```
-
-Implementing `spec.defaultPlacementTags` therefore requires only a `go.mod`
-bump to go-ceph v0.41.0 — no fork and no unreleased dependency. See
-[Setting the storage class](#setting-the-storage-class) for how the two
-placement parameters are applied on the wire.
-
-
-### Interaction with `AccountRef`
-
-`AccountRef` (added in a recent release) also links users to an RGW account and is already marked immutable. Users with `accountRef` set are account-member users. RGW itself allows a tenanted account member as long as the member's tenant equals the account's own tenant, but Rook's `CephObjectStoreAccount` cannot create a tenanted account today — see [Interaction with `AccountRef`](#interaction-with-accountref-1) for why this design rejects the combination at admission rather than exposing an always-failing configuration.
 
 ## Proposed API Changes
 
 ### `ObjectStoreUserSpec` (`pkg/apis/ceph.rook.io/v1/types.go`)
 
-`defaultPlacement` and `defaultStorageClass` are added as flat, top-level `*string` fields directly on `ObjectStoreUserSpec`, named to match the `go-ceph` `admin.User` fields exactly (`DefaultPlacement`, `DefaultStorageClass`), rather than being wrapped in a nested `ObjectStoreUserPlacementSpec` struct. This mirrors the pattern already established by PR [#17260](https://github.com/rook/rook/pull/17260), which added `DefaultStorageClass` as a flat field on the same spec — introducing a nested struct here would create two incompatible shapes for closely related fields on the same object.
-
-A nested `spec.placement` struct would make the `defaultStorageClass` requires `defaultPlacement` coupling structurally visible, which is the strongest argument for it. The flat layout expresses the same constraint with a CEL rule instead, which produces a specific, actionable error message at admission and does not require users to learn a second nesting level for what is, on the RGW side, three sibling attributes of one user. The coupling is also not total — `defaultPlacement` and `defaultPlacementTags` are each usable on their own — so a wrapper struct would group fields more tightly than their actual semantics warrant.
+`defaultPlacement` and `defaultStorageClass` are flat, top-level fields on
+`ObjectStoreUserSpec`, named after the go-ceph `admin.User` fields they map
+to. This mirrors go-ceph's flat `admin.User` shape; a nested
+`ObjectStoreUserPlacementSpec` was considered in review and set aside, as
+the nesting would cover only these two fields.
 
 ```go
 // ObjectStoreUserSpec represent the spec of an Objectstoreuser
 // +kubebuilder:validation:XValidation:message="defaultStorageClass requires defaultPlacement",rule="!has(self.defaultStorageClass) || has(self.defaultPlacement)"
-// +kubebuilder:validation:XValidation:message="defaultPlacement cannot be unset once set; RGW does not support clearing a user's default placement",rule="!has(oldSelf.defaultPlacement) || has(self.defaultPlacement)"
-// +kubebuilder:validation:XValidation:message="defaultStorageClass cannot be unset once set; RGW does not support clearing a user's default storage class",rule="!has(oldSelf.defaultStorageClass) || has(self.defaultStorageClass)"
-// +kubebuilder:validation:XValidation:message="defaultPlacementTags cannot be unset once set; RGW does not support clearing a user's placement tags",rule="!has(oldSelf.defaultPlacementTags) || has(self.defaultPlacementTags)"
 // +kubebuilder:validation:XValidation:message="tenant is immutable",rule="has(oldSelf.tenant) == has(self.tenant) && (!has(self.tenant) || self.tenant == oldSelf.tenant)"
+// +kubebuilder:validation:XValidation:message="tenant cannot be combined with accountRef (CephObjectStoreAccount does not support tenants)",rule="!(has(self.tenant) && has(self.accountRef))"
 type ObjectStoreUserSpec struct {
-    Store        string `json:"store,omitempty"`
-    DisplayName  string `json:"displayName,omitempty"`
     // ... existing fields ...
 
     // Tenant is the RGW tenant this user belongs to.
-    // Users in different tenants can have buckets with the same name without conflict.
-    // When set, the effective user ID in RGW becomes "<tenant>$<name>".
-    // This field is immutable after creation.
+    // Users in different tenants can have buckets with the same name without
+    // conflict. When set, the effective user ID in RGW is "<tenant>$<name>".
+    // This field is immutable after creation: it may not be added, changed,
+    // or removed on an existing user.
     // +optional
     // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
     // +kubebuilder:validation:MaxLength=255
     Tenant string `json:"tenant,omitempty"`
 
-    // DefaultPlacement overrides the default pool placement for buckets created by
-    // this user. It must name a placement target known to the zonegroup serving
-    // the referenced object store; RGW validates this on every create and modify
-    // and rejects unknown targets. If not provided, the zone group's
-    // default placement target is used.
-    // This field cannot be unset once set — see "Unset/Removal Behavior".
+    // DefaultPlacement sets the default pool placement target for buckets
+    // created by this user. It must name a placement target known to the
+    // zonegroup serving the referenced object store; RGW rejects unknown
+    // targets. If this field is absent the controller does not manage the
+    // user's placement: an existing value (set previously through this
+    // field, or outside of Rook) is left in place.
     // +optional
     // +kubebuilder:validation:MinLength=1
     // +kubebuilder:validation:MaxLength=2048
     // +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+$`
-    DefaultPlacement *string `json:"defaultPlacement,omitempty"`
+    DefaultPlacement string `json:"defaultPlacement,omitempty"`
 
-    // DefaultStorageClass overrides the default storage class for objects created by
-    // this user. Requires DefaultPlacement to be set. If not provided, the default
-    // `STANDARD` storage class is used.
-    // This field cannot be unset once set — see "Unset/Removal Behavior".
+    // DefaultStorageClass sets the default storage class for objects created
+    // by this user, within the placement set by DefaultPlacement (which must
+    // also be set). The storage class must exist on that placement target;
+    // RGW rejects unknown storage classes. If this field is absent the
+    // controller does not manage the user's storage class.
     // +optional
     // +kubebuilder:validation:MinLength=1
     // +kubebuilder:validation:MaxLength=2048
-    DefaultStorageClass *string `json:"defaultStorageClass,omitempty"`
-
-    // DefaultPlacementTags restricts which placement targets this user may
-    // create buckets in: if a zonegroup placement target carries tags, RGW
-    // allows bucket creation there only when one of the user's placement
-    // tags matches. Targets without tags remain usable by every user. The
-    // tags are not storage-class related and are not scoped to DefaultPlacement.
-    // This field cannot be unset once set — see "Unset/Removal Behavior".
-    // +optional
-    // +listType=atomic
-    // +kubebuilder:validation:MinItems=1
-    // +kubebuilder:validation:MaxItems=64
-    DefaultPlacementTags []string `json:"defaultPlacementTags,omitempty"`
+    DefaultStorageClass string `json:"defaultStorageClass,omitempty"`
 }
 ```
 
-Maps to `go-ceph` `admin.User` fields:
-- `DefaultPlacement` → `DefaultPlacement` (URL param `default-placement`)
-- `DefaultStorageClass` → `DefaultStorageClass` (URL param `default-storage-class`)
-- `DefaultPlacementTags` → `PlacementTags` (URL param `placement-tags`, JSON `placement_tags`)
+Notes on the validation shape, from review:
 
-### Setting the storage class
+- The `tenant` immutability rule is spec-level with `has()` guards. A
+  field-level `self == oldSelf` rule is skipped by the API server when an
+  optional field is set or unset, which would permit exactly the two
+  transitions (adding or removing `tenant` on an existing user) that orphan
+  RGW users.
+- `tenant`'s charset is RGW's: `rgw_validate_tenant_name` accepts only
+  alphanumerics and `_`. `MaxLength=255` is a rook-side bound; RGW imposes
+  no length limit.
+- `MinLength=1` on the placement fields makes the empty string
+  unrepresentable. `""` would satisfy the `has()` in the requires-rule
+  while being meaningless on the wire (empty values cannot be transmitted —
+  see [Field removal](#field-removal-unmanaged-semantics)).
+- `defaultPlacement` forbids `/`, which is the storage-class separator in
+  RGW's embedded placement-rule syntax; permitting it would make the same
+  spec value parse differently across Ceph versions (see
+  [Ceph version invariance](#ceph-version-invariance)). Note that the
+  pre-existing `PoolPlacementSpec.Name` pattern permits `/`, so a
+  slash-bearing placement target defined on a store cannot be referenced
+  from this field; such names are ambiguous in RGW's own placement-rule
+  syntax regardless, and a follow-up may tighten `PoolPlacementSpec.Name`
+  to match.
 
-RGW stores a user's default placement as a single `rgw_placement_rule` value
-with two members, `name` and `storage_class` (`src/rgw/rgw_placement_types.h`),
-but it does not present that value as one field on either side of the admin ops
-API:
+### Field removal (unmanaged semantics)
 
-- **Reading**, the two members are split across two JSON keys —
-  `"default_placement"` and `"default_storage_class"` in `RGWUserInfo::dump`
-  (`src/rgw/rgw_common.cc`). On squid and tentacle the raw `storage_class`
-  member is dumped, so a user that has never had one set reports
-  `"default_storage_class": ""`; only on main (v21) does `get_storage_class()`
-  canonicalize it to `STANDARD`. The controller treats `""` and `STANDARD`
-  as equivalent when comparing desired and live state.
-- **Writing**, the wire encoding differs by Ceph version, and the controller
-  selects it internally by `cephver` so the CRD contract is identical on
-  every supported release:
-  - **Tentacle (v20) and later** ([ceph#57985](https://github.com/ceph/ceph/pull/57985),
-    [tracker 66439](https://tracker.ceph.com/issues/66439), never backported
-    to squid): two separate URL params, and RGW composes the rule itself —
-    `target_rule.name = default_placement_str`, then
-    `target_rule.storage_class = default_storage_class_str` if non-empty
-    (`RGWOp_User_Modify::execute`).
-  - **Squid (v19)**: `default-storage-class` is never parsed; the handler
-    builds the rule with `target_rule.from_str(default_placement_str)`, which
-    splits on the first `/`. On squid only, the controller composes
-    `<placement>/<storage-class>` into the `default-placement` parameter — an
-    internal, explicitly temporary encoding, removed when squid leaves Rook's
-    support window.
+An absent `defaultPlacement`/`defaultStorageClass` means **unmanaged**: the
+controller neither writes nor compares the corresponding RGW user property.
+Removing a previously-set field stops management and leaves the last-applied
+value in place on the RGW user; it does not revert the user to the
+zonegroup default. A pre-existing RGW user adopted by a CR keeps whatever
+placement it already had, whether it was set through this field or outside
+of Rook. A user who wants zonegroup-default behavior sets `defaultPlacement`
+to the default target's name explicitly (note this pins the user to that
+target; it does not track later changes to the zonegroup default).
 
-  Both encodings produce the identical `rgw_placement_rule` on the user, are
-  validated by the same server-side `valid_placement` check (an unknown
-  placement or storage class fails with `EINVAL` on both), and are reported
-  back identically by user info — so reconcile comparisons, status, and the
-  CRD contract are version-blind. Unit tests assert the exact wire fields
-  `generateUserConfig` produces for each version.
+Revert-on-removal is not implementable today, on any supported Ceph, through
+any client: go-ceph never transmits empty parameter values
+([go-ceph#1307](https://github.com/ceph/go-ceph/issues/1307)), and RGW's
+admin ops modify handler ignores empty `default-placement` values anyway
+([tracker 79090](https://tracker.ceph.com/issues/79090)); `radosgw-admin`
+shares the same guard. Those issues track the upstream fixes. Per
+[Ceph version invariance](#ceph-version-invariance), Rook may adopt
+revert-on-removal semantics only once its minimum supported Ceph and a
+released go-ceph both support clearing — as an explicit, documented
+behavior change.
 
-The `<placement>/<storage-class>` form that appears elsewhere in Ceph is the
-*serialized* representation of that struct — `rgw_placement_rule::to_str()`
-emits it for on-disk encoding, and `from_str()` splits it back apart on decode.
-It is not the admin ops wire format. **Packing a storage class into
-`spec.defaultPlacement` (e.g. `hot-tier/STANDARD_IA`) is therefore not
-supported, and this design disallows it.** On Tentacle and later, RGW assigns
-the parameter to `target_rule.name` verbatim without splitting on `/`, and then
-validates it with
-`RGWZoneParams::valid_placement`, which does a `placement_pools.find(rule.name)`
-lookup (`src/rgw/rgw_zone.h`). A packed string will not match any configured
-placement target, so the request is rejected with `EINVAL`. The no-`/`
-pattern on `spec.defaultPlacement` additionally rejects a packed value at
-admission, before it ever reaches RGW.
-
-So the two Rook fields map one-to-one onto the two URL params, and the operator
-sends them separately. Users never see or construct the `/`-joined form. The
-reason this needed clarifying is historical: because released `go-ceph` cannot
-send `default-storage-class` at all (see [Background](#rgw-tenant-user-id-format)),
-packing looked like the only available route to set a storage class — as hit in
-[#17260](https://github.com/rook/rook/pull/17260). Fixing it in `go-ceph` is the
-correct layer, which is what [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)
-does; hiding the joined string from Rook's API is deliberate, since it is an
-RGW-internal encoding detail rather than something users should have to know.
-
-**`PlacementTags` availability and scope:** [ceph/go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290) added placement-tags support to the admin ops client and is included in released go-ceph v0.41.0, so this field only needs a `go.mod` bump — no fork. One caveat belongs on record: placement tags act only against zonegroup placement targets that themselves carry tags, and Rook's `PoolPlacementSpec` (on both `CephObjectStore` and `CephObjectZone`) has no `tags` field today. In a fully Rook-managed topology this knob therefore has no effect until targets are tagged out-of-band (`radosgw-admin zonegroup placement modify --tags ...`, which Rook's zonegroup reconcile preserves) or a `PoolPlacementSpec.tags` counterpart lands as follow-up work; deployments with externally managed zonegroups can use it as-is.
-
-### Unset/Removal Behavior
-
-Rook's long-term direction for typed APIs is that unset means disabled: removing
-a field from the spec should drive the resource back to its default, the same
-way a native Kubernetes API behaves. RGW cannot express that today for these
-three fields. The admin ops user-modify handler acts on `default-placement`,
-`default-storage-class`, and `placement-tags` only when the submitted value is
-non-empty (`if (!default_placement_str.empty())` in
-`src/rgw/driver/rados/rgw_rest_user.cc`, `RGWOp_User_Modify::execute` — the same
-guard is present on squid, tentacle, and main), so an explicitly empty value is
-silently ignored rather than treated as a clear. `radosgw-admin` gates the same
-way (`if (!placement_id.empty())` / `if (!tags.empty())` in
-`src/rgw/radosgw-admin/radosgw-admin.cc`), so this is a property of RGW itself
-and not of the admin ops REST layer. Booleans on the same handler (`suspended`, `system`,
-`account-root`) do support this, via an `s->info.args.exists(...)` check that
-distinguishes "parameter absent" from "parameter present and empty" — the
-placement parameters simply have not adopted that idiom. The client side has the
-same gap independently: released `go-ceph` never transmits empty values for
-these parameters, so the clear is not expressible from Rook even once RGW
-accepts it. Two upstream issues track closing this —
-[tracker.ceph.com#79090](https://tracker.ceph.com/issues/79090) (extend the
-`exists()` idiom to the placement parameters) and
-[ceph/go-ceph#1307](https://github.com/ceph/go-ceph/issues/1307) (send
-explicitly empty values). Until both land in versions Rook can require, there is
-no working pathway for "revert on field removal."
-
-**Caveat for the initial implementation:** `defaultPlacement`,
-`defaultStorageClass`, and `defaultPlacementTags` may be set and may be changed
-to another value, but cannot be unset once set. Rather than accept a removal and
-silently leave stale state on the RGW user, the CRD rejects the removal outright
-with the CEL transition rules shown above, so the failure is a clear, immediate
-validation error instead of drift the user cannot see. `MinLength=1` on the
-string fields closes the obvious workaround of setting the field to `""`, which
-would pass the CEL check and then be ignored by RGW. Users who need to return a
-user to the zone group's default placement must delete and recreate the
-`CephObjectStoreUser`. This caveat must be stated in the user-facing CRD
-documentation as well as in the field's Go doc comment. When the upstream fixes
-are released, the CEL rules can be relaxed and the controller taught to send the
-explicit clear, moving these fields to the unset-means-disabled behavior we
-want; because that change only removes a restriction, it is backward compatible.
-Whether to additionally mark these fields experimental for the first release is
-left to code/doc review.
+The unmanaged contract is also what protects brownfield users: reconcile
+must not churn `ModifyUser` calls (or worse, rewrite state) for users whose
+placement was configured out-of-band and whose CRs never mention it.
 
 ### Example CR
 
@@ -300,48 +269,60 @@ spec:
   tenant: tenantA
   defaultPlacement: hot-tier
   defaultStorageClass: STANDARD_IA
-  defaultPlacementTags:
-    - tenant-a
 ```
 
 ## Status
 
 The controller echoes applied state into the CR status after a successful
 reconcile: the effective `default_placement` and `default_storage_class`
-read back from user info (current Ceph releases report an unset storage
-class as `""`; the controller treats `""` and `STANDARD` as equivalent).
-A placement or storage class rejected by RGW's server-side validation
-fails the reconcile and surfaces the RGW error in the CR status; this is
-the intended validation UX. A tenant mismatch between spec and the live
-user is likewise a surfaced reconcile error, never a silent adoption.
+read back from user info. A placement or storage class rejected by RGW
+(`EINVAL` from server-side validation) fails the reconcile and surfaces the
+RGW error in the CR status; this is the intended validation UX, replacing
+operator-side pre-validation. A tenant mismatch between spec and the live
+user (see the addressing backstop above) is likewise a surfaced reconcile
+error, never a silent adoption.
 
 ## Multisite
 
 RGW user metadata — including `default_placement` and
 `default_storage_class` — is realm-scoped and replicates to every zone via
-metadata sync. Placement *targets*, however, are zonegroup-scoped, and
-their pools are zone-local. Consequences this design accepts:
+metadata sync. Placement *targets*, however, are zonegroup-scoped, and their
+pools are zone-local. Consequences this design accepts and documents:
 
 - Validation happens at apply time, by the RGW serving the referenced
   object store, against **its** zonegroup only.
-- In a realm with multiple zonegroups (or independently managed zone
-  specs), a user's synced `default_placement` may name a target that does
-  not exist in a peer zonegroup. Bucket creation there fails with
+- In a realm with multiple zonegroups (or independently-managed zone specs),
+  a user's synced `default_placement` may name a target that does not exist
+  in a peer zonegroup. Bucket creation there fails with
   `InvalidLocationConstraint` at the S3 layer; Rook does not detect this.
   Deployments using per-user placement across zonegroups should define the
   same placement target names in every zonegroup of the realm.
-- Rook does not re-validate user placements when zonegroup placement
-  targets change after the fact.
+- Rook does not re-validate user placements when zonegroup placement targets
+  change after the fact.
 
-Zone-backed stores (`spec.zone.name` set) and external-mode stores are
-fully supported: because validation is RGW-side, no rook CR needs to carry
-the placement list.
+Zone-backed stores (`spec.zone.name` set) and external-mode stores are fully
+supported: because validation is RGW-side, no rook CR needs to carry the
+placement list.
+
+## Compatibility and rollback
+
+All fields are optional; CRs created by older Rook are unaffected, and the
+new schema invalidates no stored object.
+
+Rolling back to a Rook release that predates `spec.tenant` while tenanted
+CRs exist is **destructive**: the older operator addresses the user by bare
+name, fails to find the tenanted user, creates an untenanted user with the
+same name, and repoints the CR's Secret at it — orphaning the tenanted user
+and its buckets. Before downgrading, tenanted `CephObjectStoreUser` CRs must
+be removed (or the operator scaled down). This warning ships in the release
+notes. The placement fields carry no such hazard: an older operator simply
+stops managing them.
 
 ## S3 Client Configuration for Tenanted Users
 
 RGW exposes tenanted users to S3 clients through their access key / secret key pair — the S3 client itself requires no special modification. Credentials stored in the Rook-managed Kubernetes Secret are functionally identical regardless of whether the user belongs to a tenant.
 
-```yaml
+```ini
 # AWS CLI profile for a tenanted user — identical to a non-tenanted user
 [profile tenantA-user1]
 aws_access_key_id     = <AccessKey from rook-ceph-object-user-my-store-user1>
@@ -375,49 +356,52 @@ Users who need to share buckets across tenant boundaries should be placed in
 the same tenant namespace. This aligns with Ceph's upstream direction of
 removing cross-tenant path-style access.
 
-## Compatibility and rollback
-
-All fields are optional; CRs created by older Rook are unaffected, and the
-new schema invalidates no stored object.
-
-Rolling back to a Rook release that predates `spec.tenant` while tenanted
-CRs exist is **destructive**: the older operator addresses the user by
-bare name, fails to find the tenanted user, creates an untenanted user
-with the same name, and repoints the CR's Secret at it — orphaning the
-tenanted user and its buckets. Before downgrading, tenanted
-`CephObjectStoreUser` CRs must be removed (or the operator scaled down).
-This warning ships in the release notes. The placement fields carry no
-such hazard: an older operator simply leaves the live values in place.
-
 ## Immutability
 
 `tenant` is immutable because RGW does not support moving a user between
-tenants; the only path is deletion and recreation. Attempting to change
-`tenant` on an existing `CephObjectStoreUser` would silently create a second
-user in the new tenant while leaving the original orphaned.
+tenants; the only path is deletion and recreation (`radosgw-admin user
+rename` explicitly rejects tenant changes, and the Admin Ops API has no
+rename operation). Changing `tenant` on an existing `CephObjectStoreUser`
+would create a second user in the new tenant while leaving the original
+orphaned. Enforcement is the spec-level CEL transition rule in
+[Proposed API Changes](#proposed-api-changes), backed by the controller's
+tenant-mismatch check described in
+[RGW Tenant User ID Format](#rgw-tenant-user-id-format).
 
-
-`defaultPlacement`, `defaultStorageClass`, and `defaultPlacementTags` are
-mutable — RGW supports changing a user's default placement, storage class, and
-placement tags at any time; changes only affect future bucket/object creation,
-not existing buckets/objects. Removal is the exception: as described in
-[Unset/Removal Behavior](#unsetremoval-behavior), RGW offers no way to clear
-these values, so the CRD rejects an update that unsets a previously set field.
-This is a caveat of the initial implementation, not the intended end state.
+`defaultPlacement` and `defaultStorageClass` are mutable — RGW supports
+changing a user's default placement and storage class at any time; changes
+only affect future bucket/object creation, not existing buckets/objects.
+Removal of either field is covered by
+[Field removal](#field-removal-unmanaged-semantics).
 
 ## Interaction with `AccountRef`
 
 RGW requires an account member's tenant to equal the account's tenant
-(`validate_account_tenant`, enforced at user create and modify). Rook's
-`CephObjectStoreAccount` cannot currently create tenanted accounts, so
-every expressible `tenant` + `accountRef` combination would fail at RGW
-with `EINVAL` on a doubly-immutable field pair, permanently wedging the
-CR. The spec therefore rejects the combination at admission:
+(`validate_account_tenant`, enforced at user create/modify). Rook's
+`CephObjectStoreAccount` cannot currently create tenanted accounts, so every
+expressible `tenant` + `accountRef` combination would fail at RGW with
+`EINVAL` on a doubly-immutable field pair. The spec therefore rejects the
+combination at admission (CEL rule above). Supporting tenanted account
+members requires adding a tenant field to `CephObjectStoreAccount` (go-ceph
+already transmits one) and is listed under [Future work](#future-work).
 
-```go
-// +kubebuilder:validation:XValidation:message="tenant cannot be combined with accountRef (CephObjectStoreAccount does not support tenants)",rule="!(has(self.tenant) && has(self.accountRef))"
-```
+## Future work
 
-Supporting tenanted account members later requires a tenant field on
-`CephObjectStoreAccount` (go-ceph already transmits one on account
-create/modify) and lifting this rule — a backward-compatible relaxation.
+- **`placementTags`** (deferred from this design): RGW `placement_tags` is a
+  bucket-creation authorization list — a user may only create buckets in a
+  tagged placement target when one of the user's tags matches. It is
+  deferred because (a) its enabling half, tags on zonegroup placement
+  targets, has no Rook API (`PoolPlacementSpec` would need a `tags` field);
+  (b) client support exists only in unreleased go-ceph
+  ([go-ceph#1290](https://github.com/ceph/go-ceph/pull/1290)); and (c) tags
+  cannot be cleared through the admin ops API once set
+  ([tracker 79090](https://tracker.ceph.com/issues/79090)). When revisited:
+  the field is named `placementTags` (it is not scoped to the default
+  placement), ships together with `PoolPlacementSpec.tags`, and gates on a
+  released go-ceph.
+- **Revert-on-removal** for the placement fields, once
+  [tracker 79090](https://tracker.ceph.com/issues/79090) and
+  [go-ceph#1307](https://github.com/ceph/go-ceph/issues/1307) are in Rook's
+  support floor.
+- **Tenanted accounts**: a `tenant` field on `CephObjectStoreAccount`,
+  unlocking `tenant` + `accountRef` combinations.


### PR DESCRIPTION
Extends CephObjectStoreUser with two new optional spec fields that wire existing RGW capabilities into the Rook operator:

- spec.tenant — assigns the RGW user to a named tenant, enabling bucket name isolation across tenants (tenantA$user1 and tenantB$user1 are independent users with independent bucket namespaces).
- spec.defaultPlacement — sets the user's default bucket placement target, routing new bucket creation to a specific pool placement defined in the referenced CephObjectStore.

Both fields are already present in the underlying go-ceph admin.User struct; this PR wires them through the CRD API and controller.

Closes #17274