### PR TITLE
osd: handle special float tokens in OSD dump

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -267,11 +267,102 @@ func GetOSDDump(context *clusterd.Context, clusterInfo *ClusterInfo) (*OSDDump, 
 	}
 
 	var osdDump OSDDump
-	if err := json.Unmarshal(buf, &osdDump); err != nil {
+	if err := json.Unmarshal(sanitizeJSONSpecialFloats(buf), &osdDump); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal osd dump response")
 	}
 
 	return &osdDump, nil
+}
+
+func sanitizeJSONSpecialFloats(buf []byte) []byte {
+	out := make([]byte, 0, len(buf))
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(buf); {
+		b := buf[i]
+
+		if inString {
+			out = append(out, b)
+			if escaped {
+				escaped = false
+			} else if b == '\\' {
+				escaped = true
+			} else if b == '"' {
+				inString = false
+			}
+			i++
+			continue
+		}
+
+		if b == '"' {
+			inString = true
+			out = append(out, b)
+			i++
+			continue
+		}
+
+		replacement, consumed, ok := matchJSONSpecialFloat(buf[i:])
+		if ok && specialFloatIsValueToken(out, buf[i+consumed:]) {
+			out = append(out, replacement...)
+			i += consumed
+			continue
+		}
+
+		out = append(out, b)
+		i++
+	}
+
+	return out
+}
+
+func matchJSONSpecialFloat(buf []byte) ([]byte, int, bool) {
+	switch {
+	case len(buf) >= 4 && string(buf[:4]) == "-inf":
+		return []byte("null"), 4, true
+	case len(buf) >= 3 && string(buf[:3]) == "inf":
+		return []byte("null"), 3, true
+	case len(buf) >= 3 && string(buf[:3]) == "nan":
+		return []byte("null"), 3, true
+	default:
+		return nil, 0, false
+	}
+}
+
+func specialFloatIsValueToken(prefix, suffix []byte) bool {
+	prev := lastNonSpace(prefix)
+	next := firstNonSpace(suffix)
+	if prev == 0 || next == 0 {
+		return false
+	}
+
+	prevOK := prev == ':' || prev == '[' || prev == ','
+	nextOK := next == ',' || next == '}' || next == ']'
+	return prevOK && nextOK
+}
+
+func lastNonSpace(buf []byte) byte {
+	for i := len(buf) - 1; i >= 0; i-- {
+		switch buf[i] {
+		case ' ', '\n', '\r', '\t':
+			continue
+		default:
+			return buf[i]
+		}
+	}
+	return 0
+}
+
+func firstNonSpace(buf []byte) byte {
+	for i := 0; i < len(buf); i++ {
+		switch buf[i] {
+		case ' ', '\n', '\r', '\t':
+			continue
+		default:
+			return buf[i]
+		}
+	}
+	return 0
 }
 
 func OsdSafeToDestroy(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) (bool, error) {

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -113,6 +113,38 @@ func TestOsdListNum(t *testing.T) {
 	assert.Equal(t, 0, len(list))
 }
 
+func TestGetOSDDumpHandlesSpecialFloatTokens(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		switch {
+		case args[0] == "osd" && args[1] == "dump":
+			return `{
+				"osds": [{"osd": 0, "up": 1, "in": 1}],
+				"flags": "",
+				"crush_node_flags": {},
+				"full_ratio": 0.95,
+				"backfillfull_ratio": 0.90,
+				"nearfull_ratio": 0.85,
+				"pools": [{
+					"pool": 1,
+					"pool_name": "replicapool",
+					"read_balance": {
+						"score_acting": inf,
+						"score_stable": -inf,
+						"score_primary": nan
+					}
+				}]
+			}`, nil
+		}
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+
+	dump, err := GetOSDDump(&clusterd.Context{Executor: executor}, AdminTestClusterInfo("mycluster"))
+	assert.NoError(t, err)
+	assert.Len(t, dump.OSDs, 1)
+	assert.Equal(t, "0", dump.OSDs[0].OSD.String())
+}
+
 func TestOSDDeviceClasses(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {


### PR DESCRIPTION
Resolves #17614

`ceph osd dump` can spit out bare `inf`, `-inf`, or `nan` in `read_balance`. That makes `GetOSDDump()` choke with `invalid character` and the operator trips over a pretty annoying parser error.

This keeps quoted strings alone, only rewrites bare special float tokens, and lets the unmarshal go through cleanly. It also covers `-inf` and `nan`, not just `inf`.

How to repro
1. Make `ceph osd dump` return a pool `read_balance` block with `score_acting: inf`.
2. Call `GetOSDDump()`.
3. Current code fails with `invalid character 'i' looking for beginning of value`.

Checks
- [x] Commit message follows the repo format well enough
- [x] Reviewed the PR flow docs
- [ ] Pending release notes update not needed
- [ ] Docs update not needed
- [x] Unit tests added
- [ ] Integration tests not needed
