### PR TITLE
ceph: ensure config overrides end with a trailing newline

### DIFF
--- a/deploy/examples/toolbox.yaml
+++ b/deploy/examples/toolbox.yaml
@@ -56,6 +56,7 @@ spec:
                   echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
                   echo "" >> ${CEPH_CONFIG}
                   cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+                  echo "" >> ${CEPH_CONFIG}
                 fi
               }
 

--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -44,6 +44,7 @@ EOF
     echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
     echo "" >> ${CEPH_CONFIG}
     cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
+    echo "" >> ${CEPH_CONFIG}
   fi
 }
 

--- a/pkg/operator/ceph/cluster/utils.go
+++ b/pkg/operator/ceph/cluster/utils.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -87,6 +88,14 @@ func populateConfigOverrideConfigMap(clusterdContext *clusterd.Context, namespac
 			log.NamespacedWarning(namespace, logger, "failed to add recommended labels and annotations to configmap %q. %v", existingCM.Name, err)
 		} else {
 			log.NamespacedInfo(namespace, logger, "added expected labels and annotations to configmap %q", existingCM.Name)
+		}
+	}
+	// Ensure the config string has a trailing newline.
+	if existingCM.Data != nil {
+		if configVal, ok := existingCM.Data[k8sutil.ConfigOverrideVal]; ok && configVal != "" {
+			if !strings.HasSuffix(configVal, "\n") {
+				return errors.Errorf("invalid configmap %q: config data must end with a trailing newline", k8sutil.ConfigOverrideName)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**Description**
This PR resolves a critical issue where Ceph 19.2.3+ daemons fail to start if the `rook-config-override` ConfigMap lacks a trailing newline at EOF, crashing with `parse error: expected '<empty_line>'`. 

**Changes made:**
* Added strict validation in `pkg/operator/ceph/cluster/utils.go`.
* If the `config` string in the override ConfigMap lacks a trailing `\n`, the operator now returns an explicit error. This safely halts the reconcile cycle and logs the error, forcing the cluster admin to add the trailing newline.
* *Note: Helm chart template changes were dropped, as it handles EOF newlines correctly.*

**Related Issues**
Resolves #17285 
(Closes out incomplete work from #17333)

**Checklist:**
- [x] Reviewed the developer guide
- [x] Tested in local rook-ceph cluster with the custom built operator image with this fix