### PR TITLE
docs: fix duplicated word in external-cluster consumer import

### DIFF
--- a/Documentation/CRDs/Cluster/external-cluster/consumer-import.md
+++ b/Documentation/CRDs/Cluster/external-cluster/consumer-import.md
@@ -2,7 +2,7 @@
 
 ## Installation types
 
-Install Rook in the the consumer cluster, either with [Helm](#helm-installation)
+Install Rook in the consumer cluster, either with [Helm](#helm-installation)
 or the [manifests](#manifest-installation).
 
 ### Helm Installation


### PR DESCRIPTION
The consumer-import guide read "Install Rook in the the consumer cluster" — removed the duplicated "the".
