### PR TITLE
CI: test latest k8s 1.35 patch release in the canary integration test

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -9,7 +9,7 @@ on:
         type: string
       kubernetes-version:
         description: kubernetes version to use for the workflow
-        default: '["v1.35.0"]'
+        default: '["v1.35.5"]'
         type: string
 
 defaults:


### PR DESCRIPTION
**Description:** 

It is intended that the CI test the latest patch releas of each kubernetes version that is tested.

The canary integration test tested v1.35.0 however, while the latest v1.35 patch releaase is v1.35.5.

This change updates the integration-test CI workflow to test k8s v1.35.5 instead of v1.35.0 to match the intention.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
