### PR TITLE
CI: test the latest k8s v1.35 patch release in integration tests for release-1.19

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -9,7 +9,7 @@ on:
         type: string
       kubernetes-version:
         description: kubernetes version to use for the workflow
-        default: '["v1.35.0"]'
+        default: '["v1.35.5"]'
         type: string
 
 defaults:

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephSmokeSuite
         run: |
@@ -209,7 +209,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephSmokeSuite
         run: |
@@ -249,7 +249,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephSmokeSuite
         run: |
@@ -289,7 +289,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephObjectSuite
         run: |
@@ -329,7 +329,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -369,7 +369,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.35.5"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         helm-version: ["v3.13.3", "v3.18.3"]
-        kubernetes-version: ["v1.35.0"]
+        kubernetes-version: ["v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-keystone-auth-suite.yaml
+++ b/.github/workflows/integration-test-keystone-auth-suite.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.35.0"]
+        kubernetes-version: ["v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.35.0"]
+        kubernetes-version: ["v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "v1.32.11", "v1.33.7", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.30.14", "1.35.0"]
+        kubernetes-version: ["v1.30.14", "1.35.5"]
     steps:
       - name: checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
**Description:**
 
The CI tested k8s v1.35.0 in the integrations so fat in the 1.19 release branch.

In PR #17782 proposes to change the mergify config to require k8s v1.35.5 based tests to pass for release-1.19 and release-1.20. In order for that changed rule to possibly work, this Change adjusts the CI to run integration tests onk8s v1.35.5 in the release-1.19 CI.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
