### PR TITLE
CI:  change  default minikube driver and  runtime

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -29,7 +29,6 @@ runs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: "1.26"
-
     - name: Install cri-dockerd
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
@@ -70,7 +69,20 @@ runs:
         minikube profile list
         minikube config view || true
         kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}{"\n"}'
+    - name: debug node runtime and kubectl exec
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        kubectl get nodes -o wide
+        kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" => "}{.status.nodeInfo.containerRuntimeVersion}{" | kubelet="}{.status.nodeInfo.kubeletVersion}{"\n"}{end}'
+        minikube profile list
+        minikube status
+        docker ps -a || true
 
+        kubectl create ns exec-smoke || true
+        kubectl -n exec-smoke run exec-smoke --image=busybox:1.36 --restart=Never --command -- sh -c 'sleep 3600'
+        kubectl -n exec-smoke wait --for=condition=Ready pod/exec-smoke --timeout=180s
+        kubectl -n exec-smoke exec exec-smoke -- true
+        kubectl -n exec-smoke exec exec-smoke -- sh -c 'echo exec-works'
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -4,6 +4,14 @@ inputs:
   kubernetes-version:
     description: kubernetes version to use for the workflow
     required: true
+  minikube-driver:
+    description: minikube driver to use
+    required: false
+    default: none
+  minikube-container-runtime:
+    description: minikube container runtime to use
+    required: false
+    default: docker
 
 runs:
   using: "composite"
@@ -39,8 +47,8 @@ runs:
         # longer supports older k8s version we lock to
         minikube-version: "1.38.0"
         kubernetes-version: ${{ inputs.kubernetes-version }}
-        driver: none
-        container-runtime: docker
+        driver: ${{ inputs.minikube-driver }}
+        container-runtime: ${{ inputs.minikube-container-runtime }}
         memory: 6g
         cpus: 2
         addons: ingress
@@ -55,6 +63,14 @@ runs:
         # --wait-timeout: minikube's default 6m node-ready wait expires on slow runners
         # (GUEST_START, exit code 80).
         start-args: --force --wait-timeout=15m
+
+    - name: debug minikube config
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        minikube profile list
+        minikube config view || true
+        kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}{"\n"}'
+
 
     - name: install deps
       shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -88,3 +88,20 @@ runs:
     - name: build rook
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: tests/scripts/github-action-helper.sh build_rook
+
+    - name: load rook image into minikube
+      if: ${{ inputs.minikube-driver == 'docker' }}
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        docker images
+        MINIKUBE_PROFILE=minikube minikube image ls
+
+        # Load the locally built rook image into the minikube cluster.
+        # Adjust the image name if build_rook produces a different tag.
+        minikube image load docker.io/rook/ceph:local-build
+
+    - name: verify rook image is available
+      if: ${{ inputs.minikube-driver == 'docker' }}
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: |
+        minikube image ls | grep -q 'docker.io/rook/ceph:local-build'

--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -7,11 +7,11 @@ inputs:
   minikube-driver:
     description: minikube driver to use
     required: false
-    default: none
+    default: docker
   minikube-container-runtime:
     description: minikube container runtime to use
     required: false
-    default: docker
+    default: containerd
 
 runs:
   using: "composite"
@@ -30,6 +30,7 @@ runs:
       with:
         go-version: "1.26"
     - name: Install cri-dockerd
+      if: ${{ inputs.minikube-container-runtime == 'docker' }}
       shell: bash --noprofile --norc -eo pipefail -x {0}
       run: |
         ARCH=$(go env GOARCH)

--- a/tests/scripts/collect-logs.sh
+++ b/tests/scripts/collect-logs.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 set -x
+if ! ensure_kubectl_can_reach_k8s; then
+	echo "WARNING: kubectl cannot reach a cluster; skipping Kubernetes log collection"
+	# returning success here so log collection is considered optiopnal for green CI.
+	# it is only invoked upon test failure anyway.
+	exit 0
+fi
 
 # User parameters
 : "${CLUSTER_NAMESPACE:="rook-ceph"}"
@@ -11,12 +17,54 @@ set -x
 LOG_DIR="${LOG_DIR%/}" # remove trailing slash if necessary
 mkdir -p "${LOG_DIR}"
 
-CEPH_CMD="kubectl -n ${CLUSTER_NAMESPACE} exec deploy/rook-ceph-tools -- ceph --connect-timeout 10"
 
-$CEPH_CMD -s >"${LOG_DIR}"/ceph-status.txt
-$CEPH_CMD osd dump >"${LOG_DIR}"/ceph-osd-dump.txt
-$CEPH_CMD report >"${LOG_DIR}"/ceph-report.txt
-$CEPH_CMD auth ls >"${LOG_DIR}"/ceph-auth-ls.txt
+KUBECTL_CMD="kubectl -n ${CLUSTER_NAMESPACE}"
+
+TOOLS_POD="$(${KUBECTL_CMD} get pod -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')"
+if [[ -z "${TOOLS_POD}" ]]; then
+	echo "WARNING: rook-ceph-tools pod not found; skipping ceph log collection"
+	exit 0
+fi
+
+
+# function to test if kubectl can reach the k8s cluster.
+ensure_kubectl_can_reach_k8s() {
+	echo "== kubectl diagnostics =="
+	echo "KUBECONFIG=${KUBECONFIG:-<unset>}"
+	kubectl config current-context 2>&1 || true
+	kubectl config get-contexts 2>&1 || true
+	kubectl config view --minify 2>&1 || true
+	if ! kubectl version --request-timeout=10s >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+}
+
+# wrapper for running a ceph command in the toolbox pod with kubectl exec
+ceph_exec() {
+	kubectl -n "${CLUSTER_NAMESPACE}" exec "${TOOLS_POD}" -- ceph --connect-timeout 10 "$@"
+}
+
+# a retry wrapper intended for running ceph commands
+# in the toolbox via kubectl exec
+retry_exec() {
+	local retries="${1:-5}"
+	shift
+	local i
+	# shellcheck disable=SC2034 # i is not referenced: only used to loop.
+	for i in $(seq 1 "$retries"); do
+	if "$@"; then
+		return 0
+	fi
+	sleep 5
+	done
+	return 1
+}
+
+retry_exec 5 ceph_exec -s >"${LOG_DIR}"/ceph-status.txt
+retry_exec 5 ceph_exec osd dump >"${LOG_DIR}"/ceph-osd-dump.txt
+retry_exec 5 ceph_exec report >"${LOG_DIR}"/ceph-report.txt
+retry_exec 5 ceph_exec auth ls >"${LOG_DIR}"/ceph-auth-ls.txt
 
 NAMESPACES=("$CLUSTER_NAMESPACE")
 if [[ "$OPERATOR_NAMESPACE" != "$CLUSTER_NAMESPACE" ]]; then

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -149,46 +149,90 @@ function use_local_disk_for_integration_test() {
   sudo swapoff --all --verbose
 
   # Create an extra disk if doesn't exist.
-  : "$(block_dev)"
+  # Detect if we're using docker driver and use LVM accordingly
+  local minikube_driver
+  minikube_driver=$(minikube profile list 2>/dev/null | grep -oP 'driver:\s*\K\w+' || echo "none")
+
+  if [[ "$minikube_driver" == "docker" ]]; then
+    # For docker driver: use LVM which works better with containerized K8s
+    echo "Docker driver detected - using LVM-based devices for docker driver"
+    # Create LVM volume group from available space
+    dd if=/dev/zero of=~/lvm-disk.img bs=1M seek=20480 count=0
+    local loop_dev
+    loop_dev=$(sudo losetup --find --show ~/lvm-disk.img)
+    # Create LVM VG/LV instead of raw partitions
+    sudo vgcreate rook-vg "$loop_dev" 2>/dev/null || sudo vgcreate -f rook-vg "$loop_dev"
+    sudo lvcreate -L 20G -n rook-lv rook-vg
+    # Set the block device to point to the LVM device
+    DEFAULT_BLOCK_DEV="/dev/mapper/rook-vg-rook_lv"
+    echo "LVM device ready at ${DEFAULT_BLOCK_DEV}"
+  else
+    # For other drivers: use local non-lvm devices.
+
+
+    : "$(block_dev)"
+    sudo lsblk
+
+    # Stop udev from watching the OSD disk, on every kind of runner. Without this, every
+    # close-after-write on the device retriggers a udev probe of the device, and the resulting
+    # re-probe storm during OSD restarts has been seen to wedge ceph-volume activate in
+    # uninterruptible sleep on the block device lock on runners using the iSCSI fallback disk.
+    # See https://github.com/rook/rook/issues/8975 and https://access.redhat.com/solutions/1465913
+    echo "ACTION==\"add|change\", KERNEL==\"$(block_dev_basename)\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
+    sudo udevadm control --reload-rules || true
+    sudo udevadm trigger || true
+    time sudo udevadm settle || true
+    unset pipefail
+    mountpoint -q /mnt || return 0
+    set pipefail
+    sudo umount /mnt
+    sudo sed -i.bak '/\/mnt/d' /etc/fstab
+    # search for the device since it keeps changing between sda and sdb
+    PARTITION="$(block_dev)1"
+    sudo wipefs --all --force "$PARTITION"
+    sudo dd if=/dev/zero of="${PARTITION}" bs=1M count=1
+    sudo lsblk --bytes
+    # add a udev rule to force the disk partitions to ceph
+    # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+    # for more details see: https://github.com/rook/rook/issues/7405
+    echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
+    # The partition is still getting reloaded occasionally during operation. See https://github.com/rook/rook/issues/8975
+    # Try issuing some disk-inspection commands to jog the system so it won't reload the partitions
+    # during OSD provisioning.
+    sudo udevadm control --reload-rules || true
+    sudo udevadm trigger || true
+    time sudo udevadm settle || true
+    sudo partprobe || true
+    sudo lsblk --noheadings --pairs "$(block_dev)" || true
+    sudo sgdisk --print "$(block_dev)" || true
+    sudo udevadm info --query=property "$(block_dev)" || true
+    sudo lsblk --noheadings --pairs "${PARTITION}" || true
+    journalctl -o short-precise --dmesg | tail -40 || true
+    cat /etc/fstab || true
+  fi
+}
+
+function create_partitions_for_osds() {
+  tests/scripts/create-bluestore-partitions.sh --disk "$(block_dev)" --osd-count 2
+  sudo lsblk
+    : "$(block_dev)"
   sudo lsblk
 
-  # Stop udev from watching the OSD disk, on every kind of runner. Without this, every
-  # close-after-write on the device retriggers a udev probe of the device, and the resulting
-  # re-probe storm during OSD restarts has been seen to wedge ceph-volume activate in
-  # uninterruptible sleep on the block device lock on runners using the iSCSI fallback disk.
-  # See https://github.com/rook/rook/issues/8975 and https://access.redhat.com/solutions/1465913
+  # Stop udev from watching the OSD disk...
   echo "ACTION==\"add|change\", KERNEL==\"$(block_dev_basename)\", OPTIONS:=\"nowatch\"" | sudo tee -a /etc/udev/rules.d/99-z-rook-nowatch.rules
-  sudo udevadm control --reload-rules || true
-  sudo udevadm trigger || true
-  time sudo udevadm settle || true
+  # ... etc
+}
 
-  unset pipefail
-  mountpoint -q /mnt || return 0
-  set pipefail
-  sudo umount /mnt
-  sudo sed -i.bak '/\/mnt/d' /etc/fstab
-  # search for the device since it keeps changing between sda and sdb
-  PARTITION="$(block_dev)1"
-  sudo wipefs --all --force "$PARTITION"
-  sudo dd if=/dev/zero of="${PARTITION}" bs=1M count=1
-  sudo lsblk --bytes
-  # add a udev rule to force the disk partitions to ceph
-  # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
-  # for more details see: https://github.com/rook/rook/issues/7405
-  echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
-  # The partition is still getting reloaded occasionally during operation. See https://github.com/rook/rook/issues/8975
-  # Try issuing some disk-inspection commands to jog the system so it won't reload the partitions
-  # during OSD provisioning.
-  sudo udevadm control --reload-rules || true
-  sudo udevadm trigger || true
-  time sudo udevadm settle || true
-  sudo partprobe || true
-  sudo lsblk --noheadings --pairs "$(block_dev)" || true
-  sudo sgdisk --print "$(block_dev)" || true
-  sudo udevadm info --query=property "$(block_dev)" || true
-  sudo lsblk --noheadings --pairs "${PARTITION}" || true
-  journalctl -o short-precise --dmesg | tail -40 || true
-  cat /etc/fstab || true
+function create_partitions_for_osds() {
+  tests/scripts/create-bluestore-partitions.sh --disk "$(block_dev)" --osd-count 2
+  sudo lsblk
+}
+
+function create_bluestore_partitions_and_pvcs() {
+  BLOCK_PART="$(block_dev)2"
+  DB_PART="$(block_dev)1"
+  tests/scripts/create-bluestore-partitions.sh --disk "$(block_dev)" --bluestore-type block.db --osd-count 1
+  tests/scripts/localPathPV.sh "$BLOCK_PART" "$DB_PART"
 }
 
 function create_partitions_for_osds() {


### PR DESCRIPTION
**Description:**

While trying to run the integration test suiteson minikube  k8s 1.36 (see PR #17623 ),
problems with running kubectl exec were discovereddepending on the minikube driver and container-runtime combination.
    
The docker driver combined with containerd runtime has locally been
proven to not have these problems.
    
While this combination has not yet led to complete success of integration
tests on k8s v1.36, it has been shown to at least remove this aspect of
    failure.
    
This change makes docker driver+containerd runtime the default
    while adding flexibility to override them from the invoking
    integration-test suite workflows.
    
The purpose of the change is to check whether this combination
works with k8s versions other than v1.36, thereby possibly preparing for
    later adding 1.36 testing.

In addition to the driver and runtime changes, this PR:

- makes kubectl-exec-based log collection more robust
- loads locally built images into minikube when using the docker driver
- adds diagnostic steps for early spotting of  kubectl exec problems to the shared cluster setup action

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
