### PR TITLE
docs: update node loss handling instructions

### DIFF
--- a/Documentation/Helm-Charts/csi-drivers-chart.md
+++ b/Documentation/Helm-Charts/csi-drivers-chart.md
@@ -41,6 +41,23 @@ operatorConfig:
 
 See: [CSI-Addons sidecar](../Storage-Configuration/Ceph-CSI/csi-configuration.md#csi-addons-sidecar)
 
+### Network Fencing
+
+The example below is scoped to the RBD driver only.
+
+```yaml
+drivers:
+  rbd:
+    deployCsiAddons: true
+    enableFencing: true
+```
+
+!!! important
+    The Network Fencing feature requires the CSI-Addons controller to be deployed separately for auto-unfencing. See
+    [Deploying the controller](../Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md#deploying-the-controller).
+
+See: [Network Fencing](../Storage-Configuration/Ceph-CSI/csi-configuration.md#network-fencing)
+
 ### Controller plugin replicas
 
 ```yaml

--- a/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md
+++ b/Documentation/Storage-Configuration/Block-Storage-RBD/block-storage.md
@@ -209,9 +209,12 @@ The erasure coded pool must be set as the `dataPool` parameter in
 
 If a node goes down where a pod is running where a volume is mounted, the volume cannot automatically be mounted on another node. The node must be guaranteed to be offline before the volume can be mounted on another node.
 
+Network fencing is designed to prevent a failed node from accessing the volume before it is remounted elsewhere. The feature is **not enabled by default**. For step-by-step configuration examples to enable automatic network fencing and unfencing, see:
+
+* The [`Network Fencing`](../Ceph-CSI/csi-configuration.md#network-fencing) section in the CSI configuration documentation for manifest-based examples using the RBD `Driver` CR.
+* The [`Network Fencing`](../../Helm-Charts/csi-drivers-chart.md#network-fencing) section in the Ceph-CSI driver Helm chart documentation for Helm-based examples.
 
 ### Handling Node Loss
-
 
 When a node is confirmed to be down, add the following taints to the node:
 
@@ -220,11 +223,20 @@ kubectl taint nodes <node-name> node.kubernetes.io/out-of-service=nodeshutdown:N
 kubectl taint nodes <node-name> node.kubernetes.io/out-of-service=nodeshutdown:NoSchedule
 ```
 
-After the taint is added to the node, the CephCSI driver will automatically handle the network fencing to prevent connections to Ceph from the volume on that node.
+After the taint is added to the node and the fencing feature is properly configured:
+
+* The CSI driver will retrieve the stored client address from the RBD image metadata
+* If the node has the `out-of-service` taint, the driver will add the client address to the Ceph blocklist to prevent connections to Ceph from the volume on that node
+* The blocklist entry has an extended duration (approximately 3 years) to ensure the protection persists until the node undergoes a complete power cycle.
+
+!!! warning
+    When a node becomes out of service, its mounts and device mappings will persist until the node undergoes a complete power lifecycle (includes shutdown and startup). To prevent data inconsistency or corruption, administrators **MUST NOT** remove the `node.kubernetes.io/out-of-service` taint until the node has successfully completed a full power cycle. Removing the taint prematurely may leave stale device states, active client sessions, or lingering mounts, which can lead to serious data integrity issues.
 
 ### Node Recovery
 
-If the node comes back online, the CephCSI driver will automatically handle the network unfencing when the node taints are removed:
+If the node comes back online and the fencing feature is properly configured, workloads can be rescheduled onto the recovered node once the `out-of-service` taints are removed. If the 5-minute cool-down period has passed, the CSI-Addons controller will automatically remove the client address from the blocklist.
+
+To manually remove the taints after the node has completed a full power cycle:
 
 ```console
 kubectl taint nodes <node-name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute-

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md
@@ -188,17 +188,9 @@ To use the features provided by the CSI-Addons, the `csi-addons`
 containers need to be deployed in the RBD provisioner and nodeplugin pods,
 which are not enabled by default.
 
-Execute the following to enable the CSI-Addons sidecars:
+To enable the CSI-Addons sidecars, please set `deployCsiAddons` to `true` on `OperatorConfig` or `Driver`. After applying the setting, a new sidecar container named `csi-addons` will start automatically in the RBD CSI provisioner and nodeplugin pods.
 
-* Update the `rook-ceph-operator-config` configmap and patch the
-    following configuration:
-
-    ```console
-    kubectl patch cm rook-ceph-operator-config -nrook-ceph -p $'data:\n "CSI_ENABLE_CSIADDONS": "true"'
-    ```
-
-* After enabling `CSI_ENABLE_CSIADDONS` in the configmap, a new sidecar container named `csi-addons`
-    will start automatically in the RBD CSI provisioner and nodeplugin pods.
+For details and examples, see [CSI-Addons sidecar](csi-configuration.md#csi-addons-sidecar).
 
 ### CSI-Addons Operations
 
@@ -221,6 +213,18 @@ CSI-Addons supports the following operations:
     * [Annotating PersistentVolumeClaims](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.14.0/docs/encryptionkeyrotation.md#annotating-persistentvolumeclaims)
     * [Annotating Namespace](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.14.0/docs/encryptionkeyrotation.md#annotating-namespace)
     * [Annotating StorageClass](https://github.com/csi-addons/kubernetes-csi-addons/blob/v0.14.0/docs/encryptionkeyrotation.md#annotating-storageclass)
+
+## Network Fencing
+
+Network fencing automatically blocklists a Ceph client when its node has the
+`node.kubernetes.io/out-of-service` taint, and removes the blocklist entry once
+the taint is cleared and the cool-down period has passed. This protects
+against data corruption when a volume is rescheduled from a node that is
+assumed to be down but may still have active mounts.
+
+Currently, network fencing feature is supported in CephFS and RBD.
+
+For RBD, see the [Network Fencing](csi-configuration.md#network-fencing) section for configuration examples and the [Node Loss](../Block-Storage-RBD/block-storage.md#node-loss) section for the complete operational flow.
 
 ## Enable RBD and CephFS Encryption Support
 

--- a/Documentation/Storage-Configuration/Ceph-CSI/csi-configuration.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/csi-configuration.md
@@ -52,6 +52,28 @@ spec:
     deployCsiAddons: true
 ```
 
+## Network Fencing
+
+Network fencing requires:
+
+1. Enable the [CSI-Addons controller](ceph-csi-drivers.md#csi-addons-controller).
+2. Enable the CSI-Addons sidecar by setting `deployCsiAddons: true` on the RBD `Driver`.
+3. Set `enableFencing` to `true` on the RBD `Driver`.
+
+Here is an example of RBD `Driver`:
+
+```yaml
+# Driver CR (manifest)
+apiVersion: csi.ceph.io/v1
+kind: Driver
+metadata:
+  name: rook-ceph.rbd.csi.ceph.com
+  namespace: rook-ceph
+spec:
+  deployCsiAddons: true
+  enableFencing: true
+```
+
 ## Custom container images
 
 Previously: `CSI_*_IMAGE` keys in `rook-ceph-operator-config`. Now use the `ImageSet` ConfigMap referenced by `OperatorConfig`.


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
    1. Add a description of the changes (frequently the same as the commit description)
    2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
    3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
    4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Description of the changes:**

Update the Node Loss section in block-storage.md to accurately reflect how the fencing feature works in current ceph-csi versions.

The previous documentation incorrectly stated that the CephCSI driver will "automatically handle" network fencing and unfencing. In reality:

1. The `enable-fencing` flag is **NOT enabled by default** in ceph-csi (defaults to `false`)
2. CSI-Addons sidecar must be explicitly enabled via `CSI_ENABLE_CSIADDONS` configmap
3. CSI-Addons controller must be deployed separately
4. The `enable-fencing` flag must be explicitly set to `true`

Key changes in this PR:
- Document that `enable-fencing` is NOT enabled by default in ceph-csi
- Explain the prerequisites for automatic fencing:
  * CSI-Addons sidecar must be enabled via `CSI_ENABLE_CSIADDONS` config
  * CSI-Addons controller must be deployed separately
  * `enable-fencing` flag must be set to `true`
- Add warning about not removing `out-of-service` taints until node completes full power cycle to prevent data corruption
- Document the auto-unfencing mechanism via `GetFenceClients()` RPC that only works when CSI-Addons is properly configured
- Added step-by-step instructions for enabling the required components

This fix addresses the outdated documentation which incorrectly implied that fencing/unfencing happens automatically without proper configuration.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
    - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
