### PR TITLE
build: add a  target lint.workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ SERVER_PACKAGES = $(GO_PROJECT)/cmd/rook
 TEST_PACKAGES = $(GO_PROJECT)/tests/integration
 
 CHECKMAKE=go run github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
+ACTIONLINT := go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
 # the root go project
 GO_PROJECT=github.com/rook/rook
@@ -233,6 +234,12 @@ lint.make: ## lint the Makefile
 .PHONY: lint.shell
 lint.shell: | $(SHELLCHECK) ## lint shell scripts
 	$(SHELLCHECK) --severity=warning --format=gcc --shell=bash $(shell find $(ROOT_DIR) -type f -name '*.sh') build/reset build/sed-in-place
+
+.PHONY: lint.workflows
+lint.workflows: ## lint the GitHub workflow files
+	@echo "linting GitHub workflows..."
+	@$(ACTIONLINT) -color
+	@echo "workflows are good."
 
 .PHONY: gen.codegen
 gen.codegen: codegen


### PR DESCRIPTION
**Description:**

This adds a Makefile target `lint.workflows` that checks the github workflow yaml files with the
actionlint tool.

This PR is intended as a preparation for linting the workflows in the CI (see PR #17752).

Note that `make lint.workflows` currently fails, so workflow files should be fixed to have this pass before making use of it in the CI. 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
