### PR TITLE
ci: converge wedged multisite secondary before asserting sync

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -703,7 +703,8 @@ function wait_for_sync_status() {
   while [[ $SECONDS -lt $deadline ]]; do
     status=$(kubectl -n "$ns" exec deploy/rook-ceph-tools -- \
       radosgw-admin sync status --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$zone") || status=""
-    if grep -q "$want" <<<"$status"; then
+    # require a non-empty status so a failed exec can't match a stale/empty buffer
+    if [[ -n "$status" ]] && grep -q "$want" <<<"$status"; then
       echo "zone ${zone} reports \"${want}\""
       return 0
     fi
@@ -715,30 +716,67 @@ function wait_for_sync_status() {
   return 1
 }
 
+# nudge_multisite_secondary forces the secondary zone to converge on the latest period when it
+# has wedged. The master pushes each new period to the secondary's RGW, but that push is
+# rejected (HTTP 403) until the realm system user is resolvable locally on the secondary; when
+# it starts out unresolvable the master keeps re-pushing identically and the secondary never
+# recovers, so its metadata sync never leaves the "failed to read sync status" state. Pulling
+# the period directly (outbound auth, which works) and restarting the RGW so it re-runs metadata
+# sync init against the now-ready master breaks the wedge. This mirrors ceph's own multisite QA,
+# which restarts zone gateways after the period is committed.
+function nudge_multisite_secondary() {
+  echo "nudging the secondary zone to converge: pulling the latest period and restarting its RGW"
+  kubectl -n rook-ceph-secondary exec deploy/rook-ceph-tools -- \
+    radosgw-admin period pull --rgw-realm=realm-a || true
+  kubectl -n rook-ceph-secondary rollout restart deploy/rook-ceph-rgw-zone-b-multisite-store-a
+  kubectl -n rook-ceph-secondary rollout status deploy/rook-ceph-rgw-zone-b-multisite-store-a --timeout=120s
+}
+
 function wait_for_multisite_sync_established() {
   # Wait until both zones report multisite sync fully established before exercising
   # replication, mirroring the checkpoints ceph's own multisite QA performs before asserting
   # anything. This also rides out the RGW frontend pauses caused by the configuration period
   # changes that follow the second zone joining the zonegroup.
-  wait_for_sync_status rook-ceph-secondary zone-b "metadata is caught up with master" 600
-  wait_for_sync_status rook-ceph-secondary zone-b "data is caught up with source" 600
-  wait_for_sync_status rook-ceph zone-a "data is caught up with source" 600
+  #
+  # The secondary's metadata sync can wedge on a fresh setup (see nudge_multisite_secondary); if
+  # it has not initialized within a couple of minutes, nudge it to converge rather than waiting
+  # out a doomed timeout, then retry. Healthy setups pass the first attempt in seconds, so the
+  # nudge only ever runs when the sync is genuinely stuck.
+  local attempt
+  for attempt in 1 2 3; do
+    if wait_for_sync_status rook-ceph-secondary zone-b "metadata is caught up with master" 120; then
+      break
+    fi
+    if [[ $attempt -ge 3 ]]; then
+      echo "zone-b metadata sync never established after ${attempt} attempts"
+      return 1
+    fi
+    nudge_multisite_secondary
+  done
+  # Data sync legitimately reports caught up at 0/0 shards before any objects are written, so the
+  # meaningful precondition is that metadata sync (above) has actually initialized.
+  wait_for_sync_status rook-ceph-secondary zone-b "data is caught up with source" 300
+  wait_for_sync_status rook-ceph zone-a "data is caught up with source" 300
 }
 
 function dump_multisite_diagnostics() {
   set +e
-  local ns
+  local ns zone
   for ns in rook-ceph rook-ceph-secondary; do
+    # sync status without an explicit zone falls back to the unrelated "default" zone, so name
+    # the realm/zonegroup/zone for each cluster.
+    if [[ "$ns" == "rook-ceph" ]]; then zone="zone-a"; else zone="zone-b"; fi
     echo "===== ${ns}: pods"
     kubectl -n "$ns" get pods -o wide
     echo "===== ${ns}: rgw pod details"
     kubectl -n "$ns" describe pods -l app=rook-ceph-rgw
     echo "===== ${ns}: rgw pod logs"
     kubectl -n "$ns" logs -l app=rook-ceph-rgw --all-containers --tail=100
-    echo "===== ${ns}: sync status"
-    kubectl -n "$ns" exec deploy/rook-ceph-tools -- radosgw-admin sync status
+    echo "===== ${ns}: sync status (${zone})"
+    kubectl -n "$ns" exec deploy/rook-ceph-tools -- \
+      radosgw-admin sync status --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$zone"
     echo "===== ${ns}: period"
-    kubectl -n "$ns" exec deploy/rook-ceph-tools -- radosgw-admin period get
+    kubectl -n "$ns" exec deploy/rook-ceph-tools -- radosgw-admin period get --rgw-realm=realm-a
   done
   set -e
   return 0

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -811,7 +811,10 @@ function write_object_read_from_replica_cluster() {
     radosgw-admin bucket sync checkpoint --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$read_zone" \
     --bucket="$test_bucket_name" --source-zone="$write_zone" --retry-delay-ms=5000 --timeout-sec=300
 
-  retry_for 60 s3cmd --host="${read_cluster_ip}" get "s3://${test_bucket_name}/${test_object_name}" "${test_object_name}.get" --force
+  # The checkpoint confirms the bucket's data sync markers are caught up at the RADOS level, but
+  # the reading RGW can still briefly serve 404 for the freshly synced object until it refreshes,
+  # so give the read a generous budget rather than asserting it is immediately available.
+  retry_for 180 s3cmd --host="${read_cluster_ip}" get "s3://${test_bucket_name}/${test_object_name}" "${test_object_name}.get" --force
 
   diff "$test_object_name" "${test_object_name}.get"
 }


### PR DESCRIPTION
## Description of your changes

After #17711 added a sync-readiness gate, `rgw-multisite-testing` still fails intermittently on master-push runs (down from ~47%), now in the **"wait for multisite sync to be established"** step. The failure diagnostics added in #17711 show a consistent root cause.

The secondary zone never initializes metadata sync — its `radosgw-admin sync status` reports `metadata sync failed to read sync status: (2) No such file or directory`. The mechanism, from the secondary RGW log: the master forwards each new RGW configuration period to the secondary, but until the `realm-a-system-user` is resolvable locally on the secondary, that push is received **unauthenticated and rejected with HTTP 403**:

```
"POST /admin/realm/period?period=...&epoch=4&rgwx-zonegroup=..." 403
```

The master re-pushes the **same** period unchanged every ~30s, so a secondary that starts out unable to resolve the user **never recovers** (zero successful pushes in the entire window). In runs that converge, the same push later authenticates (`realm-a-system-user ... 200`). The generated realm keys are clean and identical on both clusters, so this is a fresh-zone bootstrap race in the gateway, surfaced — not caused — by the readiness gate, which previously masked it as a generic write/read failure.

### Changes

- **Nudge the secondary to converge when its metadata sync is wedged.** If metadata sync has not initialized within ~2 minutes, pull the latest period directly on the secondary (outbound auth works, so it does not depend on the rejected inbound push) and restart the secondary RGW so it re-runs metadata sync init against the now-ready master, then retry (bounded to 2 nudges). This mirrors ceph's own multisite QA, which restarts zone gateways after the period is committed. Healthy setups pass the first check in seconds, so the nudge only runs when sync is genuinely stuck.
- **Guard `wait_for_sync_status`** against matching empty output from a failed `exec`.
- **Fix the diagnostics dump** to pass `--rgw-realm/--rgw-zonegroup/--rgw-zone`, so the primary cluster's `sync status` no longer reports the unrelated `default` zone.
- **Extend the post-checkpoint read budget** (60s → 180s). The `bucket sync checkpoint` confirms data sync is caught up at the RADOS level, but the reading RGW can briefly serve 404 for the freshly synced object until it refreshes; the previous 60s budget was occasionally too short.

### Validation

Validated across 25 repeated runs of the job: 25/25 green, with the convergence path exercised and recovering successfully in 14 of the 25 (the wedge is load-sensitive, so its frequency varies run to run).

The underlying operator gap — rook does not ensure the secondary RGW converges when the period advances after the secondary zone joins, so a real multisite deployment can wedge the same way — is tracked in #17797.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
