### PR TITLE
core: Skip node watcher during initial cache sync

### DIFF
--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -68,7 +68,10 @@ func predicateForNodeWatcher[T *corev1.Node](ctx context.Context, client client.
 	return predicate.TypedFuncs[T]{
 		CreateFunc: func(e event.TypedCreateEvent[T]) bool {
 			obj := (*corev1.Node)(e.Object)
-
+			if e.IsInInitialList {
+				// Skip node handling while the controller runtime is initializing the cache.
+				return false
+			}
 			clientCluster := newClientCluster(client, obj.GetNamespace(), context)
 			return clientCluster.onK8sNode(ctx, obj, opNamespace)
 		},


### PR DESCRIPTION
When the operator starts, there is no need to handle the node watcher immediately while the controller runtime cache is being initialized. The cluster will anyway be fully reconciled and create new OSDs if needed. The node watcher is only intended for triggering a reconcile when a node is added or updated at a later time after a sync would anyway be triggered.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #17804

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
