### PR TITLE
ci: convert CI to kind and bump latest kubernetes to v1.36.1

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -9,7 +9,7 @@ on:
         type: string
       kubernetes-version:
         description: kubernetes version to use for the workflow
-        default: '["v1.35.5"]'
+        default: '["v1.36.1"]'
         type: string
 
 defaults:

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: validate-yaml
         run: tests/scripts/github-action-helper.sh validate_yaml
@@ -87,7 +87,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -127,7 +127,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -167,7 +167,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephSmokeSuite
         run: |
@@ -207,7 +207,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephObjectSuite (without TLS)
         run: |
@@ -247,7 +247,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephObjectSuiteTLS
         run: |
@@ -287,7 +287,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -327,7 +327,7 @@ jobs:
       - name: setup cluster resources
         uses: ./.github/workflows/integration-test-setup-cluster-resources
         with:
-          kubernetes-version: "v1.35.5"
+          kubernetes-version: "v1.36.1"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         helm-version: ["v3.13.3", "v3.18.3"]
-        kubernetes-version: ["v1.35.5"]
+        kubernetes-version: ["v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-keystone-auth-suite.yaml
+++ b/.github/workflows/integration-test-keystone-auth-suite.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.35.5"]
+        kubernetes-version: ["v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.35.5"]  # test only on latest supported k8s version
+        kubernetes-version: ["v1.36.1"]  # test only on latest supported k8s version
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.35.5"]
+        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -265,7 +265,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.35.5"]  # test only on latest supported k8s version
+        kubernetes-version: ["v1.36.1"]  # test only on latest supported k8s version
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
**Description**

Builds on #17822 (the minikube→kind CI conversion) and bumps the most recent Kubernetes version exercised by the integration and canary matrices. The first commit is the kind conversion (identical to #17822); the second commit makes the version bump.

- Bumps the latest matrix version from `v1.35.5` to **`v1.36.1`** across the integration and canary workflows. The older matrix versions (`v1.31.14`, `v1.32.13`, `v1.34.8`) are unchanged.
- The `kindest/node:v1.36.1` image is provided by **kind v0.32.0**, which the conversion commit (#17822) already pins in the shared `integration-test-setup-cluster-resources` action (helm/kind-action's default kind v0.31.0 predates 1.36, so it ships no 1.36 node image). `v1.36.2` has no published `kindest/node` image (Docker Hub 404), so `v1.36.1` is the newest available 1.36 node image.

Stacked on #17822: once that merges, the first commit lands with it and this PR reduces to just the version bump.

**AI assistance:** Claude Code (Anthropic) worked out the kind / `kindest/node` version constraints, drafted the edits, and drafted this description and the commit messages.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
