### PR TITLE
build: remove v prefix from helm chart version tag

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,6 +2,6 @@
 
 ## Breaking Changes
 
-
+- Helm OCI chart tags no longer include the `v` prefix (e.g., `1.21.0` instead of `v1.21.0`). Update any scripts or tooling that reference the chart by tag.
 
 ## Features

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -122,7 +122,7 @@ ifeq ($(origin HELM_CHART_VERSION), undefined)
 # this changes the third '.' to a '-':
 #   example v1.16.0.371.g4aec70601 -> v1.16.0-371.g4aec70601
 # as helm has strict rules on allowable versions to comply with SemVer2
-HELM_CHART_VERSION := $(shell echo "$(VERSION)" | sed 's/\./-/3' )
+HELM_CHART_VERSION := $(shell echo "$(VERSION)" | sed 's/^v//' | sed 's/\./-/3'  )
 endif
 export HELM_CHART_VERSION
 


### PR DESCRIPTION
Removed the leading v from the Helm OCI chart version tag so that helm pull can auto-resolve the latest version without specifying the tag explicitly.

Closes #17653 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
