### PR TITLE
ci: provision extra disks when the runner starts with none

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -103,7 +103,7 @@ function find_extra_block_devs() {
   boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
   local devs count
   # --nodeps ignores partitions
-  devs="$(sudo lsblk --noheading --list --nodeps --output KNAME | egrep -v "($boot_dev|loop|nbd)")"
+  devs="$(sudo lsblk --noheading --list --nodeps --output KNAME | egrep -v "($boot_dev|loop|nbd)" || true)"
   count="$(echo "$devs" | grep -c . || true)"
   if [ "$count" -lt "$min_count" ]; then
     create_extra_disk "$((min_count - count))" >/dev/stderr


### PR DESCRIPTION
**Description**

`find_extra_block_devs` decides how many extra disks to provision by first reading the runner's current ones:

```sh
devs="$(sudo lsblk --noheading --list --nodeps --output KNAME | egrep -v "($boot_dev|loop|nbd)")"
```

On a runner that has **no** extra disk, that `egrep -v` matches nothing and exits 1. Under the script's `set -eo pipefail`, the assignment then aborts the function **before it reaches `create_extra_disk`**, so callers get zero disks and fail with `expected >= N extra disks, found 0` (or a bare `/dev/` device path). It only bites on runners that start with no extra disk, so it surfaces as an intermittent CI failure rather than a consistent one.

Fix: guard the `egrep` with `|| true` — exactly as the adjacent device-count line (`count="$(echo "$devs" | grep -c . || true)"`) already does — so an empty result means "no extra disks yet" and the provisioning path runs.

Found while testing a kind-based CI conversion, where a no-extra-disk runner made every job fail at cluster setup.

**AI assistance:** Claude Code (Anthropic) diagnosed the `set -eo pipefail` / empty-`egrep` interaction, drafted the one-line fix, and drafted this description and the commit message. I reviewed and own all of it.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

