### PR TITLE
ci: capture build_rook stderr so the network-retry can see it

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -269,7 +269,10 @@ function build_rook() {
   fi
   GOPATH=$(go env GOPATH) make clean
   for _ in $(seq 1 3); do
-    if ! o=$(make -j"$(nproc)" "$build_type"); then
+    # capture stderr too: go/make write network errors (the strings
+    # matched below) to stderr, so without 2>&1 $o never contains them
+    # and a transient failure skips the retry and is treated as fatal.
+    if ! o=$(make -j"$(nproc)" "$build_type" 2>&1); then
       case "$o" in
       *"$NETWORK_ERROR"*)
         echo "network failure occurred, retrying..."


### PR DESCRIPTION
`build_rook()` captures the `make` output into `$o` and inspects it for transient
network errors (`connection reset by peer`, `INTERNAL_ERROR`, `Service Unavailable`,
`500 Internal Server Error`) to retry the build up to 3 times. The capture was
stdout-only, but `go` and `make` write those errors to **stderr**, so `$o` never
contained them — the retry cases never matched and a transient module-proxy failure
fell straight through to the `*) # valid failure` branch, failing the job in the
build step before the integration test even ran.

In other words, the network-retry has been dead code for exactly the failures it
was written to absorb.

Observed in a post-merge `Integration tests on master/release` run where `make build`
hit `proxy.golang.org ... stream error: ...; INTERNAL_ERROR; received from peer` 57
times, yet logged **zero** `network failure occurred, retrying...` lines and failed
`TestCephUpgradeSuite (v1.31.14)` in `build_rook`:
https://github.com/rook/rook/actions/runs/28114795912/job/83251318456

Fix: capture stderr into `$o` as well (`2>&1`) so the existing retry logic actually
triggers on network failures. This applies to every suite, since `build_rook` runs
in all of them.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
