### PR TITLE
docs: fix function comments to match their declaration names

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2941,7 +2941,7 @@ KeystoneSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec</a>)
 </p>
 <div>
-<p>BucketNotificationSpec represent the event type of the bucket notification
+<p>BucketNotificationEvent represent the event type of the bucket notification
 See: <a href="https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types">https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types</a></p>
 </div>
 <h3 id="ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec
@@ -5325,7 +5325,7 @@ was reinstalled but OSD disk still contains the metadata from previous ceph clus
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ClientSpec">ClientSpec</a>)
 </p>
 <div>
-<p>ClinetSecuritySpec represents security settings for a Ceph Client</p>
+<p>ClientSecuritySpec represents security settings for a Ceph Client</p>
 </div>
 <table>
 <thead>
@@ -7400,7 +7400,7 @@ PeerStatSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirroringInfoSpec">FilesystemMirroringInfoSpec</a>)
 </p>
 <div>
-<p>FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem</p>
+<p>FilesystemMirroringInfo is the filesystem mirror status of a given filesystem</p>
 </div>
 <table>
 <thead>
@@ -7444,7 +7444,7 @@ int
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus</a>)
 </p>
 <div>
-<p>FilesystemMirroringInfo is the status of the pool mirroring</p>
+<p>FilesystemMirroringInfoSpec is the status of the pool mirroring</p>
 </div>
 <table>
 <thead>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -948,7 +948,7 @@ spec:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationSpec represent the event type of the bucket notification
+                      BucketNotificationEvent represent the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -9191,7 +9191,7 @@ spec:
                     daemonsStatus:
                       description: PoolMirroringStatus is the mirroring status of a filesystem
                       items:
-                        description: FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem
+                        description: FilesystemMirroringInfo is the filesystem mirror status of a given filesystem
                         properties:
                           daemon_id:
                             description: DaemonID is the cephfs-mirror name

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -949,7 +949,7 @@ spec:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationSpec represent the event type of the bucket notification
+                      BucketNotificationEvent represent the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -9186,7 +9186,7 @@ spec:
                     daemonsStatus:
                       description: PoolMirroringStatus is the mirroring status of a filesystem
                       items:
-                        description: FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem
+                        description: FilesystemMirroringInfo is the filesystem mirror status of a given filesystem
                         properties:
                           daemon_id:
                             description: DaemonID is the cephfs-mirror name

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1622,7 +1622,7 @@ type CephFilesystemStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
-// FilesystemMirroringInfo is the status of the pool mirroring
+// FilesystemMirroringInfoSpec is the status of the pool mirroring
 type FilesystemMirroringInfoSpec struct {
 	// PoolMirroringStatus is the mirroring status of a filesystem
 	// +nullable
@@ -1703,7 +1703,7 @@ type FilesystemSnapshotScheduleStatusRetention struct {
 	Active bool `json:"active,omitempty"`
 }
 
-// FilesystemMirrorInfoSpec is the filesystem mirror status of a given filesystem
+// FilesystemMirroringInfo is the filesystem mirror status of a given filesystem
 type FilesystemMirroringInfo struct {
 	// DaemonID is the cephfs-mirror name
 	// +optional
@@ -2796,7 +2796,7 @@ type CephBucketNotificationList struct {
 	Items           []CephBucketNotification `json:"items"`
 }
 
-// BucketNotificationSpec represent the event type of the bucket notification
+// BucketNotificationEvent represent the event type of the bucket notification
 // See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
 // +kubebuilder:validation:Enum="s3:ObjectCreated:*";"s3:ObjectCreated:Put";"s3:ObjectCreated:Post";"s3:ObjectCreated:Copy";"s3:ObjectCreated:CompleteMultipartUpload";"s3:ObjectRemoved:*";"s3:ObjectRemoved:Delete";"s3:ObjectRemoved:DeleteMarkerCreated";"s3:ObjectLifecycle:Expiration:Current";"s3:ObjectLifecycle:Expiration:NonCurrent";"s3:ObjectLifecycle:Expiration:DeleteMarker";"s3:ObjectLifecycle:Expiration:AbortMultipartUpload";"s3:ObjectLifecycle:Transition:Current";"s3:ObjectLifecycle:Transition:NonCurrent";"s3:LifecycleExpiration:*";"s3:LifecycleExpiration:Delete";"s3:LifecycleExpiration:DeleteMarkerCreated";"s3:LifecycleTransition";"s3:ObjectSynced:*";"s3:ObjectSynced:Create";"s3:ObjectSynced:Delete";"s3:ObjectSynced:DeletionMarkerCreated";"s3:Replication:*";"s3:Replication:Create";"s3:Replication:Delete";"s3:Replication:DeletionMarkerCreated";"s3:ObjectRestore:*";"s3:ObjectRestore:Post";"s3:ObjectRestore:Completed";"s3:ObjectRestore:Delete"
 type BucketNotificationEvent string
@@ -3460,7 +3460,7 @@ type ClientSpec struct {
 	Security ClientSecuritySpec `json:"security,omitempty"`
 }
 
-// ClinetSecuritySpec represents security settings for a Ceph Client
+// ClientSecuritySpec represents security settings for a Ceph Client
 type ClientSecuritySpec struct {
 	// CephX configures CephX key settings. More: https://docs.ceph.com/en/latest/dev/cephx/
 	// +optional
@@ -3917,7 +3917,7 @@ type CephFilesystemSubVolumeGroup struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// CephFilesystemSubVolumeGroup represents a list of Ceph Clients
+// CephFilesystemSubVolumeGroupList represents a list of Ceph filesystem subvolume groups
 type CephFilesystemSubVolumeGroupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -476,7 +476,7 @@ type SubVolumeSnapshot struct {
 // SubVolumeSnapshots is the list of snapshots in a CephFS subvolume
 type SubVolumeSnapshots []SubVolumeSnapshot
 
-// ListSubVolumeSnaphots lists all the subvolume snapshots present in the subvolume in the given filesystem's subvolume group.
+// ListSubVolumeSnapshots lists all the subvolume snapshots present in the subvolume in the given filesystem's subvolume group.
 var ListSubVolumeSnapshots = listSubVolumeSnapshots
 
 func listSubVolumeSnapshots(context *clusterd.Context, clusterInfo *ClusterInfo, fsName, subVolumeName, groupName string) (SubVolumeSnapshots, error) {

--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -34,7 +34,7 @@ var (
 	knownKMSPrefix = []string{"VAULT_", "IBM_", kmipKMSPrefix, "AZURE_"}
 )
 
-// VaultTokenEnvVarFromSecret returns the kms token secret value as an env var
+// vaultTokenEnvVarFromSecret returns the kms token secret value as an env var
 func vaultTokenEnvVarFromSecret(tokenSecretName string) v1.EnvVar {
 	return v1.EnvVar{
 		Name: api.EnvVaultToken,

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -569,7 +569,7 @@ func (c *Cluster) EnableServiceMonitor() error {
 	return nil
 }
 
-// ApplyMonitoringLabels function adds the name of the resource that manages
+// applyMonitoringLabels function adds the name of the resource that manages
 // cephcluster, as a label on the ceph metrics
 func applyMonitoringLabels(c *Cluster, serviceMonitor *monitoringv1.ServiceMonitor) {
 	if c.spec.Labels != nil {

--- a/pkg/operator/ceph/cluster/mon/endpoint.go
+++ b/pkg/operator/ceph/cluster/mon/endpoint.go
@@ -23,7 +23,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 )
 
-// FlattenMonEndpoints returns a comma-delimited string of all mons and endpoints in the form
+// flattenMonEndpoints returns a comma-delimited string of all mons and endpoints in the form
 // <mon-name>=<mon-endpoint>
 func flattenMonEndpoints(mons map[string]*cephclient.MonInfo) string {
 	endpoints := []string{}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -823,7 +823,7 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 	return d, nil
 }
 
-// GetMonPlacement returns the placement for the MON service
+// getMonPlacement returns the placement for the MON service
 func (c *Cluster) getMonPlacement(zone string) cephv1.Placement {
 	// If the mon is the arbiter in a stretch cluster and its placement is specified, return it
 	// without merging with the "all" placement so it can be handled separately from all other daemons

--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -89,7 +89,7 @@ func kubernetesTopologyLabelToCRUSHLabel(label string) string {
 	return crushLabel[len(crushLabel)-1]
 }
 
-// ExtractTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value
+// extractTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value
 func extractTopologyFromLabels(labels map[string]string) (map[string]string, string) {
 	topology := make(map[string]string)
 

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -44,7 +44,7 @@ const (
 
 var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
-// Start begins the process of running rbd mirroring daemons.
+// start begins the process of running rbd mirroring daemons.
 func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) error {
 	// Validate pod's memory if specified
 	err := controller.CheckPodMemory(cephv1.ResourcesKeyRBDMirror, cephRBDMirror.Spec.Resources, cephRbdMirrorPodMinimumMemory)

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -855,7 +855,7 @@ func RgwOpsLogSidecarContainer(opsLogFile, ns string, c cephv1.ClusterSpec, env 
 	}
 }
 
-// CreateExternalMetricsEndpoints creates external metric endpoint
+// createExternalMetricsEndpoints creates external metric endpoint
 func createExternalMetricsEndpoints(namespace string, monitoringSpec cephv1.MonitoringSpec, ownerInfo *k8sutil.OwnerInfo) (*discoveryv1.EndpointSlice, error) {
 	labels := AppLabels("rook-ceph-mgr", namespace)
 	labels[discoveryv1.LabelServiceName] = ExternalMgrAppName

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -101,7 +101,7 @@ var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context, context.Conte
 // controller)
 // var AddToManagerOpFunc = []func(manager.Manager, *clusterd.Context, opcontroller.OperatorConfig) error{}
 
-// AddToManager adds all the registered controllers to the passed manager.
+// addToManager adds all the registered controllers to the passed manager.
 // each controller package will have an Add method listed in AddToManagerFuncs
 // which will setup all the necessary watch
 func (o *Operator) addToManager(m manager.Manager, c *controllerconfig.Context, opManagerContext context.Context, opconfig opcontroller.OperatorConfig) error {

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -345,7 +345,7 @@ func GenerateMetaDataPoolName(fsName string) string {
 	return generateMetaDataPoolName(fsName, nil)
 }
 
-// GenerateMetaDataPoolName generates MetaDataPool name as specified in FilesystemSpec
+// generateMetaDataPoolName generates MetaDataPool name as specified in FilesystemSpec
 func generateMetaDataPoolName(fsName string, spec *cephv1.FilesystemSpec) string {
 	poolName := ""
 

--- a/pkg/operator/ceph/file/mds/livenessprobe.go
+++ b/pkg/operator/ceph/file/mds/livenessprobe.go
@@ -55,7 +55,7 @@ func renderProbe(mdsLivenessProbeConfigValue mdsLivenessProbeConfig) (string, er
 	return writer.String(), nil
 }
 
-// GenerateMDSLivenessProbeExecDaemon generates a liveness probe that makes sure mds daemon is present in fs map,
+// generateMDSLivenessProbeExecDaemon generates a liveness probe that makes sure mds daemon is present in fs map,
 // that it can be called, and that it returns 0
 func generateMDSLivenessProbeExecDaemon(daemonID, filesystemName, keyring string) *v1.Probe {
 	mdsLivenessProbeConfigValue := mdsLivenessProbeConfig{

--- a/pkg/operator/ceph/file/mirror/mirror.go
+++ b/pkg/operator/ceph/file/mirror/mirror.go
@@ -41,7 +41,7 @@ const (
 
 var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
-// Start begins the process of running filesystem mirroring daemons.
+// start begins the process of running filesystem mirroring daemons.
 func (r *ReconcileFilesystemMirror) start(filesystemMirror *cephv1.CephFilesystemMirror) error {
 	nsName := controller.NsName(filesystemMirror.Namespace, filesystemMirror.Name)
 	// Validate pod's memory if specified

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -555,7 +555,7 @@ func (p *Provisioner) setObjectContext() error {
 	return nil
 }
 
-// setObjectStoreDomainName sets the provisioner.storeDomainName and provisioner.port
+// setObjectStoreDomainNameAndPort sets the provisioner.storeDomainName and provisioner.port
 // must be called after setObjectStoreName and setObjectStoreNamespace
 func (p *Provisioner) setObjectStoreDomainNameAndPort(sc *storagev1.StorageClass) error {
 	// make sure the object store actually exists

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -1100,7 +1100,7 @@ func GetObjectBucketProvisioner(namespace string) (string, error) {
 	return provName, nil
 }
 
-// CheckDashboardUser returns true if the dashboard user exists and has the same credentials as the given user, else return false
+// checkDashboardUser returns true if the dashboard user exists and has the same credentials as the given user, else return false
 func checkDashboardUser(context *Context, user ObjectUser) (bool, error) {
 	dUser, errId, err := GetUser(context, DashboardUser)
 

--- a/pkg/util/sys/parse.go
+++ b/pkg/util/sys/parse.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-// grep finds the *first* line that matches, rather than multiple lines
+// Grep finds the *first* line that matches, rather than multiple lines
 func Grep(input, searchFor string) string {
 	if input == "" || searchFor == "" {
 		return ""

--- a/tests/framework/clients/notification.go
+++ b/tests/framework/clients/notification.go
@@ -47,7 +47,7 @@ func (n *NotificationOperation) UpdateNotification(notificationName string, topi
 	return n.k8sh.ResourceOperation("apply", n.manifests.GetBucketNotification(notificationName, topicName))
 }
 
-// CheckNotification if notification was set
+// CheckNotificationCR if notification was set
 func (t *NotificationOperation) CheckNotificationCR(notificationName string) bool {
 	// TODO: return result based on reconcile status of the CR
 	const resourceName = "cephbucketnotification"

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -394,7 +394,7 @@ func (h *CephInstaller) CreateRookExternalCluster(externalManifests CephManifest
 	return errors.Errorf("failed to start external cluster, state: %v", clusterStatus)
 }
 
-// InjectRookExternalClusterInfo inject connection information for an external cluster
+// injectRookExternalClusterInfo inject connection information for an external cluster
 func (h *CephInstaller) injectRookExternalClusterInfo(externalSettings *TestCephSettings) error {
 	ctx := context.TODO()
 	// get config map

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -313,7 +313,7 @@ func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace, name string, che
 	return fmt.Errorf("timed out waiting for deletion of custom resource %q", name)
 }
 
-// DeleteResource performs a kubectl delete on give args.
+// DeleteResourceAndWait performs a kubectl delete on give args.
 // If wait is false, a flag will be passed to indicate the delete should return immediately
 func (k8sh *K8sHelper) DeleteResourceAndWait(wait bool, args ...string) error {
 	if !wait {
@@ -987,7 +987,7 @@ func (k8sh *K8sHelper) IsDefaultStorageClassPresent() (bool, error) {
 	return false, nil
 }
 
-// CheckPvcCount returns True if expected number pvs for a app are found
+// CheckPvcCountAndStatus returns True if expected number pvs for a app are found
 func (k8sh *K8sHelper) CheckPvcCountAndStatus(podName string, namespace string, expectedPvcCount int, expectedStatus string) bool {
 	logger.Infof("wait until %d pvc for app=%s are present", expectedPvcCount, podName)
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podName}

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -438,7 +438,7 @@ func (s *UpgradeSuite) verifyFilesAfterUpgrade(newFileToWrite string, rbdFilesTo
 	assert.NoError(s.T(), s.k8sh.ReadFromPodRetry(s.namespace, filePodName, newFileToWrite, simpleTestMessage, retryCount))
 }
 
-// UpgradeToMaster performs the steps necessary to upgrade a Rook v1.4 cluster to master. It does not
+// upgradeToMaster performs the steps necessary to upgrade a Rook v1.4 cluster to master. It does not
 // verify the upgrade but merely starts the upgrade process.
 func (s *UpgradeSuite) upgradeToMaster() {
 	// Apply the CRDs for the latest master


### PR DESCRIPTION
Several godoc comments led with a stale or incorrect identifier — left over from renames, exported/unexported changes, copy-paste between sibling declarations, or plain typos — so the documented name no longer matched the function, method, type, or var it describes. This corrects each leading word to the name of the declaration it documents.

Follow-up to #17833, which fixed the same class of mismatch in a handful of files; this PR covers the remaining occurrences across the tree.

Notable corrections beyond plain exported/unexported case fixes:

- `pkg/apis/ceph.rook.io/v1/types.go`: the doc names on `FilesystemMirroringInfoSpec` and `FilesystemMirroringInfo` were effectively swapped between the two adjacent mirroring-status types; the `BucketNotificationEvent` comment led with `BucketNotificationSpec` (the struct defined just below it); and the `CephFilesystemSubVolumeGroupList` comment both named the wrong type and described "a list of Ceph Clients".
- Typos: `ClinetSecuritySpec` → `ClientSecuritySpec`, `ListSubVolumeSnaphots` → `ListSubVolumeSnapshots`.
- Dropped name suffixes: `setObjectStoreDomainName` → `setObjectStoreDomainNameAndPort`, `DeleteResource` → `DeleteResourceAndWait`, `CheckPvcCount` → `CheckPvcCountAndStatus`.

All changes are comment-only; no code behavior is affected.

**AI assistance:** Claude Code was used to locate the out-of-sync doc comments (via an AST scan of the tree) and to draft the resulting one-line edits. I have reviewed all changes.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
