### PR TITLE
docs: fix typos and grammar in code comments

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -876,7 +876,7 @@ time.Duration
 <p>WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
 If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
 if <code>continueUpgradeAfterChecksEvenIfNotHealthy</code> is <code>false</code>. If <code>continueUpgradeAfterChecksEvenIfNotHealthy</code> is <code>true</code>, then operator would
-continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won&rsquo;t be applied if <code>skipUpgradeChecks</code> is <code>true</code>.
+continue with the upgrade of an OSD even if it&rsquo;s not ok to stop after the timeout. This timeout won&rsquo;t be applied if <code>skipUpgradeChecks</code> is <code>true</code>.
 The default wait timeout is 10 minutes.</p>
 </td>
 </tr>
@@ -5570,7 +5570,7 @@ CephxStatus
 </em>
 </td>
 <td>
-<p>OSD shows the CephX key status of of OSDs</p>
+<p>OSD shows the CephX key status of OSDs</p>
 </td>
 </tr>
 <tr>
@@ -5863,7 +5863,7 @@ time.Duration
 <p>WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
 If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
 if <code>continueUpgradeAfterChecksEvenIfNotHealthy</code> is <code>false</code>. If <code>continueUpgradeAfterChecksEvenIfNotHealthy</code> is <code>true</code>, then operator would
-continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won&rsquo;t be applied if <code>skipUpgradeChecks</code> is <code>true</code>.
+continue with the upgrade of an OSD even if it&rsquo;s not ok to stop after the timeout. This timeout won&rsquo;t be applied if <code>skipUpgradeChecks</code> is <code>true</code>.
 The default wait timeout is 10 minutes.</p>
 </td>
 </tr>
@@ -7491,7 +7491,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChecked is the last time time the status was checked</p>
+<p>LastChecked is the last time the status was checked</p>
 </td>
 </tr>
 <tr>
@@ -7503,7 +7503,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChanged is the last time time the status last changed</p>
+<p>LastChanged is the last time the status last changed</p>
 </td>
 </tr>
 <tr>
@@ -7759,7 +7759,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChecked is the last time time the status was checked</p>
+<p>LastChecked is the last time the status was checked</p>
 </td>
 </tr>
 <tr>
@@ -7771,7 +7771,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChanged is the last time time the status last changed</p>
+<p>LastChanged is the last time the status last changed</p>
 </td>
 </tr>
 <tr>
@@ -10022,7 +10022,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChecked is the last time time the status was checked</p>
+<p>LastChecked is the last time the status was checked</p>
 </td>
 </tr>
 <tr>
@@ -10034,7 +10034,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChanged is the last time time the status last changed</p>
+<p>LastChanged is the last time the status last changed</p>
 </td>
 </tr>
 <tr>
@@ -15154,7 +15154,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChecked is the last time time the status was checked</p>
+<p>LastChecked is the last time the status was checked</p>
 </td>
 </tr>
 <tr>
@@ -15166,7 +15166,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastChanged is the last time time the status last changed</p>
+<p>LastChanged is the last time the status last changed</p>
 </td>
 </tr>
 <tr>

--- a/cmd/rook/userfacing/multus/validation/validation.go
+++ b/cmd/rook/userfacing/multus/validation/validation.go
@@ -116,7 +116,7 @@ func init() {
 		subCommand.Flags().VarPF(t, "timeout-minutes", "", /* no shorthand */
 			"The time to wait for resources to change to the expected state. For example, for the "+
 				"test web server to start, for test clients to become ready, or for test resources to be deleted. "+
-				"At longest, this may need to reflect the time it takes for client pods to to pull images, "+
+				"At longest, this may need to reflect the time it takes for client pods to pull images, "+
 				"get address assignments, and then for each client to determine that its network connection is stable. "+
 				"Minimum: 1 minute. Recommended: 2 minutes or more.")
 	}

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -191,10 +191,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     summary:
                       description: Summary is the mirroring status summary
@@ -302,10 +302,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled
@@ -729,10 +729,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     summary:
                       description: Summary is the mirroring status summary
@@ -847,10 +847,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled
@@ -5985,7 +5985,7 @@ spec:
                     WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
                     If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
                     if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
-                    continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+                    continue with the upgrade of an OSD even if it's not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
                     The default wait timeout is 10 minutes.
                   format: int64
                   type: integer
@@ -6219,7 +6219,7 @@ spec:
                           type: integer
                       type: object
                     osd:
-                      description: OSD shows the CephX key status of of OSDs
+                      description: OSD shows the CephX key status of OSDs
                       properties:
                         keyCephVersion:
                           description: |-
@@ -9272,10 +9272,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                   type: object
                 observedGeneration:
@@ -9292,10 +9292,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -194,10 +194,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     summary:
                       description: Summary is the mirroring status summary
@@ -305,10 +305,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled
@@ -731,10 +731,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     summary:
                       description: Summary is the mirroring status summary
@@ -849,10 +849,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled
@@ -5983,7 +5983,7 @@ spec:
                     WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
                     If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
                     if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
-                    continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+                    continue with the upgrade of an OSD even if it's not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
                     The default wait timeout is 10 minutes.
                   format: int64
                   type: integer
@@ -6217,7 +6217,7 @@ spec:
                           type: integer
                       type: object
                     osd:
-                      description: OSD shows the CephX key status of of OSDs
+                      description: OSD shows the CephX key status of OSDs
                       properties:
                         keyCephVersion:
                           description: |-
@@ -9267,10 +9267,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                   type: object
                 observedGeneration:
@@ -9287,10 +9287,10 @@ spec:
                       description: Details contains potential status errors
                       type: string
                     lastChanged:
-                      description: LastChanged is the last time time the status last changed
+                      description: LastChanged is the last time the status last changed
                       type: string
                     lastChecked:
-                      description: LastChecked is the last time time the status was checked
+                      description: LastChecked is the last time the status was checked
                       type: string
                     snapshotSchedules:
                       description: SnapshotSchedules is the list of snapshots scheduled

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -175,7 +175,7 @@ type ClusterSpec struct {
 	// WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
 	// If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
 	// if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then operator would
-	// continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+	// continue with the upgrade of an OSD even if it's not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
 	// The default wait timeout is 10 minutes.
 	// +optional
 	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
@@ -840,7 +840,7 @@ type ClusterCephxStatus struct {
 	Mon CephxStatus `json:"mon,omitempty"`
 	// Mgr represents the cephx key rotation status of the ceph manager daemon
 	Mgr CephxStatus `json:"mgr,omitempty"`
-	// OSD shows the CephX key status of of OSDs
+	// OSD shows the CephX key status of OSDs
 	OSD CephxStatus `json:"osd,omitempty"`
 	// CSI shows the CephX key status for Ceph-CSI components.
 	CSI CephxStatusWithKeyCount `json:"csi,omitempty"`
@@ -1167,10 +1167,10 @@ type MirroringStatusSpec struct {
 	// MirroringStatus is the mirroring status of a pool/radosNamespace
 	// +optional
 	MirroringStatus `json:",inline"`
-	// LastChecked is the last time time the status was checked
+	// LastChecked is the last time the status was checked
 	// +optional
 	LastChecked string `json:"lastChecked,omitempty"`
-	// LastChanged is the last time time the status last changed
+	// LastChanged is the last time the status last changed
 	// +optional
 	LastChanged string `json:"lastChanged,omitempty"`
 	// Details contains potential status errors
@@ -1289,10 +1289,10 @@ type SnapshotScheduleStatusSpec struct {
 	// +nullable
 	// +optional
 	SnapshotSchedules []SnapshotSchedulesSpec `json:"snapshotSchedules,omitempty"`
-	// LastChecked is the last time time the status was checked
+	// LastChecked is the last time the status was checked
 	// +optional
 	LastChecked string `json:"lastChecked,omitempty"`
-	// LastChanged is the last time time the status last changed
+	// LastChanged is the last time the status last changed
 	// +optional
 	LastChanged string `json:"lastChanged,omitempty"`
 	// Details contains potential status errors
@@ -1643,10 +1643,10 @@ type FilesystemMirroringInfoSpec struct {
 	// +nullable
 	// +optional
 	FilesystemMirroringAllInfo []FilesystemMirroringInfo `json:"daemonsStatus,omitempty"`
-	// LastChecked is the last time time the status was checked
+	// LastChecked is the last time the status was checked
 	// +optional
 	LastChecked string `json:"lastChecked,omitempty"`
-	// LastChanged is the last time time the status last changed
+	// LastChanged is the last time the status last changed
 	// +optional
 	LastChanged string `json:"lastChanged,omitempty"`
 	// Details contains potential status errors
@@ -1660,10 +1660,10 @@ type FilesystemSnapshotScheduleStatusSpec struct {
 	// +nullable
 	// +optional
 	SnapshotSchedules []FilesystemSnapshotSchedulesSpec `json:"snapshotSchedules,omitempty"`
-	// LastChecked is the last time time the status was checked
+	// LastChecked is the last time the status was checked
 	// +optional
 	LastChecked string `json:"lastChecked,omitempty"`
-	// LastChanged is the last time time the status last changed
+	// LastChanged is the last time the status last changed
 	// +optional
 	LastChanged string `json:"lastChanged,omitempty"`
 	// Details contains potential status errors

--- a/pkg/daemon/ceph/client/fake/osd.go
+++ b/pkg/daemon/ceph/client/fake/osd.go
@@ -123,7 +123,7 @@ func OsdOkToStopOutput(queriedID int, returnOsdIds []int) string {
 }
 
 // OSDDeviceClassOutput returns JSON output from 'ceph osd crush get-device-class' that can be used for unit tests.
-// osdId is a osd ID to get from crush map. If ID is empty raise a fake error.
+// osdId is an OSD ID to get from crush map. If ID is empty raise a fake error.
 func OSDDeviceClassOutput(osdId string) string {
 	if osdId == "" {
 		return "ERR: fake error from ceph cli"

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -92,7 +92,7 @@ func ListSnapshotsInRadosNamespace(context *clusterd.Context, clusterInfo *Clust
 	return snapshots, nil
 }
 
-// DeleteSnapshotInRadosNamespace deletes a image snapshot created in block pool in a given rados namespace
+// DeleteSnapshotInRadosNamespace deletes an image snapshot created in block pool in a given rados namespace
 func DeleteSnapshotInRadosNamespace(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, imageName, snapshot, namespace string) error {
 	args := []string{"snap", "rm", getImageSnapshotSpec(poolName, imageName, snapshot)}
 	if namespace != "" {

--- a/pkg/daemon/ceph/osd/key_rotation.go
+++ b/pkg/daemon/ceph/osd/key_rotation.go
@@ -78,7 +78,7 @@ func RotateKeyEncryptionKey(context *clusterd.Context, kms *kms.Config, secretNa
 	}
 
 	logger.Info("fetching the key from the KMS to verify it.")
-	// Fetch key to verify its the new key.
+	// Fetch key to verify it's the new key.
 	keyInKMS, err := kms.GetSecret(secretName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get secret %q", secretName)

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -505,7 +505,7 @@ func TestHasNodeDrained(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, expected)
 
-	// Expecting node drain because OSD pod is assigned to a non existent node
+	// Expecting node drain because OSD pod is assigned to a non-existent node
 	osdDeployment = fakeOSDDeployment(3, 0)
 	r = getFakeReconciler(t, osdDeployment.DeepCopy(), &corev1.ConfigMap{})
 	expected, err = hasOSDNodeDrained(ctx, r.client, "node-3")

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -160,7 +160,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 	}
 
-	// Watch Secrets secrets annotated for the object store
+	// Watch secrets annotated for the object store
 	err = c.Watch(
 		source.Kind(
 			mgr.GetCache(),

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -352,7 +352,7 @@ func (r *ReconcileObjectRealm) setFailedStatus(observedGeneration int64, cephObj
 	return reconcile.Result{}, *cephObjectRealm, errors.Wrapf(err, "%s", errMessage)
 }
 
-// updateStatus updates an realm with a given status
+// updateStatus updates a realm with a given status
 func (r *ReconcileObjectRealm) updateStatus(observedGeneration int64, name types.NamespacedName, status string) {
 	objectRealm := &cephv1.CephObjectRealm{}
 	if err := r.client.Get(r.opManagerContext, name, objectRealm); err != nil {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -108,8 +108,8 @@ var (
 		},
 	}
 	// Filename to store RGW ops log per pod.
-	// Relies on the on environment variables to get the pod name and namespace.
-	// podNameEnvVars have to be passed to to log collector container.
+	// Relies on the environment variables to get the pod name and namespace.
+	// podNameEnvVars have to be passed to log collector container.
 	opsLogFilename    = "ops-log.$(POD_NS).$(POD_NAME).log"
 	opsLogAbsFilename = path.Join(cephconfig.VarLogCephDir, opsLogFilename)
 )

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -434,7 +434,7 @@ func (r *ReconcileObjectZone) setFailedStatus(observedGeneration int64, cephObje
 	return reconcile.Result{}, *cephObjectZone, errors.Wrapf(err, "%s", errMessage)
 }
 
-// updateStatus updates an zone with a given status
+// updateStatus updates a zone with a given status
 func (r *ReconcileObjectZone) updateStatus(observedGeneration int64, name types.NamespacedName, status string) {
 	objectZone := &cephv1.CephObjectZone{}
 	if err := r.client.Get(r.opManagerContext, name, objectZone); err != nil {

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -310,7 +310,7 @@ func (r *ReconcileObjectZoneGroup) setFailedStatus(observedGeneration int64, nam
 	return reconcile.Result{}, errors.Wrapf(err, "%s", errMessage)
 }
 
-// updateStatus updates an zone group with a given status
+// updateStatus updates a zone group with a given status
 func (r *ReconcileObjectZoneGroup) updateStatus(observedGeneration int64, name types.NamespacedName, status string) {
 	objectZoneGroup := &cephv1.CephObjectZoneGroup{}
 	if err := r.client.Get(r.opManagerContext, name, objectZoneGroup); err != nil {

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -202,7 +202,7 @@ func validateDeviceClasses(context *clusterd.Context, clusterInfo *cephclient.Cl
 	return nil
 }
 
-// validateDeviceClassOSDs validates that the device class should have atleast one OSD
+// validateDeviceClassOSDs validates that the device class should have at least one OSD
 func validateDeviceClassOSDs(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, deviceClassName string) error {
 	deviceClassOSDs, err := cephclient.GetDeviceClassOSDs(context, clusterInfo, deviceClassName)
 	if err != nil {

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -198,8 +198,8 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 // GetDeviceProperties gets device properties
 func GetDeviceProperties(device string, executor exec.Executor) (map[string]string, error) {
 	// As we are mounting the block mode PVs on /mnt we use the entire path,
-	// e.g., if the device path is /mnt/example-pvc then its taken completely
-	// else if its just vdb then the following is used
+	// e.g., if the device path is /mnt/example-pvc then it's taken completely
+	// else if it's just vdb then the following is used
 	devicePath := strings.Split(device, "/")
 	if len(devicePath) == 1 {
 		device = fmt.Sprintf("/dev/%s", device)

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -39,7 +39,7 @@ func CreateObjectOperation(k8sh *utils.K8sHelper, manifests installer.CephManife
 	return &ObjectOperation{k8sh, manifests}
 }
 
-// ObjectCreate Function to create a object store in rook
+// ObjectCreate Function to create an object store in rook
 func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32, tlsEnable bool, swiftAndKeystone bool) error {
 	logger.Info("creating the object store via CRD")
 

--- a/tests/framework/clients/object_user.go
+++ b/tests/framework/clients/object_user.go
@@ -73,7 +73,7 @@ func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, u
 	return false
 }
 
-// ObjectUserCreate Function to create a object store user in rook
+// ObjectUserCreate Function to create an object store user in rook
 func (o *ObjectUserOperation) Create(userid, displayName, store, usercaps, maxsize string, maxbuckets, maxobjects int) error {
 	logger.Infof("creating the object store user via CRD")
 	if err := o.k8sh.ResourceOperation("apply", o.manifests.GetObjectStoreUser(userid, displayName, store, usercaps, maxsize, maxbuckets, maxobjects)); err != nil {

--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -60,7 +60,7 @@ func readManifestFromURL(url string) string {
 	var response *http.Response
 	var err error
 	for i := 1; i <= 3; i++ {
-		//nolint:gosec // // This is only test code and is expected to read from a url
+		//nolint:gosec // This is only test code and is expected to read from a url
 		response, err = http.Get(url)
 		if err != nil {
 			if i == 3 {

--- a/tests/framework/utils/exec_utils.go
+++ b/tests/framework/utils/exec_utils.go
@@ -45,7 +45,7 @@ type CommandOut struct {
 	Err      error
 }
 
-// ExecuteCommand executes a os command with stdin and returns output
+// ExecuteCommand executes an OS command with stdin and returns output
 func ExecuteCommand(cmdStruct CommandArgs) CommandOut {
 	logger.Infof("Running %s %v", cmdStruct.Command, cmdStruct.CmdArgs)
 

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -36,7 +36,7 @@ type HelmHelper struct {
 	HelmPath string
 }
 
-// NewHelmHelper creates a instance of HelmHelper
+// NewHelmHelper creates an instance of HelmHelper
 func NewHelmHelper(helmPath string) *HelmHelper {
 	executor := &exec.CommandExecutor{}
 	return &HelmHelper{executor: executor, HelmPath: helmPath}

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -80,7 +80,7 @@ func getCmd() string {
 	return cmd
 }
 
-// CreateK8sHelper creates a instance of k8sHelper
+// CreateK8sHelper creates an instance of k8sHelper
 func CreateK8sHelper(t func() *testing.T) (*K8sHelper, error) {
 	executor := &exec.CommandExecutor{}
 	config, err := config.GetConfig()
@@ -993,7 +993,7 @@ func (k8sh *K8sHelper) IsDefaultStorageClassPresent() (bool, error) {
 	return false, nil
 }
 
-// CheckPvcCountAndStatus returns True if expected number pvs for a app are found
+// CheckPvcCountAndStatus returns True if expected number of pvs for an app are found
 func (k8sh *K8sHelper) CheckPvcCountAndStatus(podName string, namespace string, expectedPvcCount int, expectedStatus string) bool {
 	logger.Infof("wait until %d pvc for app=%s are present", expectedPvcCount, podName)
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podName}

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -483,7 +483,7 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			// first ~3KiB Object should succeed
 			_, err := s3client.PutObjectInBucket(ctx, bucketName, strings.Repeat("1", 3072), ObjectKey1, contentType)
 			assert.Nil(t, err)
-			// second ~2KiB Object should fail as bucket quota is is 4KiB
+			// second ~2KiB Object should fail as bucket quota is 4KiB
 			_, err = s3client.PutObjectInBucket(ctx, bucketName, strings.Repeat("2", 2048), ObjectKey2, contentType)
 			assert.Error(t, err)
 			// cleanup bucket

--- a/tests/scripts/auto-grow-storage.sh
+++ b/tests/scripts/auto-grow-storage.sh
@@ -73,7 +73,7 @@ function growVertically() {
       if [ "1" = $? ]
       then
          newSize=${maxSize}
-         echo "Disk has reached it's MAX capacity ${maxSize}, add a new disk to it"
+         echo "Disk has reached its MAX capacity ${maxSize}, add a new disk to it"
          result=$(kubectl patch pvc "${pvc}" -n "${ns}" --type json --patch  "[{ op: replace, path: /spec/resources/requests/storage, value: ${newSize} }]")
       else
          result=$(kubectl patch pvc "${pvc}" -n "${ns}" --type json --patch  "[{ op: replace, path: /spec/resources/requests/storage, value: ${newSize}${unitSize} }]")


### PR DESCRIPTION
Fixes typos and grammar in Go code comments and a few user-facing message
strings: duplicate words ("of of", "time time", "to to", "is is", "Secrets
secrets"), incorrect articles ("a osd", "a image", "an realm", "a app"),
it's/its confusion, a missing hyphen ("non existent"), the misspelling
"atleast", and a stray duplicated `//` in a nolint directive. No code
behavior changes.

**AI assistance:** An AI coding agent located the spelling, duplicate-word, and grammar issues in the code comments and drafted the fixes in this PR.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
