### PR TITLE
core: narrow bare //nolint directives to specific linters

### DIFF
--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -82,7 +82,7 @@ func ImportRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 	defer func() error {
 		err := os.Remove(tokenFilePath.Name())
 		return err
-	}() //nolint // we don't want to return here
+	}() //nolint:errcheck // best-effort cleanup; the deferred error is intentionally not propagated
 
 	if clusterInfo.NetworkSpec.IsMultus() {
 		err = context.RemoteExecutor.CopyLocalFileToContainer(clusterInfo.Context, ProxyAppLabel, CommandProxyInitContainerName, clusterInfo.Namespace, tokenFilePath.Name(), tokenFilePath.Name())

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -708,8 +708,7 @@ func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 		if name == "" {
 			return "", errors.Errorf("node name not found on the osd pod %q", pod.Name)
 		}
-		//nolint SA4004 (go-staticcheck)
-		return name, nil
+		return name, nil //nolint:staticcheck // SA4004: intentionally returns the first pod's node name
 	}
 
 	return "", errors.Errorf("node selector not found on deployment for osd with pvc %q", pvcName)

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -1170,7 +1170,7 @@ func buildRGWEnableAPIsConfigVal(protocolSpec cephv1.ProtocolSpec) []string {
 	}
 
 	// if enabledAPIs not set, check if S3 should be disabled
-	if protocolSpec.S3 != nil && protocolSpec.S3.Enabled != nil && !*protocolSpec.S3.Enabled { //nolint // disable deprecation check
+	if protocolSpec.S3 != nil && protocolSpec.S3.Enabled != nil && !*protocolSpec.S3.Enabled { //nolint:staticcheck // S3.Enabled is deprecated but still honored for backward compatibility
 		return rgwAPIwithoutS3
 	}
 	// see also https://docs.ceph.com/en/octopus/radosgw/config-ref/#swift-settings on disabling s3

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -555,7 +555,7 @@ func (k8sh *K8sHelper) GetEventsFromNamespace(namespace, testName, platformName 
 	if events == "" {
 		return
 	}
-	file.WriteString(events) //nolint // ok to ignore this test logging
+	file.WriteString(events) //nolint:errcheck // ok to ignore this test logging
 }
 
 func (k8sh *K8sHelper) appendPodDescribe(file *os.File, namespace, name string) {
@@ -563,9 +563,9 @@ func (k8sh *K8sHelper) appendPodDescribe(file *os.File, namespace, name string) 
 	if description == "" {
 		return
 	}
-	writeHeader(file, fmt.Sprintf("Pod: %s\n", name)) //nolint // ok to ignore this test logging
-	file.WriteString(description)                     //nolint // ok to ignore this test logging
-	file.WriteString("\n")                            //nolint // ok to ignore this test logging
+	writeHeader(file, fmt.Sprintf("Pod: %s\n", name)) //nolint:errcheck // ok to ignore this test logging
+	file.WriteString(description)                     //nolint:errcheck // ok to ignore this test logging
+	file.WriteString("\n")                            //nolint:errcheck // ok to ignore this test logging
 }
 
 func (k8sh *K8sHelper) PrintPodDescribe(namespace string, args ...string) {
@@ -1496,9 +1496,9 @@ func (k8sh *K8sHelper) getPodLogs(pod v1.Pod, platformName, namespace, testName 
 }
 
 func writeHeader(file *os.File, message string) error {
-	file.WriteString("\n-----------------------------------------\n") //nolint // ok to ignore this test logging
-	file.WriteString(message)                                         //nolint // ok to ignore this test logging
-	file.WriteString("\n-----------------------------------------\n") //nolint // ok to ignore this test logging
+	file.WriteString("\n-----------------------------------------\n") //nolint:errcheck // ok to ignore this test logging
+	file.WriteString(message)                                         //nolint:errcheck // ok to ignore this test logging
+	file.WriteString("\n-----------------------------------------\n") //nolint:errcheck // ok to ignore this test logging
 
 	return nil
 }
@@ -1508,7 +1508,7 @@ func (k8sh *K8sHelper) appendContainerLogs(file *os.File, pod v1.Pod, containerN
 	if initContainer {
 		message = "INIT " + message
 	}
-	writeHeader(file, message) //nolint // ok to ignore this test logging
+	writeHeader(file, message) //nolint:errcheck // ok to ignore this test logging
 	ctx := context.TODO()
 	logOpts := &v1.PodLogOptions{Previous: previousLog}
 	if containerName != "" {


### PR DESCRIPTION
Eleven `//nolint` directives across four files omit the linter name, so each suppresses *every* linter on its line instead of the one check it needs — masking any unrelated errcheck/gosec/govet finding later introduced on those lines. This narrows each to the specific linter:

- `staticcheck` for the two operator sites: SA4004 (the intentional single-iteration loop in the OSD PVC host lookup) and SA1019 (the deliberate read of the deprecated `S3.Enabled` field in the RGW API-enable builder).
- `errcheck` for the rbd-mirror deferred token-file cleanup and the test-framework logging helpers (`WriteString` / `writeHeader`).

No behavior change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

AI assistance: Claude Code located the bare `//nolint` directives, determined which single linter each was masking, drafted the narrowed directives, and validated the result with the repo-pinned golangci-lint.
