### PR TITLE
test: build the smoke object store with the shared store fixture

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -211,7 +211,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	// now test operation of the first object store
 	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
 
-	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
+	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable, settings.Namespace, "sharedstore", 1,
 		bucketowner.Namespace,
 		userkeys.Namespace,
 		topickafka.Namespace,

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -125,10 +126,8 @@ func (s *SmokeSuite) TestObjectStorage_SmokeTest() {
 	if utils.IsPlatformOpenShift() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
-	storeName := "lite-store"
-	deleteStore := true
-	tls := false
-	runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.installer, s.settings.Namespace, storeName, 2, deleteStore, tls, false)
+	store := sharedstore.Create(s.T(), s.k8sh, s.installer, false, s.settings.Namespace, "lite-store", 2)
+	store.Destroy()
 }
 
 // Test to make sure all rook components are installed and Running

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -68,17 +68,17 @@ func (s *Sharedstore) Destroy() {
 	s.destroy()
 }
 
-// Setup creates a shared CephObjectStore and its NodePort Service in
-// ObjectStoreNamespace, waits for the store to become Ready, and returns a
-// teardown function that deletes both resources. The teardown function should
-// be deferred by the caller.
-func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, allowedNamespaces ...string) *Sharedstore {
+// Create creates a CephObjectStore named storeName in namespace (with its
+// realm, zone, shared pools, and NodePort Service), waits for it to become
+// Ready, and returns a Sharedstore whose Destroy method tears it all down;
+// Destroy should be deferred by the caller. instances sets the RGW gateway
+// count and allowedNamespaces is propagated to AllowUsersInNamespaces.
+func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, namespace, storeName string, instances int32, allowedNamespaces ...string) *Sharedstore {
 	t.Helper()
 
 	s := &Sharedstore{tlsEnable: tlsEnable}
 	ctx := context.TODO()
-	ns := "object-ns"
-	storeName := "sharedstore"
+	ns := namespace
 
 	// securePort is the in-container RGW TLS listener port. The NodePort Service
 	// below exposes the conventional 443 externally and forwards to it.
@@ -154,7 +154,7 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 			},
 			Gateway: cephv1.GatewaySpec{
 				Port:      80,
-				Instances: 1,
+				Instances: instances,
 			},
 			AllowUsersInNamespaces: allowedNamespaces,
 		},
@@ -166,7 +166,7 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 		objectStore.Spec.Gateway = cephv1.GatewaySpec{
 			SecurePort:        securePort,
 			SSLCertificateRef: certSecretName,
-			Instances:         1,
+			Instances:         instances,
 		}
 	}
 


### PR DESCRIPTION
**Experimental (`do-not-merge`).** First step toward replacing `runObjectE2ETestLite` / `createCephObjectStore` with the typed-client, watch-based `sharedstore` fixture and, eventually, emptying `tests/integration/ceph_base_object_test.go`.

### What changed

- `sharedstore.Create` is generalized to take the target namespace, store name, and RGW instance count (previously hardcoded to `object-ns` / `sharedstore` / `1`).
- `SmokeSuite.TestObjectStorage_SmokeTest` now stands up its object store through that fixture and tears it down with `Destroy`, instead of `runObjectE2ETestLite`.
- The object suite's own `sharedstore.Create` call is updated to pass its existing values, preserving behavior.

### Why only the smoke suite

`runObjectE2ETestLite` has five callers. The other four (helm, keystone, upgrade, and the object suite's "second store") each run their store **alongside another object store in the same namespace**, and `sharedstore.Create`/`Destroy` owns and deletes the cluster-global `.rgw.root` realm-metadata pool — which would corrupt the coexisting store. `lite-store` is the only object store in `smoke-ns`, so the fixture is safe there. Making the fixture safe for the coexisting-store case is deferred to a follow-up.

### Coverage note

The smoke object test's coverage shifts: it gains the shared-pools topology plus an rgw-admin/SNS client setup, and no longer performs the RGW liveness-probe / service-up / dashboard-admin / deletion-condition assertions that `runObjectE2ETestLite` did. Store health is instead proven by the fixture's `wait4` readiness wait and canary user.

AI assistance: Claude located the call sites and the `.rgw.root` ownership hazard, and drafted the edits and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
