### PR TITLE
osd-replacement-1: rename internal OSD migration field to migrateOSD

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -265,7 +265,9 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to generate ceph config")
 	}
 
-	// destroy the OSD using the OSD ID
+	// The --replace-osd flag drives the OSD *migration* feature: reprovision an OSD in place on a
+	// config change (e.g. enabling encryption) by destroying and zapping it here, then reprovisioning
+	// the same id in this prepare job. This is distinct from the disk-swap OSD-replacement flow.
 	var replaceOSD *oposd.OSDInfo
 	if replaceOSDID != -1 {
 		logger.Infof("destroying osd.%d and cleaning its backing device", replaceOSDID)

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -38,14 +38,14 @@ type OsdAgent struct {
 	storeConfig                  config.StoreConfig
 	kv                           *k8sutil.ConfigMapKVStore
 	pvcBacked                    bool
-	replaceOSD                   *oposd.OSDInfo
+	migrateOSD                   *oposd.OSDInfo
 	wipeDevicesFromOtherClusters bool
 }
 
 // NewAgent is the instantiation of the OSD agent
 func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice string, forceFormat bool,
 	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore,
-	replaceOSD *oposd.OSDInfo, pvcBacked, wipDevicesFromOtherClusters bool,
+	migrateOSD *oposd.OSDInfo, pvcBacked, wipDevicesFromOtherClusters bool,
 ) *OsdAgent {
 	return &OsdAgent{
 		devices:                      devices,
@@ -56,7 +56,7 @@ func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice
 		nodeName:                     nodeName,
 		kv:                           kv,
 		pvcBacked:                    pvcBacked,
-		replaceOSD:                   replaceOSD,
+		migrateOSD:                   migrateOSD,
 		wipeDevicesFromOtherClusters: wipDevicesFromOtherClusters,
 	}
 }
@@ -71,10 +71,10 @@ func getDeviceLVPath(context *clusterd.Context, deviceName string) string {
 	return output
 }
 
-// GetReplaceOSDId returns the OSD ID based on the device name
-func (a *OsdAgent) GetReplaceOSDId(device string) int {
-	if device == a.replaceOSD.BlockPath {
-		return a.replaceOSD.ID
+// getMigrateOSDId returns the OSD ID based on the device name
+func (a *OsdAgent) getMigrateOSDId(device string) int {
+	if device == a.migrateOSD.BlockPath {
+		return a.migrateOSD.ID
 	}
 
 	return -1

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -288,12 +288,12 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				deviceArg,
 			}...)
 
-			if a.replaceOSD != nil {
-				replaceOSDID := a.GetReplaceOSDId(device.DeviceInfo.RealPath)
-				if replaceOSDID != -1 {
+			if a.migrateOSD != nil {
+				migrateOSDID := a.getMigrateOSDId(device.DeviceInfo.RealPath)
+				if migrateOSDID != -1 {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						"--osd-id",
-						fmt.Sprintf("%d", replaceOSDID),
+						fmt.Sprintf("%d", migrateOSDID),
 					}...)
 				}
 			}
@@ -548,8 +548,8 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 				deviceArg,
 			}...)
 
-			if a.replaceOSD != nil {
-				restoreOSDID := a.GetReplaceOSDId(deviceArg)
+			if a.migrateOSD != nil {
+				restoreOSDID := a.getMigrateOSDId(deviceArg)
 				if restoreOSDID != -1 {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						"--osd-id",

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1604,7 +1604,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition when osd is prepared with existing osd ID
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, migrateOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sda"}},
@@ -1626,7 +1626,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition that --osd-id is not passed for the devices that don't match the OSD to be replaced.
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, migrateOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sdb"}},


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

1 part of 6-part stacked PR.

## Description

Some of osd-migration internal variables were using osd-replacement namig. Renamed internal vars to migration to not confuse with new osd-replacement feature and added comment on migration job entry point named replacement.





