### PR TITLE
osd-replacement-1: rename internal OSD migration field to migrateOSD

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -71,7 +71,7 @@ var (
 	ownerRefID                   string
 	clusterName                  string
 	osdID                        int
-	replaceOSDID                 int
+	migrateOSDID                 int
 	osdStoreType                 string
 	osdStringID                  string
 	osdUUID                      string
@@ -95,7 +95,7 @@ func addOSDFlags(command *cobra.Command) {
 	addOSDConfigFlags(provisionCmd)
 
 	// flags specific to provisioning
-	provisionCmd.Flags().IntVar(&replaceOSDID, "replace-osd", -1, "osd to be destroyed")
+	provisionCmd.Flags().IntVar(&migrateOSDID, "migrate-osd", -1, "osd to migrate in place")
 	provisionCmd.Flags().StringVar(&cfg.devices, "data-devices", "", "comma separated list of devices to use for storage")
 	provisionCmd.Flags().StringVar(&osdDataDeviceFilter, "data-device-filter", "", "a regex filter for the device names to use, or \"all\"")
 	provisionCmd.Flags().StringVar(&osdDataDevicePathFilter, "data-device-path-filter", "", "a regex filter for the device path names to use")
@@ -265,18 +265,20 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to generate ceph config")
 	}
 
-	// destroy the OSD using the OSD ID
-	var replaceOSD *oposd.OSDInfo
-	if replaceOSDID != -1 {
-		logger.Infof("destroying osd.%d and cleaning its backing device", replaceOSDID)
-		replaceOSD, err = osddaemon.DestroyOSD(context, &clusterInfo, replaceOSDID, cfg.pvcBacked)
+	// The --migrate-osd flag drives the OSD *migration* feature: reprovision an OSD in place on a
+	// config change (e.g. enabling encryption) by destroying and zapping it here, then reprovisioning
+	// the same id in this prepare job. This is distinct from the disk-swap OSD-replacement flow.
+	var migrateOSD *oposd.OSDInfo
+	if migrateOSDID != -1 {
+		logger.Infof("destroying osd.%d and cleaning its backing device", migrateOSDID)
+		migrateOSD, err = osddaemon.DestroyOSD(context, &clusterInfo, migrateOSDID, cfg.pvcBacked)
 		if err != nil {
-			rook.TerminateFatal(errors.Wrapf(err, "failed to destroy OSD %d.", replaceOSDID))
+			rook.TerminateFatal(errors.Wrapf(err, "failed to destroy OSD %d.", migrateOSDID))
 		}
 	}
 
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, forceFormat,
-		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, replaceOSD, cfg.pvcBacked, wipeDevicesFromOtherClusters)
+		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, migrateOSD, cfg.pvcBacked, wipeDevicesFromOtherClusters)
 
 	if cfg.metadataDevice != "" {
 		metaDevice = cfg.metadataDevice

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -38,14 +38,14 @@ type OsdAgent struct {
 	storeConfig                  config.StoreConfig
 	kv                           *k8sutil.ConfigMapKVStore
 	pvcBacked                    bool
-	replaceOSD                   *oposd.OSDInfo
+	migrateOSD                   *oposd.OSDInfo
 	wipeDevicesFromOtherClusters bool
 }
 
 // NewAgent is the instantiation of the OSD agent
 func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice string, forceFormat bool,
 	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore,
-	replaceOSD *oposd.OSDInfo, pvcBacked, wipDevicesFromOtherClusters bool,
+	migrateOSD *oposd.OSDInfo, pvcBacked, wipDevicesFromOtherClusters bool,
 ) *OsdAgent {
 	return &OsdAgent{
 		devices:                      devices,
@@ -56,7 +56,7 @@ func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice
 		nodeName:                     nodeName,
 		kv:                           kv,
 		pvcBacked:                    pvcBacked,
-		replaceOSD:                   replaceOSD,
+		migrateOSD:                   migrateOSD,
 		wipeDevicesFromOtherClusters: wipDevicesFromOtherClusters,
 	}
 }
@@ -71,10 +71,10 @@ func getDeviceLVPath(context *clusterd.Context, deviceName string) string {
 	return output
 }
 
-// GetReplaceOSDId returns the OSD ID based on the device name
-func (a *OsdAgent) GetReplaceOSDId(device string) int {
-	if device == a.replaceOSD.BlockPath {
-		return a.replaceOSD.ID
+// getMigrateOSDId returns the OSD ID based on the device name
+func (a *OsdAgent) getMigrateOSDId(device string) int {
+	if device == a.migrateOSD.BlockPath {
+		return a.migrateOSD.ID
 	}
 
 	return -1

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -241,7 +241,7 @@ func archiveCrash(clusterdContext *clusterd.Context, clusterInfo *client.Cluster
 	}
 }
 
-// DestroyOSD fetches the OSD to be replaced based on the ID and then destroys that OSD and zaps the backing device
+// DestroyOSD fetches the OSD to be migrated based on the ID and then destroys that OSD and zaps the backing device
 func DestroyOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, id int, isPVC bool) (*oposd.OSDInfo, error) {
 	osdInfo, err := GetOSDInfoById(context, clusterInfo, id)
 	if err != nil {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -288,12 +288,12 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				deviceArg,
 			}...)
 
-			if a.replaceOSD != nil {
-				replaceOSDID := a.GetReplaceOSDId(device.DeviceInfo.RealPath)
-				if replaceOSDID != -1 {
+			if a.migrateOSD != nil {
+				migrateOSDID := a.getMigrateOSDId(device.DeviceInfo.RealPath)
+				if migrateOSDID != -1 {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						"--osd-id",
-						fmt.Sprintf("%d", replaceOSDID),
+						fmt.Sprintf("%d", migrateOSDID),
 					}...)
 				}
 			}
@@ -548,8 +548,8 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 				deviceArg,
 			}...)
 
-			if a.replaceOSD != nil {
-				restoreOSDID := a.GetReplaceOSDId(deviceArg)
+			if a.migrateOSD != nil {
+				restoreOSDID := a.getMigrateOSDId(deviceArg)
 				if restoreOSDID != -1 {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						"--osd-id",

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1604,7 +1604,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition when osd is prepared with existing osd ID
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, migrateOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sda"}},
@@ -1625,8 +1625,8 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", metadataBlockPath)
 	assert.Equal(t, "", walBlockPath)
 
-	// Test for condition that --osd-id is not passed for the devices that don't match the OSD to be replaced.
-	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, replaceOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
+	// Test for condition that --osd-id is not passed for the devices that don't match the OSD to be migrated.
+	a = &OsdAgent{clusterInfo: clusterInfo, nodeName: "node1", storeConfig: config.StoreConfig{StoreType: "bluestore", DeviceClass: "foo"}, migrateOSD: &oposd.OSDInfo{ID: 3, BlockPath: "/dev/sda"}}
 	devices = &DeviceOsdMapping{
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}, DeviceInfo: &sys.LocalDisk{RealPath: "/dev/sdb"}},

--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -197,7 +197,7 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig, errs *provi
 		// Allow updating OSD prepare pod if the OSD needs migration
 		if c.migrateOSD != nil {
 			if strings.Contains(c.migrateOSD.BlockPath, dataSource.ClaimName) {
-				log.NamespacedInfo(c.clusterInfo.Namespace, logger, "updating OSD prepare pod to replace OSD.%d", c.migrateOSD.ID)
+				log.NamespacedInfo(c.clusterInfo.Namespace, logger, "updating OSD prepare pod to migrate OSD.%d", c.migrateOSD.ID)
 				skipPreparePod = false
 			}
 		}

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -48,7 +48,7 @@ const (
 	CrushDeviceClassVarName             = "ROOK_OSD_CRUSH_DEVICE_CLASS"
 	CrushInitialWeightVarName           = "ROOK_OSD_CRUSH_INITIAL_WEIGHT"
 	OSDStoreTypeVarName                 = "ROOK_OSD_STORE_TYPE"
-	ReplaceOSDIDVarName                 = "ROOK_REPLACE_OSD"
+	MigrateOSDIDVarName                 = "ROOK_MIGRATE_OSD"
 	CrushRootVarName                    = "ROOK_CRUSHMAP_ROOT"
 	tcmallocMaxTotalThreadCacheBytesEnv = "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 	wipeDevicesFromOtherClustersVarName = "ROOK_WIPE_DEVICES_FROM_OTHER_CLUSTERS"
@@ -178,8 +178,8 @@ func osdStoreTypeEnvVar(storeType string) v1.EnvVar {
 	return v1.EnvVar{Name: OSDStoreTypeVarName, Value: storeType}
 }
 
-func replaceOSDIDEnvVar(id string) v1.EnvVar {
-	return v1.EnvVar{Name: ReplaceOSDIDVarName, Value: id}
+func migrateOSDIDEnvVar(id string) v1.EnvVar {
+	return v1.EnvVar{Name: MigrateOSDIDVarName, Value: id}
 }
 
 func crushInitialWeightEnvVar(crushInitialWeight string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -314,12 +314,12 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		// Compare pvc claim name in case of OSDs on PVC
 		if osdProps.onPVC() {
 			if strings.Contains(c.migrateOSD.PVCName, osdProps.pvc.ClaimName) {
-				envVars = append(envVars, replaceOSDIDEnvVar(fmt.Sprint(c.migrateOSD.ID)))
+				envVars = append(envVars, migrateOSDIDEnvVar(fmt.Sprint(c.migrateOSD.ID)))
 			}
 		} else {
 			// Compare the node name in case of OSDs on disk
 			if c.migrateOSD.NodeName == osdProps.crushHostname {
-				envVars = append(envVars, replaceOSDIDEnvVar(fmt.Sprint(c.migrateOSD.ID)))
+				envVars = append(envVars, migrateOSDIDEnvVar(fmt.Sprint(c.migrateOSD.ID)))
 			}
 		}
 	}


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

1 part of 6-part stacked PR.

## Description

Some of osd-migration internal variables were using osd-replacement namig. Renamed internal vars to migration to not confuse with new osd-replacement feature and added comment on migration job entry point named replacement.


## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866