### PR TITLE
osd-replacement-2: implement osd replacement prepare-job

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -309,6 +309,17 @@ func HostTree(context *clusterd.Context, clusterInfo *ClusterInfo) (OsdTree, err
 	return output, nil
 }
 
+// GetDestroyedIDs returns the ids of osd nodes whose status is "destroyed".
+func (tree OsdTree) GetDestroyedIDs() []int {
+	destroyed := []int{}
+	for _, node := range tree.Nodes {
+		if node.Status == "destroyed" {
+			destroyed = append(destroyed, node.ID)
+		}
+	}
+	return destroyed
+}
+
 // OsdListNum returns the list of OSDs
 func OsdListNum(context *clusterd.Context, clusterInfo *ClusterInfo) (OsdList, error) {
 	var output OsdList

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -88,6 +88,42 @@ func TestHostTree(t *testing.T) {
 	assert.Equal(t, 0, len(tree.Nodes))
 }
 
+func TestGetDestroyedIDs(t *testing.T) {
+	treeWithDestroyed := `{
+		"nodes": [
+			{"id": -1, "name": "default", "type": "root", "type_id": 10, "children": [-3]},
+			{"id": -3, "name": "node1", "type": "host", "type_id": 1, "children": [0, 1, 2]},
+			{"id": 0, "name": "osd.0", "type": "osd", "type_id": 0, "exists": 1, "status": "up"},
+			{"id": 1, "name": "osd.1", "type": "osd", "type_id": 0, "exists": 1, "status": "destroyed"},
+			{"id": 2, "name": "osd.2", "type": "osd", "type_id": 0, "exists": 1, "status": "down"}
+		],
+		"stray": []
+	}`
+
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if args[0] == "osd" && args[1] == "tree" {
+			return treeWithDestroyed, nil
+		}
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+
+	tree, err := HostTree(&clusterd.Context{Executor: executor}, AdminTestClusterInfo("mycluster"))
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1}, tree.GetDestroyedIDs())
+
+	// no destroyed slots
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if args[0] == "osd" && args[1] == "tree" {
+			return fakeOsdTree, nil
+		}
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+	tree, err = HostTree(&clusterd.Context{Executor: executor}, AdminTestClusterInfo("mycluster"))
+	assert.NoError(t, err)
+	assert.Empty(t, tree.GetDestroyedIDs())
+}
+
 func TestOsdListNum(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyOsdListNumResult := false

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -218,6 +218,12 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 		return errors.Wrap(err, "failed to get available devices")
 	}
 
+	// Reclaim any destroyed slot on this node onto a freshly-swapped blank device, removing each
+	// consumed device from the available set; this no-ops when there is nothing to replace.
+	if err := agent.preProvisionReplacedOSDs(context, devices, crushLocation); err != nil {
+		return errors.Wrap(err, "failed to provision replacement OSDs")
+	}
+
 	// orchestration is about to start, update the status
 	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating, PvcBackedOSD: agent.pvcBacked}
 	oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)

--- a/pkg/daemon/ceph/osd/replace.go
+++ b/pkg/daemon/ceph/osd/replace.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+)
+
+// cvLVMListEntry is one entry in the output of `ceph-volume lvm list <id>`.
+type cvLVMListEntry struct {
+	Type   string  `json:"type"`    // "block", "db" or "wal"
+	VGName string  `json:"vg_name"` // volume group of the LV
+	LVName string  `json:"lv_name"` // logical volume name
+	LVUUID string  `json:"lv_uuid"` // LVM uuid of the LV; in lvm mode this is also the dm-crypt mapping name
+	Path   string  `json:"path"`    // /dev/<vg>/<lv>
+	Tags   osdTags `json:"tags"`    // ceph.* tags, including ceph.encrypted
+}
+
+// cephVolumeLVMList runs `ceph-volume lvm list <id>` and returns the entries reported for that osd id
+// (empty when the id has no lvm volumes).
+func cephVolumeLVMList(context *clusterd.Context, osdID int) ([]cvLVMListEntry, error) {
+	result, err := callCephVolume(context, "lvm", "list", strconv.Itoa(osdID), "--format", "json")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list lvm volumes for osd.%d", osdID)
+	}
+	var listResult map[string][]cvLVMListEntry
+	if err := json.Unmarshal([]byte(result), &listResult); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume lvm list result for osd.%d. %s", osdID, result)
+	}
+	return listResult[strconv.Itoa(osdID)], nil
+}
+
+// preProvisionReplacedOSDs pairs each destroyed slot belonging to this node with a freshly-swapped
+// blank device and re-provisions it into the same slot via `ceph-volume ... prepare --osd-id <id>`,
+// reusing the surviving DB LV in place when present. Devices consumed here are removed from
+// available so the normal provisioning path does not also claim them (which would create a brand-new
+// OSD id instead of reusing the destroyed slot).
+func (a *OsdAgent) preProvisionReplacedOSDs(context *clusterd.Context, available *DeviceOsdMapping, crushLocation string) error {
+	if a.pvcBacked {
+		return nil
+	}
+	// a.migrateOSD is set by the OSD-migration flow, which reprovisions an OSD in place on config
+	// changes (e.g. enabling encryption). Skip replacement provisioning when migration owns this prepare job.
+	if a.migrateOSD != nil {
+		return nil
+	}
+
+	// Fetch the osd tree once and derive both the destroyed set and the per-node filter from it.
+	tree, err := client.HostTree(context, a.clusterInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to get osd tree")
+	}
+
+	destroyedOSDIds := tree.GetDestroyedIDs()
+	destroyedOSDIds, err = filterDestroyedOSDIdsForNode(tree, destroyedOSDIds, crushLocation)
+	if err != nil {
+		return errors.Wrap(err, "failed to filter destroyed osd ids for this node")
+	}
+	if len(destroyedOSDIds) == 0 {
+		logger.Debug("no destroyed osd slots belong to this node, skipping replacement provisioning")
+		return nil
+	}
+	// Sort so the slot<->device pairing is reproducible across reconciles and operator restarts.
+	sort.Ints(destroyedOSDIds)
+	logger.Infof("destroyed osd slots on this node eligible for replacement: %v", destroyedOSDIds)
+
+	// ceph-volume prepare needs the OSD bootstrap keyring to claim the slot via `ceph osd new`.
+	// configureCVDevices also creates it but runs later, so ensure it exists here (idempotent).
+	if err := createOSDBootstrapKeyring(context, a.clusterInfo, cephConfigDir); err != nil {
+		return errors.Wrap(err, "failed to generate osd bootstrap keyring")
+	}
+
+	// A device is only offered once it is empty, so an available blank device is the signal that the
+	// disk has been swapped.
+	blankDevices := availableDataDevices(available)
+	for _, osdID := range destroyedOSDIds {
+		if len(blankDevices) == 0 {
+			logger.Infof("no blank device available yet to replace destroyed osd.%d, waiting for the disk to be swapped", osdID)
+			continue
+		}
+		// select the first blank device from the list:
+		deviceName := blankDevices[0]
+		blankDevices = blankDevices[1:]
+
+		// Consume the device up front so the normal provisioning path never claims it as a brand-new
+		// OSD, whether or not this slot succeeds.
+		entry := available.Entries[deviceName]
+		delete(available.Entries, deviceName)
+
+		// provision selected blank device into destroyed osdID slot:
+		if err := a.provisionReplacedOSD(context, osdID, entry); err != nil {
+			// Skip this slot on failure so one bad slot does not block the other slots or the normal
+			// provisioning that runs after this. The destroyed slot stays destroyed and is retried on
+			// the next reconcile.
+			logger.Errorf("failed to provision replacement for destroyed osd.%d on device %q, skipping. %v", osdID, deviceName, err)
+			continue
+		}
+		logger.Infof("provisioned replacement osd.%d on device %q", osdID, deviceName)
+	}
+
+	return nil
+}
+
+// availableDataDevices returns the names of blank, unassigned data devices, sorted so the
+// slot<->device pairing is deterministic across reconciles and operator restarts.
+func availableDataDevices(available *DeviceOsdMapping) []string {
+	devices := make([]string, 0, len(available.Entries))
+	for name, entry := range available.Entries {
+		// A non-nil Metadata slice (even if empty) marks a device reserved as a metadata/wal device by
+		// getAvailableDevices; Data != unassignedOSDID means a data device already has an OSD on it.
+		if entry.Metadata == nil && entry.Data == unassignedOSDID {
+			devices = append(devices, name)
+		}
+	}
+	sort.Strings(devices)
+	return devices
+}
+
+// filterDestroyedOSDIdsForNode narrows the cluster-wide destroyed slots to the ones whose CRUSH host
+// bucket matches this node, derived from the prepare job's crush location (`host=<name>`).
+func filterDestroyedOSDIdsForNode(tree client.OsdTree, destroyedOSDIds []int, crushLocation string) ([]int, error) {
+	if len(destroyedOSDIds) == 0 {
+		return destroyedOSDIds, nil
+	}
+	hostName := crushHostFromLocation(crushLocation)
+	if hostName == "" {
+		return nil, errors.Errorf("failed to determine crush host from location %q", crushLocation)
+	}
+
+	// OSDs are direct children of their host bucket, so the host's children are its osd ids.
+	hostOSDs := map[int]struct{}{}
+	for _, node := range tree.Nodes {
+		if node.Type == "host" && node.Name == hostName {
+			for _, id := range node.Children {
+				hostOSDs[id] = struct{}{}
+			}
+			break
+		}
+	}
+
+	destroyedOsdsOnHost := []int{}
+	for _, id := range destroyedOSDIds {
+		if _, ok := hostOSDs[id]; ok {
+			destroyedOsdsOnHost = append(destroyedOsdsOnHost, id)
+		}
+	}
+
+	return destroyedOsdsOnHost, nil
+}
+
+// crushHostFromLocation extracts the host bucket name from a CRUSH location string of the form
+// "root=default host=node-1 ...".
+func crushHostFromLocation(crushLocation string) string {
+	for _, token := range strings.Fields(crushLocation) {
+		if strings.HasPrefix(token, "host=") {
+			return strings.TrimPrefix(token, "host=")
+		}
+	}
+	return ""
+}
+
+// provisionReplacedOSD runs `ceph-volume ... prepare --osd-id <id>` to bring the destroyed slot back
+// on the supplied blank data device.
+func (a *OsdAgent) provisionReplacedOSD(context *clusterd.Context, osdID int, entry *DeviceOsdIDEntry) error {
+	dataDevice := path.Join("/dev", entry.DeviceInfo.Name)
+
+	// Recover the surviving DB LV from the destroyed OSD itself, never from the spec; empty means the
+	// OSD had no separate metadata device.
+	dbLV, err := a.recoverDBLVForOSDFromHost(context, osdID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to recover db lv for osd.%d", osdID)
+	}
+
+	// Raw mode is forced off by encryption, osdsPerDevice > 1, or a separate metadata device.
+	allowRaw, err := a.allowRawMode(context)
+	if err != nil {
+		return errors.Wrap(err, "failed to determine ceph-volume mode")
+	}
+	useRaw := allowRaw && isSafeToUseRawMode(entry) && dbLV == ""
+
+	baseCommand := "stdbuf"
+	// Match callCephVolume's log path so the failure log read below is the one this command wrote.
+	logPath := "/tmp/ceph-log"
+	if err := os.MkdirAll(logPath, 0o700); err != nil {
+		return errors.Wrapf(err, "failed to create dir %q", logPath)
+	}
+
+	if !useRaw {
+		if err := lvmPreReq(context); err != nil {
+			return errors.Wrap(err, "failed to run lvm prerequisites")
+		}
+	}
+
+	args := a.buildReplacementPrepareArgs(osdID, dataDevice, dbLV, entry, useRaw, logPath)
+
+	logger.Infof("provisioning replacement osd.%d: %s %v", osdID, baseCommand, args)
+	op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, args...)
+	cvLog := readCVLogContent(path.Join(logPath, "ceph-volume.log"))
+	if err != nil {
+		if cvLog != "" {
+			logger.Errorf("%s", cvLog)
+		}
+		return errors.Wrapf(err, "failed to run ceph-volume prepare for replacement osd.%d. %s", osdID, op)
+	}
+	if cvLog != "" {
+		logger.Infof("%s", cvLog)
+	}
+	logger.Infof("%v", op)
+
+	return nil
+}
+
+// buildReplacementPrepareArgs assembles the ceph-volume prepare invocation (the args after the
+// "stdbuf" base command) for re-provisioning a destroyed slot into the given data device. The layout
+// is selected by useRaw and the presence of a recovered DB LV:
+//   - raw single-disk:               raw prepare --osd-id <id> --data <disk> [--crush-device-class]
+//   - lvm single-disk:               lvm prepare --osd-id <id> --data <disk> [--crush-device-class]
+//   - lvm shared-metadata (plain):   lvm prepare --osd-id <id> --data <disk> --block.db <vg/lv> [--crush-device-class]
+//   - lvm shared-metadata (crypt):   lvm prepare --osd-id <id> --data <disk> --block.db <vg/lv> --dmcrypt [--crush-device-class]
+//
+// `lvm prepare` (not `lvm batch`) is required: batch reallocates the DB and refuses a surviving
+// sibling LV, whereas prepare reuses the recovered DB LV in place.
+func (a *OsdAgent) buildReplacementPrepareArgs(osdID int, dataDevice, dbLV string, entry *DeviceOsdIDEntry, useRaw bool, logPath string) []string {
+	storeFlag := a.storeConfig.GetStoreFlag()
+	cvMode := "lvm"
+	if useRaw {
+		cvMode = "raw"
+	}
+
+	args := []string{"-oL", cephVolumeCmd, "--log-path", logPath, cvMode, "prepare", storeFlag, "--osd-id", strconv.Itoa(osdID), dataFlag, dataDevice}
+
+	if !useRaw {
+		// Raw mode never has a separate DB device or encryption (those force lvm mode).
+		if dbLV != "" {
+			args = append(args, blockDBFlag, dbLV)
+		}
+		if a.storeConfig.EncryptedDevice {
+			args = append(args, encryptedFlag)
+		}
+	}
+
+	return a.appendDeviceClassArg(entry, args)
+}
+
+// recoverDBLVForOSDFromHost reads the destroyed OSD's surviving DB logical volume via `ceph-volume
+// lvm list <id>` and returns it as a "vg/lv" reference suitable for `--block.db`. It returns an empty
+// string when the OSD has no separate metadata device.
+func (a *OsdAgent) recoverDBLVForOSDFromHost(context *clusterd.Context, osdID int) (string, error) {
+	entries, err := cephVolumeLVMList(context, osdID)
+	if err != nil {
+		return "", err
+	}
+
+	for _, entry := range entries {
+		if entry.Type != "db" {
+			continue
+		}
+		if entry.VGName != "" && entry.LVName != "" {
+			return fmt.Sprintf("%s/%s", entry.VGName, entry.LVName), nil
+		}
+		if entry.Path != "" {
+			return entry.Path, nil
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/daemon/ceph/osd/replace_test.go
+++ b/pkg/daemon/ceph/osd/replace_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/rook/rook/pkg/util/sys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrushHostFromLocation(t *testing.T) {
+	assert.Equal(t, "node-1", crushHostFromLocation("root=default host=node-1"))
+	assert.Equal(t, "node-1", crushHostFromLocation("root=default host=node-1 region=r1 zone=z1"))
+	assert.Equal(t, "", crushHostFromLocation("root=default"))
+	assert.Equal(t, "", crushHostFromLocation(""))
+}
+
+func TestAvailableDataDevices(t *testing.T) {
+	t.Run("picks a blank data device", func(t *testing.T) {
+		available := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{
+			"sdb": {Data: unassignedOSDID, DeviceInfo: &sys.LocalDisk{Name: "sdb"}},
+		}}
+		assert.Equal(t, []string{"sdb"}, availableDataDevices(available))
+	})
+
+	t.Run("skips metadata device entries", func(t *testing.T) {
+		available := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{
+			"nvme0n1": {Data: unassignedOSDID, Metadata: []int{}, DeviceInfo: &sys.LocalDisk{Name: "nvme0n1"}},
+		}}
+		assert.Empty(t, availableDataDevices(available))
+	})
+
+	t.Run("skips already-assigned data devices", func(t *testing.T) {
+		available := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{
+			"sdb": {Data: 5, DeviceInfo: &sys.LocalDisk{Name: "sdb"}},
+		}}
+		assert.Empty(t, availableDataDevices(available))
+	})
+
+	t.Run("empty mapping", func(t *testing.T) {
+		assert.Empty(t, availableDataDevices(&DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{}}))
+	})
+
+	t.Run("multiple blank candidates sorted deterministically", func(t *testing.T) {
+		available := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{
+			"sdc": {Data: unassignedOSDID, DeviceInfo: &sys.LocalDisk{Name: "sdc"}},
+			"sdb": {Data: unassignedOSDID, DeviceInfo: &sys.LocalDisk{Name: "sdb"}},
+		}}
+		// Map iteration order is random; the sorted result must always be ["sdb", "sdc"].
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, []string{"sdb", "sdc"}, availableDataDevices(available))
+		}
+	})
+}
+
+func TestFilterDestroyedOSDIdsForNode(t *testing.T) {
+	treeJSON := `{
+		"nodes": [
+			{"id": -1, "name": "default", "type": "root", "type_id": 10, "children": [-3, -4]},
+			{"id": -3, "name": "node1", "type": "host", "type_id": 1, "children": [0, 1]},
+			{"id": -4, "name": "node2", "type": "host", "type_id": 1, "children": [2, 3]},
+			{"id": 0, "name": "osd.0", "type": "osd", "type_id": 0, "exists": 1, "status": "up"},
+			{"id": 1, "name": "osd.1", "type": "osd", "type_id": 0, "exists": 1, "status": "destroyed"},
+			{"id": 2, "name": "osd.2", "type": "osd", "type_id": 0, "exists": 1, "status": "destroyed"},
+			{"id": 3, "name": "osd.3", "type": "osd", "type_id": 0, "exists": 1, "status": "up"}
+		],
+		"stray": []
+	}`
+	var tree cephclient.OsdTree
+	require.NoError(t, json.Unmarshal([]byte(treeJSON), &tree))
+
+	// GetDestroyedIDs picks up only "destroyed" slots cluster-wide.
+	destroyed := tree.GetDestroyedIDs()
+	assert.ElementsMatch(t, []int{1, 2}, destroyed)
+
+	// destroyed ids cluster-wide are [1, 2]; only osd.1 belongs to node1.
+	ids, err := filterDestroyedOSDIdsForNode(tree, destroyed, "root=default host=node1")
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1}, ids)
+
+	// node2 owns osd.2 only.
+	ids, err = filterDestroyedOSDIdsForNode(tree, destroyed, "root=default host=node2")
+	assert.NoError(t, err)
+	assert.Equal(t, []int{2}, ids)
+
+	// a node with no destroyed slots returns empty.
+	ids, err = filterDestroyedOSDIdsForNode(tree, destroyed, "root=default host=node-unknown")
+	assert.NoError(t, err)
+	assert.Empty(t, ids)
+
+	// missing host token is an error.
+	_, err = filterDestroyedOSDIdsForNode(tree, destroyed, "root=default")
+	assert.Error(t, err)
+}
+
+func TestFilterDestroyedOSDIdsForNodeDeepHierarchy(t *testing.T) {
+	// Realistic multi-level CRUSH tree as seen in mid-to-large clusters, where rack-level failure
+	// domains are typical and racks/datacenters sit ABOVE the host bucket:
+	//
+	//   root(default) -> datacenter -> rack -> host -> osd
+	//
+	// type_id values are the Ceph defaults (osd=0, host=1, chassis=2, rack=3, datacenter=8,
+	// root=11), per src/osd/OSDMap.cc OSDMap::build_simple_crush_map_from_conf
+	// (crush.set_type_name(0,"osd")..(11,"root")) and doc/rados/operations/crush-map-edits.rst
+	// ("type 0 osd" .. "type 11 root"). The per-node JSON fields (id/name/type/type_id/children for
+	// buckets; id/name/type/type_id/crush_weight/depth/exists/status/reweight/primary_affinity for
+	// osd leaves) match the `ceph osd tree --format json` shape emitted by
+	// CrushTreeDumper::dump_item_fields + OSDTreeFormattingDumper::dump_item_fields, with status one
+	// of "up"/"down"/"destroyed".
+	//
+	// Layout:
+	//   dc1
+	//     rack-a1 -> host node-a1  : osd.0 (up),        osd.1 (destroyed)
+	//     rack-a2 -> host node-a2  : osd.2 (up),        osd.3 (up)
+	//   dc2
+	//     rack-b1 -> host node-b1  : osd.4 (destroyed), osd.5 (up)
+	//     rack-b1 -> host node-b2  : chassis -> osd.6 (destroyed), osd.7 (up)
+	//
+	// The node-b2 host has a non-standard intermediate `chassis` bucket BELOW the host (standard
+	// CRUSH puts chassis ABOVE the host). It is included only to exercise the recursive descent in
+	// collectOSDsUnderBucket: osd.6 sits one level deeper than a host's direct children, so it is
+	// only returned if the walk recurses through the chassis.
+	treeJSON := `{
+		"nodes": [
+			{"id": -1, "name": "default", "type": "root", "type_id": 11, "children": [-2, -3]},
+
+			{"id": -2, "name": "dc1", "type": "datacenter", "type_id": 8, "children": [-10, -11]},
+			{"id": -10, "name": "rack-a1", "type": "rack", "type_id": 3, "children": [-100]},
+			{"id": -11, "name": "rack-a2", "type": "rack", "type_id": 3, "children": [-101]},
+			{"id": -100, "name": "node-a1", "type": "host", "type_id": 1, "children": [0, 1]},
+			{"id": -101, "name": "node-a2", "type": "host", "type_id": 1, "children": [2, 3]},
+
+			{"id": -3, "name": "dc2", "type": "datacenter", "type_id": 8, "children": [-20]},
+			{"id": -20, "name": "rack-b1", "type": "rack", "type_id": 3, "children": [-200, -201]},
+			{"id": -200, "name": "node-b1", "type": "host", "type_id": 1, "children": [4, 5]},
+			{"id": -201, "name": "node-b2", "type": "host", "type_id": 1, "children": [-300]},
+			{"id": -300, "name": "node-b2-chassis", "type": "chassis", "type_id": 2, "children": [6, 7]},
+
+			{"id": 0, "name": "osd.0", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "up", "reweight": 1.0, "primary_affinity": 1.0},
+			{"id": 1, "name": "osd.1", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "destroyed", "reweight": 0.0, "primary_affinity": 1.0},
+			{"id": 2, "name": "osd.2", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "up", "reweight": 1.0, "primary_affinity": 1.0},
+			{"id": 3, "name": "osd.3", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "up", "reweight": 1.0, "primary_affinity": 1.0},
+			{"id": 4, "name": "osd.4", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "destroyed", "reweight": 0.0, "primary_affinity": 1.0},
+			{"id": 5, "name": "osd.5", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 4, "exists": 1, "status": "up", "reweight": 1.0, "primary_affinity": 1.0},
+			{"id": 6, "name": "osd.6", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 5, "exists": 1, "status": "destroyed", "reweight": 0.0, "primary_affinity": 1.0},
+			{"id": 7, "name": "osd.7", "type": "osd", "type_id": 0, "crush_weight": 1.0, "depth": 5, "exists": 1, "status": "up", "reweight": 1.0, "primary_affinity": 1.0}
+		],
+		"stray": []
+	}`
+	var tree cephclient.OsdTree
+	require.NoError(t, json.Unmarshal([]byte(treeJSON), &tree))
+
+	// Cluster-wide destroyed slots span multiple racks/datacenters: osd.1 (dc1), osd.4 and osd.6 (dc2).
+	destroyed := tree.GetDestroyedIDs()
+	assert.ElementsMatch(t, []int{1, 4, 6}, destroyed)
+
+	t.Run("returns only the destroyed osd under the target host, deep in the tree", func(t *testing.T) {
+		// node-a1 sits at root->dc1->rack-a1->host; only its own destroyed osd.1 must come back,
+		// not osd.4/osd.6 destroyed under other hosts/racks/datacenters.
+		ids, err := filterDestroyedOSDIdsForNode(tree, destroyed, "root=default datacenter=dc1 rack=rack-a1 host=node-a1")
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1}, ids)
+	})
+
+	t.Run("host in a different datacenter returns only its own destroyed osd", func(t *testing.T) {
+		ids, err := filterDestroyedOSDIdsForNode(tree, destroyed, "root=default datacenter=dc2 rack=rack-b1 host=node-b1")
+		assert.NoError(t, err)
+		assert.Equal(t, []int{4}, ids)
+	})
+
+	t.Run("host with no destroyed osds returns empty", func(t *testing.T) {
+		// node-a2 (osd.2, osd.3) has no destroyed slots even though its datacenter dc1 does (osd.1).
+		ids, err := filterDestroyedOSDIdsForNode(tree, destroyed, "root=default datacenter=dc1 rack=rack-a2 host=node-a2")
+		assert.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("osds nested below the host bucket are not matched", func(t *testing.T) {
+		// node-b2's children are a chassis bucket, not osds directly; osd.6 is one level deeper.
+		// Rook always makes OSDs direct children of the host bucket, so we only read the host's
+		// direct children: an osd nested under an intermediate bucket below the host is not matched.
+		ids, err := filterDestroyedOSDIdsForNode(tree, destroyed, "root=default datacenter=dc2 rack=rack-b1 host=node-b2")
+		assert.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}
+
+func TestRecoverDBLV(t *testing.T) {
+	a := &OsdAgent{}
+
+	t.Run("shared metadata: db lv is recovered as vg/lv", func(t *testing.T) {
+		out := `{
+			"3": [
+				{"type": "block", "vg_name": "ceph-block-vg", "lv_name": "osd-block-x", "path": "/dev/ceph-block-vg/osd-block-x"},
+				{"type": "db", "vg_name": "ceph-db-vg", "lv_name": "osd-db-y", "path": "/dev/ceph-db-vg/osd-db-y"}
+			]
+		}`
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return out, nil
+			},
+		}
+		dbLV, err := a.recoverDBLVForOSDFromHost(&clusterd.Context{Executor: executor}, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, "ceph-db-vg/osd-db-y", dbLV)
+	})
+
+	t.Run("single-disk lvm: no db lv", func(t *testing.T) {
+		out := `{"3": [{"type": "block", "vg_name": "ceph-block-vg", "lv_name": "osd-block-x", "path": "/dev/ceph-block-vg/osd-block-x"}]}`
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return out, nil
+			},
+		}
+		dbLV, err := a.recoverDBLVForOSDFromHost(&clusterd.Context{Executor: executor}, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, "", dbLV)
+	})
+
+	t.Run("single-disk raw: empty list", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return `{}`, nil
+			},
+		}
+		dbLV, err := a.recoverDBLVForOSDFromHost(&clusterd.Context{Executor: executor}, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, "", dbLV)
+	})
+}
+
+func TestBuildReplacementPrepareArgs(t *testing.T) {
+	const logPath = "/tmp/ceph-log"
+	entry := &DeviceOsdIDEntry{
+		Data:       unassignedOSDID,
+		Config:     DesiredDevice{Name: "vdb", DeviceClass: "hdd"},
+		DeviceInfo: &sys.LocalDisk{Name: "vdb"},
+	}
+
+	tests := []struct {
+		name     string
+		store    config.StoreConfig
+		dbLV     string
+		useRaw   bool
+		expected []string
+	}{
+		{
+			name:   "raw single-disk",
+			store:  config.StoreConfig{StoreType: "bluestore"},
+			dbLV:   "",
+			useRaw: true,
+			expected: []string{
+				"-oL", "ceph-volume", "--log-path", logPath, "raw", "prepare", "--bluestore",
+				"--osd-id", "0", "--data", "/dev/vdb", "--crush-device-class", "hdd",
+			},
+		},
+		{
+			name:   "lvm single-disk (no --block.db)",
+			store:  config.StoreConfig{StoreType: "bluestore"},
+			dbLV:   "",
+			useRaw: false,
+			expected: []string{
+				"-oL", "ceph-volume", "--log-path", logPath, "lvm", "prepare", "--bluestore",
+				"--osd-id", "0", "--data", "/dev/vdb", "--crush-device-class", "hdd",
+			},
+		},
+		{
+			name:   "lvm shared-metadata plain",
+			store:  config.StoreConfig{StoreType: "bluestore"},
+			dbLV:   "ceph-db-vg/osd-db-y",
+			useRaw: false,
+			expected: []string{
+				"-oL", "ceph-volume", "--log-path", logPath, "lvm", "prepare", "--bluestore",
+				"--osd-id", "0", "--data", "/dev/vdb", "--block.db", "ceph-db-vg/osd-db-y",
+				"--crush-device-class", "hdd",
+			},
+		},
+		{
+			name:   "lvm shared-metadata encrypted",
+			store:  config.StoreConfig{StoreType: "bluestore", EncryptedDevice: true},
+			dbLV:   "ceph-db-vg/osd-db-y",
+			useRaw: false,
+			expected: []string{
+				"-oL", "ceph-volume", "--log-path", logPath, "lvm", "prepare", "--bluestore",
+				"--osd-id", "0", "--data", "/dev/vdb", "--block.db", "ceph-db-vg/osd-db-y",
+				"--dmcrypt", "--crush-device-class", "hdd",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &OsdAgent{storeConfig: tc.store}
+			args := a.buildReplacementPrepareArgs(0, "/dev/vdb", tc.dbLV, entry, tc.useRaw, logPath)
+			assert.Equal(t, tc.expected, args)
+		})
+	}
+}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -105,6 +105,18 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	var block, lvPath, metadataBlock, walBlock string
 	var err error
 
+	// Destroyed OSDs are reserved for replacement and must not be reported to the status CM, or the
+	// controller would rebuild them. The ceph-volume list results below are filtered against this set.
+	// PVC-backed OSDs are never part of host-based replacement, so the set is empty there.
+	var destroyedOSDIds []int
+	if !a.pvcBacked {
+		tree, err := client.HostTree(context, a.clusterInfo)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get osd tree for destroyed slots")
+		}
+		destroyedOSDIds = tree.GetDestroyedIDs()
+	}
+
 	// Idempotency check, if the device list is empty devices have been prepared already
 	// In this case, just return the OSDInfo via a 'ceph-volume lvm|raw list' call
 	if len(devices.Entries) == 0 {
@@ -157,14 +169,14 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume")
 			}
-			osds = append(osds, lvmOsds...)
+			osds = append(osds, slices.DeleteFunc(lvmOsds, func(o oposd.OSDInfo) bool { return slices.Contains(destroyedOSDIds, o.ID) })...)
 
 			// List existing OSD(s) configured with ceph-volume raw mode
 			rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, "", "", false, false, a.devices)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get device already provisioned by ceph-volume raw")
 			}
-			osds = appendOSDInfo(osds, rawOsds)
+			osds = appendOSDInfo(osds, slices.DeleteFunc(rawOsds, func(o oposd.OSDInfo) bool { return slices.Contains(destroyedOSDIds, o.ID) }))
 		}
 
 		return osds, nil
@@ -201,7 +213,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume lvm")
 	}
-	osds = append(osds, lvmOsds...)
+	osds = append(osds, slices.DeleteFunc(lvmOsds, func(o oposd.OSDInfo) bool { return slices.Contains(destroyedOSDIds, o.ID) })...)
 
 	// List THE configured OSD with ceph-volume raw mode
 	// When the block is encrypted we need to list against the encrypted device mapper
@@ -216,7 +228,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
-	osds = appendOSDInfo(osds, rawOsds)
+	osds = appendOSDInfo(osds, slices.DeleteFunc(rawOsds, func(o oposd.OSDInfo) bool { return slices.Contains(destroyedOSDIds, o.ID) }))
 
 	return osds, err
 }

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -579,6 +579,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "sgdisk" {
 				return "Disk identifier (GUID): 18484D7E-5287-4CE9-AC73-D02FB69055CE", nil
 			}
+			if args[0] == "osd" && args[1] == "tree" {
+				return `{"nodes":[],"stray":[]}`, nil
+			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
 		deviceClassSet := false
@@ -598,6 +601,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			}
 			if args[1] == "ceph-volume" && args[2] == "--log-path" && args[3] == "/tmp/ceph-log" {
 				return `{}`, nil
+			}
+			if args[0] == "osd" && args[1] == "tree" {
+				return `{"nodes":[],"stray":[]}`, nil
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
@@ -641,6 +647,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			}
 			if args[1] == "ceph-volume" && args[2] == "--log-path" && args[3] == "/tmp/ceph-log" {
 				return `{}`, nil
+			}
+			if args[0] == "osd" && args[1] == "tree" {
+				return `{"nodes":[],"stray":[]}`, nil
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

2 part of 6-part stacked PR.

## Description

Adjust osd-prepare job to not reprovision destroyed osd and reuse osd slot when device was swapped.

## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866
