### PR TITLE
osd-replacement-3: implement osd replacement crypto close job

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -65,6 +65,11 @@ var osdRemoveCmd = &cobra.Command{
 	Short: "Removes a set of OSDs from the cluster",
 }
 
+var osdCloseEncryptedDevicesCmd = &cobra.Command{
+	Use:   "close-encrypted-devices",
+	Short: "Closes the host dm-crypt mappings for an encrypted OSD being replaced",
+}
+
 var (
 	osdDataDeviceFilter          string
 	osdDataDevicePathFilter      string
@@ -121,11 +126,15 @@ func addOSDFlags(command *cobra.Command) {
 	osdRemoveCmd.Flags().StringVar(&preservePVC, "preserve-pvc", "false", "Whether PVCs for OSDs will be deleted")
 	osdRemoveCmd.Flags().StringVar(&forceOSDRemoval, "force-osd-removal", "false", "Whether to force remove the OSD")
 
+	// flags for closing the dm-crypt mappings of an encrypted OSD being replaced
+	osdCloseEncryptedDevicesCmd.Flags().IntVar(&osdID, "osd-id", -1, "the id of the encrypted OSD whose dm-crypt mappings should be closed")
+
 	// add the subcommands to the parent osd command
 	osdCmd.AddCommand(osdConfigCmd,
 		provisionCmd,
 		osdStartCmd,
-		osdRemoveCmd)
+		osdRemoveCmd,
+		osdCloseEncryptedDevicesCmd)
 }
 
 func addOSDConfigFlags(command *cobra.Command) {
@@ -157,6 +166,22 @@ func init() {
 	provisionCmd.RunE = prepareOSD
 	osdStartCmd.RunE = startOSD
 	osdRemoveCmd.RunE = removeOSDs
+	osdCloseEncryptedDevicesCmd.RunE = closeEncryptedDevices
+}
+
+// closeEncryptedDevices closes the host dm-crypt mappings of an encrypted OSD being replaced. It runs
+// in a privileged Job on the OSD's node and needs no Ceph auth or KMS key material, so it loads
+// neither the Ceph secret nor mon endpoints.
+func closeEncryptedDevices(cmd *cobra.Command, args []string) error {
+	if osdID == -1 {
+		return errors.New("osd id not specified")
+	}
+
+	context := createContext()
+	if err := osddaemon.CloseEncryptedDevicesForOSD(context, osdID); err != nil {
+		rook.TerminateFatal(err)
+	}
+	return nil
 }
 
 // Start the osd daemon if provisioned by ceph-volume

--- a/pkg/daemon/ceph/osd/replace.go
+++ b/pkg/daemon/ceph/osd/replace.go
@@ -54,6 +54,67 @@ func cephVolumeLVMList(context *clusterd.Context, osdID int) ([]cvLVMListEntry, 
 	return listResult[strconv.Itoa(osdID)], nil
 }
 
+// CloseEncryptedDevicesForOSD closes the host dm-crypt mappings backing the encrypted OSD with the
+// given id. Mappings already closed are treated as success.
+func CloseEncryptedDevicesForOSD(context *clusterd.Context, osdID int) error {
+	dmNames, err := encryptedDMNamesForOSD(context, osdID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to resolve dm-crypt mappings for osd.%d", osdID)
+	}
+
+	if len(dmNames) == 0 {
+		logger.Infof("no dm-crypt mappings found for osd.%d, nothing to close", osdID)
+		return nil
+	}
+
+	for _, dmName := range dmNames {
+		logger.Infof("closing dm-crypt mapping %q for osd.%d", dmName, osdID)
+		if err := CloseEncryptedDevice(context, dmName); err != nil {
+			if isCryptsetupNotActive(err) {
+				logger.Infof("dm-crypt mapping %q for osd.%d is already closed", dmName, osdID)
+				continue
+			}
+			return errors.Wrapf(err, "failed to close dm-crypt mapping %q for osd.%d", dmName, osdID)
+		}
+	}
+
+	return nil
+}
+
+// encryptedDMNamesForOSD returns the host dm-crypt mapping names for the OSD with the given id,
+// resolved from `ceph-volume lvm list <id>`. In lvm mode the mapping name is the LV's lv_uuid.
+func encryptedDMNamesForOSD(context *clusterd.Context, osdID int) ([]string, error) {
+	entries, err := cephVolumeLVMList(context, osdID)
+	if err != nil {
+		return nil, err
+	}
+
+	dmNames := []string{}
+	for _, entry := range entries {
+		if entry.Tags.Encrypted != "1" {
+			continue
+		}
+		if entry.LVUUID == "" {
+			logger.Warningf("ceph-volume lvm list returned an encrypted %q entry for osd.%d with no lv_uuid; skipping", entry.Type, osdID)
+			continue
+		}
+		dmNames = append(dmNames, entry.LVUUID)
+	}
+
+	return dmNames, nil
+}
+
+// isCryptsetupNotActive reports whether err is cryptsetup's "already closed" failure (exit code 4),
+// which is treated as success so closing is idempotent. The message substring is a locale-dependent
+// fallback to the exit code.
+func isCryptsetupNotActive(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "exit status 4") || strings.Contains(msg, "is not active")
+}
+
 // preProvisionReplacedOSDs pairs each destroyed slot belonging to this node with a freshly-swapped
 // blank device and re-provisions it into the same slot via `ceph-volume ... prepare --osd-id <id>`,
 // reusing the surviving DB LV in place when present. Devices consumed here are removed from

--- a/pkg/daemon/ceph/osd/replace_test.go
+++ b/pkg/daemon/ceph/osd/replace_test.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -316,4 +317,163 @@ func TestBuildReplacementPrepareArgs(t *testing.T) {
 			assert.Equal(t, tc.expected, args)
 		})
 	}
+}
+
+func TestEncryptedDMNamesForOSD(t *testing.T) {
+	// JSON shape mirrors a real `ceph-volume lvm list <id>` for a shared-metadata encrypted OSD: the
+	// dm-crypt mapping name is the LV's lv_uuid (verified on a live cluster), and only entries tagged
+	// ceph.encrypted=1 carry a mapping to close.
+	const encryptedOut = `{
+		"5": [
+			{"type": "block", "lv_uuid": "BLOCK-UUID", "vg_name": "ceph-bvg", "lv_name": "osd-block-x", "path": "/dev/ceph-bvg/osd-block-x", "tags": {"ceph.encrypted": "1", "ceph.osd_id": "5"}},
+			{"type": "db", "lv_uuid": "DB-UUID", "vg_name": "ceph-dvg", "lv_name": "osd-db-y", "path": "/dev/ceph-dvg/osd-db-y", "tags": {"ceph.encrypted": "1", "ceph.osd_id": "5"}}
+		]
+	}`
+
+	t.Run("encrypted shared-metadata returns block and db dm names", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				assert.Contains(t, args, "list")
+				assert.Contains(t, args, "5")
+				return encryptedOut, nil
+			},
+		}
+		names, err := encryptedDMNamesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"BLOCK-UUID", "DB-UUID"}, names)
+	})
+
+	t.Run("non-encrypted OSD returns nothing", func(t *testing.T) {
+		out := `{"5": [{"type": "block", "lv_uuid": "BLOCK-UUID", "tags": {"ceph.encrypted": "0", "ceph.osd_id": "5"}}]}`
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return out, nil
+			},
+		}
+		names, err := encryptedDMNamesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Empty(t, names)
+	})
+
+	t.Run("id absent from list returns nothing", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return `{}`, nil
+			},
+		}
+		names, err := encryptedDMNamesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Empty(t, names)
+	})
+
+	t.Run("wal LV is also returned", func(t *testing.T) {
+		out := `{
+			"5": [
+				{"type": "block", "lv_uuid": "BLOCK-UUID", "tags": {"ceph.encrypted": "1"}},
+				{"type": "db", "lv_uuid": "DB-UUID", "tags": {"ceph.encrypted": "1"}},
+				{"type": "wal", "lv_uuid": "WAL-UUID", "tags": {"ceph.encrypted": "1"}}
+			]
+		}`
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return out, nil
+			},
+		}
+		names, err := encryptedDMNamesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"BLOCK-UUID", "DB-UUID", "WAL-UUID"}, names)
+	})
+
+	t.Run("encrypted entry with no lv_uuid is skipped", func(t *testing.T) {
+		out := `{
+			"5": [
+				{"type": "block", "lv_uuid": "", "tags": {"ceph.encrypted": "1"}},
+				{"type": "db", "lv_uuid": "DB-UUID", "tags": {"ceph.encrypted": "1"}}
+			]
+		}`
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return out, nil
+			},
+		}
+		names, err := encryptedDMNamesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"DB-UUID"}, names)
+	})
+}
+
+func TestCloseEncryptedDevicesForOSD(t *testing.T) {
+	const encryptedOut = `{
+		"5": [
+			{"type": "block", "lv_uuid": "BLOCK-UUID", "tags": {"ceph.encrypted": "1", "ceph.osd_id": "5"}},
+			{"type": "db", "lv_uuid": "DB-UUID", "tags": {"ceph.encrypted": "1", "ceph.osd_id": "5"}}
+		]
+	}`
+
+	t.Run("closes each encrypted mapping with luksClose", func(t *testing.T) {
+		closed := []string{}
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return encryptedOut, nil
+			},
+			MockExecuteCommandWithCombinedOutput: func(command string, args ...string) (string, error) {
+				require.Equal(t, "cryptsetup", command)
+				assert.Equal(t, []string{"--verbose", "luksClose", args[2]}, args)
+				closed = append(closed, args[2])
+				return "", nil
+			},
+		}
+		err := CloseEncryptedDevicesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"BLOCK-UUID", "DB-UUID"}, closed)
+	})
+
+	t.Run("already-closed mapping (exit status 4) is treated as success", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return encryptedOut, nil
+			},
+			MockExecuteCommandWithCombinedOutput: func(command string, args ...string) (string, error) {
+				return "Device is not active.", errors.New("exit status 4")
+			},
+		}
+		err := CloseEncryptedDevicesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+	})
+
+	t.Run("real close failure is returned", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return encryptedOut, nil
+			},
+			MockExecuteCommandWithCombinedOutput: func(command string, args ...string) (string, error) {
+				return "boom", errors.New("exit status 1")
+			},
+		}
+		err := CloseEncryptedDevicesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.Error(t, err)
+	})
+
+	t.Run("non-encrypted OSD is a no-op", func(t *testing.T) {
+		called := false
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return `{"5": [{"type": "block", "lv_uuid": "X", "tags": {"ceph.encrypted": "0"}}]}`, nil
+			},
+			MockExecuteCommandWithCombinedOutput: func(command string, args ...string) (string, error) {
+				called = true
+				return "", nil
+			},
+		}
+		err := CloseEncryptedDevicesForOSD(&clusterd.Context{Executor: executor}, 5)
+		assert.NoError(t, err)
+		assert.False(t, called)
+	})
+}
+
+func TestIsCryptsetupNotActive(t *testing.T) {
+	assert.True(t, isCryptsetupNotActive(errors.New("exit status 4")))
+	assert.True(t, isCryptsetupNotActive(errors.New("Device foo is not active.")))
+	assert.False(t, isCryptsetupNotActive(errors.New("exit status 1")))
+	assert.False(t, isCryptsetupNotActive(nil))
 }

--- a/pkg/operator/ceph/cluster/osd/replace_job.go
+++ b/pkg/operator/ceph/cluster/osd/replace_job.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	cryptCloseJobAppName = "rook-ceph-osd-crypt-close"
+	// cryptCloseJobNameFmt embeds the OSD id so each replacement gets its own replaceable Job.
+	cryptCloseJobNameFmt    = "rook-ceph-osd-crypt-close-%d"
+	cryptCloseContainerName = "crypt-close"
+)
+
+var (
+	cryptCloseJobBackoffLimit int32 = 3
+	// cryptCloseJobActiveDeadlineSeconds bounds the Job lifetime (including time spent Pending) so it
+	// surfaces as Failed rather than running forever.
+	cryptCloseJobActiveDeadlineSeconds int64 = 600
+)
+
+func cryptCloseJobName(osdID int) string {
+	return fmt.Sprintf(cryptCloseJobNameFmt, osdID)
+}
+
+// cryptCloseJobStatus is the status of a per-OSD crypto-close Job, polled by the health-monitor
+// goroutine across ticks.
+type cryptCloseJobStatus string
+
+const (
+	cryptCloseJobNotFound  cryptCloseJobStatus = "NotFound"
+	cryptCloseJobRunning   cryptCloseJobStatus = "Running"
+	cryptCloseJobSucceeded cryptCloseJobStatus = "Succeeded"
+	cryptCloseJobFailed    cryptCloseJobStatus = "Failed"
+)
+
+// startCryptCloseJob creates (or replaces) the privileged Job, pinned to the OSD's node, that closes
+// the OSD's host dm-crypt mappings. The operator pod cannot run host device-mapper operations itself.
+func (c *Cluster) startCryptCloseJob(osdID int, nodeName string) error {
+	job := c.makeCryptCloseJob(osdID, nodeName)
+
+	// deleteIfFound=true: replace any existing Job (even an active one) so a re-pinned Job always wins.
+	if err := k8sutil.RunReplaceableJob(c.clusterInfo.Context, c.context.Clientset, job, true); err != nil {
+		return errors.Wrapf(err, "failed to run crypto-close job for osd.%d on node %q", osdID, nodeName)
+	}
+	return nil
+}
+
+func (c *Cluster) cryptCloseJobStatusForOSD(osdID int) (cryptCloseJobStatus, error) {
+	job, err := c.context.Clientset.BatchV1().Jobs(c.clusterInfo.Namespace).Get(c.clusterInfo.Context, cryptCloseJobName(osdID), metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return cryptCloseJobNotFound, nil
+		}
+		return "", errors.Wrapf(err, "failed to get crypto-close job for osd.%d", osdID)
+	}
+
+	if job.Status.Succeeded > 0 {
+		return cryptCloseJobSucceeded, nil
+	}
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batch.JobFailed && condition.Status == v1.ConditionTrue {
+			return cryptCloseJobFailed, nil
+		}
+	}
+	return cryptCloseJobRunning, nil
+}
+
+// deleteCryptCloseJob removes the per-OSD crypto-close Job. It is a no-op if the Job does not exist.
+func (c *Cluster) deleteCryptCloseJob(osdID int) error {
+	return k8sutil.DeleteBatchJob(c.clusterInfo.Context, c.context.Clientset, c.clusterInfo.Namespace, cryptCloseJobName(osdID), false)
+}
+
+func (c *Cluster) makeCryptCloseJob(osdID int, nodeName string) *batch.Job {
+	podSpec := c.cryptCloseJobPodTemplateSpec(osdID)
+	podSpec.Spec.NodeSelector = map[string]string{k8sutil.LabelHostname(): nodeName}
+
+	labels := controller.AppLabels(cryptCloseJobAppName, c.clusterInfo.Namespace)
+	labels[OsdIdLabelKey] = strconv.Itoa(osdID)
+
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cryptCloseJobName(osdID),
+			Namespace: c.clusterInfo.Namespace,
+			Labels:    labels,
+		},
+		Spec: batch.JobSpec{
+			// Bound retries and lifetime so a close that cannot succeed surfaces as Failed for the
+			// health-monitor goroutine instead of running forever.
+			BackoffLimit:          &cryptCloseJobBackoffLimit,
+			ActiveDeadlineSeconds: &cryptCloseJobActiveDeadlineSeconds,
+			Template:              podSpec,
+		},
+	}
+
+	k8sutil.AddRookVersionLabelToJob(job)
+	if c.clusterInfo.OwnerInfo != nil {
+		// Best-effort owner reference so the Job is garbage-collected with the CephCluster; failure
+		// is non-fatal because the Job is also explicitly deleted by deleteCryptCloseJob.
+		if err := c.clusterInfo.OwnerInfo.SetControllerReference(job); err != nil {
+			logger.Warningf("failed to set owner reference on crypto-close job for osd.%d. %v", osdID, err)
+		}
+	}
+
+	return job
+}
+
+func (c *Cluster) cryptCloseJobContainer(osdID int) v1.Container {
+	envVars := []v1.EnvVar{
+		{Name: "ROOK_LOG_LEVEL", Value: "DEBUG"},
+		// device-mapper operations from cryptsetup hang on udev sync in a container; disable it as
+		// the cleanup job does.
+		{Name: "DM_DISABLE_UDEV", Value: "1"},
+	}
+
+	return v1.Container{
+		Name: cryptCloseContainerName,
+		// The rook image carries the rook binary as well as ceph-volume and cryptsetup (it is built on
+		// the ceph base image), so it can both resolve the dm-crypt mappings and close them.
+		Image: c.rookVersion,
+		// Run as UID 0: device-mapper and cryptsetup require root, matching the cleanup job.
+		SecurityContext: controller.PrivilegedContext(true),
+		VolumeMounts: []v1.VolumeMount{
+			{Name: "devices", MountPath: "/dev"},
+			{Name: "run-udev", MountPath: "/run/udev"},
+		},
+		Env:  envVars,
+		Args: []string{"ceph", "osd", "close-encrypted-devices", "--osd-id", strconv.Itoa(osdID)},
+	}
+}
+
+func (c *Cluster) cryptCloseJobPodTemplateSpec(osdID int) v1.PodTemplateSpec {
+	volumes := []v1.Volume{
+		{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}},
+		{Name: "run-udev", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}},
+	}
+
+	podSpec := v1.PodSpec{
+		Containers:         []v1.Container{c.cryptCloseJobContainer(osdID)},
+		Volumes:            volumes,
+		RestartPolicy:      v1.RestartPolicyOnFailure,
+		PriorityClassName:  cephv1.GetOSDPriorityClassName(c.spec.PriorityClassNames),
+		ServiceAccountName: k8sutil.DefaultServiceAccount,
+		HostNetwork:        controller.EnforceHostNetwork(),
+		SecurityContext:    &v1.PodSecurityContext{},
+		// cryptsetup synchronizes with udev on the host through a semaphore; share the host IPC
+		// namespace so luksClose can reach it, matching the OSD prepare and key-rotation jobs.
+		HostIPC: true,
+	}
+
+	// Apply the OSD placement so the pod tolerates the same node taints the OSD daemon and prepare
+	// jobs do; without this it could stay Pending forever on a tainted storage node. The hostname
+	// NodeSelector (set by makeCryptCloseJob) still pins it to the exact OSD node, and tolerations are
+	// additive, so this only widens what the pod tolerates, never where it lands.
+	c.applyAllPlacementIfNeeded(&podSpec)
+	c.spec.Placement[cephv1.KeyOSD].ApplyToPodSpec(&podSpec)
+
+	return v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cryptCloseJobAppName,
+		},
+		Spec: podSpec,
+	}
+}

--- a/pkg/operator/ceph/cluster/osd/replace_job_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_job_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMakeCryptCloseJob(t *testing.T) {
+	c := newTestReplaceCluster(fake.NewClientset())
+	job := c.makeCryptCloseJob(7, "node-a")
+
+	assert.Equal(t, "rook-ceph-osd-crypt-close-7", job.Name)
+	assert.Equal(t, "rook-ceph", job.Namespace)
+	assert.Equal(t, "7", job.Labels[OsdIdLabelKey])
+
+	spec := job.Spec.Template.Spec
+	// pinned to the OSD's node
+	assert.Equal(t, "node-a", spec.NodeSelector[k8sutil.LabelHostname()])
+	assert.Equal(t, v1.RestartPolicyOnFailure, spec.RestartPolicy)
+	assert.Equal(t, k8sutil.DefaultServiceAccount, spec.ServiceAccountName)
+
+	require.Len(t, spec.Containers, 1)
+	container := spec.Containers[0]
+	// runs the rook subcommand that resolves + closes the dm-crypt mappings by id
+	assert.Equal(t, []string{"ceph", "osd", "close-encrypted-devices", "--osd-id", "7"}, container.Args)
+	// uses the rook image (carries rook + ceph-volume + cryptsetup)
+	assert.Equal(t, "rook/ceph:test", container.Image)
+	// privileged root for device-mapper ops
+	require.NotNil(t, container.SecurityContext)
+	require.NotNil(t, container.SecurityContext.Privileged)
+	assert.True(t, *container.SecurityContext.Privileged)
+
+	// DM_DISABLE_UDEV must be set so cryptsetup doesn't hang on udev sync in a container
+	var dmDisableUdev string
+	for _, e := range container.Env {
+		if e.Name == "DM_DISABLE_UDEV" {
+			dmDisableUdev = e.Value
+		}
+	}
+	assert.Equal(t, "1", dmDisableUdev)
+
+	// /dev and /run/udev host mounts present
+	mounts := map[string]string{}
+	for _, m := range container.VolumeMounts {
+		mounts[m.Name] = m.MountPath
+	}
+	assert.Equal(t, "/dev", mounts["devices"])
+	assert.Equal(t, "/run/udev", mounts["run-udev"])
+
+	vols := map[string]string{}
+	for _, vol := range spec.Volumes {
+		if vol.HostPath != nil {
+			vols[vol.Name] = vol.HostPath.Path
+		}
+	}
+	assert.Equal(t, "/dev", vols["devices"])
+	assert.Equal(t, "/run/udev", vols["run-udev"])
+
+	// cryptsetup needs the host IPC namespace for its udev semaphore
+	assert.True(t, spec.HostIPC)
+	// pod security context present for parity with the prepare/cleanup jobs
+	require.NotNil(t, spec.SecurityContext)
+
+	// fail-fast bounds so a stuck close surfaces as Failed instead of running forever
+	require.NotNil(t, job.Spec.BackoffLimit)
+	assert.Equal(t, int32(3), *job.Spec.BackoffLimit)
+	require.NotNil(t, job.Spec.ActiveDeadlineSeconds)
+	assert.Equal(t, int64(600), *job.Spec.ActiveDeadlineSeconds)
+
+	// owner reference set so the Job is garbage-collected with the CephCluster
+	assert.NotEmpty(t, job.OwnerReferences)
+}
+
+func TestMakeCryptCloseJobAppliesOSDPlacementTolerations(t *testing.T) {
+	// An OSD node may be tainted; the close Job must tolerate it the same way the OSD daemon does, or
+	// it would stay Pending forever.
+	taintToleration := v1.Toleration{Key: "storage-node", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}
+	spec := cephv1.ClusterSpec{
+		Placement: cephv1.PlacementSpec{
+			cephv1.KeyOSD: cephv1.Placement{Tolerations: []v1.Toleration{taintToleration}},
+		},
+	}
+	c := newTestReplaceClusterWithSpec(fake.NewClientset(), spec)
+	job := c.makeCryptCloseJob(2, "node-a")
+
+	spc := job.Spec.Template.Spec
+	// NodeSelector still pins to the exact node
+	assert.Equal(t, "node-a", spc.NodeSelector[k8sutil.LabelHostname()])
+	// and the OSD toleration is applied
+	assert.Contains(t, spc.Tolerations, taintToleration)
+}
+
+func TestStartCryptCloseJob(t *testing.T) {
+	t.Run("creates the job pinned to the node", func(t *testing.T) {
+		clientset := fake.NewClientset()
+		c := newTestReplaceCluster(clientset)
+
+		err := c.startCryptCloseJob(3, "node-b")
+		require.NoError(t, err)
+
+		job, err := clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), "rook-ceph-osd-crypt-close-3", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "node-b", job.Spec.Template.Spec.NodeSelector[k8sutil.LabelHostname()])
+
+		// idempotent: re-running replaces the job without error
+		err = c.startCryptCloseJob(3, "node-b")
+		assert.NoError(t, err)
+	})
+
+	t.Run("replaces an already-active job re-pinned to a different node", func(t *testing.T) {
+		// A stale, still-running Job pinned to the wrong node must be replaced (deleteIfFound=true),
+		// not left in place. This is the active-Job branch of RunReplaceableJob.
+		existing := &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "rook-ceph-osd-crypt-close-3", Namespace: "rook-ceph"},
+			Spec: batch.JobSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{NodeSelector: map[string]string{k8sutil.LabelHostname(): "old-node"}},
+				},
+			},
+			Status: batch.JobStatus{Active: 1},
+		}
+		clientset := fake.NewClientset(existing)
+		c := newTestReplaceCluster(clientset)
+
+		err := c.startCryptCloseJob(3, "new-node")
+		require.NoError(t, err)
+
+		job, err := clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), "rook-ceph-osd-crypt-close-3", metav1.GetOptions{})
+		require.NoError(t, err)
+		// the replacement Job is pinned to the new node, proving the active job was replaced
+		assert.Equal(t, "new-node", job.Spec.Template.Spec.NodeSelector[k8sutil.LabelHostname()])
+	})
+}
+
+func TestCryptCloseJobStatusForOSD(t *testing.T) {
+	jobName := "rook-ceph-osd-crypt-close-4"
+
+	t.Run("not found", func(t *testing.T) {
+		c := newTestReplaceCluster(fake.NewClientset())
+		status, err := c.cryptCloseJobStatusForOSD(4)
+		assert.NoError(t, err)
+		assert.Equal(t, cryptCloseJobNotFound, status)
+	})
+
+	t.Run("running", func(t *testing.T) {
+		job := &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: "rook-ceph"},
+			Status:     batch.JobStatus{Active: 1},
+		}
+		c := newTestReplaceCluster(fake.NewClientset(job))
+		status, err := c.cryptCloseJobStatusForOSD(4)
+		assert.NoError(t, err)
+		assert.Equal(t, cryptCloseJobRunning, status)
+	})
+
+	t.Run("succeeded", func(t *testing.T) {
+		job := &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: "rook-ceph"},
+			Status:     batch.JobStatus{Succeeded: 1},
+		}
+		c := newTestReplaceCluster(fake.NewClientset(job))
+		status, err := c.cryptCloseJobStatusForOSD(4)
+		assert.NoError(t, err)
+		assert.Equal(t, cryptCloseJobSucceeded, status)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		job := &batch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: "rook-ceph"},
+			Status: batch.JobStatus{
+				Conditions: []batch.JobCondition{
+					{Type: batch.JobFailed, Status: v1.ConditionTrue},
+				},
+			},
+		}
+		c := newTestReplaceCluster(fake.NewClientset(job))
+		status, err := c.cryptCloseJobStatusForOSD(4)
+		assert.NoError(t, err)
+		assert.Equal(t, cryptCloseJobFailed, status)
+	})
+}
+
+func TestDeleteCryptCloseJob(t *testing.T) {
+	osdID := 9
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "rook-ceph-osd-crypt-close-" + strconv.Itoa(osdID), Namespace: "rook-ceph"},
+	}
+	clientset := fake.NewClientset(job)
+	c := newTestReplaceCluster(clientset)
+
+	err := c.deleteCryptCloseJob(osdID)
+	assert.NoError(t, err)
+
+	// idempotent: deleting a non-existent job is a no-op
+	err = c.deleteCryptCloseJob(osdID)
+	assert.NoError(t, err)
+}

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestReplaceCluster(clientset *fake.Clientset) *Cluster {
+	return newTestReplaceClusterWithSpec(clientset, cephv1.ClusterSpec{})
+}
+
+func newTestReplaceClusterWithSpec(clientset *fake.Clientset, spec cephv1.ClusterSpec) *Cluster {
+	clusterInfo := &cephclient.ClusterInfo{
+		Namespace: "rook-ceph",
+		Context:   context.TODO(),
+		OwnerInfo: cephclient.NewMinimumOwnerInfoWithOwnerRef(),
+	}
+	clusterInfo.SetName("test")
+	c := &clusterd.Context{Clientset: clientset}
+	return &Cluster{
+		context:     c,
+		clusterInfo: clusterInfo,
+		rookVersion: "rook/ceph:test",
+		spec:        spec,
+	}
+}


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

3 part of 6-part stacked PR.

## Description

entry point for crypto-close job. Crypto mappings have to be closed after encrypted OSD is destroyed. this command can be executed only on host. 


## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866