### PR TITLE
osd-replacement-4: implement osd replacement controller

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -26,6 +26,17 @@ import (
 const (
 	// SkipReconcileLabelKey is a label indicating that the pod should not be reconciled
 	SkipReconcileLabelKey = "ceph.rook.io/do-not-reconcile"
+
+	// ReplaceOSDAnnotationKey is set by a user on an OSD Deployment to trigger its replacement.
+	ReplaceOSDAnnotationKey = "osd.rook.io/replace"
+
+	// ReplaceOSDAnnotationValueFmt is the required value of ReplaceOSDAnnotationKey, where %d is the
+	// OSD id (must match the Deployment's id, as a confirmation guard). E.g. "yes-really-replace-osd-3".
+	ReplaceOSDAnnotationValueFmt = "yes-really-replace-osd-%d"
+
+	// ReadyForSwapOSDAnnotationKey is set by Rook on the OSD Deployment once the OSD is destroyed and
+	// the disk may be physically swapped. E.g. "osd.rook.io/replace-ready-for-swap": "true".
+	ReadyForSwapOSDAnnotationKey = "osd.rook.io/replace-ready-for-swap"
 )
 
 // LabelsSpec is the main spec label for all daemons

--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -92,9 +92,22 @@ func (c *createConfig) createNewOSDsFromStatus(
 
 	for i, osd := range status.OSDs {
 		if c.deployments.Exists(osd.ID) {
-			// This OSD will be handled by the updater
-			log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
-			continue
+			// A reprovisioned replacement is held as a scaled-to-zero marker Deployment; delete it here
+			// so the create flow below rebuilds it fresh from the status CM.
+			readyToRecreate, err := c.cluster.replacementReadyForSwap(osd.ID)
+			if err != nil {
+				errs.addError("%v", errors.Wrapf(err, "failed to check if replaced OSD %d is ready to recreate", osd.ID))
+				continue
+			}
+			if !readyToRecreate {
+				log.NamespacedDebug(c.cluster.clusterInfo.Namespace, logger, "not creating deployment for OSD %d which already exists", osd.ID)
+				continue
+			}
+			log.NamespacedInfo(c.cluster.clusterInfo.Namespace, logger, "replaced OSD %d is reprovisioned; deleting the marker deployment to recreate it from the status", osd.ID)
+			if err := c.cluster.deleteOSDDeployment(osd.ID); err != nil {
+				errs.addError("%v", errors.Wrapf(err, "failed to delete the marker deployment for replaced OSD %d", osd.ID))
+				continue
+			}
 		}
 
 		// osd prepare jobs don't generate cephx status info for OSDs. since this is a new OSD

--- a/pkg/operator/ceph/cluster/osd/create_test.go
+++ b/pkg/operator/ceph/cluster/osd/create_test.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -28,7 +29,10 @@ import (
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,6 +173,42 @@ func Test_createNewOSDsFromStatus(t *testing.T) {
 		assert.Equal(t, 4, awaitingStatusConfigMaps.Len())
 		assert.Equal(t, 1, createConfig.finishedStatusConfigMaps.Len())
 		assert.True(t, createConfig.finishedStatusConfigMaps.Has(statusNameNode0))
+	})
+
+	t.Run("node: finished replacement marker is deleted and OSD recreated", func(t *testing.T) {
+		// OSD 6 already has a deployment (in the existence list). Make it a finished-replacement
+		// marker: scaled to zero, carrying the replace-ready-for-swap annotation. The create path
+		// must delete the marker and recreate the OSD from the reprovisioned status.
+		zeroReplicas := int32(0)
+		marker := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        fmt.Sprintf(osdAppNameFmt, 6),
+				Namespace:   namespace,
+				Annotations: map[string]string{cephv1.ReadyForSwapOSDAnnotationKey: ""},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: &zeroReplicas},
+		}
+		_, err := clientset.AppsV1().Deployments(namespace).Create(context.TODO(), marker, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer func() {
+			_ = clientset.AppsV1().Deployments(namespace).Delete(context.TODO(), marker.Name, metav1.DeleteOptions{})
+		}()
+
+		doSetup()
+		status = &OrchestrationStatus{
+			OSDs: []OSDInfo{
+				{ID: 3}, // exists, not a replacement -> skipped
+				{ID: 6}, // finished replacement -> marker deleted, recreated
+			},
+			PvcBackedOSD: false,
+		}
+		createConfig.createNewOSDsFromStatus(status, "node0", errs)
+		assert.Zero(t, errs.len())
+		// OSD 6 is recreated; OSD 3 is left to the updater
+		assert.ElementsMatch(t, createCallsOnNode, []int{6})
+		// the marker deployment was deleted
+		_, err = clientset.AppsV1().Deployments(namespace).Get(context.TODO(), marker.Name, metav1.GetOptions{})
+		assert.True(t, kerrors.IsNotFound(err))
 	})
 
 	t.Run("node: skip creating OSDs for status configmaps that weren't created for this reconcile", func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -283,6 +283,12 @@ func (c *Cluster) Start() error {
 	}
 	log.NamespacedInfo(c.clusterInfo.Namespace, logger, "wait timeout for healthy OSDs during upgrade or restart is %q", c.clusterInfo.OsdUpgradeTimeout)
 
+	// Entry point for OSD replacement. Must run before GetDaemonsToSkipReconcile below so an OSD
+	// labeled in this reconcile is included in the skip-reconcile snapshot.
+	if err := c.validateAndStartOSDReplacement(); err != nil {
+		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to process OSD replacement requests. %v", err)
+	}
+
 	osdsToSkipReconcile, err := controller.GetDaemonsToSkipReconcile(c.clusterInfo.Context, c.context, c.clusterInfo.Namespace, OsdIdLabelKey, AppName)
 	if err != nil {
 		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to get osds to skip reconcile. %v", err)

--- a/pkg/operator/ceph/cluster/osd/replace.go
+++ b/pkg/operator/ceph/cluster/osd/replace.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
+	appsv1 "k8s.io/api/apps/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// validateAndStartOSDReplacement acts on annotated OSD deployments for replacements. Validates request and
+// adds do-not-reconcile label to hand over the process to OSD health monitor.
+func (c *Cluster) validateAndStartOSDReplacement() error {
+	deployments, err := c.getOSDDeployments()
+	if err != nil {
+		return errors.Wrap(err, "failed to list OSD deployments to check for replacement requests")
+	}
+
+	var osdTree *cephclient.OsdTree
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
+
+		replaceValue, requested := d.Annotations[cephv1.ReplaceOSDAnnotationKey]
+		if !requested {
+			// skip: dont have replace annotation
+			continue
+		}
+
+		// Already labeled: validated, and the goroutine owns it now.
+		if d.Labels[cephv1.SkipReconcileLabelKey] == "true" {
+			continue
+		}
+
+		// Fetch the osd tree only once a replacement needs validating; it carries the "destroyed"
+		// status that `ceph osd dump` does not.
+		if osdTree == nil {
+			tree, err := cephclient.HostTree(c.context, c.clusterInfo)
+			if err != nil {
+				return errors.Wrap(err, "failed to get osd tree to validate replacement requests")
+			}
+			osdTree = &tree
+		}
+
+		if err := c.validateReplaceOSD(d, replaceValue, osdTree); err != nil {
+			// Skip the OSD; without the label it keeps reconciling normally.
+			log.NamespacedWarning(c.clusterInfo.Namespace, logger,
+				"skipping OSD replacement request on deployment %q: %v", d.Name, err)
+			continue
+		}
+
+		// Setting the skip-reconcile label here as a marker of successful validation.
+		// The rest (osd drain and destroy) will be handled by OSD health goroutine.
+		k8sutil.AddLabelToDeployment(cephv1.SkipReconcileLabelKey, "true", d)
+		_, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Update(c.clusterInfo.Context, d, metav1.UpdateOptions{})
+		if err != nil {
+			log.NamespacedWarning(c.clusterInfo.Namespace, logger,
+				"failed to set %q label on OSD deployment %q for replacement: %v",
+				cephv1.SkipReconcileLabelKey, d.Name, err)
+			continue
+		}
+
+		log.NamespacedInfo(c.clusterInfo.Namespace, logger,
+			"validated OSD replacement request on deployment %q and set the %q label; OSD health monitor will drive teardown",
+			d.Name, cephv1.SkipReconcileLabelKey)
+	}
+
+	return nil
+}
+
+// validateReplaceOSD returns an error on the first failed validation check for a replacement request.
+func (c *Cluster) validateReplaceOSD(d *appsv1.Deployment, replaceValue string, osdTree *cephclient.OsdTree) error {
+	// The annotation value must match the deployment's own OSD id, guarding against a copy-paste typo.
+	osdID, err := GetOSDID(d)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %q label", OsdIdLabelKey)
+	}
+	expected := fmt.Sprintf(cephv1.ReplaceOSDAnnotationValueFmt, osdID)
+	if replaceValue != expected {
+		return errors.Errorf("annotation %q value %q does not match the deployment's OSD id (expected %q)",
+			cephv1.ReplaceOSDAnnotationKey, replaceValue, expected)
+	}
+
+	// Host-based only: PVC-backed OSDs are out of scope.
+	if _, isPVC := d.Labels[OSDOverPVCLabelKey]; isPVC {
+		return errors.Errorf("OSD %d is PVC-backed (label %q present); replacement supports host-based OSDs only",
+			osdID, OSDOverPVCLabelKey)
+	}
+
+	// Target OSD must exist in the osd tree. An already-destroyed slot is accepted so the goroutine
+	// can resume idempotently from its destroyed phase.
+	found := false
+	for _, node := range osdTree.Nodes {
+		if node.Type != "osd" || node.ID != osdID {
+			continue
+		}
+		found = true
+		break // osd ids are unique in the tree
+	}
+	if !found {
+		return errors.Errorf("OSD %d does not exist in the osd tree", osdID)
+	}
+
+	return nil
+}
+
+func (c *Cluster) replacementReadyForSwap(osdID int) (bool, error) {
+	name := fmt.Sprintf(osdAppNameFmt, osdID)
+	d, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Get(c.clusterInfo.Context, name, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "failed to get OSD deployment %q", name)
+	}
+	if _, readyForSwap := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]; !readyForSwap {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -18,10 +18,19 @@ package osd
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -43,4 +52,151 @@ func newTestReplaceClusterWithSpec(clientset *fake.Clientset, spec cephv1.Cluste
 		rookVersion: "rook/ceph:test",
 		spec:        spec,
 	}
+}
+
+// osdTreeJSON builds an `osd tree` response containing one osd-type node per given id->status pair.
+func osdTreeJSON(osds map[int]string) string {
+	nodes := ""
+	for id, status := range osds {
+		if nodes != "" {
+			nodes += ","
+		}
+		nodes += fmt.Sprintf(`{"id":%d,"name":"osd.%d","type":"osd","type_id":0,"exists":1,"status":%q}`, id, id, status)
+	}
+	return fmt.Sprintf(`{"nodes":[%s],"stray":[]}`, nodes)
+}
+
+func newReplaceClusterWithTree(clientset *fake.Clientset, osds map[int]string) *Cluster {
+	c := newTestReplaceCluster(clientset)
+	c.context.Executor = &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "tree" {
+				return osdTreeJSON(osds), nil
+			}
+			return "", nil
+		},
+	}
+	return c
+}
+
+func osdDeployment(osdID int, annotations, labels map[string]string) *appsv1.Deployment {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[k8sutil.AppAttr] = AppName
+	labels[OsdIdLabelKey] = strconv.Itoa(osdID)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf(osdAppNameFmt, osdID),
+			Namespace:   "rook-ceph",
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestValidateAndStartOSDReplacement(t *testing.T) {
+	getDep := func(c *Cluster, osdID int) *appsv1.Deployment {
+		d, err := c.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), fmt.Sprintf(osdAppNameFmt, osdID), metav1.GetOptions{})
+		require.NoError(t, err)
+		return d
+	}
+
+	t.Run("valid request gets fenced", func(t *testing.T) {
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.Equal(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+
+	t.Run("id mismatch is rejected and not fenced", func(t *testing.T) {
+		// annotation says osd 6 but the deployment is osd 5
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-6"}, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.NotEqual(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+
+	t.Run("PVC-backed OSD is rejected and not fenced", func(t *testing.T) {
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"},
+			map[string]string{OSDOverPVCLabelKey: "set1-0"})
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.NotEqual(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+
+	t.Run("already-destroyed OSD is accepted and fenced", func(t *testing.T) {
+		// A rare state (manual destroy, or fence cleared mid-flow): accept it so the goroutine can
+		// resume idempotently from its destroyed phase rather than rejecting a partway teardown.
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{5: "destroyed"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.Equal(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+
+	t.Run("nonexistent OSD is rejected and not fenced", func(t *testing.T) {
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{7: "up"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.NotEqual(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+
+	t.Run("deployment without the annotation is ignored", func(t *testing.T) {
+		dep := osdDeployment(5, nil, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
+
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
+	})
+
+	t.Run("already-fenced deployment is left untouched", func(t *testing.T) {
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"},
+			map[string]string{cephv1.SkipReconcileLabelKey: "true"})
+		clientset := fake.NewClientset(dep)
+		c := newTestReplaceCluster(clientset)
+		// no executor: an already-fenced OSD must not trigger an osd tree lookup
+		require.NoError(t, c.validateAndStartOSDReplacement())
+		assert.Equal(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
+	})
+}
+
+func TestReplacementReadyToRecreate(t *testing.T) {
+	withReplicas := func(d *appsv1.Deployment, n int32) *appsv1.Deployment {
+		d.Spec.Replicas = &n
+		return d
+	}
+
+	t.Run("ready-for-swap annotation present and scaled to zero", func(t *testing.T) {
+		dep := withReplicas(osdDeployment(5, map[string]string{cephv1.ReadyForSwapOSDAnnotationKey: ""}, nil), 0)
+		c := newTestReplaceCluster(fake.NewClientset(dep))
+		ready, err := c.replacementReadyForSwap(5)
+		require.NoError(t, err)
+		assert.True(t, ready)
+	})
+
+	t.Run("annotation absent", func(t *testing.T) {
+		dep := withReplicas(osdDeployment(5, nil, nil), 0)
+		c := newTestReplaceCluster(fake.NewClientset(dep))
+		ready, err := c.replacementReadyForSwap(5)
+		require.NoError(t, err)
+		assert.False(t, ready)
+	})
+
+	t.Run("deployment missing is not an error", func(t *testing.T) {
+		c := newTestReplaceCluster(fake.NewClientset())
+		ready, err := c.replacementReadyForSwap(5)
+		require.NoError(t, err)
+		assert.False(t, ready)
+	})
 }

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -250,6 +250,12 @@ func WatchPredicateForNonCRDObject[T client.Object](owner runtime.Object, scheme
 					}
 
 				case *appsv1.Deployment:
+					// Deployment updates are otherwise ignored below, so let a new/changed OSD replace
+					// annotation through to the controller.
+					if replaceOSDAnnotationAddedOrChanged(e.ObjectOld, e.ObjectNew) {
+						logger.Infof("reconcile due to added or changed %q annotation on deployment %q", cephv1.ReplaceOSDAnnotationKey, objectName)
+						return true
+					}
 					// If the resource is a deployment we don't reconcile
 					logger.Debug("do not reconcile deployments updates")
 					return false
@@ -420,6 +426,21 @@ func isSecretToIgnoreOnUpdate(secret *corev1.Secret) bool {
 	}
 
 	return false
+}
+
+// replaceOSDAnnotationAddedOrChanged reports whether ReplaceOSDAnnotationKey was newly set or had its
+// value changed. Firing on a value change lets a user correct a typo'd id in place; the operator
+// never writes this annotation, so any change is user-initiated.
+func replaceOSDAnnotationAddedOrChanged(oldObj, newObj client.Object) bool {
+	if oldObj == nil || newObj == nil {
+		return false
+	}
+	oldValue, hadBefore := oldObj.GetAnnotations()[cephv1.ReplaceOSDAnnotationKey]
+	newValue, hasNow := newObj.GetAnnotations()[cephv1.ReplaceOSDAnnotationKey]
+	if !hasNow {
+		return false
+	}
+	return !hadBefore || oldValue != newValue
 }
 
 func IsDoNotReconcile(labels map[string]string) bool {

--- a/pkg/operator/ceph/controller/predicate_test.go
+++ b/pkg/operator/ceph/controller/predicate_test.go
@@ -195,6 +195,45 @@ func TestIsSecretToIgnoreOnUpdate(t *testing.T) {
 	assert.True(t, isSecretToIgnoreOnUpdate(s))
 }
 
+func TestReplaceOSDAnnotationAddedOrChanged(t *testing.T) {
+	dep := func(annotations map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "rook-ceph-osd-5", Annotations: annotations}}
+	}
+
+	t.Run("annotation newly added triggers", func(t *testing.T) {
+		old := dep(nil)
+		newObj := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"})
+		assert.True(t, replaceOSDAnnotationAddedOrChanged(old, newObj))
+	})
+
+	t.Run("annotation value changed triggers", func(t *testing.T) {
+		// a user correcting a typo'd value in place must be acted upon
+		old := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-9"})
+		newObj := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"})
+		assert.True(t, replaceOSDAnnotationAddedOrChanged(old, newObj))
+	})
+
+	t.Run("annotation present with unchanged value does not trigger", func(t *testing.T) {
+		old := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"})
+		newObj := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5", "other": "x"})
+		assert.False(t, replaceOSDAnnotationAddedOrChanged(old, newObj))
+	})
+
+	t.Run("annotation removed does not trigger", func(t *testing.T) {
+		old := dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"})
+		newObj := dep(nil)
+		assert.False(t, replaceOSDAnnotationAddedOrChanged(old, newObj))
+	})
+
+	t.Run("no annotation either way does not trigger", func(t *testing.T) {
+		assert.False(t, replaceOSDAnnotationAddedOrChanged(dep(nil), dep(map[string]string{"unrelated": "y"})))
+	})
+
+	t.Run("nil objects do not trigger", func(t *testing.T) {
+		assert.False(t, replaceOSDAnnotationAddedOrChanged(nil, dep(map[string]string{cephv1.ReplaceOSDAnnotationKey: "x"})))
+	})
+}
+
 func TestIsDoNotReconcile(t *testing.T) {
 	l := map[string]string{
 		"foo": "bar",


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

4 part of 6-part stacked PR.

## Description

adjust cluster controller to handle replace osd annotation on osd deployment. controller does quick validation and adds skip-reconcile label to delegeate the rest of the flow to osd health goroutine.


## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866