### PR TITLE
osd-replacement-5: implement osd replacement health goroutine

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -320,6 +320,42 @@ func (tree OsdTree) GetDestroyedIDs() []int {
 	return destroyed
 }
 
+func OSDOut(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) error {
+	args := []string{"osd", "out", strconv.Itoa(osdID)}
+	cmd := NewCephCommand(context, clusterInfo, args)
+	if _, err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to mark osd.%d out", osdID)
+	}
+	return nil
+}
+
+func OSDIn(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) error {
+	args := []string{"osd", "in", strconv.Itoa(osdID)}
+	cmd := NewCephCommand(context, clusterInfo, args)
+	if _, err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to mark osd.%d in", osdID)
+	}
+	return nil
+}
+
+func OSDDown(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) error {
+	args := []string{"osd", "down", strconv.Itoa(osdID)}
+	cmd := NewCephCommand(context, clusterInfo, args)
+	if _, err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to mark osd.%d down", osdID)
+	}
+	return nil
+}
+
+func OSDDestroy(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) error {
+	args := []string{"osd", "destroy", fmt.Sprintf("osd.%d", osdID), confirmFlag}
+	cmd := NewCephCommand(context, clusterInfo, args)
+	if _, err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to destroy osd.%d", osdID)
+	}
+	return nil
+}
+
 // OsdListNum returns the list of OSDs
 func OsdListNum(context *clusterd.Context, clusterInfo *ClusterInfo) (OsdList, error) {
 	var output OsdList

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -124,6 +124,53 @@ func TestGetDestroyedIDs(t *testing.T) {
 	assert.Empty(t, tree.GetDestroyedIDs())
 }
 
+func TestOSDLifecycleHelpers(t *testing.T) {
+	var gotArgs []string
+	failNext := false
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			gotArgs = args
+			if failNext {
+				return "", errors.New("boom")
+			}
+			return "", nil
+		},
+	}
+	ctx := &clusterd.Context{Executor: executor}
+	info := AdminTestClusterInfo("mycluster")
+	// the ceph command appends global flags (--cluster, --conf, ...); assert only the leading args.
+	hasPrefix := func(prefix ...string) bool {
+		if len(gotArgs) < len(prefix) {
+			return false
+		}
+		for i, p := range prefix {
+			if gotArgs[i] != p {
+				return false
+			}
+		}
+		return true
+	}
+
+	assert.NoError(t, OSDOut(ctx, info, 5))
+	assert.True(t, hasPrefix("osd", "out", "5"), "got %v", gotArgs)
+
+	assert.NoError(t, OSDIn(ctx, info, 5))
+	assert.True(t, hasPrefix("osd", "in", "5"), "got %v", gotArgs)
+
+	assert.NoError(t, OSDDown(ctx, info, 5))
+	assert.True(t, hasPrefix("osd", "down", "5"), "got %v", gotArgs)
+
+	assert.NoError(t, OSDDestroy(ctx, info, 5))
+	assert.True(t, hasPrefix("osd", "destroy", "osd.5", "--yes-i-really-mean-it"), "got %v", gotArgs)
+
+	// error propagation
+	failNext = true
+	assert.Error(t, OSDOut(ctx, info, 5))
+	assert.Error(t, OSDIn(ctx, info, 5))
+	assert.Error(t, OSDDown(ctx, info, 5))
+	assert.Error(t, OSDDestroy(ctx, info, 5))
+}
+
 func TestOsdListNum(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyOsdListNumResult := false

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -91,7 +91,7 @@ func (c *ClusterController) startMonitoringCheck(cluster *cluster, clusterInfo *
 
 	case "osd":
 		if !cluster.Spec.External.Enable {
-			osdChecker := osd.NewOSDHealthMonitor(c.context, clusterInfo, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Spec.HealthCheck)
+			osdChecker := osd.NewOSDHealthMonitor(c.context, clusterInfo, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Spec.HealthCheck, *cluster.Spec, c.rookImage)
 			log.NamespacedInfo(cluster.Namespace, logger, "enabling ceph %s monitoring goroutine", daemon)
 			go osdChecker.Start(&cluster.monitoringRoutines, daemon)
 		}

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -47,15 +47,21 @@ type OSDHealthMonitor struct {
 	removeOSDsIfOUTAndSafeToRemove bool
 	interval                       *time.Duration
 	lastRequireOSDRelease          string
+	// cluster is reused for its OSD-management methods: getOSDDeployments, getOSDInfo, and the
+	// crypto-close Job builder. getOSDInfo reads the CRUSH root from the spec and makeCryptCloseJob
+	// reads spec.Placement, spec.PriorityClassNames, spec.Storage.OnlyApplyOSDPlacement and the rook
+	// image, so it holds the ClusterSpec captured when the monitor was created.
+	cluster *Cluster
 }
 
 // NewOSDHealthMonitor instantiates OSD monitoring
-func NewOSDHealthMonitor(context *clusterd.Context, clusterInfo *client.ClusterInfo, removeOSDsIfOUTAndSafeToRemove bool, healthCheck cephv1.CephClusterHealthCheckSpec) *OSDHealthMonitor {
+func NewOSDHealthMonitor(context *clusterd.Context, clusterInfo *client.ClusterInfo, removeOSDsIfOUTAndSafeToRemove bool, healthCheck cephv1.CephClusterHealthCheckSpec, spec cephv1.ClusterSpec, rookImage string) *OSDHealthMonitor {
 	h := &OSDHealthMonitor{
 		context:                        context,
 		clusterInfo:                    clusterInfo,
 		removeOSDsIfOUTAndSafeToRemove: removeOSDsIfOUTAndSafeToRemove,
 		interval:                       &defaultHealthCheckInterval,
+		cluster:                        New(context, clusterInfo, spec, rookImage),
 	}
 
 	// allow overriding the check interval
@@ -99,8 +105,13 @@ func (m *OSDHealthMonitor) Update(removeOSDsIfOUTAndSafeToRemove bool) {
 
 // checkOSDHealth takes action when needed if the OSDs are not healthy
 func (m *OSDHealthMonitor) checkOSDHealth() {
-	err := m.checkOSDDump()
+	// Drive the OSD-replacement destroy flow for marked OSDs; exclude the returned OSDs from normal health monitoring.
+	osdsUnderReplacement, err := m.processOSDsDestroyForReplacement()
 	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger, "failed to process OSD replacements. %v", err)
+	}
+
+	if err := m.checkOSDDump(osdsUnderReplacement); err != nil {
 		log.NamespacedDebug(m.clusterInfo.Namespace, logger, "failed to check OSD Dump. %v", err)
 	}
 	m.checkRequireOSDRelease()
@@ -143,7 +154,8 @@ func (m *OSDHealthMonitor) checkRequireOSDRelease() {
 	}
 }
 
-func (m *OSDHealthMonitor) checkOSDDump() error {
+// osdsUnderReplacement are owned by the OSD-replacement destroy flow and skipped here.
+func (m *OSDHealthMonitor) checkOSDDump(osdsUnderReplacement map[int]struct{}) error {
 	osdDump, err := client.GetOSDDump(m.context, m.clusterInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to get osd dump")
@@ -155,6 +167,11 @@ func (m *OSDHealthMonitor) checkOSDDump() error {
 			continue
 		}
 		id := int(id64)
+
+		if _, replacing := osdsUnderReplacement[id]; replacing {
+			log.NamespacedDebug(m.clusterInfo.Namespace, logger, "skipping normal health processing for osd.%d under replacement", id)
+			continue
+		}
 
 		log.NamespacedDebug(m.clusterInfo.Namespace, logger, "validating status of osd.%d", id)
 

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -18,7 +18,6 @@ package osd
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -86,10 +85,10 @@ func TestOSDHealthCheck(t *testing.T) {
 	assert.Equal(t, 1, len(dp.Items))
 
 	// Initializing an OSD monitoring
-	osdMon := NewOSDHealthMonitor(context, clusterInfo, true, cephv1.CephClusterHealthCheckSpec{})
+	osdMon := NewOSDHealthMonitor(context, clusterInfo, true, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/ceph:test")
 
 	// Run OSD monitoring routine
-	err := osdMon.checkOSDDump()
+	err := osdMon.checkOSDDump(nil)
 	assert.Nil(t, err)
 	// After creating an OSD, the dump has 1 mocked cmd and safe to destroy has 1 mocked cmd
 	assert.Equal(t, 2, execCount)
@@ -107,7 +106,7 @@ func TestMonitorStart(t *testing.T) {
 		InternalCancel: cancel,
 	})
 
-	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, client.AdminTestClusterInfo("ns"), true, cephv1.CephClusterHealthCheckSpec{})
+	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, client.AdminTestClusterInfo("ns"), true, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/ceph:test")
 	logger.Infof("starting osd monitor")
 	go osdMon.Start(&monitoringRoutines, "osd")
 	cancel()
@@ -123,18 +122,23 @@ func TestNewOSDHealthMonitor(t *testing.T) {
 		healthCheck                    cephv1.CephClusterHealthCheckSpec
 	}
 	tests := []struct {
-		name string
-		args args
-		want *OSDHealthMonitor
+		name         string
+		args         args
+		wantInterval *time.Duration
 	}{
-		{"default-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{}}, &OSDHealthMonitor{c, clusterInfo, false, &defaultHealthCheckInterval, ""}},
-		{"10s-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{DaemonHealth: cephv1.DaemonHealthSpec{ObjectStorageDaemon: cephv1.HealthCheckSpec{Interval: &metav1.Duration{Duration: time10s}}}}}, &OSDHealthMonitor{c, clusterInfo, false, &time10s, ""}},
+		{"default-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{}}, &defaultHealthCheckInterval},
+		{"10s-interval", args{c, false, cephv1.CephClusterHealthCheckSpec{DaemonHealth: cephv1.DaemonHealthSpec{ObjectStorageDaemon: cephv1.HealthCheckSpec{Interval: &metav1.Duration{Duration: time10s}}}}}, &time10s},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewOSDHealthMonitor(tt.args.context, clusterInfo, tt.args.removeOSDsIfOUTAndSafeToRemove, tt.args.healthCheck); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewOSDHealthMonitor() = %v, want %v", got, tt.want)
-			}
+			got := NewOSDHealthMonitor(tt.args.context, clusterInfo, tt.args.removeOSDsIfOUTAndSafeToRemove, tt.args.healthCheck, cephv1.ClusterSpec{}, "rook/ceph:test")
+			assert.Equal(t, tt.args.context, got.context)
+			assert.Equal(t, clusterInfo, got.clusterInfo)
+			assert.Equal(t, tt.args.removeOSDsIfOUTAndSafeToRemove, got.removeOSDsIfOUTAndSafeToRemove)
+			assert.Equal(t, tt.wantInterval, got.interval)
+			assert.Equal(t, "", got.lastRequireOSDRelease)
+			// The monitor must build a Cluster so it can drive the replacement state machine.
+			assert.NotNil(t, got.cluster)
 		})
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -383,7 +383,7 @@ func TestAddRemoveNode(t *testing.T) {
 	assert.NoError(t, err)
 
 	removeIfOutAndSafeToRemove := true
-	healthMon := NewOSDHealthMonitor(context, cephclient.AdminTestClusterInfo(namespace), removeIfOutAndSafeToRemove, cephv1.CephClusterHealthCheckSpec{})
+	healthMon := NewOSDHealthMonitor(context, cephclient.AdminTestClusterInfo(namespace), removeIfOutAndSafeToRemove, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/ceph:test")
 	healthMon.checkOSDHealth()
 	_, err = clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName(1), metav1.GetOptions{})
 	assert.True(t, k8serrors.IsNotFound(err))

--- a/pkg/operator/ceph/cluster/osd/replace_destroy.go
+++ b/pkg/operator/ceph/cluster/osd/replace_destroy.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// processOSDsDestroyForReplacement runs the OSD-replacement destroy flow, a long-running process spread across
+// health ticks: it marks each replacement-marked OSD out, drains and destroys it, then annotates the
+// fully-destroyed OSD as ready-for-swap to signal the user to swap the disk. Everything after the
+// swap is handled by the prepare job.
+//
+// Called from OSD health goroutine. Returns owned OSD ids to ignore from normal OSD health goroutine flow.
+func (m *OSDHealthMonitor) processOSDsDestroyForReplacement() (map[int]struct{}, error) {
+	osdsUnderReplacement := map[int]struct{}{}
+
+	// OSD replacement is host-based only; on a PVC-backed cluster there is nothing to process, so
+	// skip the per-tick listing of all OSD deployments to avoid a needless scan every health tick.
+	if len(m.cluster.spec.Storage.StorageClassDeviceSets) > 0 {
+		return osdsUnderReplacement, nil
+	}
+
+	deployments, err := m.cluster.getOSDDeployments()
+	if err != nil {
+		return osdsUnderReplacement, errors.Wrap(err, "failed to list OSD deployments for replacement processing")
+	}
+
+	// Collect the replacement-marked deployments. Every one (incl. ready-for-swap) goes into the
+	// exclusion set, but only those with work left are processed below: a deployment without the
+	// do-not-reconcile label is not owned by this function, and one already annotated ready-for-swap is done.
+	var toProcess []*appsv1.Deployment
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
+		if d.Labels[cephv1.SkipReconcileLabelKey] != "true" {
+			continue
+		}
+
+		osdID, err := GetOSDID(d)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"skipping replacement processing for deployment %q: %v", d.Name, err)
+			continue
+		}
+
+		osdsUnderReplacement[osdID] = struct{}{}
+		if _, readyForSwap := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]; readyForSwap {
+			// already processed
+			continue
+		}
+		toProcess = append(toProcess, d)
+	}
+
+	if len(toProcess) == 0 {
+		return osdsUnderReplacement, nil
+	}
+
+	tree, err := cephclient.HostTree(m.context, m.clusterInfo)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed to get osd tree for replacement processing; will retry next tick. %v", err)
+		return osdsUnderReplacement, nil
+	}
+	osdDump, err := cephclient.GetOSDDump(m.context, m.clusterInfo)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed to get osd dump for replacement processing; will retry next tick. %v", err)
+		return osdsUnderReplacement, nil
+	}
+
+	for _, d := range toProcess {
+		osdID, _ := GetOSDID(d) // already validated above
+		if err := m.processOSDReplacementDestroy(d, osdID, &tree, osdDump); err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"failed to advance replacement for osd.%d; will retry next tick. %v", osdID, err)
+		}
+	}
+
+	return osdsUnderReplacement, nil
+}
+
+// processOSDReplacementDestroy advances one replacement-marked OSD's destroy flow from durable markers on every
+// OSD heath tick
+func (m *OSDHealthMonitor) processOSDReplacementDestroy(d *appsv1.Deployment, osdID int, osdTree *cephclient.OsdTree, osdDump *cephclient.OSDDump) error {
+	_, isReplaceRequested := d.Annotations[cephv1.ReplaceOSDAnnotationKey]
+	isDestroyed := isOSDDestroyedInTree(osdTree, osdID)
+	isDownscaled := d.Spec.Replicas != nil && *d.Spec.Replicas == 0
+
+	// Cancellation: the replace annotation was removed. Honored only before the slot is destroyed —
+	// once destroyed, the Ceph state cannot be cheaply reversed, so the flow completes instead. Kept
+	// ahead of every query so a cancellation can always mark the OSD back in.
+	if !isReplaceRequested && !isDestroyed {
+		return m.cancelReplaceOSD(d, osdID)
+	}
+
+	// Slot already destroyed: annotate ready-for-swap to signal the user.
+	if isDestroyed {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+			"osd.%d is destroyed; annotating deployment %q as ready for swap", osdID, d.Name)
+		return m.annotateReadyForSwap(d, osdID)
+	}
+
+	if isDownscaled {
+		gone, err := m.isOSDPodGone(osdID)
+		if err != nil {
+			return err
+		}
+		if !gone {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"osd.%d is scaled down; waiting for the pod to terminate before destroying", osdID)
+			return nil
+		}
+		// Pod is gone, run job to close crypto mappings on host for encrypted OSDs only.
+		isEncrypted, err := m.isReplaceOSDEncrypted(d)
+		if err != nil {
+			return err
+		}
+		if isEncrypted {
+			// run job or check status
+			done, err := m.runCryptCloseJobForOSD(d, osdID)
+			if err != nil {
+				return err
+			}
+			if !done {
+				return nil
+			}
+			// if job done. delete right away and proceed to osd-destroy.
+			if err := m.cluster.deleteCryptCloseJob(osdID); err != nil {
+				return errors.Wrapf(err, "failed to delete crypto-close job for osd.%d", osdID)
+			}
+		}
+		// double check safe-to-destroy before destroy
+		safe, err := cephclient.OsdSafeToDestroy(m.context, m.clusterInfo, osdID)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"failed to check safe-to-destroy for osd.%d; will re-check next tick. %v", osdID, err)
+			return nil
+		}
+		if !safe {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"osd.%d is not yet safe-to-destroy; will re-check next tick", osdID)
+			return nil
+		}
+		// force the mon view to down to dodge a heartbeat-lag EBUSY on destroy (idempotent), then destroy
+		if err := cephclient.OSDDown(m.context, m.clusterInfo, osdID); err != nil {
+			return err
+		}
+		if err := cephclient.OSDDestroy(m.context, m.clusterInfo, osdID); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// OSD deployment is not yet scaled down: drive the drain.
+	isOSDIn := true
+	if _, in, err := osdDump.StatusByID(int64(osdID)); err != nil {
+		// OSD absent from the dump but its slot is not destroyed. Treat it as in: marking out is
+		// idempotent and the next tick re-reads once the dump reflects reality.
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"osd.%d not found in osd dump while not destroyed; treating it as in to begin drain. %v", osdID, err)
+	} else {
+		isOSDIn = in == inStatus
+	}
+
+	// Mark the OSD out to begin the drain. A just-out OSD cannot be safe-to-destroy yet, so return
+	// and wait for the drain on the next ticks; never destroy in the same tick it went out.
+	if isOSDIn {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "marking osd.%d out to begin replacement drain", osdID)
+		if err := cephclient.OSDOut(m.context, m.clusterInfo, osdID); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// OSD is out: wait until it has drained and is safe to destroy, then scale the deployment to 0 so
+	// the daemon releases the data/DB LVs. The pod-gone branch above takes over once the pod exits.
+	safe, err := cephclient.OsdSafeToDestroy(m.context, m.clusterInfo, osdID)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed to check safe-to-destroy for osd.%d; will re-check next tick. %v", osdID, err)
+		return nil
+	}
+	if !safe {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+			"osd.%d is draining; not yet safe-to-destroy, will re-check next tick", osdID)
+		return nil
+	}
+
+	return m.scaleDownOSDDeployment(d, osdID)
+}
+
+// isOSDPodGone reports whether the OSD daemon pod has terminated. PodsRunningWithLabel counts pods
+// whose phase is Running; a terminating pod stays Running until its containers exit, so this only
+// reads true once the daemon has actually released the data/DB LVs.
+func (m *OSDHealthMonitor) isOSDPodGone(osdID int) (bool, error) {
+	label := fmt.Sprintf("%s=%d", OsdIdLabelKey, osdID)
+	running, err := k8sutil.PodsRunningWithLabel(m.clusterInfo.Context, m.context.Clientset, m.clusterInfo.Namespace, label)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check for running pods of osd.%d", osdID)
+	}
+	if running > 0 {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+			"osd.%d still has %d running pod(s) after scale-down; will re-check next tick", osdID, running)
+		return false, nil
+	}
+	return true, nil
+}
+
+// scaleDownOSDDeployment sets the deployment replicas to 0 (only if not already). It is idempotent
+// across ticks; pod-gone is checked separately by the caller.
+func (m *OSDHealthMonitor) scaleDownOSDDeployment(d *appsv1.Deployment, osdID int) error {
+	if d.Spec.Replicas != nil && *d.Spec.Replicas == 0 {
+		return nil
+	}
+	log.NamespacedInfo(m.clusterInfo.Namespace, logger, "scaling osd.%d deployment %q to replicas=0", osdID, d.Name)
+	zero := int32(0)
+	d.Spec.Replicas = &zero
+	updated, err := m.cluster.context.Clientset.AppsV1().Deployments(m.clusterInfo.Namespace).Update(m.clusterInfo.Context, d, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to scale osd.%d deployment %q to zero", osdID, d.Name)
+	}
+	// Keep the caller's copy in sync so a later update in the same flow does not clobber the
+	// replicas change with a stale object.
+	*d = *updated
+	return nil
+}
+
+// runCryptCloseJobForOSD ensures the per-OSD crypto-close Job exists and reports whether it has
+// succeeded. It (re)creates the Job when none exists or a previous one failed, and polls otherwise.
+// Idempotent across ticks.
+func (m *OSDHealthMonitor) runCryptCloseJobForOSD(d *appsv1.Deployment, osdID int) (bool, error) {
+	status, err := m.cluster.cryptCloseJobStatusForOSD(osdID)
+	if err != nil {
+		return false, err
+	}
+
+	switch status {
+	case cryptCloseJobSucceeded:
+		return true, nil
+	case cryptCloseJobRunning:
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "crypto-close job for osd.%d is still running", osdID)
+		return false, nil
+	default:
+		// NotFound or Failed: (re)create the Job, pinned to the OSD's node.
+		nodeName, err := m.replaceOSDNodeName(d, osdID)
+		if err != nil {
+			return false, err
+		}
+		// A previously-Failed Job means a genuinely stuck dm-crypt close (it already exhausted its
+		// in-container BackoffLimit / ActiveDeadlineSeconds). The design has no timeout — the user
+		// cancels by removing the annotation — so we keep recreating, but at Warning level so a wedged
+		// replacement is visible rather than silently looping every tick.
+		if status == cryptCloseJobFailed {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"crypto-close job for osd.%d previously failed; recreating it on node %q", osdID, nodeName)
+		} else {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"creating crypto-close job for osd.%d on node %q", osdID, nodeName)
+		}
+		if err := m.cluster.startCryptCloseJob(osdID, nodeName); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+}
+
+// annotateReadyForSwap adds the ready-for-swap annotation to the deployment and persists it. It is
+// idempotent: if the annotation is already present, it is a no-op.
+func (m *OSDHealthMonitor) annotateReadyForSwap(d *appsv1.Deployment, osdID int) error {
+	if _, ok := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]; ok {
+		return nil
+	}
+	if d.Annotations == nil {
+		d.Annotations = map[string]string{}
+	}
+	d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey] = "true"
+	_, err := m.cluster.context.Clientset.AppsV1().Deployments(m.clusterInfo.Namespace).Update(m.clusterInfo.Context, d, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to annotate osd.%d deployment %q as ready for swap", osdID, d.Name)
+	}
+	return nil
+}
+
+// cancelReplaceOSD reverses a drain that was cancelled before the OSD was destroyed: mark the OSD
+// back `in`, delete any in-flight crypto-close Job, and clear the do-not-reconcile label so the
+// updater scales the deployment back to replicas=1. The goroutine only ever clears this label, never
+// sets it. Idempotent across ticks.
+func (m *OSDHealthMonitor) cancelReplaceOSD(d *appsv1.Deployment, osdID int) error {
+	log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+		"replacement of osd.%d was cancelled before destroy; marking it back in and clearing the do-not-reconcile label", osdID)
+
+	if err := cephclient.OSDIn(m.context, m.clusterInfo, osdID); err != nil {
+		return errors.Wrapf(err, "failed to mark osd.%d back in on cancellation", osdID)
+	}
+
+	// Delete any in-flight crypto-close Job before clearing the fence label. If the encrypted OSD was
+	// cancelled after its crypto-close Job was created, a lingering `cryptsetup close` would race the
+	// daemon once it scales back up, so the Job must be gone before the label is cleared. The delete is
+	// idempotent (no-op if absent); a failed delete is returned so the cancellation retries next tick.
+	if err := m.cluster.deleteCryptCloseJob(osdID); err != nil {
+		return errors.Wrapf(err, "failed to delete crypto-close job for osd.%d on cancellation", osdID)
+	}
+
+	if d.Labels[cephv1.SkipReconcileLabelKey] != "true" {
+		return nil // already cleared on a previous tick
+	}
+	delete(d.Labels, cephv1.SkipReconcileLabelKey)
+	_, err := m.cluster.context.Clientset.AppsV1().Deployments(m.clusterInfo.Namespace).Update(m.clusterInfo.Context, d, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to clear the %q label on osd.%d deployment %q", cephv1.SkipReconcileLabelKey, osdID, d.Name)
+	}
+	return nil
+}
+
+// isReplaceOSDEncrypted reports whether the OSD deployment is encrypted, using the same detection
+// as getOSDInfo: the "encrypted" label, or a dmcrypt block path. The label is checked first so the
+// common case needs no OSD-info parse.
+func (m *OSDHealthMonitor) isReplaceOSDEncrypted(d *appsv1.Deployment) (bool, error) {
+	if d.Labels[encrypted] == "true" {
+		return true, nil
+	}
+	osdInfo, err := m.cluster.getOSDInfo(d)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read OSD info from deployment %q to determine encryption", d.Name)
+	}
+	return osdInfo.Encrypted, nil
+}
+
+// replaceOSDNodeName resolves the node the OSD runs on, so the crypto-close Job can be pinned to it.
+func (m *OSDHealthMonitor) replaceOSDNodeName(d *appsv1.Deployment, osdID int) (string, error) {
+	osdInfo, err := m.cluster.getOSDInfo(d)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read OSD info from deployment %q to resolve its node", d.Name)
+	}
+	if strings.TrimSpace(osdInfo.NodeName) == "" {
+		return "", errors.Errorf("could not resolve the node name for osd.%d from deployment %q", osdID, d.Name)
+	}
+	return osdInfo.NodeName, nil
+}
+
+// isOSDDestroyedInTree reports whether the given OSD's slot is marked "destroyed" in the osd tree.
+func isOSDDestroyedInTree(osdTree *cephclient.OsdTree, osdID int) bool {
+	for _, node := range osdTree.Nodes {
+		if node.Type == "osd" && node.ID == osdID {
+			return node.Status == "destroyed"
+		}
+	}
+	return false
+}

--- a/pkg/operator/ceph/cluster/osd/replace_destroy_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_destroy_test.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// replaceTestState is the durable Ceph state a fake cluster reports, plus a record of the mutating
+// ceph commands the teardown issues. It lets a test assert both the action taken and that the
+// teardown reads only durable state.
+type replaceTestState struct {
+	// tree maps osd id -> status ("up", "destroyed", ...) as reported by `osd tree`.
+	tree map[int]string
+	// inByID maps osd id -> in status (1 = in, 0 = out) as reported by `osd dump`.
+	inByID map[int]int
+	// safeToDestroy is the set of ids `osd safe-to-destroy` reports as safe.
+	safeToDestroy map[int]bool
+
+	cephCmds []string // recorded "osd out", "osd destroy 5", etc.
+}
+
+func osdDumpJSON(inByID map[int]int) string {
+	osds := ""
+	for id, in := range inByID {
+		if osds != "" {
+			osds += ","
+		}
+		osds += fmt.Sprintf(`{"osd":%d,"up":0,"in":%d}`, id, in)
+	}
+	return fmt.Sprintf(`{"osds":[%s]}`, osds)
+}
+
+// newReplaceHealthMonitor wires an OSDHealthMonitor to a mock executor backed by st.
+func newReplaceHealthMonitor(t *testing.T, clientset *fake.Clientset, st *replaceTestState) *OSDHealthMonitor {
+	t.Helper()
+	clusterInfo := cephclient.AdminTestClusterInfo("rook-ceph")
+	clusterInfo.Context = context.TODO()
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "tree" {
+				return osdTreeJSON(st.tree), nil
+			}
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "dump" {
+				return osdDumpJSON(st.inByID), nil
+			}
+			if len(args) >= 3 && args[0] == "osd" && args[1] == "safe-to-destroy" {
+				id, _ := strconv.Atoi(args[2])
+				if st.safeToDestroy[id] {
+					return fmt.Sprintf(`{"safe_to_destroy":[%d]}`, id), nil
+				}
+				return `{"safe_to_destroy":[]}`, nil
+			}
+			// record mutating commands: osd out/in/down/destroy. Only the meaningful leading args
+			// are recorded; the ceph command appends global flags (--cluster, --conf, ...).
+			if len(args) >= 2 && args[0] == "osd" {
+				switch args[1] {
+				case "out", "in", "down":
+					st.cephCmds = append(st.cephCmds, strings.Join(args[:3], " "))
+				case "destroy":
+					st.cephCmds = append(st.cephCmds, strings.Join(args[:4], " "))
+				}
+			}
+			return "", nil
+		},
+	}
+	ctx := &clusterd.Context{Executor: executor, Clientset: clientset}
+	return NewOSDHealthMonitor(ctx, clusterInfo, false, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/ceph:test")
+}
+
+func getReplaceDep(t *testing.T, m *OSDHealthMonitor, osdID int) *appsv1.Deployment {
+	t.Helper()
+	d, err := m.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), fmt.Sprintf(osdAppNameFmt, osdID), metav1.GetOptions{})
+	require.NoError(t, err)
+	return d
+}
+
+// replaceMarkedDep builds an OSD deployment that carries the replace annotation and the
+// do-not-reconcile label, the normal starting state for the goroutine. It includes the minimal "osd"
+// container so the up-front encryption derivation can read OSD info, mirroring a real deployment.
+func replaceMarkedDep(osdID int) *appsv1.Deployment {
+	return withOSDContainer(osdDeployment(osdID,
+		map[string]string{cephv1.ReplaceOSDAnnotationKey: fmt.Sprintf(cephv1.ReplaceOSDAnnotationValueFmt, osdID)},
+		map[string]string{cephv1.SkipReconcileLabelKey: "true"}), "node-1", false)
+}
+
+// withOSDContainer adds the minimal "osd" container env that getOSDInfo reads, so encryption and
+// node-name detection work in unit tests. node is the node the OSD runs on; encrypted controls the
+// dmcrypt block path.
+func withOSDContainer(d *appsv1.Deployment, node string, isEncrypted bool) *appsv1.Deployment {
+	blockPath := "/dev/vg/osd-block-foo"
+	if isEncrypted {
+		blockPath = "/dev/mapper/foo-block-dmcrypt"
+		if d.Labels == nil {
+			d.Labels = map[string]string{}
+		}
+		d.Labels[encrypted] = "true"
+	}
+	d.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "osd",
+		Env: []corev1.EnvVar{
+			{Name: "ROOK_NODE_NAME", Value: node},
+			{Name: "ROOK_OSD_UUID", Value: "00000000-0000-0000-0000-000000000000"},
+			{Name: "ROOK_BLOCK_PATH", Value: blockPath},
+			{Name: "ROOK_CV_MODE", Value: "lvm"},
+		},
+	}}
+	return d
+}
+
+// advanceFromState reads the durable Ceph state from the fake and runs processOSDReplacementDestroy
+// on the given deployment, mirroring one tick of processOSDsDestroyForReplacement for one OSD.
+func advanceFromState(t *testing.T, m *OSDHealthMonitor, st *replaceTestState, d *appsv1.Deployment, osdID int) error {
+	t.Helper()
+	return m.processOSDReplacementDestroy(d, osdID, treeFromState(t, m, st), dumpFromState(t, m, st))
+}
+
+func TestProcessOSDReplacementDestroy(t *testing.T) {
+	osdID := 5
+	t.Run("not selected without the do-not-reconcile label", func(t *testing.T) {
+		dep := osdDeployment(osdID, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 1}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		// A deployment without the do-not-reconcile label is not selected by the goroutine at all.
+		replacing, err := m.processOSDsDestroyForReplacement()
+		require.NoError(t, err)
+		assert.NotContains(t, replacing, osdID)
+		assert.Empty(t, st.cephCmds)
+	})
+
+	t.Run("in -> osd out, no fall-through to destroy", func(t *testing.T) {
+		dep := replaceMarkedDep(osdID)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 1}, safeToDestroy: map[int]bool{osdID: true}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		assert.Contains(t, st.cephCmds, fmt.Sprintf("osd out %d", osdID))
+		// Even though the fake reports safe-to-destroy, a just-out OSD must NOT be destroyed in the
+		// same tick: the out step returns and waits for the real drain.
+		assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	})
+
+	t.Run("draining when out but not safe", func(t *testing.T) {
+		dep := replaceMarkedDep(osdID)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		// not safe -> no destroy commands
+		assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	})
+
+	t.Run("out and safe destroys this tick, annotates next tick", func(t *testing.T) {
+		// out + safe-to-destroy with the pod already gone: the drain gate and destroy steps collapse
+		// into this tick, which ends with osd destroy and returns. The ready-for-swap annotation is a
+		// separate transition driven by the destroyed slot on the next tick. Use an OSD container so
+		// the (non-encrypted) destroy can complete.
+		dep := withOSDContainer(replaceMarkedDep(osdID), "node-1", false)
+		zero := int32(0)
+		dep.Spec.Replicas = &zero // already scaled down, no pod present
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{osdID: true}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+
+		// Destroy tick: slot destroyed, not yet annotated.
+		require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+		assert.Contains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+		assert.NotContains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey,
+			"annotate is a separate transition once the slot reads destroyed")
+
+		// Next tick: the slot now reads destroyed in the tree -> annotate ready-for-swap.
+		st.tree[osdID] = "destroyed"
+		require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+		assert.Contains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+	})
+
+	t.Run("destroyed -> annotate ready for swap", func(t *testing.T) {
+		dep := replaceMarkedDep(osdID)
+		st := &replaceTestState{tree: map[int]string{osdID: "destroyed"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		got := getReplaceDep(t, m, osdID)
+		assert.Contains(t, got.Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+		// destroyed slot: no destructive ceph commands re-issued.
+		assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	})
+
+	t.Run("done when ready for swap present", func(t *testing.T) {
+		dep := replaceMarkedDep(osdID)
+		dep.Annotations[cephv1.ReadyForSwapOSDAnnotationKey] = "true"
+		st := &replaceTestState{tree: map[int]string{osdID: "destroyed"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		assert.Empty(t, st.cephCmds)
+	})
+
+	t.Run("cancellation before destroy -> osd in + clear do-not-reconcile label", func(t *testing.T) {
+		// do-not-reconcile label set + NO replace annotation, slot not destroyed = cancellation
+		dep := osdDeployment(osdID, nil, map[string]string{cephv1.SkipReconcileLabelKey: "true"})
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		assert.Contains(t, st.cephCmds, fmt.Sprintf("osd in %d", osdID))
+		got := getReplaceDep(t, m, osdID)
+		assert.NotContains(t, got.Labels, cephv1.SkipReconcileLabelKey)
+	})
+
+	t.Run("cancellation deletes in-flight crypto-close job", func(t *testing.T) {
+		// Encrypted OSD cancelled after its crypto-close Job was created: do-not-reconcile label set +
+		// NO replace annotation, slot not destroyed = cancellation. The lingering Job must be deleted
+		// before the fence label is cleared so its `cryptsetup close` cannot race the daemon scaling
+		// back up.
+		dep := withOSDContainer(osdDeployment(osdID, nil, map[string]string{cephv1.SkipReconcileLabelKey: "true"}), "node-1", true)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		// a crypto-close Job exists from a prior tick before the cancellation.
+		require.NoError(t, m.cluster.startCryptCloseJob(osdID, "node-1"))
+		_, err := m.context.Clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), cryptCloseJobName(osdID), metav1.GetOptions{})
+		require.NoError(t, err, "crypto-close job should exist before cancellation")
+
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+
+		// OSD marked back in and fence label cleared.
+		assert.Contains(t, st.cephCmds, fmt.Sprintf("osd in %d", osdID))
+		got := getReplaceDep(t, m, osdID)
+		assert.NotContains(t, got.Labels, cephv1.SkipReconcileLabelKey)
+		// the in-flight crypto-close Job is gone.
+		_, err = m.context.Clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), cryptCloseJobName(osdID), metav1.GetOptions{})
+		assert.True(t, kerrors.IsNotFound(err), "crypto-close job must be deleted on cancellation")
+	})
+
+	t.Run("cancellation after destroy is not honored", func(t *testing.T) {
+		// do-not-reconcile label set + NO replace annotation, but slot already destroyed: must NOT mark in.
+		dep := withOSDContainer(osdDeployment(osdID, nil, map[string]string{cephv1.SkipReconcileLabelKey: "true"}), "node-1", false)
+		st := &replaceTestState{tree: map[int]string{osdID: "destroyed"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		require.NoError(t, advanceFromState(t, m, st, dep, osdID))
+		assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd in %d", osdID))
+		got := getReplaceDep(t, m, osdID)
+		assert.Contains(t, got.Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+	})
+}
+
+func treeFromState(t *testing.T, m *OSDHealthMonitor, st *replaceTestState) *cephclient.OsdTree {
+	t.Helper()
+	tree, err := cephclient.HostTree(m.context, m.clusterInfo)
+	require.NoError(t, err)
+	return &tree
+}
+
+func dumpFromState(t *testing.T, m *OSDHealthMonitor, st *replaceTestState) *cephclient.OSDDump {
+	t.Helper()
+	dump, err := cephclient.GetOSDDump(m.context, m.clusterInfo)
+	require.NoError(t, err)
+	return dump
+}
+
+// TestReplaceScaleDown covers the scale-to-0 step. Pod-gone is checked separately by the caller (see
+// TestReplaceWaitsForPodToTerminate), not by this helper.
+func TestReplaceScaleDown(t *testing.T) {
+	osdID := 5
+	t.Run("scales to zero, idempotent when already zero", func(t *testing.T) {
+		dep := replaceMarkedDep(osdID)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+
+		// not yet scaled down -> scales to 0
+		d := getReplaceDep(t, m, osdID)
+		require.NoError(t, m.scaleDownOSDDeployment(d, osdID))
+		assert.Equal(t, int32(0), *getReplaceDep(t, m, osdID).Spec.Replicas)
+
+		// already at 0 -> no-op, no error
+		require.NoError(t, m.scaleDownOSDDeployment(getReplaceDep(t, m, osdID), osdID))
+		assert.Equal(t, int32(0), *getReplaceDep(t, m, osdID).Spec.Replicas)
+	})
+}
+
+// TestReplaceWaitsForPodToTerminate verifies the downscaled-but-pod-not-gone wait: the deployment is
+// scaled to 0 but the daemon pod is still Running (terminating), so the flow must NOT destroy. A
+// terminating pod still holds the data/DB LVs open, so destroying here would be premature.
+func TestReplaceWaitsForPodToTerminate(t *testing.T) {
+	osdID := 5
+	dep := withOSDContainer(replaceMarkedDep(osdID), "node-1", false)
+	zero := int32(0)
+	dep.Spec.Replicas = &zero
+	// a still-Running (terminating) pod for this OSD blocks pod-gone.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-osd-5-abc",
+			Namespace: "rook-ceph",
+			Labels:    map[string]string{OsdIdLabelKey: strconv.Itoa(osdID)},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{osdID: true}}
+	m := newReplaceHealthMonitor(t, fake.NewClientset(dep, pod), st)
+
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	// pod still Running -> not pod-gone -> no destroy this tick.
+	assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	assert.NotContains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+
+	// Remove the pod (daemon terminated) and re-run: now pod-gone -> destroy proceeds.
+	require.NoError(t, m.context.Clientset.CoreV1().Pods("rook-ceph").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}))
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.Contains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+}
+
+// TestReplaceDestroySteps covers the destroy steps for a non-encrypted OSD reached from out +
+// safe-to-destroy with the pod already gone: osd down -> osd destroy (no crypto job). The annotate is
+// a separate transition once the slot reads destroyed on the next tick.
+func TestReplaceDestroySteps(t *testing.T) {
+	osdID := 5
+	dep := withOSDContainer(replaceMarkedDep(osdID), "node-1", false)
+	zero := int32(0)
+	dep.Spec.Replicas = &zero // already scaled down, no pod present
+	st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{osdID: true}}
+	m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.Contains(t, st.cephCmds, fmt.Sprintf("osd down %d", osdID))
+	assert.Contains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	assert.NotContains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey,
+		"annotate is a separate transition once the slot reads destroyed")
+
+	// Next tick: the slot reads destroyed -> annotate ready-for-swap.
+	st.tree[osdID] = "destroyed"
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.Contains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+}
+
+// TestReplaceDestroyStepsEncrypted covers the encrypted path: the destroy steps must spawn the
+// crypto-close Job and wait for it before running osd down/destroy.
+func TestReplaceDestroyStepsEncrypted(t *testing.T) {
+	osdID := 5
+	dep := withOSDContainer(replaceMarkedDep(osdID), "node-1", true)
+	zero := int32(0)
+	dep.Spec.Replicas = &zero
+	st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{osdID: true}}
+	m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+
+	// First tick: no crypto job yet -> it is created, destroy steps NOT run.
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	assert.NotContains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey, "crypto job not yet done, so not destroyed this tick")
+	job, err := m.context.Clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), cryptCloseJobName(osdID), metav1.GetOptions{})
+	require.NoError(t, err, "crypto-close job should have been created")
+
+	// Mark the job succeeded and re-run: destroy steps proceed and the job is deleted BEFORE destroy.
+	job.Status.Succeeded = 1
+	_, err = m.context.Clientset.BatchV1().Jobs("rook-ceph").UpdateStatus(context.TODO(), job, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.Contains(t, st.cephCmds, fmt.Sprintf("osd down %d", osdID))
+	assert.Contains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
+	assert.NotContains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey,
+		"annotate is a separate transition once the slot reads destroyed")
+	_, err = m.context.Clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), cryptCloseJobName(osdID), metav1.GetOptions{})
+	assert.True(t, kerrors.IsNotFound(err), "crypto-close job is deleted on the destroy tick, before/with osd destroy")
+
+	// Next tick: the slot reads destroyed -> pure annotate ready-for-swap; the Job is already gone, so
+	// this tick must not touch it.
+	st.tree[osdID] = "destroyed"
+	require.NoError(t, advanceFromState(t, m, st, getReplaceDep(t, m, osdID), osdID))
+	assert.Contains(t, getReplaceDep(t, m, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey, "crypto job succeeded and slot destroyed")
+	_, err = m.context.Clientset.BatchV1().Jobs("rook-ceph").Get(context.TODO(), cryptCloseJobName(osdID), metav1.GetOptions{})
+	assert.True(t, kerrors.IsNotFound(err), "crypto-close job remains deleted; the destroyed tick does not touch it")
+}
+
+// TestReplaceExcludedFromNormalHealth verifies a replacement-marked OSD is reported as under
+// replacement so the caller can exclude it from normal health processing.
+func TestReplaceExcludedFromNormalHealth(t *testing.T) {
+	osdID := 5
+	dep := replaceMarkedDep(osdID)
+	st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 1}}
+	m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+
+	replacing, err := m.processOSDsDestroyForReplacement()
+	require.NoError(t, err)
+	assert.Contains(t, replacing, osdID)
+}
+
+// TestReplaceExclusionSetCompleteOnFetchFailure verifies the exclusion set is fully populated even
+// when the Ceph fetch fails: the set is built over all replacement-marked deployments before any
+// Ceph query, so a tree/dump failure that aborts the per-OSD actions still returns every marked OSD.
+// Without this, a down+out+safe replacement not yet reached this tick could have its marker deleted
+// by removeOSDDeploymentIfSafeToDestroy.
+func TestReplaceExclusionSetCompleteOnFetchFailure(t *testing.T) {
+	dep5 := replaceMarkedDep(5)
+	dep7 := replaceMarkedDep(7)
+	clusterInfo := cephclient.AdminTestClusterInfo("rook-ceph")
+	clusterInfo.Context = context.TODO()
+	// Executor fails the osd tree fetch, so processOSDsDestroyForReplacement aborts the per-OSD actions.
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "tree" {
+				return "", fmt.Errorf("simulated osd tree failure")
+			}
+			return "", nil
+		},
+	}
+	ctx := &clusterd.Context{Executor: executor, Clientset: fake.NewClientset(dep5, dep7)}
+	m := NewOSDHealthMonitor(ctx, clusterInfo, false, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/ceph:test")
+
+	replacing, err := m.processOSDsDestroyForReplacement()
+	require.NoError(t, err)
+	// Both marked OSDs must be in the exclusion set despite the fetch failure aborting the actions.
+	assert.Contains(t, replacing, 5)
+	assert.Contains(t, replacing, 7)
+}
+
+// TestReplaceMarkerSurvivesNormalHealthPath is the highest-value exclusion test: it drives the full
+// checkOSDHealth -> checkOSDDump path against a replacement-marked, down+out, safe-to-destroy OSD with
+// removeOSDsIfOUTAndSafeToRemove enabled. Without the exclusion, removeOSDDeploymentIfSafeToDestroy
+// would delete the marker deployment (the OSD is down, out, safe-to-destroy, and the fake
+// deployment's zero creation timestamp is well past graceTime). The marker MUST survive because the
+// replacement processing excludes it from the normal path.
+func TestReplaceMarkerSurvivesNormalHealthPath(t *testing.T) {
+	osdID := 5
+	dep := replaceMarkedDep(osdID)
+	// down + out so the normal path would consider it for removal; safe-to-destroy so the grace gate
+	// is the only remaining guard (which the zero creation timestamp clears).
+	st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{osdID: true}}
+	m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+	// enable the dangerous normal-path action.
+	m.removeOSDsIfOUTAndSafeToRemove = true
+
+	// Sanity: the marker exists before the tick.
+	_ = getReplaceDep(t, m, osdID)
+
+	m.checkOSDHealth()
+
+	// The marker deployment must still exist — it was excluded from removeOSDDeploymentIfSafeToDestroy.
+	_, err := m.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), fmt.Sprintf(osdAppNameFmt, osdID), metav1.GetOptions{})
+	assert.NoError(t, err, "replacement marker must survive the normal health path")
+}
+
+// TestReplaceIdempotentRestartResume verifies the memory-less teardown resumes from durable
+// state: a SECOND, freshly-constructed monitor (simulating an operator restart that loses all
+// in-memory state) re-reads the shared durable state (clientset + Ceph tree/dump) and takes the
+// correct next action — only ever annotating once and issuing no further destroy commands. Using a
+// distinct monitor instance is what would catch a regression that smuggled progress into a monitor
+// field.
+func TestReplaceIdempotentRestartResume(t *testing.T) {
+	osdID := 5
+	dep := replaceMarkedDep(osdID)
+	st := &replaceTestState{tree: map[int]string{osdID: "destroyed"}, inByID: map[int]int{osdID: 0}}
+	clientset := fake.NewClientset(dep)
+
+	// First tick on the first monitor: slot destroyed, no ready-for-swap -> annotate.
+	m1 := newReplaceHealthMonitor(t, clientset, st)
+	_, err := m1.processOSDsDestroyForReplacement()
+	require.NoError(t, err)
+	assert.Contains(t, getReplaceDep(t, m1, osdID).Annotations, cephv1.ReadyForSwapOSDAnnotationKey)
+
+	// Second tick on a brand-new monitor over the SAME clientset and durable Ceph state, modeling an
+	// operator restart: it must read Done from durable state and issue no further ceph commands.
+	before := len(st.cephCmds)
+	m2 := newReplaceHealthMonitor(t, clientset, st)
+	_, err = m2.processOSDsDestroyForReplacement()
+	require.NoError(t, err)
+	assert.Equal(t, before, len(st.cephCmds), "an already-ready-for-swap replacement issues no ceph commands")
+}


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

5 part of 6-part stacked PR.

## Description

drain&destroy OSD flow implemented inside OSD health goroutine. uses osd-health ticks to implement osd-destory state machine for destroy flow:
1. out
2. safe-to-destroy
3. downscale deployment to zero
4. wait pod terminated
5. run close crypto job for encrypted osd
6. destory osd
7. add "ready to swap" annotation

## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866
