### PR TITLE
osd-replacement-6: implement osd replacement pdb exemption

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
@@ -460,6 +461,17 @@ func (r *ReconcileClusterDisruption) getOSDFailureDomains(clusterInfo *cephclien
 				topologyLocationLabel, deployment.Name)
 		}
 
+		// Skip OSDs being replaced. The marker Deployment sits at replicas=0 during the replacement, so
+		// counting it as down would create blocking PDBs on the other failure domains and freeze
+		// cluster-wide maintenance for the whole (possibly multi-day) replacement.
+		if shouldIgnoreOSD(&deployment) {
+			logger.Debugf("skipping OSD deployment %q from down-detection because it is marked for replacement", deployment.Name)
+			if !allFailureDomains.Has(failureDomainName) {
+				allFailureDomains.Insert(failureDomainName)
+			}
+			continue
+		}
+
 		// Assume node drain if osd deployment ReadyReplicas count is 0 and OSD pod is not scheduled on a node
 		if deployment.Status.ReadyReplicas < 1 {
 			if !osdDownFailureDomains.Has(failureDomainName) {
@@ -506,6 +518,18 @@ func (r *ReconcileClusterDisruption) getOSDFailureDomains(clusterInfo *cephclien
 		}
 	}
 	return sets.List(allFailureDomains), sets.List(nodeDrainFailureDomains), sets.List(osdDownFailureDomains), downOSDs, nil
+}
+
+// shouldIgnoreOSD reports whether an OSD Deployment is part of an in-flight replacement. It keys
+// solely on the fence label SkipReconcileLabelKey=="true": the goroutine scales the OSD to
+// replicas=0 only after the controller has set this label, so the label alone covers the entire
+// window the replacement OSD is down. The replace annotation is deliberately not consulted: a
+// validation-rejected annotation lingers on a NOT-fenced, still-running OSD, and keying on it would
+// wrongly exempt that OSD from PDB down-detection if it later genuinely fails. The value is matched
+// exactly so a generic do-not-reconcile label set for manual maintenance is not mistaken for a
+// replacement.
+func shouldIgnoreOSD(deployment *appsv1.Deployment) bool {
+	return deployment.GetLabels()[cephv1.SkipReconcileLabelKey] == "true"
 }
 
 // hasOSDNodeDrained returns true if OSD pod is not assigned to any node or if the OSD node is not schedulable

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -84,6 +84,68 @@ func fakeOSDDeployment(id, readyReplicas int) appsv1.Deployment {
 	return osd
 }
 
+func TestGetOSDFailureDomainsSkipsReplacementOSD(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if args[0] == "osd" && args[1] == "metadata" {
+			return `[{"id": 1, "hostname": "node-1"}, {"id": 2, "hostname": "node-2"}, {"id": 3, "hostname": "node-3"}]`, nil
+		}
+		return "", errors.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	// osd.1 is being replaced: scaled to 0 (ReadyReplicas=0) and fenced with the label value "true"
+	// (as the controller sets it). The fence label alone makes it exempt, so it must not pull its
+	// failure domain into the down/draining sets nor enter downOSDs.
+	replacementOSD := fakeOSDDeployment(1, 0)
+	replacementOSD.Labels[cephv1.SkipReconcileLabelKey] = "true"
+	replacementOSD.Annotations = map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-1"}
+
+	// osd.2 carries only the replace annotation and NO fence label (e.g. a validation-rejected
+	// annotation that lingered on a still-running, not-fenced OSD). It must be treated as a NORMAL
+	// OSD: with replicas=0 and a schedulable node it is genuinely down, so it must enter
+	// down-detection rather than be exempted.
+	annotationOnlyOSD := fakeOSDDeployment(2, 0)
+	annotationOnlyOSD.Annotations = map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-2"}
+
+	// osd.3 is a genuinely down (replicas=0) non-replacement OSD on an unschedulable node that an
+	// operator has labelled with the generic do-not-reconcile label for manual maintenance (note the
+	// value is not "true" and there is no replace annotation). It must STILL be detected as down so it
+	// keeps its PDB protection — exempting it would be the over-match bug.
+	genuinelyDownOSD := fakeOSDDeployment(3, 0)
+	genuinelyDownOSD.Labels[cephv1.SkipReconcileLabelKey] = "manual-maintenance"
+
+	objs := []runtime.Object{
+		cephCluster,
+		&corev1.ConfigMap{},
+		getNodeObject("node-1", false),
+		getNodeObject("node-2", false),
+		getNodeObject("node-3", true),
+		replacementOSD.DeepCopy(),
+		annotationOnlyOSD.DeepCopy(),
+		genuinelyDownOSD.DeepCopy(),
+	}
+
+	r := getFakeReconciler(t, objs...)
+	clusterInfo := getFakeClusterInfo()
+	clusterInfo.Context = context.TODO()
+	r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor}}
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
+
+	allFailureDomains, nodeDrainFailureDomains, osdDownFailureDomains, downOSDs, err := r.getOSDFailureDomains(clusterInfo, request, "zone")
+	assert.NoError(t, err)
+	// all three zones are still reported as present failure domains
+	assert.ElementsMatch(t, []string{"zone-1", "zone-2", "zone-3"}, allFailureDomains)
+	// osd.2 (annotation-only, not fenced) and osd.3 (genuinely down) are both detected as down;
+	// only the fence-labelled osd.1 is exempt.
+	assert.ElementsMatch(t, []string{"zone-2", "zone-3"}, osdDownFailureDomains)
+	// only osd.3 is on an unschedulable node, so only it is a node-drain failure domain.
+	assert.Equal(t, []string{"zone-3"}, nodeDrainFailureDomains)
+	assert.ElementsMatch(t, []int{2, 3}, downOSDs)
+	// the fence-labelled replacement OSD must NOT appear as down on its failure domain
+	assert.NotContains(t, downOSDs, 1)
+	assert.NotContains(t, osdDownFailureDomains, "zone-1")
+}
+
 func fakePDBConfigMap(drainingFailureDomain string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: pdbStateMapName, Namespace: namespace},


### PR DESCRIPTION
Closes #13240

Based on design: https://github.com/rook/rook/blob/master/design/ceph/osd-replacement.md

6 part of 6-part stacked PR.

## Description

make PDB aware of downscaled osd replacement


## pr queue
1. #17861
2. #17862 
3. #17863
4. #17864
5. #17865 
6. #17866
