### PR TITLE
object: restrict admin capabilities for users in other namespaces

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -98,6 +98,11 @@ When the `zone` section is set pools with the object stores name will not be cre
     the namespace must be added to this list of allowed namespaces, or specify "*" to allow all namespaces.
     This is useful for applications that need object store credentials to be created in their own namespace,
     where neither OBCs nor COSI is being used to create buckets. The default is empty.
+* `allowAdminCapsInNamespaces`: The list of namespaces (in addition to the object store namespace) where object
+    store users may be granted admin capabilities (`spec.capabilities`). These capabilities are store-wide, so by
+    default a user created in another namespace (via `allowUsersInNamespaces`) may not hold them. Add the namespace
+    to this list, or specify "*" to allow all namespaces. The COSI driver requires its namespace to be listed here.
+    The default is empty.
 
 ### Realm
 

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -49,6 +49,7 @@ spec:
     * `maxObjects`: Maximum number of objects across all the user's buckets.
 * `capabilities`: Ceph allows users to be given additional permissions. Due to missing APIs in go-ceph for updating the user capabilities, this setting can currently only be used during the creation of the object store user. If a user's capabilities need modified, the user must be deleted and re-created.
     See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/#add-remove-admin-capabilities) for more info.
+    Because these are **store-wide** admin capabilities (access to every user and bucket via the admin-ops API), Rook rejects them on a user whose `clusterNamespace` differs from its own namespace unless that namespace is listed in the CephObjectStore's `allowAdminCapsInNamespaces`. Users created in the object store's own namespace are unaffected.
     Rook supports adding `read`, `write`, `read, write`, or `*` permissions for the following resources:
     * `user`
     * `buckets`

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2037,6 +2037,23 @@ is being used to create buckets. The default is empty.</p>
 </tr>
 <tr>
 <td>
+<code>allowAdminCapsInNamespaces</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The list of namespaces (in addition to the object store namespace) where
+object store users may be granted admin capabilities (spec.capabilities).
+These capabilities are store-wide, so by default a user created in another
+namespace (via allowUsersInNamespaces) may not hold them. Specify &ldquo;*&rdquo; to
+allow all namespaces, otherwise list individual namespaces. The COSI driver
+requires its namespace to be listed here. The default is empty.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>hosting</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.ObjectStoreHostingSpec">
@@ -12356,6 +12373,23 @@ namespaces, otherwise list individual namespaces that are to be allowed.
 This is useful for applications that need object store credentials
 to be created in their own namespace, where neither OBCs nor COSI
 is being used to create buckets. The default is empty.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allowAdminCapsInNamespaces</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The list of namespaces (in addition to the object store namespace) where
+object store users may be granted admin capabilities (spec.capabilities).
+These capabilities are store-wide, so by default a user created in another
+namespace (via allowUsersInNamespaces) may not hold them. Specify &ldquo;*&rdquo; to
+allow all namespaces, otherwise list individual namespaces. The COSI driver
+requires its namespace to be listed here. The default is empty.</p>
 </td>
 </tr>
 <tr>

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,5 +3,6 @@
 ## Breaking Changes
 
 - Helm OCI chart tags no longer include the `v` prefix (e.g., `1.21.0` instead of `v1.21.0`). Update any scripts or tooling that reference the chart by tag.
+- CephObjectStoreUsers created in a namespace other than their CephObjectStore (via the CephObjectStore `allowUsersInNamespaces` feature) can no longer be granted RGW admin capabilities (`spec.capabilities`) by default, because those capabilities are store-wide. Add the user's namespace to the CephObjectStore's new `allowAdminCapsInNamespaces` list to permit it. Users created in the object store's own namespace are unaffected.
 
 ## Features

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -12848,6 +12848,22 @@ spec:
             spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
+                allowAdminCapsInNamespaces:
+                  description: |-
+                    The list of namespaces (in addition to the object store namespace) where
+                    object store users may be granted admin capabilities (spec.capabilities).
+                    These capabilities are store-wide, so by default a user created in another
+                    namespace (via allowUsersInNamespaces) may not hold them. Specify "*" to
+                    allow all namespaces, otherwise list individual namespaces. The COSI driver
+                    requires its namespace to be listed here. The default is empty.
+                  items:
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                  maxItems: 1000
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-type: set
                 allowUsersInNamespaces:
                   description: |-
                     The list of allowed namespaces in addition to the object store namespace

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -12837,6 +12837,22 @@ spec:
             spec:
               description: ObjectStoreSpec represent the spec of a pool
               properties:
+                allowAdminCapsInNamespaces:
+                  description: |-
+                    The list of namespaces (in addition to the object store namespace) where
+                    object store users may be granted admin capabilities (spec.capabilities).
+                    These capabilities are store-wide, so by default a user created in another
+                    namespace (via allowUsersInNamespaces) may not hold them. Specify "*" to
+                    allow all namespaces, otherwise list individual namespaces. The COSI driver
+                    requires its namespace to be listed here. The default is empty.
+                  items:
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                  maxItems: 1000
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-type: set
                 allowUsersInNamespaces:
                   description: |-
                     The list of allowed namespaces in addition to the object store namespace

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1867,6 +1867,20 @@ type ObjectStoreSpec struct {
 	// +optional
 	AllowUsersInNamespaces []string `json:"allowUsersInNamespaces,omitempty"`
 
+	// The list of namespaces (in addition to the object store namespace) where
+	// object store users may be granted admin capabilities (spec.capabilities).
+	// These capabilities are store-wide, so by default a user created in another
+	// namespace (via allowUsersInNamespaces) may not hold them. Specify "*" to
+	// allow all namespaces, otherwise list individual namespaces. The COSI driver
+	// requires its namespace to be listed here. The default is empty.
+	// +kubebuilder:validation:MinItems=0
+	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:items:MaxLength=63
+	// +listType=set
+	// +optional
+	AllowAdminCapsInNamespaces []string `json:"allowAdminCapsInNamespaces,omitempty"`
+
 	// Hosting settings for the object store.
 	// A common use case for hosting configuration is to inform Rook of endpoints that support DNS
 	// wildcards, which in turn allows virtual host-style bucket addressing.

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -4510,6 +4510,11 @@ func (in *ObjectStoreSpec) DeepCopyInto(out *ObjectStoreSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowAdminCapsInNamespaces != nil {
+		in, out := &in.AllowAdminCapsInNamespaces, &out.AllowAdminCapsInNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Hosting != nil {
 		in, out := &in.Hosting, &out.Hosting
 		*out = new(ObjectStoreHostingSpec)

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -523,6 +523,17 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 				u.Spec.Store,
 				u.Namespace)
 		}
+		// RGW admin capabilities are store-wide, so a user in another namespace
+		// may carry them only if the object store lists its namespace in
+		// allowAdminCapsInNamespaces. Skipped on delete so an existing user is
+		// still cleaned up.
+		if u.DeletionTimestamp.IsZero() && hasAnyCapability(u.Spec.Capabilities) &&
+			!userInNamespaceAllowed(u.Namespace, store.Spec.AllowAdminCapsInNamespaces) {
+			return fmt.Errorf(
+				"object store %q does not allow admin capabilities for users in namespace %q, the namespace must first be added to allowAdminCapsInNamespaces",
+				u.Spec.Store,
+				u.Namespace)
+		}
 	}
 
 	advertiseEndpoint, err := store.GetAdvertiseEndpointUrl()
@@ -540,6 +551,22 @@ func userInNamespaceAllowed(requestedNamespace string, allowedNamespaces []strin
 	for _, allowedNamespace := range allowedNamespaces {
 		if allowedNamespace == "*" || allowedNamespace == requestedNamespace {
 			log.NamespacedDebug(requestedNamespace, logger, "allow creating object user in namespace")
+			return true
+		}
+	}
+	return false
+}
+
+// hasAnyCapability reports whether any RGW admin capability is requested. Every
+// field of ObjectUserCapSpec is an admin-ops capability (a normal S3 user has
+// none), so any non-empty field means administrative access to the store.
+func hasAnyCapability(caps *cephv1.ObjectUserCapSpec) bool {
+	if caps == nil {
+		return false
+	}
+	v := reflect.ValueOf(*caps)
+	for i := 0; i < v.NumField(); i++ {
+		if f := v.Field(i); f.Kind() == reflect.String && f.String() != "" {
 			return true
 		}
 	}

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -660,6 +660,14 @@ func TestValidateUser(t *testing.T) {
 	})
 }
 
+func TestHasAnyCapability(t *testing.T) {
+	assert.False(t, hasAnyCapability(nil))
+	assert.False(t, hasAnyCapability(&cephv1.ObjectUserCapSpec{}))
+	assert.True(t, hasAnyCapability(&cephv1.ObjectUserCapSpec{Users: "*"}))
+	assert.True(t, hasAnyCapability(&cephv1.ObjectUserCapSpec{MetaData: "read"}))
+	assert.True(t, hasAnyCapability(&cephv1.ObjectUserCapSpec{Bucket: "read, write"}))
+}
+
 func TestResolveAccountRef(t *testing.T) {
 	ctx := context.TODO()
 	s := scheme.Scheme

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -211,15 +211,22 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	// now test operation of the first object store
 	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
 
-	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
-		bucketowner.Namespace,
-		userkeys.Namespace,
-		topickafka.Namespace,
-		useropmask.Namespace,
-		usercaps.Namespace,
-		cosi.Namespace,
-		notification.Namespace,
-	)
+	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, sharedstore.Config{
+		TLSEnable: tlsEnable,
+		AllowUsersInNamespaces: []string{
+			bucketowner.Namespace,
+			userkeys.Namespace,
+			topickafka.Namespace,
+			useropmask.Namespace,
+			usercaps.Namespace,
+			cosi.Namespace,
+			notification.Namespace,
+		},
+		// only the COSI driver namespace may be granted admin capabilities;
+		// usercaps.Namespace is intentionally excluded so the caps test can
+		// assert that admin caps in another namespace are rejected
+		AllowAdminCapsInNamespaces: []string{cosi.Namespace},
+	})
 	defer sharedObjectStore.Destroy()
 
 	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)

--- a/tests/integration/object/user/caps/caps.go
+++ b/tests/integration/object/user/caps/caps.go
@@ -35,79 +35,64 @@ import (
 	"github.com/rook/rook/tests/integration/object/util/wait4"
 )
 
-const Namespace = "test-usercaps"
+const Namespace = "test-usercaps" // a namespace other than the object store's
 
 func TestObjectStoreUserCaps(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
 	var (
-		defaultName = Namespace
 		objectStore = store.ObjectStore()
 		adminClient = store.AdminClient()
+		storeNS     = objectStore.Namespace
 
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: defaultName,
-			},
+		otherNS = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}
+
+		// A user in the object store's own namespace; capabilities are always
+		// permitted, so this exercises capability propagation to RGW
+		// independent of the namespaced-caps setting.
+		sameNSUser = cephv1.CephObjectStoreUser{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-usercaps-samens", Namespace: storeNS},
+			Spec:       cephv1.ObjectStoreUserSpec{Store: objectStore.Name},
 		}
+		sameNSUserClient = k8sh.RookClientset.CephV1().CephObjectStoreUsers(storeNS)
 
-		osu1 = cephv1.CephObjectStoreUser{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      defaultName + "-user1",
-				Namespace: ns.Name,
-			},
-			Spec: cephv1.ObjectStoreUserSpec{
-				Store:            objectStore.Name,
-				ClusterNamespace: objectStore.Namespace,
-			},
+		// A user in another namespace, created via allowUsersInNamespaces.
+		otherNSUser = cephv1.CephObjectStoreUser{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-usercaps-otherns", Namespace: Namespace},
+			Spec:       cephv1.ObjectStoreUserSpec{Store: objectStore.Name, ClusterNamespace: storeNS},
 		}
-
-		osuClient = k8sh.RookClientset.CephV1().CephObjectStoreUsers(ns.Name)
+		otherNSUserClient = k8sh.RookClientset.CephV1().CephObjectStoreUsers(Namespace)
 	)
 
 	t.Run("ObjectStoreUser caps", func(t *testing.T) {
 		ctx := t.Context()
 
-		fixture.RequireNamespace(t, k8sh, ns)
-
-		t.Run(fmt.Sprintf("create CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
-			// user creation may be slow right after rgw start up
-			wait4.RequireCreate(ctx, t, osuClient, &osu1, wait4.ObjectStoreUser, wait4.TimeoutLong)
+		// capability propagation works for a user in the store's own namespace
+		t.Run("create user in store namespace", func(t *testing.T) {
+			wait4.RequireCreate(ctx, t, sameNSUserClient, &sameNSUser, wait4.ObjectStoreUser, wait4.TimeoutLong)
 		})
 
-		t.Run(fmt.Sprintf("verify caps on CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
-			liveUser, err := adminClient.GetUser(ctx, admin.User{ID: osu1.Name})
+		t.Run("store-namespace user caps default to empty", func(t *testing.T) {
+			liveUser, err := adminClient.GetUser(ctx, admin.User{ID: sameNSUser.Name})
 			require.NoError(t, err)
-			assert.Empty(t, liveUser.Caps) // caps should default to `[]`
+			assert.Empty(t, liveUser.Caps)
 		})
 
-		t.Run(fmt.Sprintf("update caps on CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
-			liveOsu, err := osuClient.Get(ctx, osu1.Name, metav1.GetOptions{})
+		t.Run("grant caps to store-namespace user", func(t *testing.T) {
+			live, err := sameNSUserClient.Get(ctx, sameNSUser.Name, metav1.GetOptions{})
 			require.NoError(t, err)
-
-			liveOsu.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
-				Buckets: "*",
-				Usage:   "read",
-			}
-
-			_, err = osuClient.Update(ctx, liveOsu, metav1.UpdateOptions{})
+			live.Spec.Capabilities = &cephv1.ObjectUserCapSpec{Buckets: "*", Usage: "read"}
+			_, err = sameNSUserClient.Update(ctx, live, metav1.UpdateOptions{})
 			require.NoError(t, err)
 		})
 
-		t.Run(fmt.Sprintf("verify caps on CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
+		t.Run("store-namespace user caps sync to rgw", func(t *testing.T) {
 			wait4.AssertEventually(ctx, t, wait4.TimeoutShort, "rgw user caps match spec", func(ctx context.Context) error {
-				liveUser, err := adminClient.GetUser(ctx, admin.User{ID: osu1.Name})
+				liveUser, err := adminClient.GetUser(ctx, admin.User{ID: sameNSUser.Name})
 				if err != nil {
 					return err
 				}
-
 				if !cmp.Equal(liveUser.Caps, []admin.UserCapSpec{
-					{
-						Type: "buckets",
-						Perm: "*",
-					},
-					{
-						Type: "usage",
-						Perm: "read",
-					},
+					{Type: "buckets", Perm: "*"},
+					{Type: "usage", Perm: "read"},
 				}) {
 					return fmt.Errorf("caps not yet in sync: %+v", liveUser.Caps)
 				}
@@ -115,39 +100,37 @@ func TestObjectStoreUserCaps(t *testing.T, k8sh *utils.K8sHelper, store *shareds
 			})
 		})
 
-		t.Run(fmt.Sprintf("remove caps on CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
-			liveOsu, err := osuClient.Get(ctx, osu1.Name, metav1.GetOptions{})
-			require.NoError(t, err)
-
-			liveOsu.Spec.Capabilities = nil
-
-			_, err = osuClient.Update(ctx, liveOsu, metav1.UpdateOptions{})
-			require.NoError(t, err)
+		t.Run("delete store-namespace user", func(t *testing.T) {
+			wait4.AssertDelete(ctx, t, sameNSUserClient, sameNSUser.Name, wait4.TimeoutShort)
 		})
 
-		t.Run(fmt.Sprintf("verify caps on CephObjectStoreUser %q returns to default", osu1.Name), func(t *testing.T) {
-			wait4.AssertEventually(ctx, t, wait4.TimeoutShort, "rgw user caps are empty", func(ctx context.Context) error {
-				liveUser, err := adminClient.GetUser(ctx, admin.User{ID: osu1.Name})
-				if err != nil {
-					return err
-				}
+		// a user in another namespace must not be granted store-wide admin caps
+		// by default
+		fixture.RequireNamespace(t, k8sh, otherNS)
 
-				if len(liveUser.Caps) != 0 {
-					return fmt.Errorf("caps not yet empty: %+v", liveUser.Caps)
-				}
-				return nil
-			})
+		t.Run("create user in another namespace without caps", func(t *testing.T) {
+			wait4.RequireCreate(ctx, t, otherNSUserClient, &otherNSUser, wait4.ObjectStoreUser, wait4.TimeoutLong)
 		})
 
-		t.Run(fmt.Sprintf("delete CephObjectStoreUser %q", osu1.Name), func(t *testing.T) {
-			wait4.AssertDelete(ctx, t, osuClient, osu1.Name, wait4.TimeoutShort)
-		})
-
-		t.Run(fmt.Sprintf("no CephObjectStoreUsers in ns %q", ns.Name), func(t *testing.T) {
-			osus, err := osuClient.List(ctx, metav1.ListOptions{})
+		t.Run("granting admin caps to a user in another namespace is rejected", func(t *testing.T) {
+			live, err := otherNSUserClient.Get(ctx, otherNSUser.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			live.Spec.Capabilities = &cephv1.ObjectUserCapSpec{Users: "*"}
+			_, err = otherNSUserClient.Update(ctx, live, metav1.UpdateOptions{})
 			require.NoError(t, err)
 
-			assert.Len(t, osus.Items, 0)
+			// the operator refuses the spec; the CR reports ReconcileFailed
+			wait4.RequireCondition(ctx, t, otherNSUserClient, otherNSUser.Name,
+				wait4.ObjectStoreUserPhase(string(cephv1.ReconcileFailed)), wait4.TimeoutShort)
+
+			// and the caps are never applied to the live rgw user
+			liveUser, err := adminClient.GetUser(ctx, admin.User{ID: otherNSUser.Name})
+			require.NoError(t, err)
+			assert.Empty(t, liveUser.Caps)
+		})
+
+		t.Run("delete user in another namespace", func(t *testing.T) {
+			wait4.AssertDelete(ctx, t, otherNSUserClient, otherNSUser.Name, wait4.TimeoutShort)
 		})
 	})
 }

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -68,13 +68,21 @@ func (s *Sharedstore) Destroy() {
 	s.destroy()
 }
 
+// Config holds the tunable settings for the shared CephObjectStore.
+type Config struct {
+	TLSEnable                  bool
+	AllowUsersInNamespaces     []string
+	AllowAdminCapsInNamespaces []string
+}
+
 // Setup creates a shared CephObjectStore and its NodePort Service in
 // ObjectStoreNamespace, waits for the store to become Ready, and returns a
 // teardown function that deletes both resources. The teardown function should
 // be deferred by the caller.
-func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, allowedNamespaces ...string) *Sharedstore {
+func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, cfg Config) *Sharedstore {
 	t.Helper()
 
+	tlsEnable := cfg.TLSEnable
 	s := &Sharedstore{tlsEnable: tlsEnable}
 	ctx := context.TODO()
 	ns := "object-ns"
@@ -156,7 +164,8 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 				Port:      80,
 				Instances: 1,
 			},
-			AllowUsersInNamespaces: allowedNamespaces,
+			AllowUsersInNamespaces:     cfg.AllowUsersInNamespaces,
+			AllowAdminCapsInNamespaces: cfg.AllowAdminCapsInNamespaces,
 		},
 	}
 


### PR DESCRIPTION
A `CephObjectStoreUser`'s `spec.capabilities` are RGW admin-ops capabilities that apply **store-wide** — they grant access to every user and bucket in the object store via the admin-ops API. The `CephObjectStore` `allowUsersInNamespaces` feature lets users be created in namespaces other than the object store's; such a user could request these capabilities for itself and gain administrative control of the whole object store.

This adds a `CephObjectStore.spec.allowAdminCapsInNamespaces` field: a user whose `clusterNamespace` differs from its own namespace may hold `spec.capabilities` only if its namespace is listed there (or `*`). Users created in the object store's own namespace are unaffected. The COSI driver, which provisions buckets and users with a privileged user in another namespace, lists its namespace in `allowAdminCapsInNamespaces`.

The check runs in `initializeObjectStoreContext` and is skipped while a user is being deleted, so an existing user that already has capabilities is still cleaned up.

**AI assistance:** AI was used to locate the validation code path, design and implement the per-store `allowAdminCapsInNamespaces` policy, and write/adjust the unit and integration tests and documentation.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
