### PR TITLE
object: use passed context for S3 v2 API calls

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -130,7 +130,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		// if bucket already exists, this returns error: TooManyBuckets because we set the quota
 		// below. If it already exists, assume we are good to go
 		log.NamedDebug(nsName, logger, "creating bucket %q owned by user %q", p.bucketName, p.cephUserName)
-		err = p.s3Agent.CreateBucket(p.bucketName)
+		err = p.s3Agent.CreateBucket(p.clusterInfo.Context, p.bucketName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating bucket %q", p.bucketName)
 		}
@@ -224,7 +224,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	// generate the bucket policy if it isn't managed by the user
 
 	// if the policy does not exist, we'll create a new and append the statement to it
-	policy, err := p.s3Agent.GetBucketPolicy(p.bucketName)
+	policy, err := p.s3Agent.GetBucketPolicy(p.clusterInfo.Context, p.bucketName)
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
@@ -246,7 +246,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	} else {
 		policy = policy.ModifyBucketPolicy(*statement)
 	}
-	out, err := p.s3Agent.PutBucketPolicy(p.bucketName, *policy)
+	out, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
 
 	log.NamedInfo(nsName, logger, "PutBucketPolicy output: %v", out)
 	if err != nil {
@@ -322,7 +322,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 
 		// Ignore cases where there is no bucket policy. This may have occurred if an error ended a Grant()
 		// call before the policy was attached to the bucket
-		policy, err := p.s3Agent.GetBucketPolicy(p.bucketName)
+		policy, err := p.s3Agent.GetBucketPolicy(p.clusterInfo.Context, p.bucketName)
 		if err != nil {
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchBucketPolicy" {
@@ -348,7 +348,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 			} else {
 				policy = policy.ModifyBucketPolicy(*statement)
 			}
-			out, err := p.s3Agent.PutBucketPolicy(p.bucketName, *policy)
+			out, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
 			log.NamedInfo(nsName, logger, "PutBucketPolicy output: %v", out)
 			if err != nil {
 				return errors.Wrap(err, "failed to update policy")
@@ -360,7 +360,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 		// drop policy if present
 		if policy != nil {
 			policy = policy.DropPolicyStatements(p.cephUserName)
-			_, err := p.s3Agent.PutBucketPolicy(p.bucketName, *policy)
+			_, err := p.s3Agent.PutBucketPolicy(p.clusterInfo.Context, p.bucketName, *policy)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/ceph/object/policy.go
+++ b/pkg/operator/ceph/object/policy.go
@@ -161,7 +161,7 @@ func NewBucketPolicy(ps ...PolicyStatement) *BucketPolicy {
 }
 
 // PutBucketPolicy applies the policy to the bucket
-func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBucketPolicyOutput, error) {
+func (s *S3Agent) PutBucketPolicy(ctx context.Context, bucket string, policy BucketPolicy) (*s3.PutBucketPolicyOutput, error) {
 	confirmRemoveSelfBucketAccess := false
 	serializedPolicy, _ := json.Marshal(policy)
 	consumablePolicy := string(serializedPolicy)
@@ -171,15 +171,15 @@ func (s *S3Agent) PutBucketPolicy(bucket string, policy BucketPolicy) (*s3.PutBu
 		ConfirmRemoveSelfBucketAccess: &confirmRemoveSelfBucketAccess,
 		Policy:                        &consumablePolicy,
 	}
-	out, err := s.Client.PutBucketPolicy(context.TODO(), p)
+	out, err := s.Client.PutBucketPolicy(ctx, p)
 	if err != nil {
 		return out, err
 	}
 	return out, nil
 }
 
-func (s *S3Agent) GetBucketPolicy(bucket string) (*BucketPolicy, error) {
-	out, err := s.Client.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{
+func (s *S3Agent) GetBucketPolicy(ctx context.Context, bucket string) (*BucketPolicy, error) {
+	out, err := s.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: &bucket,
 	})
 	if err != nil {

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -96,11 +96,11 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 }
 
 // CreateBucket creates a bucket with the given name
-func (s *S3Agent) CreateBucket(name string) error {
-	return s.createBucket(name, true)
+func (s *S3Agent) CreateBucket(ctx context.Context, name string) error {
+	return s.createBucket(ctx, name, true)
 }
 
-func (s *S3Agent) createBucket(name string, infoLogging bool) error {
+func (s *S3Agent) createBucket(ctx context.Context, name string, infoLogging bool) error {
 	if infoLogging {
 		logger.Infof("creating bucket %q", name)
 	} else {
@@ -111,7 +111,7 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 		Bucket: &name,
 	}
 
-	_, err := s.Client.CreateBucket(context.TODO(), input)
+	_, err := s.Client.CreateBucket(ctx, input)
 	if err != nil {
 		var alreadyExists *s3types.BucketAlreadyExists
 		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
@@ -131,10 +131,10 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 }
 
 // PutObjectInBucket function puts an object in a bucket using s3 client
-func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
+func (s *S3Agent) PutObjectInBucket(ctx context.Context, bucketname string, body string, key string,
 	contentType string,
 ) (bool, error) {
-	_, err := s.Client.PutObject(context.TODO(), &s3.PutObjectInput{
+	_, err := s.Client.PutObject(ctx, &s3.PutObjectInput{
 		Body:        strings.NewReader(body),
 		Bucket:      &bucketname,
 		Key:         &key,
@@ -148,8 +148,8 @@ func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 }
 
 // GetObjectInBucket function retrieves an object from a bucket using s3 client
-func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, error) {
-	result, err := s.Client.GetObject(context.TODO(), &s3.GetObjectInput{
+func (s *S3Agent) GetObjectInBucket(ctx context.Context, bucketname string, key string) (string, error) {
+	result, err := s.Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &bucketname,
 		Key:    &key,
 	})
@@ -167,8 +167,8 @@ func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, erro
 }
 
 // DeleteObjectInBucket function deletes given bucket using s3 client
-func (s *S3Agent) DeleteObjectInBucket(bucketname string, key string) (bool, error) {
-	_, err := s.Client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+func (s *S3Agent) DeleteObjectInBucket(ctx context.Context, bucketname string, key string) (bool, error) {
+	_, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &bucketname,
 		Key:    &key,
 	})

--- a/tests/integration/ceph_bucket_notification_test.go
+++ b/tests/integration/ceph_bucket_notification_test.go
@@ -130,7 +130,7 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
 		t.Run("put object", func(t *testing.T) {
-			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey1, contentType)
+			_, err := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey1, contentType)
 			assert.Nil(t, err)
 		})
 
@@ -145,7 +145,7 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		})
 
 		t.Run("delete objects", func(t *testing.T) {
-			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
+			_, err := s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 
@@ -230,7 +230,7 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
 		t.Run("put object", func(t *testing.T) {
-			_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
+			_, err := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, err)
 		})
 
@@ -241,7 +241,7 @@ func testBucketNotifications(s *suite.Suite, helper *clients.TestClient, k8sh *u
 		})
 
 		t.Run("delete objects", func(t *testing.T) {
-			_, err := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
+			_, err := s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey1)
 			assert.Nil(t, err)
 		})
 

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -300,27 +300,27 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 
 		t.Run("put object", func(t *testing.T) {
-			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey1, contentType)
+			_, poErr := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey1, contentType)
 			assert.Nil(t, poErr)
 		})
 
 		t.Run("get object", func(t *testing.T) {
-			read, err := s3client.GetObjectInBucket(bucketname, ObjectKey1)
+			read, err := s3client.GetObjectInBucket(ctx, bucketname, ObjectKey1)
 			assert.Nil(t, err)
 			assert.Equal(t, ObjBody, read)
 		})
 
 		t.Run("user quota enforcement", func(t *testing.T) {
-			_, poErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey2, contentType)
+			_, poErr := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey2, contentType)
 			assert.Nil(t, poErr)
 			logger.Infof("Testing the max object limit")
 			quotaEnforced := utils.Retry(30, 2*time.Second, "user quota enforced", func() bool {
-				_, err := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
+				_, err := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey3, contentType)
 				if err != nil {
 					return true
 				}
 				// delete so next attempt creates a new object rather than overwriting
-				s3client.DeleteObjectInBucket(bucketname, ObjectKey3) //nolint:errcheck
+				s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey3) //nolint:errcheck
 				return false
 			})
 			assert.True(t, quotaEnforced)
@@ -334,26 +334,26 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 			})
 			assert.True(t, updated)
 			logger.Infof("Testing the updated object limit")
-			_, poErr = s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey3, contentType)
+			_, poErr = s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey3, contentType)
 			assert.NoError(t, poErr)
 			quotaEnforced := utils.Retry(30, 2*time.Second, "updated user quota enforced", func() bool {
-				_, putErr := s3client.PutObjectInBucket(bucketname, ObjBody, ObjectKey4, contentType)
+				_, putErr := s3client.PutObjectInBucket(ctx, bucketname, ObjBody, ObjectKey4, contentType)
 				if putErr != nil {
 					return true
 				}
 				// delete so next attempt creates a new object rather than overwriting
-				s3client.DeleteObjectInBucket(bucketname, ObjectKey4) //nolint:errcheck
+				s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey4) //nolint:errcheck
 				return false
 			})
 			assert.True(t, quotaEnforced)
 		})
 
 		t.Run("delete objects", func(t *testing.T) {
-			_, delobjErr := s3client.DeleteObjectInBucket(bucketname, ObjectKey1)
+			_, delobjErr := s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey1)
 			assert.Nil(t, delobjErr)
-			_, delobjErr = s3client.DeleteObjectInBucket(bucketname, ObjectKey2)
+			_, delobjErr = s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey2)
 			assert.Nil(t, delobjErr)
-			_, delobjErr = s3client.DeleteObjectInBucket(bucketname, ObjectKey3)
+			_, delobjErr = s3client.DeleteObjectInBucket(ctx, bucketname, ObjectKey3)
 			assert.Nil(t, delobjErr)
 			logger.Info("Objects deleted on bucket successfully")
 		})
@@ -430,15 +430,15 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 
 		t.Run("bucketMaxObjects quota is enforced", func(t *testing.T) {
 			// first object should succeed
-			_, err := s3client.PutObjectInBucket(bucketName, ObjBody, ObjectKey1, contentType)
+			_, err := s3client.PutObjectInBucket(ctx, bucketName, ObjBody, ObjectKey1, contentType)
 			assert.Nil(t, err)
 			// second object should fail as bucket quota is 1
-			_, err = s3client.PutObjectInBucket(bucketName, ObjBody, ObjectKey2, contentType)
+			_, err = s3client.PutObjectInBucket(ctx, bucketName, ObjBody, ObjectKey2, contentType)
 			assert.Error(t, err)
 			// cleanup bucket
-			_, err = s3client.DeleteObjectInBucket(bucketName, ObjectKey1)
+			_, err = s3client.DeleteObjectInBucket(ctx, bucketName, ObjectKey1)
 			assert.Nil(t, err)
-			_, err = s3client.DeleteObjectInBucket(bucketName, ObjectKey2)
+			_, err = s3client.DeleteObjectInBucket(ctx, bucketName, ObjectKey2)
 			assert.Nil(t, err)
 		})
 
@@ -481,15 +481,15 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 
 		t.Run("bucketMaxSize quota is enforced", func(t *testing.T) {
 			// first ~3KiB Object should succeed
-			_, err := s3client.PutObjectInBucket(bucketName, strings.Repeat("1", 3072), ObjectKey1, contentType)
+			_, err := s3client.PutObjectInBucket(ctx, bucketName, strings.Repeat("1", 3072), ObjectKey1, contentType)
 			assert.Nil(t, err)
 			// second ~2KiB Object should fail as bucket quota is is 4KiB
-			_, err = s3client.PutObjectInBucket(bucketName, strings.Repeat("2", 2048), ObjectKey2, contentType)
+			_, err = s3client.PutObjectInBucket(ctx, bucketName, strings.Repeat("2", 2048), ObjectKey2, contentType)
 			assert.Error(t, err)
 			// cleanup bucket
-			_, err = s3client.DeleteObjectInBucket(bucketName, ObjectKey1)
+			_, err = s3client.DeleteObjectInBucket(ctx, bucketName, ObjectKey1)
 			assert.Nil(t, err)
-			_, err = s3client.DeleteObjectInBucket(bucketName, ObjectKey2)
+			_, err = s3client.DeleteObjectInBucket(ctx, bucketName, ObjectKey2)
 			assert.Nil(t, err)
 		})
 


### PR DESCRIPTION
The AWS SDK v1 to v2 migration in #17468 left the `S3Agent` wrapper methods calling the SDK with `context.TODO()`. As raised in #17526, that means S3 operations cannot be cancelled when the controller context is cancelled.

This threads a `context.Context` through the wrappers and forwards it to the underlying client instead of `context.TODO()`:

- `pkg/operator/ceph/object/s3-handlers.go`: add a leading `ctx context.Context` to `CreateBucket`, `createBucket`, `PutObjectInBucket`, `GetObjectInBucket`, and `DeleteObjectInBucket`, and pass `ctx` to the `s.Client.*` calls.
- `pkg/operator/ceph/object/policy.go`: same for `PutBucketPolicy` and `GetBucketPolicy`.
- `pkg/operator/ceph/object/bucket/provisioner.go`: the six call sites pass `p.clusterInfo.Context`, the controller context the provisioner already uses elsewhere in the same file, so the S3 calls are tied to the reconcile lifecycle.
- `tests/integration/`: the object and bucket-notification tests pass their in-scope `ctx` to the updated signatures.

There is no functional behavior change; this is signature plumbing so the controller context reaches the S3 API calls.

I left the `context.TODO()` at `pkg/operator/ceph/object/notification/provisioner.go` and `pkg/operator/ceph/object/topic/controller.go` alone: those are not `S3Agent` wrappers and touching them would widen the diff beyond this issue. Happy to do a follow-up if you would prefer them covered here too.

_AI assistance disclosure: I used an AI coding assistant to help locate the `context.TODO()` call sites and their callers. I reviewed, ran, and verified the change myself._

**Issue resolved by this Pull Request:**
Resolves #17526

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
