### PR TITLE
ci: fix broken-pipe race in find_extra_block_dev

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -83,7 +83,9 @@ function create_extra_disk() {
 # iSCSI disk if none exist. Thin wrapper over find_extra_block_devs(); kept as a
 # convenience for its many callers that expect a single basename.
 function find_extra_block_dev() {
-  find_extra_block_devs 1 | head -1
+  local devs
+  mapfile -t devs < <(find_extra_block_devs 1)
+  echo "${devs[0]}" # the first disk
 }
 
 # find_extra_block_devs [min_count]


### PR DESCRIPTION
**Description:**

Canary jobs have recently been failing at disk provisioning with:

```
tests/scripts/github-action-helper.sh: line 113: echo: write error: Broken pipe
##[error]Process completed with exit code 1.
```

`find_extra_block_dev` piped `find_extra_block_devs` into `head -1`.
`find_extra_block_devs` prints every eligible whole disk and ends with
`echo "$devs"`, so `head` closes the pipe after reading the first line and
the producer's `echo` races into `SIGPIPE`. Under the runner shell's
`pipefail`/`errexit` (inherited via the exported `SHELLOPTS`) the failed
`echo` propagates out of the command substitution and fails the whole step.

The race only started firing broadly now that the runners present two data
disks (`sdb` and `sdc`), so `find_extra_block_devs 1` emits multiple lines
and `head -1` reliably closes the pipe early. With a single disk the
one-line output almost never triggered it.

The fix reads the producer to completion with `mapfile` via process
substitution and returns the first element, mirroring the existing
`find_second_block_dev`, so there is no downstream `head` to close the pipe
early.

**AI assistance:** AI (Claude Code) helped diagnose the SIGPIPE race from
the failing job log, locate the offending function, and draft the fix and
this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
