### PR TITLE
osd: list prepared devices individually when missing from raw list

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,9 @@
 ## Breaking Changes
 
 - Helm OCI chart tags no longer include the `v` prefix (e.g., `1.21.0` instead of `v1.21.0`). Update any scripts or tooling that reference the chart by tag.
+- The OSD prepare job now fails, and is retried by Kubernetes, when a freshly prepared device is
+  missing from the `ceph-volume raw list` output, instead of silently reporting fewer OSDs than
+  were prepared (which left OSDs registered in the osdmap with no OSD deployment created).
 
 ## Features
 

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -189,6 +189,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	}
 
 	// Check if the PVC is an LVM block device (certain StorageClass do this)
+	var preparedRawDevices []string
 	if a.pvcBacked {
 		for _, device := range devices.Entries {
 			dev := device.Config.Name
@@ -202,7 +203,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			return nil, errors.Wrap(err, "failed to initialize devices on PVC")
 		}
 	} else {
-		err = a.initializeDevices(context, devices)
+		preparedRawDevices, err = a.initializeDevices(context, devices)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to initialize osd")
 		}
@@ -228,9 +229,73 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
+
+	// "ceph-volume raw list" without a device argument can miss freshly prepared OSDs.
+	// On Ceph v20.2.0/v20.2.1, get_devices() enumerates via udev data under /run/udev/data
+	// and returns nothing when that data is empty or not yet populated
+	// (https://tracker.ceph.com/issues/77968). On every released v20.2.x, a sub-4KiB block
+	// device in the scan (e.g. an MBR extended-partition node) crashes the batched
+	// ceph-bluestore-tool call behind the listing, which ceph-volume reports as an empty
+	// result (https://tracker.ceph.com/issues/76354). Either way the listing comes back
+	// empty or incomplete even though the OSD exists. Without this check the prepare job
+	// would silently report fewer OSDs than it just prepared and the operator would never
+	// create the missing OSD deployments.
+	if !isEncrypted {
+		rawOsds, err = ensurePreparedDevicesListed(context, a.clusterInfo, rawOsds, preparedRawDevices, a.devices)
+		if err != nil {
+			return nil, err
+		}
+	}
 	osds = appendOSDInfo(osds, slices.DeleteFunc(rawOsds, func(o oposd.OSDInfo) bool { return slices.Contains(destroyedOSDIds, o.ID) }))
 
 	return osds, err
+}
+
+// ensurePreparedDevicesListed verifies that every device that was just prepared in raw mode is
+// represented in the OSD list reported by "ceph-volume raw list". Any prepared device missing
+// from the results is listed individually ("ceph-volume raw list <device>"), which is immune to
+// the failure modes that can blank the no-argument listing. If a prepared device still yields no OSD,
+// an error is returned so the prepare job exits non-zero and Kubernetes restarts it with a
+// freshly re-scanned environment, rather than silently under-reporting the OSDs on the node.
+func ensurePreparedDevicesListed(context *clusterd.Context, clusterInfo *client.ClusterInfo, osds []oposd.OSDInfo, preparedDevices []string, devices []DesiredDevice) ([]oposd.OSDInfo, error) {
+	for _, device := range preparedDevices {
+		if deviceInOSDInfoList(device, osds) {
+			continue
+		}
+
+		logger.Warningf("prepared device %q is missing from the ceph-volume raw list results, listing the device individually", device)
+		deviceOsds, err := GetCephVolumeRawOSDs(context, clusterInfo, clusterInfo.FSID, device, "", "", false, false, devices)
+		if err != nil {
+			return nil, errors.Wrapf(err, "an OSD was prepared on device %q, but listing it individually failed", device)
+		}
+		if len(deviceOsds) == 0 {
+			return nil, errors.Errorf("an OSD was prepared on device %q, but ceph-volume does not report it", device)
+		}
+		osds = appendOSDInfo(osds, deviceOsds)
+	}
+
+	return osds, nil
+}
+
+// deviceInOSDInfoList returns true if the given device path is the block path of one of the
+// given OSDs. Paths are compared after symlink resolution since ceph-volume may report a device
+// through a different alias (e.g. /dev/sdb1 configured as /dev/disk/by-id/...-part1).
+func deviceInOSDInfoList(device string, osds []oposd.OSDInfo) bool {
+	resolve := func(devicePath string) string {
+		if resolved, err := filepath.EvalSymlinks(devicePath); err == nil {
+			return resolved
+		}
+		return devicePath
+	}
+
+	resolvedDevice := resolve(device)
+	for _, osd := range osds {
+		if osd.BlockPath == device || resolve(osd.BlockPath) == resolvedDevice {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *DeviceOsdMapping, lvBackedPV bool) (string, string, string, error) {
@@ -487,18 +552,20 @@ func lvmModeAllowed(device *DeviceOsdIDEntry, storeConfig *config.StoreConfig) b
 	return true
 }
 
-func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceOsdMapping) error {
+// initializeDevices prepares the given devices with ceph-volume and returns the paths of the
+// devices that were newly prepared in raw mode.
+func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceOsdMapping) ([]string, error) {
 	// Should we allow ceph-volume raw mode?
 	allowRawMode, err := a.allowRawMode(context)
 	if err != nil {
-		return errors.Wrap(err, "failed to determine which ceph-volume mode to use")
+		return nil, errors.Wrap(err, "failed to determine which ceph-volume mode to use")
 	}
 
 	// If not raw mode we must execute a few LVM prerequisites
 	if !allowRawMode {
 		err = lvmPreReq(context)
 		if err != nil {
-			return errors.Wrap(err, "failed to run lvm prerequisites")
+			return nil, errors.Wrap(err, "failed to run lvm prerequisites")
 		}
 	}
 
@@ -530,26 +597,29 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		}
 	}
 
-	err = a.initializeDevicesRawMode(context, rawDevices)
+	preparedRawDevices, err := a.initializeDevicesRawMode(context, rawDevices)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = a.initializeDevicesLVMMode(context, lvmDevices)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return preparedRawDevices, nil
 }
 
-func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *DeviceOsdMapping) error {
+// initializeDevicesRawMode prepares the given devices with "ceph-volume raw prepare" and returns
+// the paths of the devices that were newly prepared.
+func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *DeviceOsdMapping) ([]string, error) {
 	baseCommand := "stdbuf"
 	cephVolumeMode := "raw"
 	storeFlag := a.storeConfig.GetStoreFlag()
 
 	baseArgs := []string{"-oL", cephVolumeCmd, cephVolumeMode, "prepare", storeFlag}
 
+	var preparedDevices []string
 	for name, device := range devices.Entries {
 		deviceArg := path.Join("/dev", name)
 		if device.Data == -1 {
@@ -585,15 +655,16 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 				}
 
 				// Return failure
-				return errors.Wrapf(err, "failed to run ceph-volume raw command. %s", op) // fail return here as validation provided by ceph-volume
+				return nil, errors.Wrapf(err, "failed to run ceph-volume raw command. %s", op) // fail return here as validation provided by ceph-volume
 			}
 			logger.Infof("%v", op)
+			preparedDevices = append(preparedDevices, deviceArg)
 		} else {
 			logger.Infof("skipping device %q with osd %d already configured", deviceArg, device.Data)
 		}
 	}
 
-	return nil
+	return preparedDevices, nil
 }
 
 func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *DeviceOsdMapping) error {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -582,6 +582,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			if args[0] == "osd" && args[1] == "tree" {
 				return `{"nodes":[],"stray":[]}`, nil
 			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
 		deviceClassSet := false
@@ -591,19 +594,6 @@ func TestConfigureCVDevices(t *testing.T) {
 				assert.Equal(t, "myclass", args[8])
 				deviceClassSet = true
 				return "", nil
-			}
-			return "", errors.Errorf("unknown command %s %s", command, args)
-		}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
-			if args[0] == "auth" && args[1] == "get-or-create-key" {
-				return "{\"key\":\"mysecurekey\"}", nil
-			}
-			if args[1] == "ceph-volume" && args[2] == "--log-path" && args[3] == "/tmp/ceph-log" {
-				return `{}`, nil
-			}
-			if args[0] == "osd" && args[1] == "tree" {
-				return `{"nodes":[],"stray":[]}`, nil
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
@@ -618,9 +608,10 @@ func TestConfigureCVDevices(t *testing.T) {
 				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
 			},
 		}
-		_, err := agent.configureCVDevices(context, devices)
+		deviceOSDs, err := agent.configureCVDevices(context, devices)
 		assert.Nil(t, err)
 		assert.True(t, deviceClassSet)
+		assert.Len(t, deviceOSDs, 1)
 	}
 
 	{
@@ -678,6 +669,109 @@ func TestConfigureCVDevices(t *testing.T) {
 		_, err := agent.configureCVDevices(context, devices)
 		assert.Nil(t, err)
 		assert.True(t, deviceClassSet)
+	}
+
+	{
+		// "ceph-volume raw list" without a device argument can miss freshly prepared OSDs.
+		// The freshly prepared device must be listed individually and the OSD must be returned.
+		t.Log("Test case for a raw mode OSD missing from the ceph-volume raw list results")
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
+			if command == "lsblk" && (args[0] == "/dev/vdb1") {
+				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="part" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
+			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" && args[6] == "/dev/vdb1" {
+				// listing the specific device finds the OSD
+				return cephVolumeRawPartitionTestResult, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
+				// listing all devices misses the freshly prepared OSD
+				return `{}`, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
+				return `{}`, nil
+			}
+			if args[0] == "osd" && args[1] == "tree" {
+				return `{"nodes":[],"stray":[]}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
+			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" {
+				return "", nil
+			}
+			if command == "cryptsetup" && args[0] == "luksDump" {
+				return "", errors.Errorf("%s is not a valid LUKS device", args[1])
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		clusterInfo := &cephclient.ClusterInfo{
+			FSID:    clusterFSID,
+			Context: context.TODO(),
+		}
+		context := &clusterd.Context{Executor: executor, ConfigDir: cephConfigDir}
+		agent := &OsdAgent{clusterInfo: clusterInfo, nodeName: nodeName, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+		devices := &DeviceOsdMapping{
+			Entries: map[string]*DeviceOsdIDEntry{
+				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
+			},
+		}
+		deviceOSDs, err := agent.configureCVDevices(context, devices)
+		require.NoError(t, err)
+		require.Len(t, deviceOSDs, 1)
+		assert.Equal(t, "/dev/vdb1", deviceOSDs[0].BlockPath)
+	}
+
+	{
+		// If a freshly prepared device cannot be listed even individually, the prepare job
+		// must fail instead of silently reporting fewer OSDs than were prepared.
+		t.Log("Test case for a raw mode OSD missing from all ceph-volume raw list results")
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
+				return `{}`, nil
+			}
+			if args[1] == "ceph-volume" && args[4] == "lvm" && args[5] == "list" {
+				return `{}`, nil
+			}
+			if args[0] == "osd" && args[1] == "tree" {
+				return `{"nodes":[],"stray":[]}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
+			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" {
+				return "", nil
+			}
+			if command == "cryptsetup" && args[0] == "luksDump" {
+				return "", errors.Errorf("%s is not a valid LUKS device", args[1])
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		clusterInfo := &cephclient.ClusterInfo{
+			FSID:    clusterFSID,
+			Context: context.TODO(),
+		}
+		context := &clusterd.Context{Executor: executor, ConfigDir: cephConfigDir}
+		agent := &OsdAgent{clusterInfo: clusterInfo, nodeName: nodeName, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
+		devices := &DeviceOsdMapping{
+			Entries: map[string]*DeviceOsdIDEntry{
+				"vdb1": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/vdb1"}, DeviceInfo: &sys.LocalDisk{Type: sys.PartType}},
+			},
+		}
+		_, err := agent.configureCVDevices(context, devices)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ceph-volume does not report it")
 	}
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix. Fixes #17905; reported upstream as [tracker.ceph.com/issues/77968](https://tracker.ceph.com/issues/77968). Alternative to #17733; relates to #17716.

**What is this PR about? / Why do we need it?**

The OSD prepare job runs `ceph-volume raw prepare` per device, then trusts a no-argument `ceph-volume raw list` to report the OSDs it just created. That listing can come back missing a freshly prepared device, and Rook then silently reports fewer OSDs than it prepared — the operator never creates the missing OSD deployment, and the cluster is left with OSDs in the osdmap but no daemons running.

**Root cause (Ceph v20.2.x / Tentacle):** two independent ceph-volume failure modes can blank the no-argument `raw list`. On v20.2.0/v20.2.1, `get_devices()` — the enumeration behind the no-argument `raw list` — reads udev data from `/run/udev/data/*` ([pr#65921](https://github.com/ceph/ceph/pull/65921)); when that data is empty or not yet populated, `get_devices()` returns nothing, so the listing is empty even though the OSD exists ([tracker.ceph.com/issues/77968](https://tracker.ceph.com/issues/77968); the v20.2.1 attempt to handle empty udev-data files, [pr#65923](https://github.com/ceph/ceph/pull/65923), was incomplete — see #17716). v20.2.2 restructured the no-argument listing away from `get_devices()`, closing that path, but every released v20.2.x has a second route to the same `{}`: a block device smaller than 4KiB in the scan (e.g. the 1KiB extended-partition node of an MBR-partitioned OS disk) crashes the single batched `ceph-bluestore-tool` call behind the listing ([tracker.ceph.com/issues/76354](https://tracker.ceph.com/issues/76354) — the bug behind #17992), which ceph-volume reports as an empty result. Listing a device *by name* is immune to both: it bypasses the udev-data enumeration, and a named OSD device is never sub-4KiB.

The same empty-list symptom also appears transiently on the canary CI right after prepare (e.g. runs [27149222715](https://github.com/rook/rook/actions/runs/27149222715) where `raw list` returned `{}`, and [24675046082](https://github.com/rook/rook/actions/runs/24675046082) where it returned 1 of 2 prepared devices).

Scope: this covers the fresh-prepare path only. The re-run-over-existing-OSDs path from #17716 (prepare job re-triggered by a CephCluster spec change, taking the "no new devices" idempotency branch) is not changed by this PR and would need a follow-up.

**The fix:** verify that every device prepared in raw mode is present in the listing. For any that is missing, list the device individually (`ceph-volume raw list <device>`), which reports the OSD. If even the per-device listing is empty, return an error so the prepare pod exits non-zero and Kubernetes restarts it with a freshly re-scanned environment, rather than silently under-reporting the OSDs.

**How this differs from #17733:** that PR retries the per-device listing in-process (5× with sleeps) to ride out udev settling. This variant drops the in-process retry loop: the per-device listing bypasses the udev-data path rather than waiting for it, so it succeeds on the first call. The only case it can't resolve inline is a genuinely unready environment, and a full pod restart handles that more cleanly than an in-process sleep — so we fail and let Kubernetes restart the job.

The bug, its CI evidence, and the upstream ceph-volume root cause are written up in #17905. The activate init container's rename fallback shares the single-batched-call weakness; #18006 fixes it the same way (see #17992).

Opened as a draft to validate against the canary CI job.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.





