### PR TITLE
docs: design doc for OBC bucket versioning support

### DIFF
--- a/design/ceph/object/obc-bucket-versioning.md
+++ b/design/ceph/object/obc-bucket-versioning.md
@@ -1,0 +1,201 @@
+---
+title: Bucket versioning support for ObjectBucketClaims
+target-version: release-1.18
+---
+
+# Bucket versioning support for ObjectBucketClaims
+
+Reference issue: [#17318](https://github.com/rook/rook/issues/17318)
+
+## Summary
+
+[S3 bucket versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html)
+keeps multiple variants of an object in the same bucket, allowing users to
+preserve, retrieve, and restore every version of every object stored in a
+bucket. Ceph RGW supports the standard S3 `GetBucketVersioning` /
+`PutBucketVersioning` APIs.
+
+Today, users who provision buckets via ObjectBucketClaims (OBCs) must enable
+versioning out-of-band with an S3 client after the bucket is provisioned. This
+proposal adds a `bucketVersioning` key to the OBC `spec.additionalConfig` map
+so that versioning is declaratively managed by the Rook bucket provisioner,
+following the same pattern as the existing `bucketPolicy` and
+`bucketLifecycle` config fields.
+
+## Versioning has three states, not two
+
+A boolean is not sufficient to model S3 versioning. Per the
+[S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html#versioning-states),
+a bucket is always in exactly one of three versioning states:
+
+1. **Unversioned** (the default): the bucket has never had versioning enabled.
+   Objects have a `null` version ID.
+2. **Versioning-enabled** (`Enabled`): all new objects get a unique version ID.
+3. **Versioning-suspended** (`Suspended`): versioning was previously enabled
+   and is now suspended. Existing object versions are retained; new objects
+   get a `null` version ID.
+
+Critically, the transition out of the unversioned state is **one-way**: once
+versioning has been enabled on a bucket, the bucket can never return to the
+unversioned state — it can only alternate between `Enabled` and `Suspended`.
+
+The proposed `bucketVersioning` value is therefore a string enum rather than a
+bool, with values matching the S3 `VersioningConfiguration.Status` wire
+values:
+
+| `bucketVersioning` value | Meaning |
+| ------------------------ | ------- |
+| _key not present_        | Rook does not manage versioning. The bucket's current versioning state, whatever it is, is left untouched. |
+| `Enabled`                | Rook reconciles the bucket's versioning status to `Enabled`. |
+| `Suspended`              | Rook reconciles the bucket's versioning status to `Suspended`. |
+
+Any other value is a validation error, and the OBC will fail to reconcile with
+an error event, consistent with how invalid `maxSize`/`maxObjects` values are
+handled.
+
+### Why "key not present" means "unmanaged" instead of "delete"
+
+For `bucketPolicy` and `bucketLifecycle`, removing the key from
+`additionalConfig` causes the provisioner to delete the live policy/lifecycle
+configuration. Versioning cannot follow that convention because there is no
+"delete" operation for versioning state — an S3 bucket that has ever been
+versioned cannot go back to unversioned.
+
+The two candidate semantics for a removed `bucketVersioning` key are:
+
+1. **Unmanaged** (proposed): leave the live state as-is.
+2. **Suspend**: reconcile the bucket to `Suspended`.
+
+Option 2 is rejected because it makes key-removal a destructive state change
+(new object writes silently stop being versioned), which is surprising and
+inconsistent with the general principle that removing a config key returns
+control to the user rather than forcing a specific state. Option 1 also
+matches what `Suspended` is for: users who explicitly want versioning off
+can say so.
+
+This asymmetry with `bucketPolicy`/`bucketLifecycle` removal semantics will be
+called out in the user-facing documentation.
+
+### `Suspended` on a never-versioned bucket
+
+Calling `PutBucketVersioning` with `Suspended` on an unversioned bucket is
+accepted by the S3 API and by RGW; the bucket transitions to the
+versioning-suspended state, which behaves equivalently to unversioned for new
+writes. The provisioner does not need to special-case this, but the
+documentation will note that setting `Suspended` on a fresh bucket is
+effectively a no-op for object behavior while still marking the bucket as
+"has seen versioning".
+
+## Proposal details
+
+### API
+
+No CRD/API schema changes are required. `ObjectBucketClaim.spec.additionalConfig`
+is already an arbitrary `map[string]string` defined by lib-bucket-provisioner.
+
+Example OBC:
+
+```yaml
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ceph-bucket
+spec:
+  bucketName: ceph-bucket
+  storageClassName: rook-ceph-bucket
+  additionalConfig:
+    bucketVersioning: "Enabled" # one of "Enabled" or "Suspended"
+```
+
+### Operator gating (disabled by default)
+
+Like `bucketMaxObjects`, `bucketMaxSize`, `bucketPolicy`, `bucketLifecycle`,
+and `bucketOwner`, the new `bucketVersioning` field will **not** be allowed by
+default. Administrators must opt in via the existing
+`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` operator setting, e.g.:
+
+```
+ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "bucketVersioning"
+```
+
+The risk profile is lower than `bucketPolicy` (a user cannot affect other
+users' buckets), but enabling versioning can grow storage consumption without
+bound if no lifecycle rule cleans up noncurrent versions, and bucket quota
+accounting includes all versions. This is an administrator-visible tradeoff
+and justifies keeping the field opt-in. The documentation will recommend
+pairing `bucketVersioning` with a `bucketLifecycle` rule using
+`NoncurrentVersionExpiration`.
+
+### Provisioner behavior
+
+A new `bucketVersioning *string` field is added to the internal
+`additionalConfigSpec` struct
+(`pkg/operator/ceph/object/bucket/provisioner.go`), parsed and validated in
+`additionalConfigSpecFromMap()` (`pkg/operator/ceph/object/bucket/util.go`)
+with the same allow-list check used by the other gated fields.
+
+A new `setBucketVersioning()` step is appended to `setAdditionalSettings()`,
+which runs on OBC Provision, Grant, and update reconciles. It follows the
+established read-compare-write pattern of `setBucketPolicy()` /
+`setBucketLifecycle()`:
+
+1. `GetBucketVersioning` on the bucket via the S3 SDK (using the bucket
+   owner's credentials, so this works with `bucketOwner` as well).
+2. If `bucketVersioning` is unset, return without action (unmanaged).
+3. Compare the live status against the desired status. A live empty status
+   (unversioned bucket) is only ever different from the desired state, since
+   `Enabled`/`Suspended` are the only accepted values.
+4. On difference, call `PutBucketVersioning` with the desired
+   `VersioningConfiguration.Status` and log the change.
+
+The operation is idempotent and level-triggered: repeated reconciles converge
+and drift introduced by direct S3 API calls is corrected on the next
+reconcile, consistent with the other `additionalConfig` fields.
+
+### Greenfield and brownfield
+
+- **Provision** (greenfield): versioning is applied immediately after bucket
+  creation and quota setup.
+- **Grant** (brownfield, pre-existing bucket): versioning is reconciled on the
+  existing bucket the same way quotas are today. If the existing bucket is
+  already versioned and the OBC does not set `bucketVersioning`, the live
+  state is preserved.
+
+### Out of scope (and how this design leaves room for it)
+
+- **MFA Delete**: `VersioningConfiguration` also carries an `MFADelete`
+  field. RGW's support is limited and OBCs have no natural way to carry MFA
+  device state. Not supported; the single-key string design leaves room for a
+  separate `bucketVersioningMFADelete` key later without breaking changes.
+- **Object Lock** ([#17883](https://github.com/rook/rook/issues/17883)):
+  object lock requires versioning to be enabled at bucket **creation** time
+  (`ObjectLockEnabledForBucket` on `CreateBucket`) and prevents versioning
+  from ever being suspended. It is a distinct feature with its own retention
+  configuration and should be designed separately. This proposal is a
+  prerequisite step in that direction: a future `bucketObjectLock` key would
+  compose with `bucketVersioning: Enabled` and add a validation rejecting
+  `Suspended` when object lock is requested.
+- **CephObjectStoreUser / COSI**: this proposal only covers the OBC
+  provisioner. COSI support can reuse the same provisioner-side helper when
+  COSI bucket features are extended.
+
+## Validation and testing
+
+- Unit tests for `additionalConfigSpecFromMap()`: accepted values, rejected
+  values (`true`, `enabled`, arbitrary strings), and allow-list gating.
+- Unit tests for `setBucketVersioning()` using the existing mocked S3/admin
+  API test fixtures in `provisioner_test.go`: enable on unversioned bucket,
+  no-op when in sync, suspend transition, unmanaged when key absent.
+- CI integration: extend the object bucket e2e suite
+  (`tests/integration`) with an OBC that sets `bucketVersioning: Enabled`,
+  asserts `GetBucketVersioning` returns `Enabled`, flips to `Suspended`, and
+  asserts convergence.
+
+## Documentation changes
+
+- `Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md`:
+  document the new key, its three-state semantics, the one-way nature of
+  enabling versioning, the unmanaged-when-absent behavior, and the
+  recommendation to pair with a noncurrent-version lifecycle rule.
+- `deploy/examples/object-bucket-claim-versioning.yaml` (or extend the
+  existing OBC example): commented example manifest.

--- a/design/ceph/object/obc-bucket-versioning.md
+++ b/design/ceph/object/obc-bucket-versioning.md
@@ -51,7 +51,9 @@ values:
 
 Any other value is a validation error, and the OBC will fail to reconcile with
 an error event, consistent with how invalid `maxSize`/`maxObjects` values are
-handled.
+handled. Validation is case-sensitive: only the exact strings `Enabled` and
+`Suspended` (matching the S3 `VersioningConfiguration.Status` wire values) are
+accepted. Variants such as `enabled`, `ENABLED`, or `suspended` are rejected.
 
 ### Why "key not present" means "unmanaged" instead of "delete"
 
@@ -128,25 +130,25 @@ pairing `bucketVersioning` with a `bucketLifecycle` rule using
 
 ### Provisioner behavior
 
-A new `bucketVersioning *string` field is added to the internal
-`additionalConfigSpec` struct
-(`pkg/operator/ceph/object/bucket/provisioner.go`), parsed and validated in
-`additionalConfigSpecFromMap()` (`pkg/operator/ceph/object/bucket/util.go`)
-with the same allow-list check used by the other gated fields.
+When `bucketVersioning` is set in the OBC `additionalConfig`, the provisioner
+manages the bucket's versioning state during both Provision (greenfield) and
+Grant (brownfield) paths. It follows the same read-compare-write pattern as
+`bucketPolicy` and `bucketLifecycle`:
 
-A new `setBucketVersioning()` step is appended to `setAdditionalSettings()`,
-which runs on OBC Provision, Grant, and update reconciles. It follows the
-established read-compare-write pattern of `setBucketPolicy()` /
-`setBucketLifecycle()`:
-
-1. `GetBucketVersioning` on the bucket via the S3 SDK (using the bucket
-   owner's credentials, so this works with `bucketOwner` as well).
-2. If `bucketVersioning` is unset, return without action (unmanaged).
-3. Compare the live status against the desired status. A live empty status
-   (unversioned bucket) is only ever different from the desired state, since
-   `Enabled`/`Suspended` are the only accepted values.
+1. Read the current versioning configuration from the bucket via
+   `GetBucketVersioning` (using the bucket owner's credentials, so this
+   composes with `bucketOwner`).
+2. If `bucketVersioning` is unset, take no action — the live state is left
+   as-is (unmanaged).
+3. Compare the live status against the desired status. An unversioned bucket
+   (empty live status) is treated as different from the desired
+   `Enabled`/`Suspended` value.
 4. On difference, call `PutBucketVersioning` with the desired
    `VersioningConfiguration.Status` and log the change.
+
+Versioning is applied **before** lifecycle configuration, so that a
+`bucketLifecycle` rule targeting noncurrent versions (e.g.
+`NoncurrentVersionExpiration`) has versioned objects to act on.
 
 The operation is idempotent and level-triggered: repeated reconciles converge
 and drift introduced by direct S3 API calls is corrected on the next

--- a/design/ceph/object/obc-bucket-versioning.md
+++ b/design/ceph/object/obc-bucket-versioning.md
@@ -45,7 +45,7 @@ values:
 
 | `bucketVersioning` value | Meaning |
 | ------------------------ | ------- |
-| _key not present_        | Rook does not manage versioning. The bucket's current versioning state, whatever it is, is left untouched. |
+| _key not present_        | When `bucketVersioning` is in `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`, Rook reconciles the bucket's versioning status to `Suspended` — the deterministic default. When the field is **not** in the allow-list, Rook does not manage versioning and the bucket's current state is left untouched. |
 | `Enabled`                | Rook reconciles the bucket's versioning status to `Enabled`. |
 | `Suspended`              | Rook reconciles the bucket's versioning status to `Suspended`. |
 
@@ -55,7 +55,7 @@ handled. Validation is case-sensitive: only the exact strings `Enabled` and
 `Suspended` (matching the S3 `VersioningConfiguration.Status` wire values) are
 accepted. Variants such as `enabled`, `ENABLED`, or `suspended` are rejected.
 
-### Why "key not present" means "unmanaged" instead of "delete"
+### Why "key not present" means "Suspended" (deterministic default) when the field is managed
 
 For `bucketPolicy` and `bucketLifecycle`, removing the key from
 `additionalConfig` causes the provisioner to delete the live policy/lifecycle
@@ -63,20 +63,35 @@ configuration. Versioning cannot follow that convention because there is no
 "delete" operation for versioning state — an S3 bucket that has ever been
 versioned cannot go back to unversioned.
 
-The two candidate semantics for a removed `bucketVersioning` key are:
+The two candidate semantics for a removed `bucketVersioning` key (when the
+field is in `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`) are:
 
-1. **Unmanaged** (proposed): leave the live state as-is.
-2. **Suspend**: reconcile the bucket to `Suspended`.
+1. **Unmanaged**: leave the live state as-is.
+2. **Suspend** (preferred): reconcile the bucket to `Suspended` — the
+   deterministic default.
 
-Option 2 is rejected because it makes key-removal a destructive state change
-(new object writes silently stop being versioned), which is surprising and
-inconsistent with the general principle that removing a config key returns
-control to the user rather than forcing a specific state. Option 1 also
-matches what `Suspended` is for: users who explicitly want versioning off
-can say so.
+**Option 2 is preferred.** The maintainers (see discussion on PR #17886)
+chose it because it makes the bucket's state deterministic from the OBC
+spec alone, irrespective of the resource's history: removing
+`bucketVersioning` from the OBC reliably sets versioning off, rather than
+leaving the bucket in whatever state a prior edit or out-of-band change left
+it in. This matches the usual Kubernetes expectation that the observed state
+converges to a known value derived from the spec. The "unmanaged" behavior is
+treated as a side-effect of the legacy removal handling rather than an intent
+to preserve unknown history. Users who want versioning on the bucket can
+explicitly set `Enabled`; users who want versioning off can either omit the key
+(or set `Suspended`) and get `Suspended`.
 
-This asymmetry with `bucketPolicy`/`bucketLifecycle` removal semantics will be
-called out in the user-facing documentation.
+This asymmetric behavior with `bucketPolicy`/`bucketLifecycle` removal
+semantics will be called out in the user-facing documentation, along with the
+important caveat that `Suspended` is **one-way-reachable only from the
+unversioned state** — once a bucket has been `Enabled`, `Suspended` retains
+all existing object versions and simply stops creating new ones.
+
+This deterministic-default behavior only applies when `bucketVersioning` is
+listed in `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`. When it is **not** in the
+allow-list (the default), Rook does not manage versioning at all, preserving
+existing installs and avoiding surprising behavior on upgrade.
 
 ### `Suspended` on a never-versioned bucket
 
@@ -128,6 +143,12 @@ and justifies keeping the field opt-in. The documentation will recommend
 pairing `bucketVersioning` with a `bucketLifecycle` rule using
 `NoncurrentVersionExpiration`.
 
+When `bucketVersioning` is in `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`, an OBC
+that does **not** set the key gets the field reconciled to `Suspended` by
+default (the deterministic-default behavior adopted for PR #17886), so the
+observed state always converges to a known value. When the field is **not** in
+the allow-list (the default), Rook does not manage versioning at all.
+
 ### Provisioner behavior
 
 When `bucketVersioning` is set in the OBC `additionalConfig`, the provisioner
@@ -138,11 +159,14 @@ Grant (brownfield) paths. It follows the same read-compare-write pattern as
 1. Read the current versioning configuration from the bucket via
    `GetBucketVersioning` (using the bucket owner's credentials, so this
    composes with `bucketOwner`).
-2. If `bucketVersioning` is unset, take no action — the live state is left
-   as-is (unmanaged).
+2. If `bucketVersioning` is unset but the field **is** in
+   `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`, Rook reconciles the bucket to
+   `Suspended` — the deterministic default when the field is managed. If the
+   field is **not** in the allow-list, Rook takes no action and the live
+   versioning state is left untouched (preserving existing installs).
 3. Compare the live status against the desired status. An unversioned bucket
-   (empty live status) is treated as different from the desired
-   `Enabled`/`Suspended` value.
+   (empty live status) is treated as different from a desired `Enabled` value,
+   and as matching a desired `Suspended` value.
 4. On difference, call `PutBucketVersioning` with the desired
    `VersioningConfiguration.Status` and log the change.
 
@@ -160,8 +184,10 @@ reconcile, consistent with the other `additionalConfig` fields.
   creation and quota setup.
 - **Grant** (brownfield, pre-existing bucket): versioning is reconciled on the
   existing bucket the same way quotas are today. If the existing bucket is
-  already versioned and the OBC does not set `bucketVersioning`, the live
-  state is preserved.
+  already versioned and the OBC does not set `bucketVersioning`, the outcome
+  depends on gating: when `bucketVersioning` is **not** in the allow-list the
+  live state is preserved; when it **is** in the allow-list, Rook reconciles
+  the bucket to `Suspended` (the deterministic default).
 
 ### Out of scope (and how this design leaves room for it)
 
@@ -187,7 +213,9 @@ reconcile, consistent with the other `additionalConfig` fields.
   values (`true`, `enabled`, arbitrary strings), and allow-list gating.
 - Unit tests for `setBucketVersioning()` using the existing mocked S3/admin
   API test fixtures in `provisioner_test.go`: enable on unversioned bucket,
-  no-op when in sync, suspend transition, unmanaged when key absent.
+  no-op when in sync, suspend transition, and the key-absent deterministic
+  default (`Suspended` when the field is in the allow-list, unmanaged when it
+  is not).
 - CI integration: extend the object bucket e2e suite
   (`tests/integration`) with an OBC that sets `bucketVersioning: Enabled`,
   asserts `GetBucketVersioning` returns `Enabled`, flips to `Suspended`, and
@@ -197,7 +225,9 @@ reconcile, consistent with the other `additionalConfig` fields.
 
 - `Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md`:
   document the new key, its three-state semantics, the one-way nature of
-  enabling versioning, the unmanaged-when-absent behavior, and the
-  recommendation to pair with a noncurrent-version lifecycle rule.
+  enabling versioning, the deterministic-default behavior when the key is
+  absent (`Suspended` when the field is in the allow-list, unmanaged when it
+  is not), and the recommendation to pair with a noncurrent-version lifecycle
+  rule.
 - `deploy/examples/object-bucket-claim-versioning.yaml` (or extend the
   existing OBC example): commented example manifest.

--- a/design/ceph/object/obc-bucket-versioning.md
+++ b/design/ceph/object/obc-bucket-versioning.md
@@ -1,6 +1,6 @@
 ---
 title: Bucket versioning support for ObjectBucketClaims
-target-version: release-1.18
+target-version: release-1.21
 ---
 
 # Bucket versioning support for ObjectBucketClaims


### PR DESCRIPTION
**Description of your changes:**

Design document for allowing S3 bucket versioning to be managed via the ObjectBucketClaim `additionalConfig` map, as requested in #17318 (labeled `needs-design-document`).

Key design points, addressing the maintainer feedback in that issue:

- **Not a bool.** S3 versioning has [three states](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html#versioning-states) (unversioned / enabled / suspended) and the unversioned state is unreachable once versioning has ever been enabled. The proposal is a `bucketVersioning` string key accepting `Enabled` or `Suspended` (matching the S3 `VersioningConfiguration.Status` wire values), with an absent key meaning "unmanaged" — the design explains why absent-means-unmanaged instead of the delete semantics used by `bucketPolicy`/`bucketLifecycle`.
- Gated behind the existing `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` operator setting, disabled by default like the other non-quota fields.
- Reconciled with the established read-compare-write pattern in `setAdditionalSettings()`, so it applies to Provision, Grant (brownfield), and OBC updates, and composes with `bucketOwner`.
- Explicitly scopes out MFA Delete and Object Lock (#17883), while noting how the design leaves room for both.

This PR intentionally does **not** close #17318; implementation will follow in a separate PR once the design is agreed on. I'm happy to implement it.

Note: this PR was written with AI assistance (Claude), per the [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines); I reviewed the content.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release. (design doc only — will be updated with the implementation PR)
- [ ] Documentation has been updated, if necessary. (design doc only)
- [ ] Unit tests have been added, if necessary. (design doc only)
- [ ] Integration tests have been added, if necessary. (design doc only)