### PR TITLE
test: convert the object store dependents suite to a private store

### DIFF
--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -48,15 +48,12 @@ const (
 )
 
 var (
-	userid                 = "rook-user"
-	userdisplayname        = "A rook RGW user"
-	bucketname             = "smokebkt"
-	obcName                = "smoke-delete-bucket"
-	maxObject              = "2"
-	bucketStorageClassName = "rook-smoke-delete-bucket"
-	maxBucket              = 1
-	maxSize                = "100000"
-	userCap                = "*"
+	userdisplayname = "A rook RGW user"
+	obcName         = "smoke-delete-bucket"
+	maxObject       = "2"
+	maxBucket       = 1
+	maxSize         = "100000"
+	userCap         = "*"
 )
 
 // Test Object StoreCreation on Rook that was installed via helm

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -18,19 +18,12 @@ package integration
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
-	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
@@ -40,6 +33,7 @@ import (
 	bucketquota "github.com/rook/rook/tests/integration/object/bucket/quota"
 	bucketrw "github.com/rook/rook/tests/integration/object/bucket/rw"
 	"github.com/rook/rook/tests/integration/object/cosi"
+	"github.com/rook/rook/tests/integration/object/dependents"
 	"github.com/rook/rook/tests/integration/object/notification"
 	topickafka "github.com/rook/rook/tests/integration/object/topic/kafka"
 	usercaps "github.com/rook/rook/tests/integration/object/user/caps"
@@ -162,22 +156,32 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
 	})
 
-	// now test operation of the first object store
-	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
+	// the deletion checks that consumed this store live in the dependents
+	// package now; delete it so it cannot block cluster teardown
+	s.T().Run("delete the suite object store", func(t *testing.T) {
+		deleteObjectStore(t, k8sh, namespace, storeName)
+		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
+	})
 
-	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable, settings.Namespace, "sharedstore", 1,
-		bucketlifecycle.Namespace,
-		bucketowner.Namespace,
-		bucketpolicy.Namespace,
-		bucketquota.Namespace,
-		bucketrw.Namespace,
-		userkeys.Namespace,
-		topickafka.Namespace,
-		useropmask.Namespace,
-		usercaps.Namespace,
-		cosi.Namespace,
-		notification.Namespace,
-	)
+	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, sharedstore.Config{
+		Namespace: settings.Namespace,
+		StoreName: "sharedstore",
+		Instances: 1,
+		TLSEnable: tlsEnable,
+		AllowUsersInNamespaces: []string{
+			bucketlifecycle.Namespace,
+			bucketowner.Namespace,
+			bucketpolicy.Namespace,
+			bucketquota.Namespace,
+			bucketrw.Namespace,
+			userkeys.Namespace,
+			topickafka.Namespace,
+			useropmask.Namespace,
+			usercaps.Namespace,
+			cosi.Namespace,
+			notification.Namespace,
+		},
+	})
 	defer sharedObjectStore.Destroy()
 
 	zonepools.TestZonePools(s.T(), k8sh, sharedObjectStore)
@@ -194,151 +198,8 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	// suite skips itself in the TLS pass
 	cosi.TestCephCOSIDriver(s.T(), k8sh, sharedObjectStore)
 	notification.TestBucketNotification(s.T(), k8sh, sharedObjectStore)
-}
 
-func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper, settings *installer.TestCephSettings, storeName string, swiftAndKeystone bool) {
-	ctx := context.TODO()
-	namespace := settings.Namespace
-	clusterInfo := client.AdminTestClusterInfo(namespace)
-	t := s.T()
-
-	logger.Infof("Testing Object Operations on %s", storeName)
-	t.Run("create CephObjectStoreUser", func(t *testing.T) {
-		createCephObjectUser(s, helper, k8sh, namespace, storeName, userid, true)
-		i := 0
-		for i = 0; i < 4; i++ {
-			if helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid) {
-				break
-			}
-			logger.Info("waiting 5 more seconds for user secret to exist")
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-	})
-
-	context := k8sh.MakeContext()
-	objectStore, err := k8sh.RookClientset.CephV1().CephObjectStores(namespace).Get(ctx, storeName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	rgwcontext, err := rgw.NewMultisiteContext(context, clusterInfo, objectStore)
-	assert.Nil(t, err)
-	t.Run("create ObjectBucketClaim", func(t *testing.T) {
-		logger.Infof("create OBC %q with storageclass %q - using reclaim policy 'delete' so buckets don't block deletion", obcName, bucketStorageClassName)
-		cobErr := helper.BucketClient.CreateBucketStorageClass(namespace, storeName, bucketStorageClassName, "Delete")
-		assert.Nil(t, cobErr)
-		cobcErr := helper.BucketClient.CreateObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
-		assert.Nil(t, cobcErr)
-		created := utils.Retry(20, 2*time.Second, "OBC is created", func() bool {
-			return helper.BucketClient.CheckOBC(obcName, "bound")
-		})
-		assert.True(t, created)
-		logger.Info("OBC created successfully")
-
-		var bkt rgw.ObjectBucket
-		i := 0
-		for i = 0; i < 4; i++ {
-			b, code, err := rgw.GetBucket(rgwcontext, bucketname)
-			if b != nil && err == nil {
-				bkt = *b
-				break
-			}
-			logger.Warningf("cannot get bucket %q, retrying... bucket: %v. code: %d, err: %v", bucketname, b, code, err)
-			logger.Infof("(%d) check bucket exists, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-		assert.Equal(t, bucketname, bkt.Name)
-		logger.Info("OBC, Secret and ConfigMap created")
-	})
-
-	t.Run("delete CephObjectStore should be blocked by OBC bucket and CephObjectStoreUser", func(t *testing.T) {
-		deleteObjectStore(t, k8sh, namespace, storeName)
-
-		store := &cephv1.CephObjectStore{}
-		i := 0
-		for i = 0; i < 4; i++ {
-			storeStr, err := k8sh.GetResource("-n", namespace, "CephObjectStore", storeName, "-o", "json")
-			assert.NoError(t, err)
-
-			err = json.Unmarshal([]byte(storeStr), &store)
-			assert.NoError(t, err)
-
-			cond := cephv1.FindStatusCondition(store.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
-			if cond != nil {
-				break
-			}
-			logger.Info("waiting 2 more seconds for CephObjectStore to reach Deleting state")
-			time.Sleep(2 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-
-		assert.Equal(t, cephv1.ConditionDeleting, store.Status.Phase) // phase == "Deleting"
-		// verify deletion is blocked b/c object has dependents
-		cond := cephv1.FindStatusCondition(store.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
-		logger.Infof("condition: %+v", cond)
-		assert.Equal(t, v1.ConditionTrue, cond.Status)
-		assert.Equal(t, cephv1.ObjectHasDependentsReason, cond.Reason)
-		// the CephObjectStoreUser and the bucket should both block deletion
-		assert.Contains(t, cond.Message, "CephObjectStoreUsers")
-		assert.Contains(t, cond.Message, userid)
-		assert.Contains(t, cond.Message, "buckets")
-		assert.Contains(t, cond.Message, bucketname)
-
-		// The event is created by the same method that adds that condition, so we can be pretty
-		// sure it exists here. No need to do extra work to validate the event.
-	})
-
-	t.Run("delete OBC", func(t *testing.T) {
-		i := 0
-		dobcErr := helper.BucketClient.DeleteObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
-		assert.Nil(t, dobcErr)
-		logger.Info("Checking to see if the obc, secret, and cm have all been deleted")
-		for i = 0; i < 4 && !helper.BucketClient.CheckOBC(obcName, "deleted"); i++ {
-			logger.Infof("(%d) obc deleted check, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-
-		logger.Info("ensure OBC bucket was deleted")
-		var rgwErr int
-		for i = 0; i < 4; i++ {
-			_, rgwErr, _ = rgw.GetBucket(rgwcontext, bucketname)
-			if rgwErr == rgw.RGWErrorNotFound {
-				break
-			}
-			logger.Infof("(%d) check bucket deleted, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-		assert.Equal(t, rgwErr, rgw.RGWErrorNotFound)
-
-		dobErr := helper.BucketClient.DeleteBucketStorageClass(namespace, storeName, bucketStorageClassName, "Delete")
-		assert.Nil(t, dobErr)
-	})
-
-	t.Run("delete CephObjectStoreUser", func(t *testing.T) {
-		dosuErr := helper.ObjectUserClient.Delete(namespace, userid)
-		assert.Nil(t, dosuErr)
-		logger.Info("Object store user deleted successfully")
-		logger.Info("Checking to see if the user secret has been deleted")
-		i := 0
-		for i = 0; i < 4 && helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid) == true; i++ {
-			logger.Infof("(%d) secret check sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.False(t, helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid))
-	})
-
-	t.Run("Regression check: mgrs are not in a crashloop", func(t *testing.T) {
-		assert.True(t, k8sh.CheckPodCountAndState("rook-ceph-mgr", namespace, 1, "Running"))
-	})
-
-	// tests are complete, now delete the objectstore
-	s.T().Run("CephObjectStore should delete now that dependents are gone", func(t *testing.T) {
-		// wait initially since it will almost never detect on the first try without this.
-		time.Sleep(3 * time.Second)
-
-		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
-	})
-
-	// TODO : Add case for brownfield/cleanup s3 client}
+	// last: this one builds and deletes a store of its own, so keep it clear of
+	// the packages sharing the fixture store
+	dependents.TestCephObjectStoreDependents(s.T(), k8sh, installer, settings.Namespace, tlsEnable)
 }

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -126,7 +126,11 @@ func (s *SmokeSuite) TestObjectStorage_SmokeTest() {
 	if utils.IsPlatformOpenShift() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
-	store := sharedstore.Create(s.T(), s.k8sh, s.installer, false, s.settings.Namespace, "lite-store", 2)
+	store := sharedstore.Create(s.T(), s.k8sh, s.installer, sharedstore.Config{
+		Namespace: s.settings.Namespace,
+		StoreName: "lite-store",
+		Instances: 2,
+	})
 	store.Destroy()
 }
 

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -2,7 +2,7 @@
 
 This tree holds the new-style integration tests for rook's object storage
 features. It is the model for converting the remaining old-style object tests
-(`testObjectStoreOperations`, store lifecycle);
+(store lifecycle);
 follow the conventions here exactly so the conversion happens once.
 
 ## Execution model
@@ -38,13 +38,14 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `bucket/quota` | `object/bucket` | OBC maxObjects user quota + bucketMaxObjects/bucketMaxSize bucket quota |
 | `bucket/rw` | `object/bucket` | OBC S3 read/write/delete + OBC-stays-Bound |
 | `cosi` | `object/cosi` | CephCOSIDriver + COSI bucket provisioning |
+| `dependents` | `object` | CephObjectStore deletion blocked by dependents |
 | `notification` | `object/notification` | CephBucketNotification HTTP endpoint delivery |
 | `topic/kafka` | `object/topic` | CephBucketTopic kafka endpoints |
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
 | `zonepools` | `object` | zone.json pool fields covered by Rook's shared-pool mapping |
-| reserved: `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
+| reserved: `tests/integration/object/lifecycle` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -60,7 +61,9 @@ Shared utilities live under `util/`:
   per-OBC S3 client.
 - `secrets` — verification helpers for the Secret references object CRDs
   publish in their status, shared by more than one package.
-- `sharedstore` — the shared CephObjectStore fixture.
+- `sharedstore` — the CephObjectStore fixture: the shared store, and the
+  private stores the private-store packages build (`Config.Kind` selects a
+  zoned or classic store).
 - `client` — rgw admin, SNS, and S3 client builders and TLS cert generation.
 
 ## Anatomy of a package
@@ -98,7 +101,12 @@ func TestObjectStoreUserCaps(t *testing.T, k8sh *utils.K8sHelper, store *shareds
 Rules encoded in that shape:
 
 - The entry signature is `(t, k8sh, store)` and never changes. New
-  dependencies are added as `Sharedstore` accessors, not parameters.
+  dependencies are added as `Sharedstore` accessors, not parameters. The one
+  exception is a package whose subject is destructive to the store itself
+  (deleting it, or a behavior the operator gates on the store's own spec):
+  it cannot share the fixture store, so it builds a private one with
+  `sharedstore.Create` and takes `(t, k8sh, installer, namespace, tlsEnable)`
+  instead. `dependents` is the model.
 - The var block declares everything the test uses: fixture objects (use
   constructors — `obc.StorageClass`, package-local helpers like
   `awsKeySecret`/`objectUserKey` — to keep literals one line each), then the
@@ -210,6 +218,5 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `testObjectStoreOperations` deletion-blocked-by-dependents | `tests/integration/object/dependents` | private-store fixture, store condition predicates in `wait4` |
 | `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts | `tests/integration/object/lifecycle` | store create/health/delete helpers |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/dependents/dependents.go
+++ b/tests/integration/object/dependents/dependents.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dependents
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/obc"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const Namespace = "test-dependents"
+
+// TestCephObjectStoreDependents verifies a CephObjectStore's deletion is blocked
+// while it has dependents (a CephObjectStoreUser and an OBC bucket) and completes
+// once they are gone. Deleting a store is destructive, so — unlike the other
+// object packages — it does not take the shared fixture; it builds its own store,
+// which coexists with the shared store in the same cluster namespace.
+//
+// The store must be classic: the operator only checks for user and bucket
+// dependents on a non-multisite store (or a master zone), so a multisite store
+// here would delete unblocked and the test would assert nothing.
+func TestCephObjectStoreDependents(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, namespace string, tlsEnable bool) {
+	t.Run("CephObjectStore dependents", func(t *testing.T) {
+		ctx := t.Context()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}
+
+		store := sharedstore.Create(t, k8sh, installer, sharedstore.Config{
+			Namespace: namespace,
+			StoreName: ns.Name,
+			Instances: 1,
+			TLSEnable: tlsEnable,
+			Kind:      sharedstore.Classic,
+		})
+		objectStore := store.ObjectStore()
+
+		storageClass := obc.StorageClass(ns.Name, objectStore)
+
+		user1 := &cephv1.CephObjectStoreUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ns.Name + "-user1",
+				Namespace: namespace,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				Store:       objectStore.Name,
+				DisplayName: "dependents test user",
+			},
+		}
+
+		obc1 := &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ns.Name + "-obc1",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       ns.Name + "-obc1",
+				StorageClassName: storageClass.Name,
+			},
+		}
+
+		obcClient := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(ns.Name)
+		cosClient := k8sh.RookClientset.CephV1().CephObjectStores(namespace)
+		osuClient := k8sh.RookClientset.CephV1().CephObjectStoreUsers(namespace)
+
+		fixture.RequireNamespace(t, k8sh, ns)
+		fixture.RequireStorageClass(t, k8sh, storageClass)
+
+		// The scenario tears the store down itself, via Destroy, as its final
+		// assertion; Teardown is a no-op by then. This fallback is for an abort
+		// partway through: it sweeps the dependents so the store can delete, then
+		// deletes the store. It must be registered after the fixtures above so
+		// that, cleanups running LIFO, the OBC is deleted while its StorageClass
+		// still exists — the bucket provisioner resolves the class before it acts
+		// on a deletion, and cannot release the OBC's finalizer without it. It
+		// calls Teardown rather than Destroy because Destroy's t.Run would panic
+		// inside a t.Cleanup.
+		t.Cleanup(func() {
+			bg := context.Background()
+			_ = obcClient.Delete(bg, obc1.Name, metav1.DeleteOptions{})
+			_ = osuClient.Delete(bg, user1.Name, metav1.DeleteOptions{})
+			store.Teardown(t)
+		})
+
+		t.Run(fmt.Sprintf("create CephObjectStoreUser %q", user1.Name), func(t *testing.T) {
+			wait4.RequireCreate(ctx, t, osuClient, user1, wait4.ObjectStoreUser, wait4.TimeoutLong)
+		})
+
+		obc.RequireBound(ctx, t, k8sh, obc1)
+
+		t.Run(fmt.Sprintf("deleting CephObjectStore %q is blocked by its dependents", objectStore.Name), func(t *testing.T) {
+			err := cosClient.Delete(ctx, objectStore.Name, metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			live := wait4.RequireCondition(ctx, t, cosClient, objectStore.Name, wait4.ObjectStoreDeletionBlocked, wait4.TimeoutShort)
+
+			assert.Equal(t, cephv1.ConditionDeleting, live.Status.Phase)
+
+			cond := cephv1.FindStatusCondition(live.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
+			require.NotNil(t, cond)
+			assert.Equal(t, cephv1.ObjectHasDependentsReason, cond.Reason)
+			assert.Contains(t, cond.Message, "CephObjectStoreUsers")
+			assert.Contains(t, cond.Message, user1.Name)
+			assert.Contains(t, cond.Message, "buckets")
+			assert.Contains(t, cond.Message, obc1.Spec.BucketName)
+		})
+
+		t.Run(fmt.Sprintf("delete obc %q", obc1.Name), func(t *testing.T) {
+			obc.DeleteAndWait(ctx, t, k8sh, ns.Name, obc1.Name)
+		})
+
+		t.Run(fmt.Sprintf("delete CephObjectStoreUser %q", user1.Name), func(t *testing.T) {
+			wait4.RequireDelete(ctx, t, osuClient, user1.Name, wait4.TimeoutShort)
+		})
+
+		// With the dependents gone, the store — already terminating from the
+		// blocked delete above — finishes deleting. Destroy asserts that, and
+		// deletes the Service the store fixture created for it.
+		store.Destroy()
+
+		t.Run("mgrs are not in a crashloop", func(t *testing.T) {
+			assert.True(t, k8sh.CheckPodCountAndState("rook-ceph-mgr", namespace, 1, "Running"))
+		})
+	})
+}

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -47,6 +47,8 @@ type Sharedstore struct {
 	installer   *installer.CephInstaller
 	tlsEnable   bool
 	destroy     func()
+	teardown    func(*testing.T)
+	tornDown    bool
 }
 
 func (s *Sharedstore) AdminClient() *admin.API {
@@ -75,17 +77,73 @@ func (s *Sharedstore) Destroy() {
 	s.destroy()
 }
 
-// Create creates a CephObjectStore named storeName in namespace (with its
-// realm, zone, shared pools, and NodePort Service), waits for it to become
+// Teardown deletes the store's resources the same way Destroy does but without
+// the enclosing t.Run subtest, so — unlike Destroy — it is safe to call from a
+// t.Cleanup, where t.Run panics. It is a no-op once the store has been torn
+// down, so a caller that tears down explicitly can still call it unconditionally
+// from a cleanup. Failures are reported against t.
+func (s *Sharedstore) Teardown(t *testing.T) {
+	if s.tornDown {
+		return
+	}
+	s.teardown(t)
+}
+
+// StoreKind selects the shape of the CephObjectStore a Config describes.
+type StoreKind int
+
+const (
+	// Zoned is a multisite store. It owns CephObjectRealm, CephObjectZoneGroup
+	// and CephObjectZone CRs, and its pools are CephBlockPool CRs the zone
+	// references as shared pool placements.
+	Zoned StoreKind = iota
+
+	// Classic is a non-multisite store. Its pools are declared in the store
+	// spec for the operator to provision, so it owns no zone or pool CRs of its
+	// own. The operator only looks for user and bucket dependents on a store of
+	// this shape (or on a multisite store whose zone is its zonegroup's
+	// master), so a test of deletion being blocked by dependents needs it.
+	Classic
+)
+
+// Config describes the CephObjectStore for Create to build. Its zero value is
+// a Zoned store, so a caller sets only what it needs.
+type Config struct {
+	// Namespace is the cluster namespace holding the store.
+	Namespace string
+
+	// StoreName names the CephObjectStore and everything derived from it.
+	StoreName string
+
+	// Instances is the RGW gateway count.
+	Instances int32
+
+	// TLSEnable serves the store over https with a generated certificate
+	// instead of plain http.
+	TLSEnable bool
+
+	// Kind selects a Zoned (default) or Classic store.
+	Kind StoreKind
+
+	// AllowUsersInNamespaces is propagated to the store field of the same name,
+	// which gates CephObjectStoreUsers that name this store from another
+	// namespace.
+	AllowUsersInNamespaces []string
+}
+
+// Create creates the CephObjectStore cfg describes, along with its Service and
+// — for a Zoned store — its realm, zone, and pools, waits for it to become
 // Ready, and returns a Sharedstore whose Destroy method tears it all down;
-// Destroy should be deferred by the caller. instances sets the RGW gateway
-// count and allowedNamespaces is propagated to AllowUsersInNamespaces.
-func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, namespace, storeName string, instances int32, allowedNamespaces ...string) *Sharedstore {
+// Destroy should be deferred by the caller.
+func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, cfg Config) *Sharedstore {
 	t.Helper()
 
-	s := &Sharedstore{tlsEnable: tlsEnable, installer: installer}
+	s := &Sharedstore{tlsEnable: cfg.TLSEnable, installer: installer}
 	ctx := context.TODO()
-	ns := namespace
+	ns := cfg.Namespace
+	storeName := cfg.StoreName
+	classic := cfg.Kind == Classic
+	tlsEnable := cfg.TLSEnable
 
 	// securePort is the in-container RGW TLS listener port. The NodePort Service
 	// below exposes the conventional 443 externally and forwards to it.
@@ -161,10 +219,23 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 			},
 			Gateway: cephv1.GatewaySpec{
 				Port:      80,
-				Instances: instances,
+				Instances: cfg.Instances,
 			},
-			AllowUsersInNamespaces: allowedNamespaces,
+			AllowUsersInNamespaces: cfg.AllowUsersInNamespaces,
 		},
+	}
+
+	if classic {
+		// Zone must stay empty: it is what ObjectStoreSpec.IsMultisite keys on.
+		// The operator creates these pools itself, so the store owns no pool CRs.
+		objectStore.Spec.Zone = cephv1.ZoneSpec{}
+		objectStore.Spec.MetadataPool = cephv1.PoolSpec{
+			Replicated:      cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+			CompressionMode: "passive",
+		}
+		objectStore.Spec.DataPool = cephv1.PoolSpec{
+			Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+		}
 	}
 
 	if tlsEnable {
@@ -173,7 +244,7 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 		objectStore.Spec.Gateway = cephv1.GatewaySpec{
 			SecurePort:        securePort,
 			SSLCertificateRef: certSecretName,
-			Instances:         instances,
+			Instances:         cfg.Instances,
 		}
 	}
 
@@ -262,24 +333,26 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 
 	ceph := k8sh.RookClientset.CephV1()
 
-	{
-		_, err := ceph.CephObjectRealms(ns).Create(ctx, realm, metav1.CreateOptions{})
-		require.NoError(t, err)
-	}
+	if !classic {
+		{
+			_, err := ceph.CephObjectRealms(ns).Create(ctx, realm, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
 
-	{
-		_, err := ceph.CephObjectZoneGroups(ns).Create(ctx, zoneGroup, metav1.CreateOptions{})
-		require.NoError(t, err)
-	}
+		{
+			_, err := ceph.CephObjectZoneGroups(ns).Create(ctx, zoneGroup, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
 
-	{
-		_, err := ceph.CephObjectZones(ns).Create(ctx, zone, metav1.CreateOptions{})
-		require.NoError(t, err)
-	}
+		{
+			_, err := ceph.CephObjectZones(ns).Create(ctx, zone, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
 
-	for _, p := range pools {
-		_, err := ceph.CephBlockPools(ns).Create(ctx, p, metav1.CreateOptions{})
-		require.NoError(t, err)
+		for _, p := range pools {
+			_, err := ceph.CephBlockPools(ns).Create(ctx, p, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
 	}
 
 	// the cert secret must exist before the store is created so the operator can
@@ -315,11 +388,13 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 
 	s.objectStore = objectStore
 
-	s.destroy = func() {
-		t.Run(fmt.Sprintf("destroy CephObjectStore %s", objectStore.Name), func(t *testing.T) {
-			wait4.AssertDelete(ctx, t, k8sh.Clientset.CoreV1().Services(ns), svc.Name, 30*time.Second)
-			wait4.AssertDelete(ctx, t, ceph.CephObjectStores(ns), objectStore.Name, 5*time.Minute)
+	s.teardown = func(t *testing.T) {
+		s.tornDown = true
 
+		wait4.AssertDelete(ctx, t, k8sh.Clientset.CoreV1().Services(ns), svc.Name, 30*time.Second)
+		wait4.AssertDelete(ctx, t, ceph.CephObjectStores(ns), objectStore.Name, 5*time.Minute)
+
+		if !classic {
 			// The multisite CRs must be deleted before the pools. Their deletion
 			// finalizers run radosgw-admin, which reads the realm/zonegroup/zone
 			// metadata stored in the .rgw.root pool. Deleting the pools first
@@ -333,11 +408,14 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 			for _, p := range pools {
 				wait4.AssertDelete(ctx, t, ceph.CephBlockPools(ns), p.Name, time.Minute)
 			}
+		}
 
-			if tlsEnable {
-				wait4.AssertDelete(ctx, t, k8sh.Clientset.CoreV1().Secrets(ns), certSecretName, 30*time.Second)
-			}
-		})
+		if tlsEnable {
+			wait4.AssertDelete(ctx, t, k8sh.Clientset.CoreV1().Secrets(ns), certSecretName, 30*time.Second)
+		}
+	}
+	s.destroy = func() {
+		t.Run(fmt.Sprintf("destroy CephObjectStore %s", objectStore.Name), s.teardown)
 	}
 
 	return s

--- a/tests/integration/object/util/wait4/ready.go
+++ b/tests/integration/object/util/wait4/ready.go
@@ -18,6 +18,7 @@ package wait4
 
 import (
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
@@ -25,6 +26,16 @@ import (
 // ObjectStore reports whether a CephObjectStore has been reconciled to Ready.
 func ObjectStore(os *cephv1.CephObjectStore) bool {
 	return os.Status != nil && os.Status.Phase == cephv1.ConditionReady
+}
+
+// ObjectStoreDeletionBlocked reports whether a CephObjectStore's deletion is
+// blocked on dependents.
+func ObjectStoreDeletionBlocked(os *cephv1.CephObjectStore) bool {
+	if os.Status == nil {
+		return false
+	}
+	cond := cephv1.FindStatusCondition(os.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
+	return cond != nil && cond.Status == corev1.ConditionTrue
 }
 
 // ObjectStoreUser reports whether a CephObjectStoreUser has been reconciled to


### PR DESCRIPTION
**Description of your changes:**

Deleting a store is destructive, so the object-store "dependents" suite
(deletion blocked while a `CephObjectStoreUser` and an OBC bucket reference the
store) needs its own store rather than the shared fixture. This builds it with
the shared fixture's machinery instead of a hand-rolled CR. `Create` now takes
a `Config` describing the store rather than a row of positional arguments, with
a `Kind` selecting a **zoned** store — the default, and what the shared store
is — or a **classic** one, whose pools are declared in the store spec rather
than in a zone's shared pools, so it owns no realm, zone, or pool CRs and
coexists with the zoned shared store.

The store must be classic. The operator only looks for user and bucket
dependents on a non-multisite store, or on a multisite store whose zone is its
zonegroup's master (`CephObjectStoreDependents` in
`pkg/operator/ceph/object/dependents.go`); a multisite store here reports no
dependents and deletes unblocked, so the test would assert nothing.

The suite deletes the store itself to observe the deletion being blocked, then
removes the dependents and lets `Destroy` assert the now-unblocked deletion and
tear down what is left. A guarded `t.Cleanup` sweeps the store on an early
abort, through a new `Teardown` that does `Destroy`'s work without its enclosing
subtest, since `t.Run` panics when called from a `t.Cleanup`.

The entry signature drops the shared `*Sharedstore` for
`(installer, namespace, tlsEnable)`, and `test-dependents` is removed from the
shared store's `AllowUsersInNamespaces` since its user lives in the store's own
cluster namespace.

**AI assistance:** an AI agent located the operator's multisite dependent-check
behavior, implemented the classic-store fixture variant and the dependents
rewrite, and ran the build/lint and adversarial pre-PR review passes.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.


