### PR TITLE
test: retire the legacy object store prologue

### DIFF
--- a/tests/integration/ceph_auth_keystone_test.go
+++ b/tests/integration/ceph_auth_keystone_test.go
@@ -160,7 +160,6 @@ func (h *KeystoneAuthSuite) TestWithSwiftAndKeystone() {
 	tls := false
 	swiftAndKeystone := true
 
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
 	runSwiftE2ETest(h.T(), h.helper, h.k8shelper, h.installer, h.settings.Namespace, "default", 3, deleteStore, tls, swiftAndKeystone)
 	cleanUpTLSks(h)
 }
@@ -170,7 +169,6 @@ func (h *KeystoneAuthSuite) TestWithS3AndKeystone() {
 	tls := false
 	swiftAndKeystone := true
 
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
 	runS3E2ETest(h.T(), h.helper, h.k8shelper, h.installer, h.settings.Namespace, "default", 3, deleteStore, tls, swiftAndKeystone)
 	cleanUpTLSks(h)
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -17,14 +17,10 @@ limitations under the License.
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 	bucketlifecycle "github.com/rook/rook/tests/integration/object/bucket/lifecycle"
@@ -43,13 +39,6 @@ import (
 	"github.com/rook/rook/tests/integration/object/zonepools"
 )
 
-const (
-	objectStoreServicePrefixUniq = "rook-ceph-rgw-"
-	objectStoreTLSName           = "tls-test-store"
-)
-
-var objectStoreServicePrefix = "rook-ceph-rgw-"
-
 func TestCephObjectSuite(t *testing.T) {
 	s := new(ObjectSuite)
 	defer func(s *ObjectSuite) {
@@ -60,7 +49,6 @@ func TestCephObjectSuite(t *testing.T) {
 
 type ObjectSuite struct {
 	suite.Suite
-	helper    *clients.TestClient
 	settings  *installer.TestCephSettings
 	installer *installer.CephInstaller
 	k8sh      *utils.K8sHelper
@@ -84,7 +72,6 @@ func (s *ObjectSuite) SetupSuite() {
 	}
 	s.settings.ApplyEnvVars()
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
-	s.helper = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
 }
 
 func (s *ObjectSuite) AfterTest(suiteName, testName string) {
@@ -100,21 +87,7 @@ func (s *ObjectSuite) TestWithTLS() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
 
-	tls := true
-	swiftAndKeystone := false
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.installer, &s.Suite, s.settings, tls, swiftAndKeystone)
-	cleanUpTLS(s)
-}
-
-func cleanUpTLS(s *ObjectSuite) {
-	err := s.k8sh.Clientset.CoreV1().Secrets(s.settings.Namespace).Delete(context.TODO(), objectTLSSecretName, metav1.DeleteOptions{})
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			logger.Fatal("failed to deleted store TLS secret")
-		}
-	}
-	logger.Info("successfully deleted store TLS secret")
+	runObjectE2ETest(s.T(), s.k8sh, s.installer, s.settings.Namespace, true)
 }
 
 func (s *ObjectSuite) TestWithoutTLS() {
@@ -122,49 +95,12 @@ func (s *ObjectSuite) TestWithoutTLS() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
 
-	tls := false
-	swiftAndKeystone := false
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.installer, &s.Suite, s.settings, tls, swiftAndKeystone)
+	runObjectE2ETest(s.T(), s.k8sh, s.installer, s.settings.Namespace, false)
 }
 
-// Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
-// Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,
-// Check issues in MGRs, Delete Bucket and Delete user
-// Test for ObjectStore with and without TLS enabled
-func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, installer *installer.CephInstaller, s *suite.Suite, settings *installer.TestCephSettings, tlsEnable bool, swiftAndKeystone bool) {
-	namespace := settings.Namespace
-	storeName := "test-store"
-	if tlsEnable {
-		storeName = objectStoreTLSName
-	}
-
-	logger.Infof("Running on Rook Cluster %s", namespace)
-	// a single gateway makes quota enforcement deterministic: rgw quota checks
-	// run against per-instance cached stats, and with multiple gateways an
-	// instance can be blind to writes served by its peers for up to
-	// rgw_user_quota_bucket_sync_interval; multi-instance deployment is still
-	// covered by the keystone suite
-	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 1, tlsEnable, swiftAndKeystone)
-
-	// test that a second object store can be created (and deleted) while the first exists
-	s.T().Run("run a second object store", func(t *testing.T) {
-		otherStoreName := "other-" + storeName
-		// The lite e2e test is perfect, as it only creates a cluster, checks that it is healthy,
-		// and then deletes it.
-		deleteStore := true
-		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
-	})
-
-	// the deletion checks that consumed this store live in the dependents
-	// package now; delete it so it cannot block cluster teardown
-	s.T().Run("delete the suite object store", func(t *testing.T) {
-		deleteObjectStore(t, k8sh, namespace, storeName)
-		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
-	})
-
-	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, sharedstore.Config{
-		Namespace: settings.Namespace,
+func runObjectE2ETest(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, namespace string, tlsEnable bool) {
+	sharedObjectStore := sharedstore.Create(t, k8sh, installer, sharedstore.Config{
+		Namespace: namespace,
 		StoreName: "sharedstore",
 		Instances: 1,
 		TLSEnable: tlsEnable,
@@ -184,22 +120,22 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	})
 	defer sharedObjectStore.Destroy()
 
-	zonepools.TestZonePools(s.T(), k8sh, sharedObjectStore)
-	bucketlifecycle.TestObjectBucketClaimLifecycle(s.T(), k8sh, sharedObjectStore)
-	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)
-	bucketpolicy.TestObjectBucketClaimPolicy(s.T(), k8sh, sharedObjectStore)
-	bucketquota.TestObjectBucketClaimQuota(s.T(), k8sh, sharedObjectStore)
-	bucketrw.TestObjectBucketClaimReadWrite(s.T(), k8sh, sharedObjectStore)
-	userkeys.TestObjectStoreUserKeys(s.T(), k8sh, sharedObjectStore)
-	topickafka.TestBucketTopicKafka(s.T(), k8sh, sharedObjectStore)
-	useropmask.TestObjectStoreUserOpMask(s.T(), k8sh, sharedObjectStore)
-	usercaps.TestObjectStoreUserCaps(s.T(), k8sh, sharedObjectStore)
+	zonepools.TestZonePools(t, k8sh, sharedObjectStore)
+	bucketlifecycle.TestObjectBucketClaimLifecycle(t, k8sh, sharedObjectStore)
+	bucketowner.TestObjectBucketClaimBucketOwner(t, k8sh, sharedObjectStore)
+	bucketpolicy.TestObjectBucketClaimPolicy(t, k8sh, sharedObjectStore)
+	bucketquota.TestObjectBucketClaimQuota(t, k8sh, sharedObjectStore)
+	bucketrw.TestObjectBucketClaimReadWrite(t, k8sh, sharedObjectStore)
+	userkeys.TestObjectStoreUserKeys(t, k8sh, sharedObjectStore)
+	topickafka.TestBucketTopicKafka(t, k8sh, sharedObjectStore)
+	useropmask.TestObjectStoreUserOpMask(t, k8sh, sharedObjectStore)
+	usercaps.TestObjectStoreUserCaps(t, k8sh, sharedObjectStore)
 	// the ceph-cosi driver cannot reach a TLS object store endpoint, so this
 	// suite skips itself in the TLS pass
-	cosi.TestCephCOSIDriver(s.T(), k8sh, sharedObjectStore)
-	notification.TestBucketNotification(s.T(), k8sh, sharedObjectStore)
+	cosi.TestCephCOSIDriver(t, k8sh, sharedObjectStore)
+	notification.TestBucketNotification(t, k8sh, sharedObjectStore)
 
-	// last: this one builds and deletes a store of its own, so keep it clear of
-	// the packages sharing the fixture store
-	dependents.TestCephObjectStoreDependents(s.T(), k8sh, installer, settings.Namespace, tlsEnable)
+	// last: this builds and deletes a store of its own, so keep it clear of the
+	// packages sharing the fixture store
+	dependents.TestCephObjectStoreDependents(t, k8sh, installer, namespace, tlsEnable)
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -99,23 +99,20 @@ func (s *ObjectSuite) TestWithoutTLS() {
 }
 
 func runObjectE2ETest(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, namespace string, tlsEnable bool) {
+	// only the packages that create CephObjectStoreUsers in their own namespace
+	// need to be allowed; the rest reach the store through OBCs, which this does
+	// not gate
 	sharedObjectStore := sharedstore.Create(t, k8sh, installer, sharedstore.Config{
 		Namespace: namespace,
 		StoreName: "sharedstore",
 		Instances: 1,
 		TLSEnable: tlsEnable,
 		AllowUsersInNamespaces: []string{
-			bucketlifecycle.Namespace,
 			bucketowner.Namespace,
-			bucketpolicy.Namespace,
-			bucketquota.Namespace,
-			bucketrw.Namespace,
-			userkeys.Namespace,
-			topickafka.Namespace,
-			useropmask.Namespace,
-			usercaps.Namespace,
 			cosi.Namespace,
-			notification.Namespace,
+			usercaps.Namespace,
+			userkeys.Namespace,
+			useropmask.Namespace,
 		},
 	})
 	defer sharedObjectStore.Destroy()

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -1,9 +1,9 @@
 # Object storage integration tests
 
 This tree holds the new-style integration tests for rook's object storage
-features. It is the model for converting the remaining old-style object tests
-(store lifecycle);
-follow the conventions here exactly so the conversion happens once.
+features; follow the conventions here exactly. Object storage is also exercised
+by the keystone, helm, and upgrade suites, which keep their own old-style
+tests.
 
 ## Execution model
 
@@ -45,7 +45,6 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
 | `zonepools` | `object` | zone.json pool fields covered by Rook's shared-pool mapping |
-| reserved: `tests/integration/object/lifecycle` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -62,8 +61,10 @@ Shared utilities live under `util/`:
 - `secrets` — verification helpers for the Secret references object CRDs
   publish in their status, shared by more than one package.
 - `sharedstore` — the CephObjectStore fixture: the shared store, and the
-  private stores the private-store packages build (`Config.Kind` selects a
-  zoned or classic store).
+  private store a private-store package builds (`Config.Kind` selects a zoned
+  or classic store). Create waits for the store to be Ready and publish an
+  endpoint, and Destroy asserts it deletes, so every store the suites build
+  covers the store lifecycle.
 - `client` — rgw admin, SNS, and S3 client builders and TLS cert generation.
 
 ## Anatomy of a package
@@ -106,7 +107,7 @@ Rules encoded in that shape:
   (deleting it, or a behavior the operator gates on the store's own spec):
   it cannot share the fixture store, so it builds a private one with
   `sharedstore.Create` and takes `(t, k8sh, installer, namespace, tlsEnable)`
-  instead. `dependents` is the model.
+  instead. `dependents` is the only one.
 - The var block declares everything the test uses: fixture objects (use
   constructors — `obc.StorageClass`, package-local helpers like
   `awsKeySecret`/`objectUserKey` — to keep literals one line each), then the
@@ -218,5 +219,4 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts | `tests/integration/object/lifecycle` | store create/health/delete helpers |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -205,8 +205,12 @@ the CI object suite.
 2. Write the entry func following the anatomy section; pick a globally unique
    outer `t.Run` name.
 3. Wire one dispatcher line in `tests/integration/ceph_object_test.go` and,
-   if the package creates CephObjectStoreUsers, add its namespace to the
-   shared store's `AllowUsersInNamespaces`.
+   if the package creates CephObjectStoreUsers in its own namespace against
+   the shared store, add its namespace to the shared store's
+   `AllowUsersInNamespaces`. That list gates one thing only — a user CR
+   naming a store in another namespace — so a package that reaches the store
+   through an ObjectBucketClaim, or that creates its users in the cluster
+   namespace, does not belong on it.
 4. Verify with the build/vet/gofmt commands above.
 
 ## Conversion playbook (old-style tests)

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -361,8 +362,10 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 		client.GenerateRgwTLSCertSecret(t, k8sh, ns, certSecretName, rgwServiceName)
 	}
 
-	wait4.RequireCreate(ctx, t, ceph.CephObjectStores(ns), objectStore, wait4.ObjectStore,
+	live := wait4.RequireCreate(ctx, t, ceph.CephObjectStores(ns), objectStore, wait4.ObjectStore,
 		3*time.Minute, "shared CephObjectStore did not become Ready")
+	assert.NotEmpty(t, live.Status.Info["endpoint"],
+		"CephObjectStore %q became Ready without publishing an endpoint", storeName)
 
 	{
 		_, err := k8sh.Clientset.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})


### PR DESCRIPTION
**Description of your changes:**

`runObjectE2ETest` opened every pass by creating a store with
`createCephObjectStore`, running a second one through the lite e2e helper to show
two could coexist, and deleting the first so it could not block teardown. The
shared store fixture now covers all of that: each suite creates a store, waits
for it to be Ready, and asserts it deletes again, and the dependents suite stands
a second store beside the shared one on every run.

So the prologue goes, and the dispatcher **collapses** to creating the shared
store and dispatching the packages. Retired with it are the per-pass store and
its TLS secret cleanup, the suite's `TestClient`, and the unread rgw service
prefix globals.

The one check the prologue made that the fixture did not is that a Ready store
publishes an endpoint. `sharedstore.Create` asserts that now, so every store
built by any suite is covered rather than the one the prologue happened to make.

The second commit narrows the shared store's `AllowUsersInNamespaces` from eleven
namespaces to five. The operator consults that list in exactly one place, the
`CephObjectStoreUser` controller, when a user CR names a store in another
namespace; packages that reach the store through an ObjectBucketClaim never take
that path, and six of the eleven listed namespaces create no user CRs at all.
The contributor checklist that governs the list is narrowed to match.

**AI assistance:** an AI agent performed the dispatcher collapse, audited which
store-lifecycle assertions the fixture already covers and folded the one gap into
`Create`, audited the `AllowUsersInNamespaces` consumers per package, and ran the
build/lint and adversarial pre-PR review passes.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.

