### PR TITLE
ci: skip rbd-mirror validation in the arm64 canary

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -62,7 +62,10 @@ jobs:
         run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
 
       - name: wait for ceph to be ready
-        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
+        # rbd-mirror crashes on arm64 with Ceph v20 (rook issue 17568,
+        # https://tracker.ceph.com/issues/76967); validate every other daemon
+        # until the upstream fix lands
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd,mds,rgw,fs_mirror,nfs 2
 
       - name: collect common logs
         if: always()


### PR DESCRIPTION
The nightly `canary-arm64` job has failed every night since late May: rbd-mirror crashloops on arm64 with the Ceph v20 image, so it never registers in `ceph -s` and the `wait for ceph to be ready` step times out on it (#17568, upstream https://tracker.ceph.com/issues/76967). The collected logs from the 2026-07-06 run show every other daemon healthy — mon quorum, mgr, 2 osds up/in, mds, both rgw zones, cephfs-mirror active, and the nfs pod ready — so the constant red is masking any real arm64 regression in those daemons.

Validate the other daemons explicitly, skipping only `rbd_mirror`, until the upstream crash is fixed. This does not resolve #17568; it restores the job's signal while that fix is pending.

AI assistance: AI helped diagnose the failure from the nightly job logs and artifacts and drafted this change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.