### PR TITLE
ci: skip osd-with-metadata-partition-device canary on Ceph v20+

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -617,6 +617,14 @@ jobs:
       matrix:
         ceph-image: ${{ fromJson(inputs.ceph_images) }}
         kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
+        # ceph-volume in Ceph v20+ records no block.db tags for a raw
+        # partition, leaving the OSD unable to start (rook issue 17901,
+        # https://github.com/ceph/ceph/pull/69506); skip those images until
+        # the upstream fix ships
+        exclude:
+          - ceph-image: quay.io/ceph/ceph:v20
+          - ceph-image: quay.ceph.io/ceph-ci/ceph:main
+          - ceph-image: quay.ceph.io/ceph-ci/ceph:tentacle
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
The nightly `canary-tests / osd-with-metadata-partition-device` legs for `quay.io/ceph/ceph:v20`, `quay.ceph.io/ceph-ci/ceph:main`, and `quay.ceph.io/ceph-ci/ceph:tentacle` have failed every night: ceph-volume in Ceph v20+ records no `ceph.db_device` tags when `--block.db` is a raw partition, so activation never recreates the `block.db` symlink and the OSD crashloops in the `expand-bluefs` init container decoding the bluefs superblock (#17901). The identical regression and reproduction are described by the open upstream fix https://github.com/ceph/ceph/pull/69506.

Exclude the affected images from this scenario's matrix until the upstream fix ships in the published images. The v19 leg (which `.mergify.yml` pins for backport automerge) and the squid leg keep running, and the PR/push canary suite only passes v19, so its check names are unaffected.

This does not resolve #17901; that issue tracks re-enabling the excluded legs.

AI assistance: AI helped diagnose the failure from the nightly job logs and artifacts, locate the upstream ceph fix, and drafted this change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.