### PR TITLE
build: retry the docs deploy when the gh-pages push is rejected

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -93,9 +93,16 @@ build.docs: deps.docs
 
 publish.docs:
 	if ! git remote show docs > /dev/null 2>&1; then git remote add docs $(DOCS_GIT_REPO); fi
-	git fetch -u docs gh-pages
-	# Switch to root of repo and then run the build and deploy of the documentation
-	cd $(ROOT_DIR) && mike deploy --remote docs --push --branch gh-pages --update-aliases --deploy-prefix $(DOCS_PREFIX) $(DOCS_VERSION) $(DOCS_VERSION_ALIAS)
+	# a concurrent build can push gh-pages between our fetch and mike's push,
+	# getting the push rejected as non-fast-forward; reset the local branch to
+	# the remote tip and redeploy when that happens
+	cd $(ROOT_DIR) && for attempt in 1 2 3; do \
+		git fetch --force --update-head-ok docs gh-pages:gh-pages && \
+		mike deploy --remote docs --push --branch gh-pages --update-aliases --deploy-prefix $(DOCS_PREFIX) $(DOCS_VERSION) $(DOCS_VERSION_ALIAS) && \
+		exit 0; \
+		echo "docs deploy attempt $$attempt failed"; \
+		sleep 15; \
+	done; exit 1
 
 # ====================================================================================
 # helm


### PR DESCRIPTION
Each master push publishes docs by running `mike deploy --push` against the `rook.github.io` `gh-pages` branch. When two builds run close together, the branch can advance between one build's `git fetch` and its push, and git rejects the push as non-fast-forward — failing the whole `push-image-to-container-registry` job even though the images were already published and signed. This happened on the 2026-07-06 master push burst ([run 28794301676](https://github.com/rook/rook/actions/runs/28794301676)):

```
error: failed to push branch gh-pages to docs:
  To https://github.com/rook/rook.github.io.git
   ! [rejected]              gh-pages -> gh-pages (fetch first)
```

Wrap the deploy in a retry loop that force-resets the local `gh-pages` branch to the remote tip before each attempt; `mike deploy` recreates its commit on the fresh tip, so a lost race redeploys instead of failing the build. The fetch now targets the local branch explicitly (`gh-pages:gh-pages`) so a stale mike commit from a rejected attempt is discarded rather than reused as the base.

AI assistance: AI helped diagnose the race from the failed run's logs and drafted this change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.