### PR TITLE
build: fail clearly  when  the container command is missing or unusable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,19 +197,19 @@ lint.go: lint.fmt lint.vet golangci-lint ## run various go linters
 
 
 .PHONY: lint.markdown
-lint.markdown: ## Check formatting of documentation sources
+lint.markdown: check.container.runtime ## Check formatting of documentation sources
 	@$(MARKDOWNLINT) "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --config .markdownlint-cli2.cjs
 
 .PHONY: lint.markdown-links
-lint.markdown-links:
+lint.markdown-links: check.container.runtime
 	@$(DOCKERCMD) run --rm -v "$$PWD:/workspace" --entrypoint "/workspace/tests/scripts/check-markdown-links-internal.sh" ghcr.io/tcort/markdown-link-check:stable
 
 .PHONY: fix.markdown
-fix.markdown: ## Check and fix formatting of documentation sources
+fix.markdown: check.container.runtime ## Check and fix formatting of documentation sources
 	@$(MARKDOWNLINT) "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs
 
 .PHONY: lint.yaml
-lint.yaml: ## lint yaml files
+lint.yaml: check.container.runtime ## lint yaml files
 	$(YAMLLINT) -c .yamllint deploy/examples/ --no-warnings
 
 .PHONY: lint.helm

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -35,6 +35,10 @@ DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 endif
 
+.PHONY: check.container.runtime
+check.container.runtime:
+	$(if $(shell $(DOCKERCMD) version >/dev/null 2>&1 && echo available),,$(error no usable container runtime found. Install docker or podman, or set DOCKERCMD to a working command.))
+
 MARKDOWNLINT := $(DOCKERCMD) run --rm -v $$PWD:/workdir davidanson/markdownlint-cli2:$(MARKDOWNLINT_IMAGE_VERSION)
 
 ifneq ($(strip $(YAMLLINT_IMAGE_SHA)),)

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -60,14 +60,16 @@ do.build:
 	@mkdir -p $(BUILD_CONTEXT_DIR)/rook-external/test-data
 	@cp $(MANIFESTS_DIR)/create-external-cluster-resources.* $(BUILD_CONTEXT_DIR)/rook-external/
 	@cd $(BUILD_CONTEXT_DIR) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
-	@if [ "$(BUILD_CONTAINER_IMAGE)" != "false" ]; then\
+	@if [ "$(BUILD_CONTAINER_IMAGE)" = "false" ]; then\
+		echo "=== skipping container build because BUILD_CONTAINER_IMAGE=false"; \
+	elif ! $(DOCKERCMD) version >/dev/null 2>&1; then \
+		echo "=== skipping container build because no usable container runtime was found"; \
+	else \
 		$(DOCKERCMD) build --platform linux/$(GOARCH) $(BUILD_ARGS) \
 		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
 		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
 		-t $(CEPH_IMAGE) \
 		$(BUILD_CONTEXT_DIR);\
-	else \
-		echo "=== skipping container build because BUILD_CONTAINER_IMAGE=false"; \
 	fi
 	@if [ -z "$(SAVE_BUILD_CONTEXT_DIR)" ]; then\
 		rm -fr $(BUILD_CONTEXT_DIR);\

--- a/images/image.mk
+++ b/images/image.mk
@@ -75,9 +75,16 @@ BUILD_BASE_ARGS += $(BUILD_ARGS)
 all: build
 
 build: do.build ## Build images for the host platform.
-	@$(MAKE) cache.images
+	@if [ "$(BUILD_CONTAINER_IMAGE)" != "false" ] && $(DOCKERCMD) version >/dev/null 2>&1; then \
+		$(MAKE) cache.images; \
+	fi
 
-clean: clean.build ## Remove all images created from the current build.
+clean: ## Remove all images created from the current build.
+	@if $(DOCKERCMD) version >/dev/null 2>&1; then \
+		$(MAKE) clean.build; \
+	else \
+		echo "=== skipping image cleanup because no usable container runtime was found"; \
+	fi
 
 prune: cache.prune ## Prunes orphaned and cached images at the host level.
 

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -933,7 +933,7 @@ func adjustZoneDefaultPools(objContext *Context, zone map[string]interface{}, sp
 		// default pool is not presented in shared pool spec
 		return zone, nil
 	}
-	// add zone namespace to metadata pool to safely share accorss rgw instances or zones.
+	// add zone namespace to metadata pool to safely share across rgw instances or zones.
 	// in non-multisite case zone name equals to rgw instance name
 	defaultMetaPool = defaultMetaPool + ":" + name
 	for pool, nsSuffix := range zonePoolNSSuffix {


### PR DESCRIPTION
When neither docker nor podman is available and usable, `make build`, `make lint.yaml`, and `lint.markdown` used to fail with confusing error messages like `run: command not found` or `build: command not found`.

This change lets `make TARGET` fail with a clear error message that a working
installation of container runtime with podman or docker is required if `TARGET` involves running a container.

For example:
```shell
$ cd $(go env GOPATH)/src/github/com/rook/rook
$ make lint.yaml                                          
Makefile:209: *** Failed to find docker or podman in PATH. Please install either docker or podman, or set DOCKERCMD explicitly.  Stop.
$ echo $?
2
$ 
```

The new logic is this:
    
- If docker is present and usable, use it
- otherwise, if podman is present and usable, use it
- otherwise, if DOCKERCMD is explicitly set to a usable command, use it.
- otherwise, error out at corresponding targets.

In order to avoid adding new confusions, `make clean`is additionally made robust to
gracefully skip image cleanup with an informational message instead of failing when no usable container command is provided or detected.




**Issue resolved by this Pull Request:**

Resolves #17907 


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
