### PR TITLE
ci: use kind's latest published v1.32 image (v1.32.11) on-release

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
+        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
+        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
+        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
+        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.13", "v1.34.8", "v1.36.1"]
+        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.36.1"]
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
**Description**

The minikube→kind conversion (#17822) moved the master/release integration tests (`.github/workflows/integration-tests-on-release.yaml`) to kind, which selects the Kubernetes version via the `kindest/node:<version>` image tag. That matrix pins `v1.32.13`, but **there is no published `kindest/node:v1.32.13` image** — Docker Hub and the registry manifest endpoint both return 404. The latest 1.32 node image kind ever built is **`v1.32.11`** (later kind releases advanced to 1.33+ and never produced a newer 1.32 patch). So the `v1.32.13` matrix entries now fail to create a cluster on master.

This pins the on-release matrix's 1.32 entry to `v1.32.11`, keeping the 1.32-line coverage with a node image that actually exists. The other matrix versions (`v1.31.14`, `v1.34.8`, `v1.36.1`) already have published images.

**AI assistance:** Claude Code (Anthropic) verified `kindest/node` image availability via registry manifest checks, located the matrix references, and drafted this change and the description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
