### PR TITLE
build: set the release version to v1.20.2

### DIFF
--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -36,7 +36,7 @@ To configure the Ceph storage cluster, at least one of these local storage optio
 A simple Rook cluster is created for Kubernetes with the following `kubectl` commands and [example manifests](https://github.com/rook/rook/blob/master/deploy/examples).
 
 ```console
-$ git clone --single-branch --branch v1.20.1 https://github.com/rook/rook.git
+$ git clone --single-branch --branch v1.20.2 https://github.com/rook/rook.git
 cd rook/deploy/examples
 kubectl create -f crds.yaml -f common.yaml -f csi-operator.yaml
 kubectl create -f operator.yaml -f cluster.yaml

--- a/Documentation/Helm-Charts/csi-drivers-chart.md
+++ b/Documentation/Helm-Charts/csi-drivers-chart.md
@@ -24,7 +24,7 @@ Ceph-CSI publishes the drivers chart from the `ceph-csi-operator` Helm repositor
 ```console
 helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
 helm install ceph-csi-drivers --namespace rook-ceph ceph-csi-operator/ceph-csi-drivers \
-  -f https://raw.githubusercontent.com/rook/rook/v1.20.1/deploy/charts/ceph-csi-drivers/values.yaml
+  -f https://raw.githubusercontent.com/rook/rook/v1.20.2/deploy/charts/ceph-csi-drivers/values.yaml
 ```
 
 ## Custom settings

--- a/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+++ b/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
@@ -48,7 +48,7 @@ There are two sources for metrics collection:
 From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
-$ git clone --single-branch --branch v1.20.1 https://github.com/rook/rook.git
+$ git clone --single-branch --branch v1.20.2 https://github.com/rook/rook.git
 cd rook/deploy/examples/monitoring
 ```
 

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -57,11 +57,11 @@ With this upgrade guide, there are a few notes to consider:
 
 Unless otherwise noted due to extenuating requirements, upgrades from one patch release of Rook to
 another are as simple as updating the common resources and the image of the Rook operator. For
-example, when Rook v1.20.1 is released, the process of updating from v1.20.0 is as simple as running
+example, when Rook v1.20.2 is released, the process of updating from v1.20.0 is as simple as running
 the following:
 
 ```console
-git clone --single-branch --depth=1 --branch v1.20.1 https://github.com/rook/rook.git
+git clone --single-branch --depth=1 --branch v1.20.2 https://github.com/rook/rook.git
 cd rook/deploy/examples
 ```
 
@@ -74,7 +74,7 @@ Operator image.
 
 ```console
 kubectl apply -f common.yaml -f crds.yaml -f csi-operator.yaml
-kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.20.1
+kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.20.2
 ```
 
 A good practice is to update Rook common resources from the example
@@ -144,7 +144,7 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
 ## Rook Operator Upgrade
 
 The examples given in this guide upgrade a live Rook cluster running `v1.19.7` to
-the version `v1.20.1`. This upgrade should work from any official patch release of Rook v1.19 to any
+the version `v1.20.2`. This upgrade should work from any official patch release of Rook v1.19 to any
 official patch release of v1.20.
 
 Let's get started!
@@ -195,7 +195,7 @@ by the Operator. Also update the Custom Resource Definitions (CRDs).
 Get the latest common resources manifests that contain the latest changes.
 
 ```console
-git clone --single-branch --depth=1 --branch v1.20.1 https://github.com/rook/rook.git
+git clone --single-branch --depth=1 --branch v1.20.2 https://github.com/rook/rook.git
 cd rook/deploy/examples
 ```
 
@@ -237,7 +237,7 @@ The largest portion of the upgrade is triggered when the operator's image is upd
 When the operator is updated, it will proceed to update all of the Ceph daemons.
 
 ```console
-kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.20.1
+kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.20.2
 ```
 
 ### **4. Update Ceph CSI Custom Images**
@@ -261,16 +261,16 @@ watch --exec kubectl -n $ROOK_CLUSTER_NAMESPACE get deployments -l rook_cluster=
 ```
 
 As an example, this cluster is midway through updating the OSDs. When all deployments report `1/1/1`
-availability and `rook-version=v1.20.1`, the Ceph cluster's core components are fully updated.
+availability and `rook-version=v1.20.2`, the Ceph cluster's core components are fully updated.
 
 ```console
 Every 2.0s: kubectl -n rook-ceph get deployment -o j...
 
-rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.20.1
-rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.20.1
-rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.20.1
-rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.20.1
-rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.20.1
+rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.20.2
+rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.20.2
+rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.20.2
+rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.20.2
+rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.20.2
 rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.19.7
 rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.19.7
 ```
@@ -282,14 +282,14 @@ An easy check to see if the upgrade is totally finished is to check that there i
 # kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
   rook-version=v1.19.7
-  rook-version=v1.20.1
+  rook-version=v1.20.2
 This cluster is finished:
-  rook-version=v1.20.1
+  rook-version=v1.20.2
 ```
 
 ### **6. Verify the updated cluster**
 
-At this point, the Rook operator should be running version `rook/ceph:v1.20.1`.
+At this point, the Rook operator should be running version `rook/ceph:v1.20.2`.
 
 Verify the CSI drivers:
 

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: docker.io/rook/ceph
   # -- Image tag
   # @default -- `master`
-  tag: v1.20.1
+  tag: v1.20.2
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/deploy/examples/cleanup-job.yaml
+++ b/deploy/examples/cleanup-job.yaml
@@ -61,7 +61,7 @@ spec:
 
       containers:
         - name: host-cleanup
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           imagePullPolicy: IfNotPresent
           args: ["ceph", "clean", "host"]
 

--- a/deploy/examples/direct-mount.yaml
+++ b/deploy/examples/direct-mount.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-direct-mount
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           command: ["/bin/bash"]
           args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -1,4 +1,4 @@
-docker.io/rook/ceph:v1.20.1
+docker.io/rook/ceph:v1.20.2
 gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
 quay.io/ceph/ceph:v20.2.2
 quay.io/ceph/cosi:v0.1.4

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -282,7 +282,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -201,7 +201,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true

--- a/deploy/examples/osd-purge.yaml
+++ b/deploy/examples/osd-purge.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: rook-ceph-purge-osd
       containers:
         - name: osd-removal
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           # TODO: Insert the OSD ID in the last parameter that is to be removed
           # The OSD IDs are a comma-separated list. For example: "0" or "0,2".
           # If you want to preserve the OSD PVCs, set `--preserve-pvc true`.

--- a/deploy/examples/toolbox-job.yaml
+++ b/deploy/examples/toolbox-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
         - name: config-init
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           command: ["/usr/local/bin/toolbox.sh"]
           args: ["--skip-watch"]
           imagePullPolicy: IfNotPresent
@@ -32,7 +32,7 @@ spec:
               readOnly: true
       containers:
         - name: script
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config

--- a/deploy/examples/toolbox-operator-image.yaml
+++ b/deploy/examples/toolbox-operator-image.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-ceph-tools-operator-image
-          image: docker.io/rook/ceph:v1.20.1
+          image: docker.io/rook/ceph:v1.20.2
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION

For the patch release update the docs and images to v1.20.2.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
