### PR TITLE
monitoring: deduplicate pool growth prediction series

### DIFF
--- a/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
+++ b/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
@@ -566,7 +566,8 @@ groups:
         annotations:
           description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
           summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
-        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        expr: "(predict_linear(avg by (cluster,pool_id) (ceph_pool_percent_used)[2d:], 3600 * 24 * 5) * on(cluster,pool_id) group_right() avg by (cluster,pool_id, name) (ceph_pool_metadata)) >= 95"
+        for: "1h"
         labels:
           oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
           severity: "warning"

--- a/deploy/examples/monitoring/localrules.yaml
+++ b/deploy/examples/monitoring/localrules.yaml
@@ -571,7 +571,8 @@ spec:
           annotations:
             description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
             summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
-          expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+          expr: "(predict_linear(avg by (cluster,pool_id) (ceph_pool_percent_used)[2d:], 3600 * 24 * 5) * on(cluster,pool_id) group_right() avg by (cluster,pool_id, name) (ceph_pool_metadata)) >= 95"
+          for: "1h"
           labels:
             oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
             severity: "warning"


### PR DESCRIPTION
**Description:**

`CephPoolGrowthWarning` currently applies `predict_linear()` over a two-day range and then joins directly with `ceph_pool_metadata`. After a mgr pod replacement, the two-day range can include both old and current pod time series, which can make the join non-unique and cause Prometheus to reject the rule evaluation with:

```text
many-to-many matching not allowed: matching labels must be unique on one side
```

This updates the bundled Rook copy of the rule to aggregate pool usage by `cluster,pool_id` before `predict_linear()`, joins on pool identity instead of mgr `instance`, and adds `for: "1h"` to avoid transient alerting. This matches the existing Ceph source-rule PR: https://github.com/ceph/ceph/pull/68621.

**Validation:**

- Parsed both changed YAML files with `yq e '.'`.
- Tested the updated PromQL expression against an affected cluster where the original rule was failing; the updated expression evaluated successfully.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release. Not applicable: this is a targeted alert-rule bug fix.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary. Not applicable: YAML-only Prometheus rule copy change; source-rule tests are in ceph/ceph#68621.
- [x] Integration tests have been added, if necessary. Not applicable: YAML-only Prometheus rule copy change.

_AI assistance was used to investigate the failing Prometheus rule, test the expression, and prepare this PR description; the change was reviewed and tested by the contributor._

_This was AI generated._
