### PR TITLE
file: reveal swallowed errors on cephfs reconciliation

### DIFF
--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -375,9 +375,9 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 	log.NamedDebug(request.NamespacedName, logger, "reconciling ceph filesystem store deployments")
 	reconcileResponse, err = r.reconcileCreateFilesystem(cephFilesystem)
 	if err != nil {
-		_, err := r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, cephv1.ConditionFailure, nil, nil)
-		if err != nil {
-			return reconcile.Result{}, *cephFilesystem, errors.Wrapf(err, "failed to set failure status on cephFileSystem %q when file system creation failed", request.NamespacedName)
+		_, statusErr := r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, cephv1.ConditionFailure, nil, nil)
+		if statusErr != nil {
+			return reconcile.Result{}, *cephFilesystem, errors.Wrapf(statusErr, "failed to set failure status on cephFileSystem %q after filesystem creation error: %q", request.NamespacedName, err)
 		}
 		return reconcileResponse, *cephFilesystem, err
 	}
@@ -411,9 +411,9 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 			log.NamedInfo(request.NamespacedName, logger, "reconciling create cephfs-mirror peer configuration")
 			reconcileResponse, err = opcontroller.CreateBootstrapPeerSecret(r.context, r.clusterInfo, cephFilesystem, k8sutil.NewOwnerInfo(cephFilesystem, r.scheme))
 			if err != nil {
-				_, err := r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, cephv1.ConditionFailure, nil, nil)
-				if err != nil {
-					return reconcile.Result{}, *cephFilesystem, errors.Wrapf(err, "failed to set failure status on cephFileSystem %q when peer secret bootstrap failed", request.NamespacedName)
+				_, statusErr := r.updateStatus(k8sutil.ObservedGenerationNotAvailable, request.NamespacedName, cephv1.ConditionFailure, nil, nil)
+				if statusErr != nil {
+					return reconcile.Result{}, *cephFilesystem, errors.Wrapf(statusErr, "failed to set failure status on cephFileSystem %q after peer secret bootstrap error: %q", request.NamespacedName, err)
 				}
 				return reconcileResponse, *cephFilesystem,
 					errors.Wrapf(err, "failed to create cephfs-mirror bootstrap peer for filesystem %q.", cephFilesystem.Name)


### PR DESCRIPTION
## Description

This PR is digging out errors that were being swallowed during CephFS creation because of a wrong variable assignation.
The `err` variable which contained the error was being replaced with the resulted error from the kubernetes update status call on the CRD.
This fixes that and aggregate both errors if there is both a kubernetes status update failure and a creation error.

## Checklist

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary. -- N/A
- [ ] Unit tests have been added, if necessary. -- N/A
- [ ] Integration tests have been added, if necessary. -- N/A
