### PR TITLE
build: fix go.mod.check sed for apis module replace

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -188,7 +188,7 @@ go.mod.check:
 	@echo === syncing root modules with APIs modules
 	@cp -a go.sum pkg/apis/go.sum
 	@cat go.mod | sed -e 's|^module github.com/rook/rook|module github.com/rook/rook/pkg/apis|' \
-	                  -e '\:^replace github.com/rook/rook/pkg/apis => ./pkg/apis:d' > pkg/apis/go.mod
+	                  -e '\:[[:space:]]*github.com/rook/rook/pkg/apis => ./pkg/apis:d' > pkg/apis/go.mod
 	@echo === ensuring APIs modules are tidied
 	@(cd pkg/apis/; $(GOHOST) mod tidy -compat=$(GO_VERSION))
 	@echo === ensuring root modules are tidied

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -9,7 +9,6 @@ replace (
 	// TODO: remove this replace once https://github.com/libopenstorage/secrets/pull/83 is merged
 	github.com/libopenstorage/secrets => github.com/rook/secrets v0.0.0-20240315053144-3195f6906937
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
-	github.com/rook/rook/pkg/apis => ./pkg/apis
 )
 
 require (


### PR DESCRIPTION
The go.mod.check target generates pkg/apis/go.mod from the root go.mod and must remove the root-only replace directive that points github.com/rook/rook/pkg/apis to ./pkg/apis. The sed pattern expected the line to start with "replace", but the actual line is tab-indented inside the replace block, so the directive was never removed.
Update the sed pattern to match optional leading whitespace and remove the incorrect self-replace from pkg/apis/go.mod.

Present since -https://github.com/rook/rook/pull/13113/changes