### PR TITLE
docs: fix typo 'in under' -> 'is under' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## How to Contribute
 
-The Rook project in under [Apache 2.0 license](LICENSE). We accept contributions via
+The Rook project is under [Apache 2.0 license](LICENSE). We accept contributions via
 GitHub pull requests. This document outlines some of the conventions related to
 development workflow, commit message formatting, contact points and other
 resources to make it easier to get your contribution accepted.


### PR DESCRIPTION
Fix typo in CONTRIBUTING.md: 'The Rook project in under' -> 'The Rook project is under'.