### PR TITLE
test: create the upgrade suite's object store with typed clients

### DIFF
--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -48,15 +48,12 @@ const (
 )
 
 var (
-	userid                 = "rook-user"
-	userdisplayname        = "A rook RGW user"
-	bucketname             = "smokebkt"
-	obcName                = "smoke-delete-bucket"
-	maxObject              = "2"
-	bucketStorageClassName = "rook-smoke-delete-bucket"
-	maxBucket              = 1
-	maxSize                = "100000"
-	userCap                = "*"
+	userdisplayname = "A rook RGW user"
+	obcName         = "smoke-delete-bucket"
+	maxObject       = "2"
+	maxBucket       = 1
+	maxSize         = "100000"
+	userCap         = "*"
 )
 
 // Test Object StoreCreation on Rook that was installed via helm

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -22,19 +22,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,15 +42,6 @@ const (
 	rgwPrefix = "rook-ceph-rgw"
 	//nolint:gosec // since this is not leaking any hardcoded credentials, it's just the secret name
 	objectTLSSecretName = rgwPrefix + "-tls-test-store-csr"
-)
-
-var (
-	userdisplayname = "A rook RGW user"
-	obcName         = "smoke-delete-bucket"
-	maxObject       = "2"
-	maxBucket       = 1
-	maxSize         = "100000"
-	userCap         = "*"
 )
 
 // Test Object StoreCreation on Rook that was installed via helm
@@ -234,50 +222,6 @@ func assertObjectStoreDeletion(t *testing.T, k8sh *utils.K8sHelper, namespace, s
 
 	err := k8sh.WaitUntilResourceIsDeleted("CephObjectStore", namespace, storeName)
 	assert.NoError(t, err)
-}
-
-func createCephObjectUser(
-	s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper,
-	namespace, storeName, userID string, checkQuotaAndCaps bool,
-) {
-	maxObjectInt, err := strconv.Atoi(maxObject)
-	assert.Nil(s.T(), err)
-	logger.Infof("creating CephObjectStore user %q for store %q in namespace %q", userID, storeName, namespace)
-	cosuErr := helper.ObjectUserClient.Create(userID, userdisplayname, storeName, userCap, maxSize, maxBucket, maxObjectInt)
-	assert.Nil(s.T(), cosuErr)
-	logger.Infof("Waiting 5 seconds for the object user %q to be created", userID)
-	time.Sleep(5 * time.Second)
-	logger.Infof("Checking to see if user %q secret has been created", userID)
-	for i := 0; i < 6 && helper.ObjectUserClient.UserSecretExists(namespace, storeName, userID) == false; i++ {
-		logger.Infof("(%d) secret check sleeping for 5 seconds ...", i)
-		time.Sleep(5 * time.Second)
-	}
-
-	checkCephObjectUser(s, helper, k8sh, namespace, storeName, userID, checkQuotaAndCaps)
-}
-
-func checkCephObjectUser(
-	s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper,
-	namespace, storeName, userID string, checkQuotaAndCaps bool,
-) {
-	logger.Infof("checking object store \"%s/%s\" user %q", namespace, storeName, userID)
-	require.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userID), "user secret not found for %q", userID)
-
-	userInfo, err := helper.ObjectUserClient.GetUser(namespace, storeName, userID)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), userID, userInfo.UserID)
-	assert.Equal(s.T(), userdisplayname, *userInfo.DisplayName)
-
-	phase, err := k8sh.GetResource("--namespace", namespace, "cephobjectstoreuser", userID, "--output", "jsonpath={.status.phase}")
-	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), k8sutil.ReadyStatus, phase)
-}
-
-func objectStoreCleanUp(s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, storeName string) {
-	logger.Infof("Delete Object Store (will fail if users and buckets still exist)")
-	err := helper.ObjectClient.Delete(namespace, storeName)
-	assert.Nil(s.T(), err)
-	logger.Infof("Done deleting object store")
 }
 
 func generateRgwTlsCertSecret(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, storeName, rgwServiceName string) {

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -17,19 +17,10 @@ limitations under the License.
 package integration
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
@@ -40,6 +31,7 @@ import (
 	bucketrw "github.com/rook/rook/tests/integration/object/bucket/rw"
 	"github.com/rook/rook/tests/integration/object/cosi"
 	"github.com/rook/rook/tests/integration/object/dependents"
+	storelifecycle "github.com/rook/rook/tests/integration/object/lifecycle"
 	"github.com/rook/rook/tests/integration/object/notification"
 	topickafka "github.com/rook/rook/tests/integration/object/topic/kafka"
 	usercaps "github.com/rook/rook/tests/integration/object/user/caps"
@@ -48,10 +40,7 @@ import (
 	"github.com/rook/rook/tests/integration/object/util/sharedstore"
 )
 
-const (
-	objectStoreServicePrefixUniq = "rook-ceph-rgw-"
-	objectStoreTLSName           = "tls-test-store"
-)
+const objectStoreServicePrefixUniq = "rook-ceph-rgw-"
 
 var objectStoreServicePrefix = "rook-ceph-rgw-"
 
@@ -105,21 +94,7 @@ func (s *ObjectSuite) TestWithTLS() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
 
-	tls := true
-	swiftAndKeystone := false
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.installer, &s.Suite, s.settings, tls, swiftAndKeystone)
-	cleanUpTLS(s)
-}
-
-func cleanUpTLS(s *ObjectSuite) {
-	err := s.k8sh.Clientset.CoreV1().Secrets(s.settings.Namespace).Delete(context.TODO(), objectTLSSecretName, metav1.DeleteOptions{})
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			logger.Fatal("failed to deleted store TLS secret")
-		}
-	}
-	logger.Info("successfully deleted store TLS secret")
+	runObjectE2ETest(s.k8sh, s.installer, &s.Suite, true)
 }
 
 func (s *ObjectSuite) TestWithoutTLS() {
@@ -127,74 +102,10 @@ func (s *ObjectSuite) TestWithoutTLS() {
 		s.T().Skip("object store tests skipped on openshift")
 	}
 
-	tls := false
-	swiftAndKeystone := false
-	objectStoreServicePrefix = objectStoreServicePrefixUniq
-	runObjectE2ETest(s.helper, s.k8sh, s.installer, &s.Suite, s.settings, tls, swiftAndKeystone)
+	runObjectE2ETest(s.k8sh, s.installer, &s.Suite, false)
 }
 
-// Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
-// Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,
-// Check issues in MGRs, Delete Bucket and Delete user
-// Test for ObjectStore with and without TLS enabled
-func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, installer *installer.CephInstaller, s *suite.Suite, settings *installer.TestCephSettings, tlsEnable bool, swiftAndKeystone bool) {
-	namespace := settings.Namespace
-	storeName := "test-store"
-	if tlsEnable {
-		storeName = objectStoreTLSName
-	}
-
-	logger.Infof("Running on Rook Cluster %s", namespace)
-	// a single gateway makes quota enforcement deterministic: rgw quota checks
-	// run against per-instance cached stats, and with multiple gateways an
-	// instance can be blind to writes served by its peers for up to
-	// rgw_user_quota_bucket_sync_interval; multi-instance deployment is still
-	// covered by the keystone suite
-	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 1, tlsEnable, swiftAndKeystone)
-
-	// Canary test: verify all *_pool fields in zone.json are covered by Rook's zonePoolNSSuffix map.
-	// This catches new RGW pool fields added in newer Ceph versions that Rook doesn't yet handle,
-	// which would cause ghost default pools when shared pools are configured.
-	// Run right after store creation when the zone is fresh and definitely accessible.
-	s.T().Run("all zone.json pool fields are covered by Rook shared pool mapping", func(t *testing.T) {
-		output, err := installer.Execute("radosgw-admin",
-			[]string{"zone", "get", fmt.Sprintf("--rgw-zone=%s", storeName), fmt.Sprintf("--rgw-realm=%s", storeName)}, namespace)
-		require.NoError(t, err, "failed to get zone config; output: %s", output)
-		require.NotEmpty(t, output, "zone config is empty")
-
-		var zoneConfig map[string]interface{}
-		err = json.Unmarshal([]byte(output), &zoneConfig)
-		require.NoError(t, err, "failed to parse zone config JSON; output: %s", output)
-
-		knownPools := rgw.ZoneJsonPoolKeys()
-		for field, val := range zoneConfig {
-			if _, ok := val.(string); !ok {
-				continue
-			}
-			if !strings.HasSuffix(field, "_pool") {
-				continue
-			}
-			assert.Contains(t, knownPools, field,
-				"RGW zone.json contains unknown pool field %q — add it to zonePoolNSSuffix in pkg/operator/ceph/object/objectstore.go", field)
-		}
-	})
-
-	// test that a second object store can be created (and deleted) while the first exists
-	s.T().Run("run a second object store", func(t *testing.T) {
-		otherStoreName := "other-" + storeName
-		// The lite e2e test is perfect, as it only creates a cluster, checks that it is healthy,
-		// and then deletes it.
-		deleteStore := true
-		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
-	})
-
-	// the deletion checks that consumed this store live in the dependents
-	// package now; delete it so it cannot block cluster teardown
-	s.T().Run("delete the suite object store", func(t *testing.T) {
-		deleteObjectStore(t, k8sh, namespace, storeName)
-		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
-	})
-
+func runObjectE2ETest(k8sh *utils.K8sHelper, installer *installer.CephInstaller, s *suite.Suite, tlsEnable bool) {
 	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
 		bucketlifecycle.Namespace,
 		bucketowner.Namespace,
@@ -225,4 +136,5 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	cosi.TestCephCOSIDriver(s.T(), k8sh, sharedObjectStore)
 	dependents.TestCephObjectStoreDependents(s.T(), k8sh, sharedObjectStore)
 	notification.TestBucketNotification(s.T(), k8sh, sharedObjectStore)
+	storelifecycle.TestCephObjectStoreLifecycle(s.T(), k8sh, sharedObjectStore)
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -22,17 +22,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
@@ -43,6 +39,7 @@ import (
 	bucketquota "github.com/rook/rook/tests/integration/object/bucket/quota"
 	bucketrw "github.com/rook/rook/tests/integration/object/bucket/rw"
 	"github.com/rook/rook/tests/integration/object/cosi"
+	"github.com/rook/rook/tests/integration/object/dependents"
 	"github.com/rook/rook/tests/integration/object/notification"
 	topickafka "github.com/rook/rook/tests/integration/object/topic/kafka"
 	usercaps "github.com/rook/rook/tests/integration/object/user/caps"
@@ -191,8 +188,12 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 		runObjectE2ETestLite(t, helper, k8sh, installer, namespace, otherStoreName, 1, deleteStore, tlsEnable, swiftAndKeystone)
 	})
 
-	// now test operation of the first object store
-	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
+	// the deletion checks that consumed this store live in the dependents
+	// package now; delete it so it cannot block cluster teardown
+	s.T().Run("delete the suite object store", func(t *testing.T) {
+		deleteObjectStore(t, k8sh, namespace, storeName)
+		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
+	})
 
 	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
 		bucketlifecycle.Namespace,
@@ -205,6 +206,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 		useropmask.Namespace,
 		usercaps.Namespace,
 		cosi.Namespace,
+		dependents.Namespace,
 		notification.Namespace,
 	)
 	defer sharedObjectStore.Destroy()
@@ -221,152 +223,6 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	// the ceph-cosi driver cannot reach a TLS object store endpoint, so this
 	// suite skips itself in the TLS pass
 	cosi.TestCephCOSIDriver(s.T(), k8sh, sharedObjectStore)
+	dependents.TestCephObjectStoreDependents(s.T(), k8sh, sharedObjectStore)
 	notification.TestBucketNotification(s.T(), k8sh, sharedObjectStore)
-}
-
-func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper, settings *installer.TestCephSettings, storeName string, swiftAndKeystone bool) {
-	ctx := context.TODO()
-	namespace := settings.Namespace
-	clusterInfo := client.AdminTestClusterInfo(namespace)
-	t := s.T()
-
-	logger.Infof("Testing Object Operations on %s", storeName)
-	t.Run("create CephObjectStoreUser", func(t *testing.T) {
-		createCephObjectUser(s, helper, k8sh, namespace, storeName, userid, true)
-		i := 0
-		for i = 0; i < 4; i++ {
-			if helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid) {
-				break
-			}
-			logger.Info("waiting 5 more seconds for user secret to exist")
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-	})
-
-	context := k8sh.MakeContext()
-	objectStore, err := k8sh.RookClientset.CephV1().CephObjectStores(namespace).Get(ctx, storeName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	rgwcontext, err := rgw.NewMultisiteContext(context, clusterInfo, objectStore)
-	assert.Nil(t, err)
-	t.Run("create ObjectBucketClaim", func(t *testing.T) {
-		logger.Infof("create OBC %q with storageclass %q - using reclaim policy 'delete' so buckets don't block deletion", obcName, bucketStorageClassName)
-		cobErr := helper.BucketClient.CreateBucketStorageClass(namespace, storeName, bucketStorageClassName, "Delete")
-		assert.Nil(t, cobErr)
-		cobcErr := helper.BucketClient.CreateObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
-		assert.Nil(t, cobcErr)
-		created := utils.Retry(20, 2*time.Second, "OBC is created", func() bool {
-			return helper.BucketClient.CheckOBC(obcName, "bound")
-		})
-		assert.True(t, created)
-		logger.Info("OBC created successfully")
-
-		var bkt rgw.ObjectBucket
-		i := 0
-		for i = 0; i < 4; i++ {
-			b, code, err := rgw.GetBucket(rgwcontext, bucketname)
-			if b != nil && err == nil {
-				bkt = *b
-				break
-			}
-			logger.Warningf("cannot get bucket %q, retrying... bucket: %v. code: %d, err: %v", bucketname, b, code, err)
-			logger.Infof("(%d) check bucket exists, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-		assert.Equal(t, bucketname, bkt.Name)
-		logger.Info("OBC, Secret and ConfigMap created")
-	})
-
-	t.Run("delete CephObjectStore should be blocked by OBC bucket and CephObjectStoreUser", func(t *testing.T) {
-		deleteObjectStore(t, k8sh, namespace, storeName)
-
-		store := &cephv1.CephObjectStore{}
-		i := 0
-		for i = 0; i < 4; i++ {
-			storeStr, err := k8sh.GetResource("-n", namespace, "CephObjectStore", storeName, "-o", "json")
-			assert.NoError(t, err)
-
-			err = json.Unmarshal([]byte(storeStr), &store)
-			assert.NoError(t, err)
-
-			cond := cephv1.FindStatusCondition(store.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
-			if cond != nil {
-				break
-			}
-			logger.Info("waiting 2 more seconds for CephObjectStore to reach Deleting state")
-			time.Sleep(2 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-
-		assert.Equal(t, cephv1.ConditionDeleting, store.Status.Phase) // phase == "Deleting"
-		// verify deletion is blocked b/c object has dependents
-		cond := cephv1.FindStatusCondition(store.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
-		logger.Infof("condition: %+v", cond)
-		assert.Equal(t, v1.ConditionTrue, cond.Status)
-		assert.Equal(t, cephv1.ObjectHasDependentsReason, cond.Reason)
-		// the CephObjectStoreUser and the bucket should both block deletion
-		assert.Contains(t, cond.Message, "CephObjectStoreUsers")
-		assert.Contains(t, cond.Message, userid)
-		assert.Contains(t, cond.Message, "buckets")
-		assert.Contains(t, cond.Message, bucketname)
-
-		// The event is created by the same method that adds that condition, so we can be pretty
-		// sure it exists here. No need to do extra work to validate the event.
-	})
-
-	t.Run("delete OBC", func(t *testing.T) {
-		i := 0
-		dobcErr := helper.BucketClient.DeleteObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
-		assert.Nil(t, dobcErr)
-		logger.Info("Checking to see if the obc, secret, and cm have all been deleted")
-		for i = 0; i < 4 && !helper.BucketClient.CheckOBC(obcName, "deleted"); i++ {
-			logger.Infof("(%d) obc deleted check, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-
-		logger.Info("ensure OBC bucket was deleted")
-		var rgwErr int
-		for i = 0; i < 4; i++ {
-			_, rgwErr, _ = rgw.GetBucket(rgwcontext, bucketname)
-			if rgwErr == rgw.RGWErrorNotFound {
-				break
-			}
-			logger.Infof("(%d) check bucket deleted, sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.NotEqual(t, 4, i)
-		assert.Equal(t, rgwErr, rgw.RGWErrorNotFound)
-
-		dobErr := helper.BucketClient.DeleteBucketStorageClass(namespace, storeName, bucketStorageClassName, "Delete")
-		assert.Nil(t, dobErr)
-	})
-
-	t.Run("delete CephObjectStoreUser", func(t *testing.T) {
-		dosuErr := helper.ObjectUserClient.Delete(namespace, userid)
-		assert.Nil(t, dosuErr)
-		logger.Info("Object store user deleted successfully")
-		logger.Info("Checking to see if the user secret has been deleted")
-		i := 0
-		for i = 0; i < 4 && helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid) == true; i++ {
-			logger.Infof("(%d) secret check sleeping for 5 seconds ...", i)
-			time.Sleep(5 * time.Second)
-		}
-		assert.False(t, helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid))
-	})
-
-	t.Run("Regression check: mgrs are not in a crashloop", func(t *testing.T) {
-		assert.True(t, k8sh.CheckPodCountAndState("rook-ceph-mgr", namespace, 1, "Running"))
-	})
-
-	// tests are complete, now delete the objectstore
-	s.T().Run("CephObjectStore should delete now that dependents are gone", func(t *testing.T) {
-		// wait initially since it will almost never detect on the first try without this.
-		time.Sleep(3 * time.Second)
-
-		assertObjectStoreDeletion(t, k8sh, namespace, storeName)
-	})
-
-	// TODO : Add case for brownfield/cleanup s3 client}
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 	bucketowner "github.com/rook/rook/tests/integration/object/bucket/owner"
+	bucketpolicy "github.com/rook/rook/tests/integration/object/bucket/policy"
 	bucketquota "github.com/rook/rook/tests/integration/object/bucket/quota"
 	bucketrw "github.com/rook/rook/tests/integration/object/bucket/rw"
 	"github.com/rook/rook/tests/integration/object/cosi"
@@ -215,6 +216,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 
 	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
 		bucketowner.Namespace,
+		bucketpolicy.Namespace,
 		bucketquota.Namespace,
 		bucketrw.Namespace,
 		userkeys.Namespace,
@@ -227,6 +229,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	defer sharedObjectStore.Destroy()
 
 	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)
+	bucketpolicy.TestObjectBucketClaimPolicy(s.T(), k8sh, sharedObjectStore)
 	bucketquota.TestObjectBucketClaimQuota(s.T(), k8sh, sharedObjectStore)
 	bucketrw.TestObjectBucketClaimReadWrite(s.T(), k8sh, sharedObjectStore)
 	userkeys.TestObjectStoreUserKeys(s.T(), k8sh, sharedObjectStore)
@@ -291,248 +294,6 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		assert.NotEqual(t, 4, i)
 		assert.Equal(t, bucketname, bkt.Name)
 		logger.Info("OBC, Secret and ConfigMap created")
-	})
-
-	t.Run("OBC bucket policy management", func(t *testing.T) {
-		bucketName := "bucket-policy-test"
-		var obName string
-		var s3client *rgw.S3Agent
-		bucketPolicy1 := `
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam:::user/foo"
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject",
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": [
-                "arn:aws:s3:::bucket-policy-test/*"
-            ]
-        }
-    ]
-}
-		`
-
-		bucketPolicy2 := `
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam:::user/bar"
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": [
-                "arn:aws:s3:::bucket-policy-test/*"
-            ]
-        }
-    ]
-}
-		`
-
-		t.Run("create obc with bucketPolicy", func(t *testing.T) {
-			newObc := v1alpha1.ObjectBucketClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      bucketName,
-					Namespace: namespace,
-				},
-				Spec: v1alpha1.ObjectBucketClaimSpec{
-					BucketName:       bucketName,
-					StorageClassName: bucketStorageClassName,
-					AdditionalConfig: map[string]string{
-						"bucketPolicy": bucketPolicy1,
-					},
-				},
-			}
-			_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Create(ctx, &newObc, metav1.CreateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, 2*time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, 2*time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that bucketPolicy is set
-			assert.Equal(t, bucketPolicy1, obc.Spec.AdditionalConfig["bucketPolicy"])
-
-			// as the tests are running external to k8s, the internal svc can't be used
-			labelSelector := "rgw=" + storeName
-			services, err := k8sh.Clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-			assert.Nil(t, err)
-			assert.Equal(t, 1, len(services.Items))
-			s3endpoint := services.Items[0].Spec.ClusterIP + ":80"
-
-			secret, err := k8sh.Clientset.CoreV1().Secrets(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			s3AccessKey := string(secret.Data["AWS_ACCESS_KEY_ID"])
-			s3SecretKey := string(secret.Data["AWS_SECRET_ACCESS_KEY"])
-
-			insecure := objectStore.Spec.IsTLSEnabled()
-			s3client, err = rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, true, nil, insecure, nil)
-			assert.Nil(t, err)
-			logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
-		})
-
-		t.Run("policy was applied verbatim to bucket", func(t *testing.T) {
-			policyResp, err := s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
-				Bucket: &bucketName,
-			})
-			require.NoError(t, err)
-			assert.Equal(t, bucketPolicy1, *policyResp.Policy)
-		})
-
-		t.Run("update obc bucketPolicy", func(t *testing.T) {
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-
-			obc.Spec.AdditionalConfig["bucketPolicy"] = bucketPolicy2
-
-			_, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Update(ctx, obc, metav1.UpdateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that updated bucketPolicy is set
-			assert.Equal(t, bucketPolicy2, obc.Spec.AdditionalConfig["bucketPolicy"])
-		})
-
-		t.Run("policy update applied verbatim to bucket", func(t *testing.T) {
-			var livePolicy string
-			utils.Retry(20, time.Second, "policy changed", func() bool {
-				policyResp, err := s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
-					Bucket: &bucketName,
-				})
-				if err != nil {
-					return false
-				}
-
-				livePolicy = *policyResp.Policy
-				return bucketPolicy2 == livePolicy
-			})
-			assert.Equal(t, bucketPolicy2, livePolicy)
-		})
-
-		t.Run("remove obc bucketPolicy", func(t *testing.T) {
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-
-			obc.Spec.AdditionalConfig = map[string]string{}
-
-			_, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Update(ctx, obc, metav1.UpdateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that bucketPolicy is unset
-			assert.NotContains(t, obc.Spec.AdditionalConfig, "bucketPolicy")
-		})
-
-		t.Run("policy was removed from bucket", func(t *testing.T) {
-			var err error
-			utils.Retry(20, time.Second, "policy is gone", func() bool {
-				_, err = s3client.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
-					Bucket: &bucketName,
-				})
-				return err != nil
-			})
-			require.Error(t, err)
-			var apiErr smithy.APIError
-			require.True(t, errors.As(err, &apiErr))
-			assert.Equal(t, "NoSuchBucketPolicy", apiErr.ErrorCode())
-		})
-
-		t.Run("delete bucket", func(t *testing.T) {
-			err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Delete(ctx, bucketName, metav1.DeleteOptions{})
-			assert.Nil(t, err)
-
-			absent := utils.Retry(20, time.Second, "OBC is absent", func() bool {
-				_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				return err != nil
-			})
-			assert.True(t, absent)
-
-			absent = utils.Retry(20, time.Second, "OB is absent", func() bool {
-				_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				return err != nil
-			})
-			assert.True(t, absent)
-		})
 	})
 
 	t.Run("OBC bucket lifecycle management", func(t *testing.T) {

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -19,18 +19,11 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	smithy "github.com/aws/smithy-go"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -44,6 +37,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	bucketlifecycle "github.com/rook/rook/tests/integration/object/bucket/lifecycle"
 	bucketowner "github.com/rook/rook/tests/integration/object/bucket/owner"
 	bucketpolicy "github.com/rook/rook/tests/integration/object/bucket/policy"
 	bucketquota "github.com/rook/rook/tests/integration/object/bucket/quota"
@@ -63,20 +57,6 @@ const (
 )
 
 var objectStoreServicePrefix = "rook-ceph-rgw-"
-
-var lifecycleCmpOpts = cmp.Options{
-	cmpopts.IgnoreUnexported(
-		s3types.LifecycleRule{},
-		s3types.LifecycleExpiration{},
-		s3types.LifecycleRuleFilter{},
-		s3types.LifecycleRuleAndOperator{},
-		s3types.AbortIncompleteMultipartUpload{},
-		s3types.NoncurrentVersionExpiration{},
-		s3types.NoncurrentVersionTransition{},
-		s3types.Transition{},
-		s3types.Tag{},
-	),
-}
 
 func TestCephObjectSuite(t *testing.T) {
 	s := new(ObjectSuite)
@@ -215,6 +195,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
 
 	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable,
+		bucketlifecycle.Namespace,
 		bucketowner.Namespace,
 		bucketpolicy.Namespace,
 		bucketquota.Namespace,
@@ -228,6 +209,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	)
 	defer sharedObjectStore.Destroy()
 
+	bucketlifecycle.TestObjectBucketClaimLifecycle(s.T(), k8sh, sharedObjectStore)
 	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)
 	bucketpolicy.TestObjectBucketClaimPolicy(s.T(), k8sh, sharedObjectStore)
 	bucketquota.TestObjectBucketClaimQuota(s.T(), k8sh, sharedObjectStore)
@@ -294,261 +276,6 @@ func testObjectStoreOperations(s *suite.Suite, helper *clients.TestClient, k8sh 
 		assert.NotEqual(t, 4, i)
 		assert.Equal(t, bucketname, bkt.Name)
 		logger.Info("OBC, Secret and ConfigMap created")
-	})
-
-	t.Run("OBC bucket lifecycle management", func(t *testing.T) {
-		bucketName := "bucket-lifecycle-test"
-		var obName string
-		var s3client *rgw.S3Agent
-		bucketLifecycle1 := `
-{
-  "Rules":[
-    {
-      "ID": "AbortIncompleteMultipartUploads",
-      "Status": "Enabled",
-      "Prefix": "",
-      "AbortIncompleteMultipartUpload": {
-        "DaysAfterInitiation": 1
-      }
-    }
-  ]
-}
-		`
-
-		// rules must be sorted by ID to be idempotent
-		bucketLifecycle2 := `
-{
-  "Rules": [
-    {
-      "ID": "AbortIncompleteMultipartUploads",
-      "Status": "Enabled",
-      "Prefix": "",
-      "AbortIncompleteMultipartUpload": {
-        "DaysAfterInitiation": 1
-      }
-    },
-    {
-      "ID": "ExpireAfter30Days",
-      "Status": "Enabled",
-      "Prefix": "",
-      "Expiration": {
-        "Days": 30
-      }
-    }
-  ]
-}
-		`
-
-		t.Run("create obc with bucketLifecycle", func(t *testing.T) {
-			newObc := v1alpha1.ObjectBucketClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      bucketName,
-					Namespace: namespace,
-				},
-				Spec: v1alpha1.ObjectBucketClaimSpec{
-					BucketName:       bucketName,
-					StorageClassName: bucketStorageClassName,
-					AdditionalConfig: map[string]string{
-						"bucketLifecycle": bucketLifecycle1,
-					},
-				},
-			}
-			_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Create(ctx, &newObc, metav1.CreateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, 2*time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, 2*time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that bucketLifecycle is set
-			assert.Equal(t, bucketLifecycle1, obc.Spec.AdditionalConfig["bucketLifecycle"])
-
-			// as the tests are running external to k8s, the internal svc can't be used
-			labelSelector := "rgw=" + storeName
-			services, err := k8sh.Clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-			assert.Nil(t, err)
-			assert.Equal(t, 1, len(services.Items))
-			s3endpoint := services.Items[0].Spec.ClusterIP + ":80"
-
-			secret, err := k8sh.Clientset.CoreV1().Secrets(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			s3AccessKey := string(secret.Data["AWS_ACCESS_KEY_ID"])
-			s3SecretKey := string(secret.Data["AWS_SECRET_ACCESS_KEY"])
-
-			insecure := objectStore.Spec.IsTLSEnabled()
-			s3client, err = rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, true, nil, insecure, nil)
-			assert.Nil(t, err)
-			logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
-		})
-
-		t.Run("lifecycle was applied verbatim to bucket", func(t *testing.T) {
-			liveLc, err := s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
-				Bucket: &bucketName,
-			})
-			require.NoError(t, err)
-
-			confLc := &s3types.BucketLifecycleConfiguration{}
-			err = json.Unmarshal([]byte(bucketLifecycle1), confLc)
-			require.NoError(t, err)
-
-			assert.True(t, cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...), cmp.Diff(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...))
-		})
-
-		t.Run("update obc bucketLifecycle", func(t *testing.T) {
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-
-			obc.Spec.AdditionalConfig["bucketLifecycle"] = bucketLifecycle2
-
-			_, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Update(ctx, obc, metav1.UpdateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that updated bucketLifecycle is set
-			assert.Equal(t, bucketLifecycle2, obc.Spec.AdditionalConfig["bucketLifecycle"])
-		})
-
-		t.Run("lifecycle update applied verbatim to bucket", func(t *testing.T) {
-			var liveLc *s3.GetBucketLifecycleConfigurationOutput
-
-			confLc := &s3types.BucketLifecycleConfiguration{}
-			err = json.Unmarshal([]byte(bucketLifecycle2), confLc)
-			require.NoError(t, err)
-
-			utils.Retry(20, time.Second, "lifecycle changed", func() bool {
-				liveLc, err = s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
-					Bucket: &bucketName,
-				})
-				if err != nil {
-					return false
-				}
-
-				return cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...)
-			})
-			assert.True(t, cmp.Equal(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...), cmp.Diff(confLc.Rules, liveLc.Rules, lifecycleCmpOpts...))
-		})
-
-		t.Run("remove obc bucketLifecycle", func(t *testing.T) {
-			obc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-
-			obc.Spec.AdditionalConfig = map[string]string{}
-
-			_, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Update(ctx, obc, metav1.UpdateOptions{})
-			assert.Nil(t, err)
-			obcBound := utils.Retry(20, time.Second, "OBC is Bound", func() bool {
-				liveObc, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveObc.Status.Phase == v1alpha1.ObjectBucketClaimStatusPhaseBound
-			})
-			assert.True(t, obcBound)
-
-			// wait until obc is Bound to lookup the ob name
-			obc, err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-			assert.Nil(t, err)
-			obName = obc.Spec.ObjectBucketName
-
-			obBound := utils.Retry(20, time.Second, "OB is Bound", func() bool {
-				liveOb, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				if err != nil {
-					return false
-				}
-
-				return liveOb.Status.Phase == v1alpha1.ObjectBucketStatusPhaseBound
-			})
-			assert.True(t, obBound)
-
-			// verify that bucketLifecycle is unset
-			assert.NotContains(t, obc.Spec.AdditionalConfig, "bucketLifecycle")
-		})
-
-		t.Run("lifecycle was removed from bucket", func(t *testing.T) {
-			cephcluster, err := k8sh.RookClientset.CephV1().CephClusters(namespace).Get(ctx, settings.ClusterName, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("failed to get CephCluster: %v", err)
-			}
-			logger.Infof("CephCluster version: %s", cephcluster.Status.CephVersion.Version)
-			if strings.HasPrefix(cephcluster.Status.CephVersion.Version, "19.2.3") {
-				t.Skip("Waiting for rgw fix from regression in v19.2.3")
-			}
-			utils.Retry(20, time.Second, "lifecycle is gone", func() bool {
-				_, err = s3client.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
-					Bucket: &bucketName,
-				})
-				var apiErr smithy.APIError
-				if errors.As(err, &apiErr) {
-					return apiErr.ErrorCode() == "NoSuchLifecycleConfiguration"
-				}
-				return false
-			})
-			require.Error(t, err)
-			var apiErr smithy.APIError
-			require.True(t, errors.As(err, &apiErr))
-			assert.Equal(t, "NoSuchLifecycleConfiguration", apiErr.ErrorCode())
-		})
-
-		t.Run("delete bucket", func(t *testing.T) {
-			err = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Delete(ctx, bucketName, metav1.DeleteOptions{})
-			assert.Nil(t, err)
-
-			absent := utils.Retry(20, time.Second, "OBC is absent", func() bool {
-				_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(namespace).Get(ctx, bucketName, metav1.GetOptions{})
-				return err != nil
-			})
-			assert.True(t, absent)
-
-			absent = utils.Retry(20, time.Second, "OB is absent", func() bool {
-				_, err := k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBuckets().Get(ctx, obName, metav1.GetOptions{})
-				return err != nil
-			})
-			assert.True(t, absent)
-		})
 	})
 
 	t.Run("delete CephObjectStore should be blocked by OBC bucket and CephObjectStoreUser", func(t *testing.T) {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -29,9 +29,12 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -40,6 +43,10 @@ const (
 	blockName         = "block-claim-upgrade"
 	bucketPrefix      = "generate-me" // use generated bucket name for this test
 	simpleTestMessage = "my simple message"
+
+	objectUserDisplayName = "A rook RGW user"
+	obcName               = "smoke-delete-bucket"
+	maxObject             = "2"
 )
 
 // ************************************************
@@ -121,7 +128,7 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
 		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
-		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
+		s.cleanUpObjectStore()
 	}()
 
 	// Delete Object-SC before upgrade test (https://github.com/rook/rook/issues/10153)
@@ -145,7 +152,7 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
 
-	checkCephObjectUser(&s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, false)
+	s.checkObjectUser(objectUserID)
 
 	// should be Bound after upgrade to Rook master
 	// do not need retry b/c the OBC controller runs parallel to Rook-Ceph orchestration
@@ -169,7 +176,7 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
 	logger.Infof("Verified upgrade from squid to tentacle")
 
-	checkCephObjectUser(&s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, false)
+	s.checkObjectUser(objectUserID)
 }
 
 func (s *UpgradeSuite) TestUpgradeCephToSquidDevel() {
@@ -189,7 +196,7 @@ func (s *UpgradeSuite) TestUpgradeCephToSquidDevel() {
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
 		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
-		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
+		s.cleanUpObjectStore()
 	}()
 
 	//
@@ -203,7 +210,7 @@ func (s *UpgradeSuite) TestUpgradeCephToSquidDevel() {
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
 	logger.Infof("verified upgrade from squid stable to squid devel")
 
-	checkCephObjectUser(&s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, false)
+	s.checkObjectUser(objectUserID)
 }
 
 func (s *UpgradeSuite) TestUpgradeCephToTentacleDevel() {
@@ -223,7 +230,7 @@ func (s *UpgradeSuite) TestUpgradeCephToTentacleDevel() {
 		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
 		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
 		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
-		objectStoreCleanUp(&s.Suite, s.helper, s.k8sh, s.settings.Namespace, installer.ObjectStoreName)
+		s.cleanUpObjectStore()
 	}()
 
 	//
@@ -237,7 +244,7 @@ func (s *UpgradeSuite) TestUpgradeCephToTentacleDevel() {
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
 	logger.Infof("verified upgrade from tentacle stable to tentacle devel")
 
-	checkCephObjectUser(&s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, false)
+	s.checkObjectUser(objectUserID)
 }
 
 func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preFilename string) (int, []string, []string) {
@@ -274,7 +281,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 	}
 
 	logger.Infof("Initializing object user before the upgrade")
-	createCephObjectUser(&s.Suite, s.helper, s.k8sh, s.namespace, installer.ObjectStoreName, objectUserID, false)
+	s.createObjectUser(objectUserID)
 
 	logger.Info("Initializing object bucket claim before the upgrade")
 	cobErr := s.helper.BucketClient.CreateBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreName, "Delete")
@@ -306,6 +313,52 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 	require.NotEqual(s.T(), 0, numOSDs)
 
 	return numOSDs, rbdFilesToRead, cephfsFilesToRead
+}
+
+func (s *UpgradeSuite) createObjectUser(userID string) {
+	maxBuckets := 1
+	maxObjects := int64(2)
+	maxSize := resource.MustParse("100000")
+	user := &v1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userID,
+			Namespace: s.namespace,
+		},
+		Spec: v1.ObjectStoreUserSpec{
+			Store:       installer.ObjectStoreName,
+			DisplayName: objectUserDisplayName,
+			Capabilities: &v1.ObjectUserCapSpec{
+				User:   "*",
+				Bucket: "*",
+			},
+			Quotas: &v1.ObjectUserQuotaSpec{
+				MaxBuckets: &maxBuckets,
+				MaxObjects: &maxObjects,
+				MaxSize:    &maxSize,
+			},
+		},
+	}
+	wait4.RequireCreate(context.TODO(), s.T(),
+		s.k8sh.RookClientset.CephV1().CephObjectStoreUsers(s.namespace),
+		user, wait4.ObjectStoreUser, wait4.TimeoutLong)
+}
+
+func (s *UpgradeSuite) checkObjectUser(userID string) {
+	wait4.RequireCondition(context.TODO(), s.T(),
+		s.k8sh.RookClientset.CephV1().CephObjectStoreUsers(s.namespace),
+		userID, wait4.ObjectStoreUser, wait4.TimeoutShort)
+
+	userInfo, err := s.helper.ObjectUserClient.GetUser(s.namespace, installer.ObjectStoreName, userID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), userID, userInfo.UserID)
+	require.NotNil(s.T(), userInfo.DisplayName)
+	assert.Equal(s.T(), objectUserDisplayName, *userInfo.DisplayName)
+}
+
+func (s *UpgradeSuite) cleanUpObjectStore() {
+	wait4.AssertDelete(context.TODO(), s.T(),
+		s.k8sh.RookClientset.CephV1().CephObjectStores(s.settings.Namespace),
+		installer.ObjectStoreName, 5*time.Minute)
 }
 
 func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -275,9 +275,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 
 	if !s.settings.UseHelm {
 		logger.Infof("Initializing object before the upgrade")
-		deleteStore := false
-		tls := false
-		runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.installer, s.settings.Namespace, installer.ObjectStoreName, 1, deleteStore, tls, false)
+		s.createObjectStore()
 	}
 
 	logger.Infof("Initializing object user before the upgrade")
@@ -313,6 +311,38 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 	require.NotEqual(s.T(), 0, numOSDs)
 
 	return numOSDs, rbdFilesToRead, cephfsFilesToRead
+}
+
+func (s *UpgradeSuite) createObjectStore() {
+	store := &v1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      installer.ObjectStoreName,
+			Namespace: s.namespace,
+		},
+		Spec: v1.ObjectStoreSpec{
+			MetadataPool: v1.PoolSpec{
+				Replicated: v1.ReplicatedSpec{
+					Size:                   1,
+					RequireSafeReplicaSize: false,
+				},
+				CompressionMode: "passive",
+			},
+			DataPool: v1.PoolSpec{
+				Replicated: v1.ReplicatedSpec{
+					Size:                   1,
+					RequireSafeReplicaSize: false,
+				},
+			},
+			Gateway: v1.GatewaySpec{
+				Port:      80,
+				Instances: 1,
+			},
+		},
+	}
+	live := wait4.RequireCreate(context.TODO(), s.T(),
+		s.k8sh.RookClientset.CephV1().CephObjectStores(s.namespace),
+		store, wait4.ObjectStore, 5*time.Minute)
+	assert.NotEmpty(s.T(), live.Status.Info["endpoint"])
 }
 
 func (s *UpgradeSuite) createObjectUser(userID string) {

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -32,6 +32,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 
 | test package | operator package | covers |
 |---|---|---|
+| `bucket/lifecycle` | `object/bucket` | OBC bucketLifecycle management |
 | `bucket/owner` | `object/bucket` | OBC `bucketOwner` handling |
 | `bucket/policy` | `object/bucket` | OBC bucketPolicy management |
 | `bucket/quota` | `object/bucket` | OBC maxObjects user quota + bucketMaxObjects/bucketMaxSize bucket quota |
@@ -42,7 +43,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
-| reserved: `bucket/lifecycle`, `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
+| reserved: `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -208,7 +209,6 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `testObjectStoreOperations` bucket lifecycle | `bucket/lifecycle` | move `lifecycleCmpOpts` out of the dispatcher |
 | `testObjectStoreOperations` deletion-blocked-by-dependents | `tests/integration/object/dependents` | private-store fixture, store condition predicates in `wait4` |
 | `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts + zone.json canary | `tests/integration/object/lifecycle` | store create/health/delete helpers, `Sharedstore.Installer()` accessor |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -1,9 +1,7 @@
 # Object storage integration tests
 
-This tree holds the new-style integration tests for rook's object storage
-features. It is the model for converting the remaining old-style object tests
-(`testObjectStoreOperations`, store lifecycle);
-follow the conventions here exactly so the conversion happens once.
+This tree holds the integration tests for rook's object storage features;
+follow the conventions here exactly.
 
 ## Execution model
 
@@ -39,12 +37,12 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `bucket/rw` | `object/bucket` | OBC S3 read/write/delete + OBC-stays-Bound |
 | `cosi` | `object/cosi` | CephCOSIDriver + COSI bucket provisioning |
 | `dependents` | `object` | CephObjectStore deletion blocked by dependents |
+| `lifecycle` | `object` | CephObjectStore create/health/delete + the zone.json pool canary |
 | `notification` | `object/notification` | CephBucketNotification HTTP endpoint delivery |
 | `topic/kafka` | `object/topic` | CephBucketTopic kafka endpoints |
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
-| reserved: `tests/integration/object/lifecycle` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -210,5 +208,4 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts + zone.json canary | `tests/integration/object/lifecycle` | store create/health/delete helpers, `Sharedstore.Installer()` accessor |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -33,6 +33,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 | test package | operator package | covers |
 |---|---|---|
 | `bucket/owner` | `object/bucket` | OBC `bucketOwner` handling |
+| `bucket/policy` | `object/bucket` | OBC bucketPolicy management |
 | `bucket/quota` | `object/bucket` | OBC maxObjects user quota + bucketMaxObjects/bucketMaxSize bucket quota |
 | `bucket/rw` | `object/bucket` | OBC S3 read/write/delete + OBC-stays-Bound |
 | `cosi` | `object/cosi` | CephCOSIDriver + COSI bucket provisioning |
@@ -41,7 +42,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
-| reserved: `bucket/policy`, `bucket/lifecycle`, `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
+| reserved: `bucket/lifecycle`, `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -207,7 +208,6 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `testObjectStoreOperations` bucket policy | `bucket/policy` | — |
 | `testObjectStoreOperations` bucket lifecycle | `bucket/lifecycle` | move `lifecycleCmpOpts` out of the dispatcher |
 | `testObjectStoreOperations` deletion-blocked-by-dependents | `tests/integration/object/dependents` | private-store fixture, store condition predicates in `wait4` |
 | `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts + zone.json canary | `tests/integration/object/lifecycle` | store create/health/delete helpers, `Sharedstore.Installer()` accessor |

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -38,12 +38,13 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `bucket/quota` | `object/bucket` | OBC maxObjects user quota + bucketMaxObjects/bucketMaxSize bucket quota |
 | `bucket/rw` | `object/bucket` | OBC S3 read/write/delete + OBC-stays-Bound |
 | `cosi` | `object/cosi` | CephCOSIDriver + COSI bucket provisioning |
+| `dependents` | `object` | CephObjectStore deletion blocked by dependents |
 | `notification` | `object/notification` | CephBucketNotification HTTP endpoint delivery |
 | `topic/kafka` | `object/topic` | CephBucketTopic kafka endpoints |
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
-| reserved: `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
+| reserved: `tests/integration/object/lifecycle` | | future conversions |
 
 Shared utilities live under `util/`:
 
@@ -209,6 +210,5 @@ verification; wire the dispatcher; delete the old code; retire
 
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
-| `testObjectStoreOperations` deletion-blocked-by-dependents | `tests/integration/object/dependents` | private-store fixture, store condition predicates in `wait4` |
 | `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts + zone.json canary | `tests/integration/object/lifecycle` | store create/health/delete helpers, `Sharedstore.Installer()` accessor |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/bucket/lifecycle/lifecycle.go
+++ b/tests/integration/object/bucket/lifecycle/lifecycle.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rgw "github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/obc"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const lifecycle1 = `
+{
+  "Rules":[
+    {
+      "ID": "AbortIncompleteMultipartUploads",
+      "Status": "Enabled",
+      "Prefix": "",
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 1
+      }
+    }
+  ]
+}
+`
+
+// rules must be sorted by ID to be idempotent
+const lifecycle2 = `
+{
+  "Rules": [
+    {
+      "ID": "AbortIncompleteMultipartUploads",
+      "Status": "Enabled",
+      "Prefix": "",
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 1
+      }
+    },
+    {
+      "ID": "ExpireAfter30Days",
+      "Status": "Enabled",
+      "Prefix": "",
+      "Expiration": {
+        "Days": 30
+      }
+    }
+  ]
+}
+`
+
+var lifecycleCmpOpts = cmp.Options{
+	cmpopts.IgnoreUnexported(
+		s3types.LifecycleRule{},
+		s3types.LifecycleExpiration{},
+		s3types.LifecycleRuleFilter{},
+		s3types.LifecycleRuleAndOperator{},
+		s3types.AbortIncompleteMultipartUpload{},
+		s3types.NoncurrentVersionExpiration{},
+		s3types.NoncurrentVersionTransition{},
+		s3types.Transition{},
+		s3types.Tag{},
+	),
+}
+
+// requireLifecycleApplied waits until the bucket's live lifecycle rules match
+// the expected JSON configuration.
+func requireLifecycleApplied(ctx context.Context, t *testing.T, s3agent *rgw.S3Agent, bucket, expected string) {
+	t.Helper()
+
+	conf := &s3types.BucketLifecycleConfiguration{}
+	require.NoError(t, json.Unmarshal([]byte(expected), conf))
+
+	wait4.RequireEventually(ctx, t, wait4.TimeoutShort, "bucket lifecycle applied", func(ctx context.Context) error {
+		resp, err := s3agent.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: &bucket})
+		if err != nil {
+			return err
+		}
+		if !cmp.Equal(conf.Rules, resp.Rules, lifecycleCmpOpts...) {
+			return fmt.Errorf("bucket lifecycle rules not in sync: %s", cmp.Diff(conf.Rules, resp.Rules, lifecycleCmpOpts...))
+		}
+		return nil
+	})
+}
+
+const Namespace = "test-bucketlifecycle"
+
+func TestObjectBucketClaimLifecycle(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		defaultName = Namespace
+		objectStore = store.ObjectStore()
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultName,
+			},
+		}
+
+		storageClass = obc.StorageClass(defaultName, objectStore)
+
+		bucketName = defaultName + "-obc1"
+
+		obc1 = &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bucketName,
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       bucketName,
+				StorageClassName: storageClass.Name,
+				AdditionalConfig: map[string]string{"bucketLifecycle": lifecycle1},
+			},
+		}
+
+		obcClient  = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(ns.Name)
+		cephClient = k8sh.RookClientset.CephV1().CephClusters(objectStore.Namespace)
+	)
+
+	t.Run("ObjectBucketClaim lifecycle", func(t *testing.T) {
+		ctx := t.Context()
+
+		fixture.RequireNamespace(t, k8sh, ns)
+		fixture.RequireStorageClass(t, k8sh, storageClass)
+
+		obc.RequireBound(ctx, t, k8sh, obc1)
+		s3agent := obc.NewS3Agent(ctx, t, k8sh, store, ns.Name, obc1.Name)
+
+		t.Run(fmt.Sprintf("lifecycle is applied verbatim to bucket %q", bucketName), func(t *testing.T) {
+			requireLifecycleApplied(ctx, t, s3agent, bucketName, lifecycle1)
+		})
+
+		t.Run(fmt.Sprintf("update obc %q bucketLifecycle", obc1.Name), func(t *testing.T) {
+			obc.Update(ctx, t, k8sh, ns.Name, obc1.Name, func(live *bktv1alpha1.ObjectBucketClaim) {
+				live.Spec.AdditionalConfig["bucketLifecycle"] = lifecycle2
+			})
+		})
+
+		t.Run(fmt.Sprintf("lifecycle update is applied verbatim to bucket %q", bucketName), func(t *testing.T) {
+			requireLifecycleApplied(ctx, t, s3agent, bucketName, lifecycle2)
+		})
+
+		t.Run(fmt.Sprintf("remove obc %q bucketLifecycle", obc1.Name), func(t *testing.T) {
+			obc.Update(ctx, t, k8sh, ns.Name, obc1.Name, func(live *bktv1alpha1.ObjectBucketClaim) {
+				live.Spec.AdditionalConfig = map[string]string{}
+			})
+		})
+
+		t.Run(fmt.Sprintf("lifecycle is removed from bucket %q", bucketName), func(t *testing.T) {
+			clusters, err := cephClient.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, clusters.Items)
+			if strings.HasPrefix(clusters.Items[0].Status.CephVersion.Version, "19.2.3") {
+				t.Skip("waiting for the rgw fix for the lifecycle removal regression in v19.2.3")
+			}
+
+			wait4.RequireEventually(ctx, t, wait4.TimeoutShort, "bucket lifecycle removed", func(ctx context.Context) error {
+				_, err := s3agent.Client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: &bucketName})
+				if err == nil {
+					return errors.New("bucket lifecycle still present")
+				}
+
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchLifecycleConfiguration" {
+					return nil
+				}
+				return err
+			})
+		})
+
+		t.Run(fmt.Sprintf("delete obc %q", obc1.Name), func(t *testing.T) {
+			obc.DeleteAndWait(ctx, t, k8sh, ns.Name, obc1.Name)
+		})
+
+		t.Run(fmt.Sprintf("no obc(s) in ns %q", ns.Name), func(t *testing.T) {
+			list, err := obcClient.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Len(t, list.Items, 0)
+		})
+	})
+}

--- a/tests/integration/object/bucket/policy/policy.go
+++ b/tests/integration/object/bucket/policy/policy.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/obc"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+// bucketPolicy returns an S3 bucket policy allowing principal the given actions
+// on every object in bucket.
+func bucketPolicy(bucket, principal string, actions ...string) string {
+	return fmt.Sprintf(`{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam:::user/%s"
+            },
+            "Action": [
+                "%s"
+            ],
+            "Resource": [
+                "arn:aws:s3:::%s/*"
+            ]
+        }
+    ]
+}`, principal, strings.Join(actions, `",
+                "`), bucket)
+}
+
+const Namespace = "test-bucketpolicy"
+
+func TestObjectBucketClaimPolicy(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		defaultName = Namespace
+		objectStore = store.ObjectStore()
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultName,
+			},
+		}
+
+		storageClass = obc.StorageClass(defaultName, objectStore)
+
+		bucketName = defaultName + "-obc1"
+
+		policy1 = bucketPolicy(bucketName, "foo",
+			"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket", "s3:GetBucketLocation")
+		policy2 = bucketPolicy(bucketName, "bar",
+			"s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation")
+
+		obc1 = &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bucketName,
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       bucketName,
+				StorageClassName: storageClass.Name,
+				AdditionalConfig: map[string]string{"bucketPolicy": policy1},
+			},
+		}
+
+		obcClient = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(ns.Name)
+	)
+
+	t.Run("ObjectBucketClaim policy", func(t *testing.T) {
+		ctx := t.Context()
+
+		fixture.RequireNamespace(t, k8sh, ns)
+		fixture.RequireStorageClass(t, k8sh, storageClass)
+
+		obc.RequireBound(ctx, t, k8sh, obc1)
+		s3agent := obc.NewS3Agent(ctx, t, k8sh, store, ns.Name, obc1.Name)
+
+		t.Run(fmt.Sprintf("policy is applied verbatim to bucket %q", bucketName), func(t *testing.T) {
+			resp, err := s3agent.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucketName})
+			require.NoError(t, err)
+			require.NotNil(t, resp.Policy)
+			assert.Equal(t, policy1, *resp.Policy)
+		})
+
+		t.Run(fmt.Sprintf("update obc %q bucketPolicy", obc1.Name), func(t *testing.T) {
+			obc.Update(ctx, t, k8sh, ns.Name, obc1.Name, func(live *bktv1alpha1.ObjectBucketClaim) {
+				live.Spec.AdditionalConfig["bucketPolicy"] = policy2
+			})
+		})
+
+		t.Run(fmt.Sprintf("policy update is applied verbatim to bucket %q", bucketName), func(t *testing.T) {
+			wait4.RequireEventually(ctx, t, wait4.TimeoutShort, "bucket policy updated", func(ctx context.Context) error {
+				resp, err := s3agent.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucketName})
+				if err != nil {
+					return err
+				}
+				if resp.Policy == nil || *resp.Policy != policy2 {
+					return errors.New("bucket policy not yet updated")
+				}
+				return nil
+			})
+		})
+
+		t.Run(fmt.Sprintf("remove obc %q bucketPolicy", obc1.Name), func(t *testing.T) {
+			obc.Update(ctx, t, k8sh, ns.Name, obc1.Name, func(live *bktv1alpha1.ObjectBucketClaim) {
+				live.Spec.AdditionalConfig = map[string]string{}
+			})
+		})
+
+		t.Run(fmt.Sprintf("policy is removed from bucket %q", bucketName), func(t *testing.T) {
+			wait4.RequireEventually(ctx, t, wait4.TimeoutShort, "bucket policy removed", func(ctx context.Context) error {
+				_, err := s3agent.Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucketName})
+				if err == nil {
+					return errors.New("bucket policy still present")
+				}
+
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchBucketPolicy" {
+					return nil
+				}
+				return err
+			})
+		})
+
+		t.Run(fmt.Sprintf("delete obc %q", obc1.Name), func(t *testing.T) {
+			obc.DeleteAndWait(ctx, t, k8sh, ns.Name, obc1.Name)
+		})
+
+		t.Run(fmt.Sprintf("no obc(s) in ns %q", ns.Name), func(t *testing.T) {
+			list, err := obcClient.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Len(t, list.Items, 0)
+		})
+	})
+}

--- a/tests/integration/object/dependents/dependents.go
+++ b/tests/integration/object/dependents/dependents.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dependents
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/obc"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const Namespace = "test-dependents"
+
+func TestCephObjectStoreDependents(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		defaultName = Namespace
+		clusterNS   = store.ObjectStore().Namespace
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultName,
+			},
+		}
+
+		// deleting a store is destructive, so these tests get a private store
+		// rather than the shared fixture
+		privateStore = &cephv1.CephObjectStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName,
+				Namespace: clusterNS,
+			},
+			Spec: cephv1.ObjectStoreSpec{
+				MetadataPool: cephv1.PoolSpec{
+					Replicated:      cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+					CompressionMode: "passive",
+				},
+				DataPool: cephv1.PoolSpec{
+					Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+				},
+				Gateway: cephv1.GatewaySpec{
+					Port:      80,
+					Instances: 1,
+				},
+			},
+		}
+
+		storageClass = obc.StorageClass(defaultName, privateStore)
+
+		user1 = &cephv1.CephObjectStoreUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-user1",
+				Namespace: clusterNS,
+			},
+			Spec: cephv1.ObjectStoreUserSpec{
+				Store:       privateStore.Name,
+				DisplayName: "dependents test user",
+			},
+		}
+
+		obc1 = &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-obc1",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-obc1",
+				StorageClassName: storageClass.Name,
+			},
+		}
+
+		cosClient = k8sh.RookClientset.CephV1().CephObjectStores(clusterNS)
+		osuClient = k8sh.RookClientset.CephV1().CephObjectStoreUsers(clusterNS)
+	)
+
+	t.Run("CephObjectStore dependents", func(t *testing.T) {
+		ctx := t.Context()
+
+		fixture.RequireNamespace(t, k8sh, ns)
+		fixture.RequireStorageClass(t, k8sh, storageClass)
+
+		t.Run(fmt.Sprintf("create CephObjectStore %q", privateStore.Name), func(t *testing.T) {
+			// store creation races rgw startup; same bespoke timeout as the
+			// shared store fixture
+			wait4.RequireCreate(ctx, t, cosClient, privateStore, wait4.ObjectStore, 3*time.Minute)
+		})
+
+		t.Run(fmt.Sprintf("create CephObjectStoreUser %q", user1.Name), func(t *testing.T) {
+			wait4.RequireCreate(ctx, t, osuClient, user1, wait4.ObjectStoreUser, wait4.TimeoutLong)
+		})
+
+		obc.RequireBound(ctx, t, k8sh, obc1)
+
+		t.Run(fmt.Sprintf("deleting CephObjectStore %q is blocked by its dependents", privateStore.Name), func(t *testing.T) {
+			err := cosClient.Delete(ctx, privateStore.Name, metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			live := wait4.RequireCondition(ctx, t, cosClient, privateStore.Name, wait4.ObjectStoreDeletionBlocked, wait4.TimeoutShort)
+
+			assert.Equal(t, cephv1.ConditionDeleting, live.Status.Phase)
+
+			cond := cephv1.FindStatusCondition(live.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
+			require.NotNil(t, cond)
+			assert.Equal(t, cephv1.ObjectHasDependentsReason, cond.Reason)
+			assert.Contains(t, cond.Message, "CephObjectStoreUsers")
+			assert.Contains(t, cond.Message, user1.Name)
+			assert.Contains(t, cond.Message, "buckets")
+			assert.Contains(t, cond.Message, obc1.Spec.BucketName)
+		})
+
+		t.Run(fmt.Sprintf("delete obc %q", obc1.Name), func(t *testing.T) {
+			obc.DeleteAndWait(ctx, t, k8sh, ns.Name, obc1.Name)
+		})
+
+		t.Run(fmt.Sprintf("delete CephObjectStoreUser %q", user1.Name), func(t *testing.T) {
+			wait4.RequireDelete(ctx, t, osuClient, user1.Name, wait4.TimeoutShort)
+		})
+
+		t.Run(fmt.Sprintf("CephObjectStore %q deletes once its dependents are gone", privateStore.Name), func(t *testing.T) {
+			wait4.RequireAbsent(ctx, t, cosClient, privateStore.Name, 3*time.Minute)
+		})
+
+		t.Run("mgrs are not in a crashloop", func(t *testing.T) {
+			assert.True(t, k8sh.CheckPodCountAndState("rook-ceph-mgr", clusterNS, 1, "Running"))
+		})
+	})
+}

--- a/tests/integration/object/lifecycle/lifecycle.go
+++ b/tests/integration/object/lifecycle/lifecycle.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rgw "github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/client"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const storeName = "test-lifecycle"
+
+func TestCephObjectStoreLifecycle(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		clusterNS = store.ObjectStore().Namespace
+
+		rgwName        = "rook-ceph-rgw-" + storeName
+		certSecretName = storeName + "-tls"
+
+		// deleting a store is destructive, so these tests get a private store
+		// rather than the shared fixture; it also exercises a second store
+		// coexisting with the shared one
+		privateStore = &cephv1.CephObjectStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      storeName,
+				Namespace: clusterNS,
+			},
+			Spec: cephv1.ObjectStoreSpec{
+				MetadataPool: cephv1.PoolSpec{
+					Replicated:      cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+					CompressionMode: "passive",
+				},
+				DataPool: cephv1.PoolSpec{
+					Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false},
+				},
+				Gateway: cephv1.GatewaySpec{
+					Port:      80,
+					Instances: 1,
+				},
+			},
+		}
+
+		cosClient    = k8sh.RookClientset.CephV1().CephObjectStores(clusterNS)
+		deployClient = k8sh.Clientset.AppsV1().Deployments(clusterNS)
+		svcClient    = k8sh.Clientset.CoreV1().Services(clusterNS)
+	)
+
+	t.Run("CephObjectStore lifecycle", func(t *testing.T) {
+		ctx := t.Context()
+
+		// canary: catch new RGW pool fields added in newer Ceph versions that
+		// rook's zonePoolNSSuffix map does not yet cover, which would cause
+		// ghost default pools when shared pools are configured
+		t.Run("all zone.json pool fields are covered by the shared pool mapping", func(t *testing.T) {
+			sharedName := store.ObjectStore().Name
+			output, err := store.Installer().Execute("radosgw-admin",
+				[]string{"zone", "get", fmt.Sprintf("--rgw-zone=%s", sharedName), fmt.Sprintf("--rgw-realm=%s", sharedName)}, clusterNS)
+			require.NoError(t, err, "failed to get zone config; output: %s", output)
+			require.NotEmpty(t, output, "zone config is empty")
+
+			var zoneConfig map[string]interface{}
+			err = json.Unmarshal([]byte(output), &zoneConfig)
+			require.NoError(t, err, "failed to parse zone config JSON; output: %s", output)
+
+			knownPools := rgw.ZoneJsonPoolKeys()
+			for field, val := range zoneConfig {
+				if _, ok := val.(string); !ok {
+					continue
+				}
+				if !strings.HasSuffix(field, "_pool") {
+					continue
+				}
+				assert.Contains(t, knownPools, field,
+					"RGW zone.json contains unknown pool field %q — add it to zonePoolNSSuffix in pkg/operator/ceph/object/objectstore.go", field)
+			}
+		})
+
+		if store.TLSEnabled() {
+			client.GenerateRgwTLSCertSecret(t, k8sh, clusterNS, certSecretName, rgwName)
+			t.Cleanup(func() {
+				// the store consumes the secret only while it exists; cleanup
+				// runs after the test context is canceled
+				_ = k8sh.Clientset.CoreV1().Secrets(clusterNS).Delete(context.Background(), certSecretName, metav1.DeleteOptions{})
+			})
+			privateStore.Spec.Gateway = cephv1.GatewaySpec{
+				SecurePort:        443,
+				SSLCertificateRef: certSecretName,
+				Instances:         1,
+			}
+		}
+
+		t.Run(fmt.Sprintf("create CephObjectStore %q", privateStore.Name), func(t *testing.T) {
+			// store creation races rgw startup; same bespoke timeout as the
+			// shared store fixture
+			live := wait4.RequireCreate(ctx, t, cosClient, privateStore, wait4.ObjectStore, 3*time.Minute)
+			assert.NotEmpty(t, live.Status.Info["endpoint"])
+		})
+
+		t.Run(fmt.Sprintf("rgw deployment for store %q is ready", privateStore.Name), func(t *testing.T) {
+			wait4.RequireCondition(ctx, t, deployClient, rgwName+"-a",
+				func(d *appsv1.Deployment) bool { return d.Status.ReadyReplicas >= 1 }, wait4.TimeoutShort)
+		})
+
+		t.Run(fmt.Sprintf("rgw service for store %q exists", privateStore.Name), func(t *testing.T) {
+			_, err := svcClient.Get(ctx, rgwName, metav1.GetOptions{})
+			require.NoError(t, err)
+		})
+
+		t.Run(fmt.Sprintf("delete CephObjectStore %q", privateStore.Name), func(t *testing.T) {
+			wait4.RequireDelete(ctx, t, cosClient, privateStore.Name, 3*time.Minute)
+		})
+	})
+}

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -44,12 +44,19 @@ type Sharedstore struct {
 	adminClient *admin.API
 	snsClient   *sns.Client
 	objectStore *cephv1.CephObjectStore
+	installer   *installer.CephInstaller
 	tlsEnable   bool
 	destroy     func()
 }
 
 func (s *Sharedstore) AdminClient() *admin.API {
 	return s.adminClient
+}
+
+// Installer returns the suite installer, for tests that must run commands
+// (e.g. radosgw-admin) inside the cluster.
+func (s *Sharedstore) Installer() *installer.CephInstaller {
+	return s.installer
 }
 
 func (s *Sharedstore) SnsClient() *sns.Client {
@@ -75,7 +82,7 @@ func (s *Sharedstore) Destroy() {
 func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, allowedNamespaces ...string) *Sharedstore {
 	t.Helper()
 
-	s := &Sharedstore{tlsEnable: tlsEnable}
+	s := &Sharedstore{tlsEnable: tlsEnable, installer: installer}
 	ctx := context.TODO()
 	ns := "object-ns"
 	storeName := "sharedstore"

--- a/tests/integration/object/util/wait4/ready.go
+++ b/tests/integration/object/util/wait4/ready.go
@@ -18,6 +18,7 @@ package wait4
 
 import (
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
@@ -25,6 +26,16 @@ import (
 // ObjectStore reports whether a CephObjectStore has been reconciled to Ready.
 func ObjectStore(os *cephv1.CephObjectStore) bool {
 	return os.Status != nil && os.Status.Phase == cephv1.ConditionReady
+}
+
+// ObjectStoreDeletionBlocked reports whether a CephObjectStore's deletion is
+// blocked on dependents.
+func ObjectStoreDeletionBlocked(os *cephv1.CephObjectStore) bool {
+	if os.Status == nil {
+		return false
+	}
+	cond := cephv1.FindStatusCondition(os.Status.Conditions, cephv1.ConditionDeletionIsBlocked)
+	return cond != nil && cond.Status == corev1.ConditionTrue
 }
 
 // ObjectStoreUser reports whether a CephObjectStoreUser has been reconciled to


### PR DESCRIPTION
> [!NOTE]
> Stacked on #17928 → #17897 → #17895 → #17894 → #17884. Only the final commit is unique to this PR — review that one. The branch will be rebased down as the stack merges.

### What changed

Following up #17928 (which converted the upgrade suite's object user/store-cleanup checks), this converts the suite's one remaining call into `ceph_base_object_test.go`: the pre-upgrade object store creation via `runObjectE2ETestLite`. A suite-local `createObjectStore` helper now builds the same `CephObjectStore` spec the retired manifest path applied — replica-1 metadata/data pools (`compressionMode: passive` on the metadata pool), gateway on port 80 with one instance — creates it with the typed client, waits for it to reconcile to Ready via `wait4`, and keeps the status-endpoint-populated assertion.

With this, the upgrade suite no longer references `ceph_base_object_test.go` at all. The remaining `runObjectE2ETestLite` callers are the smoke (#17857), helm, and keystone suites; the shared helpers can be deleted once those are converted.

### Coverage note

The conversion drops pieces of the legacy path that nothing in the upgrade suite consumed:

- the `rgw-external-<store>` NodePort service (the suite never reads through it),
- the RGW liveness-probe / service-up / dashboard-admin assertions.

Store health is instead proven by the `wait4` Ready wait plus the object user and OBC creation steps that immediately follow and depend on a working store. This is the same coverage shift #17857 describes for the smoke suite.

### AI assistance

Claude traced the legacy `runObjectE2ETestLite` call chain (manifest contents, external-service side effect, health checks) to determine what the upgrade suite actually depends on, and drafted the helper, the conversion, and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
