### PR TITLE
test: create the upgrade suite object store with the shared store fixture

### DIFF
--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
 	"github.com/rook/rook/tests/integration/object/util/wait4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,11 +69,12 @@ func TestCephUpgradeSuite(t *testing.T) {
 
 type UpgradeSuite struct {
 	suite.Suite
-	helper    *clients.TestClient
-	k8sh      *utils.K8sHelper
-	settings  *installer.TestCephSettings
-	installer *installer.CephInstaller
-	namespace string
+	helper      *clients.TestClient
+	k8sh        *utils.K8sHelper
+	settings    *installer.TestCephSettings
+	installer   *installer.CephInstaller
+	namespace   string
+	objectStore *sharedstore.Sharedstore
 }
 
 func (s *UpgradeSuite) SetupSuite() {
@@ -85,6 +87,9 @@ func (s *UpgradeSuite) TearDownSuite() {
 
 func (s *UpgradeSuite) baseSetup(useHelm bool, initialRookVersion string, initialCephVersion v1.CephVersionSpec) {
 	s.namespace = "upgrade"
+	// the suite instance is shared across test methods; a fixture left over
+	// from a previous method must not leak into this one's cleanup routing
+	s.objectStore = nil
 	s.settings = &installer.TestCephSettings{
 		ClusterName:                 s.namespace,
 		Namespace:                   s.namespace,
@@ -275,9 +280,11 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 
 	if !s.settings.UseHelm {
 		logger.Infof("Initializing object before the upgrade")
-		deleteStore := false
-		tls := false
-		runObjectE2ETestLite(s.T(), s.helper, s.k8sh, s.installer, s.settings.Namespace, installer.ObjectStoreName, 1, deleteStore, tls, false)
+		s.objectStore = sharedstore.Create(s.T(), s.k8sh, s.installer, sharedstore.Config{
+			Namespace: s.settings.Namespace,
+			StoreName: installer.ObjectStoreName,
+			Instances: 1,
+		})
 	}
 
 	logger.Infof("Initializing object user before the upgrade")
@@ -364,6 +371,11 @@ func (s *UpgradeSuite) checkObjectUser(userID string) {
 }
 
 func (s *UpgradeSuite) cleanUpObjectStore() {
+	if s.objectStore != nil {
+		s.objectStore.Destroy()
+		return
+	}
+	// the helm variant's store comes from the chart's retained default CRs
 	wait4.AssertDelete(context.TODO(), s.T(),
 		s.k8sh.RookClientset.CephV1().CephObjectStores(s.settings.Namespace),
 		installer.ObjectStoreName, 5*time.Minute)

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -319,6 +319,10 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 			Spec: cephv1.NamedBlockPoolSpec{
 				Name: v,
 				PoolSpec: cephv1.PoolSpec{
+					// These are rgw backing pools. Without an explicit application
+					// the operator defaults a CephBlockPool to "rbd" and runs
+					// `rbd pool init` on it, which misrepresents the store's pools.
+					Application: "rgw",
 					Replicated: cephv1.ReplicatedSpec{
 						Size:                   1,
 						RequireSafeReplicaSize: false,


### PR DESCRIPTION
### What changed

Following up #17928 (which converted the upgrade suite's object user/store-cleanup checks to typed clients), this converts the suite's one remaining call into `ceph_base_object_test.go`: the pre-upgrade object store creation via `runObjectE2ETestLite`.

The upgrade suite's pre-upgrade store is now stood up through the `sharedstore` fixture instead of `runObjectE2ETestLite`, and torn down with `Destroy`. The fixture's namespace / store-name / instance-count parameters were added upstream in #17857 (now merged), so the upgrade wiring only touches `ceph_upgrade_test.go`. The helm variant keeps the chart's default store and the existing deletion path.

This PR also tags the `sharedstore` fixture's RGW backing pools with `application: rgw` (folded in from a separate fix): without it the operator defaults them to `rbd` and runs `rbd pool init`, misrepresenting the store's pools. That correction benefits every fixture consumer — the object and smoke suites as well as this upgrade suite.

With this, the upgrade suite no longer references `ceph_base_object_test.go` at all. The remaining `runObjectE2ETestLite` callers are the helm and keystone suites; the shared helpers can be deleted once those are converted.

### Coverage note

The store the suite upgrades changes shape: the fixture builds a multisite zone with shared pool placements and pre-created pool CRs (including the cluster-global `.rgw.root`), created and reconciled by the previous rook release, instead of the legacy classic in-spec `metadataPool`/`dataPool` store. The upgrade path now covers the shared-pools topology end to end — created by the old operator, upgraded rook→master and Ceph squid→tentacle, and torn down (zone, zone group, realm, pools) by master.

The residual gap: no scenario now carries a classic in-spec `metadataPool`/`dataPool` store through the Ceph-version upgrades (the helm variant keeps the chart's classic store but returns before them) — recorded here so the loss stays a decision rather than an accident.

The conversion drops pieces of the legacy path that nothing in the upgrade suite consumed: the `rgw-external-<store>` NodePort service and the RGW liveness-probe / service-up / dashboard-admin assertions. Store health is instead proven by the fixture's Ready wait and canary user — whose reconcile requires the RGW admin API to answer over HTTP — plus the object user and OBC steps that immediately follow.

### AI assistance

Claude traced the legacy `runObjectE2ETestLite` call chain to determine what the upgrade suite actually depends on, wired the upgrade suite to the fixture, identified the fixture's `rgw` pool-application gap via an adversarial review, and drafted this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.



