### PR TITLE
docs: correct typos and misleading doc comment

### DIFF
--- a/pkg/operator/ceph/controller/network.go
+++ b/pkg/operator/ceph/controller/network.go
@@ -426,7 +426,7 @@ func cidrForIp(infos []k8sutil.LinuxIpAddrInfo, ip string) (string, error) {
 	}
 
 	// <ip>/<range> works but isn't reduced. the CIDR must be reduced so that it doesn't change
-	// every tme the operator reconciles and the net canary gets a new IP
+	// every time the operator reconciles and the net canary gets a new IP
 	naiveCIDR := fmt.Sprintf("%s/%d", info.Local, info.PrefixLen)
 
 	_, reduced, err := net.ParseCIDR(naiveCIDR)

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -341,7 +341,7 @@ func getPriorKeyCount(currentKeyCount int) int {
 // getCsiKeyRotationInfo runs the `ceph auth ls` command to fetch all the keys and filter out the keys with same base name. Example
 // for base name `client.csi-rbd-node`.
 // From the list of key name return from `getMatchingClient` we'll read the suffix index eg; for key `client.csi-rbd-node.3` we'll take `3` and compare with
-// KeyGeneration and basaed on the comparison we'll return bool to check if we should rotate the keys or not and returning list
+// KeyGeneration and based on the comparison we'll return bool to check if we should rotate the keys or not and returning list
 // of all the matching keys.
 func getCsiKeyRotationInfo(context *clusterd.Context, clusterInfo *client.ClusterInfo, keyBaseName string) (int, []string, error) {
 	authList, err := client.AuthList(context, clusterInfo)

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -143,7 +143,7 @@ func (v *CephVersion) Supported() bool {
 	return slices.ContainsFunc(supportedVersions, v.isRelease)
 }
 
-// Unsupported checks if a given release is supported
+// Unsupported checks if a given release is not supported
 func (v *CephVersion) Unsupported() bool {
 	return slices.ContainsFunc(unsupportedVersions, v.isExactly)
 }


### PR DESCRIPTION
## What this PR does

This PR fixes three minor issues found during code review:

1. **`pkg/operator/ceph/controller/network.go:429`** - Fixed typo `tme` → `time`
2. **`pkg/operator/ceph/csi/secrets.go:344`** - Fixed typo `basaed` → `based`
3. **`pkg/operator/ceph/version/version.go:146`** - Fixed misleading doc comment that said "is supported" for the `Unsupported()` method (should be "is not supported")

## How to verify

- Review each file change to confirm the corrections are accurate
- Run tests: `make test` (no code logic changed, only documentation fixes)

Signed-off-by: Akanksha Trehan <akankshatrehun@gmail.com>