### PR TITLE
object: option to update rgw caps with account

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -64,6 +64,8 @@ spec:
     * `user-policy`
     * `odic-provider`
     * `ratelimit`
+    * `userInfoWithoutKeys` # minimum ceph version 19.2.0 for supporting this cap
+    * `accounts` # minimum ceph version 19.2.3 for supporting this cap
 * `opMask`: Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported:
     * `read`
     * `write`

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -12943,6 +12943,32 @@ string
 <p>Add capabilities for user to set rate limiter for user and bucket. Documented in <a href="https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities">https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>userInfoWithoutKeys</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Add capabilities for user to fetch user info without keys. Documented in <a href="https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities">https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities</a>
+Note: Only supported from Ceph Squid (v19.2.0) onwards</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accounts</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Add capabilities for user to manage accounts. Documented in <a href="https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities">https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities</a>
+Note: Only supported from Ceph Squid (v19.2.3) onwards</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ObjectUserKey">ObjectUserKey

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -15203,6 +15203,16 @@ spec:
                   description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
+                    accounts:
+                      description: |-
+                        Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.3) onwards
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
                     amz-cache:
                       description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api
                       enum:
@@ -15309,6 +15319,16 @@ spec:
                       type: string
                     user-policy:
                       description: Add capabilities for user to change user policies. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
+                    userInfoWithoutKeys:
+                      description: |-
+                        Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.0) onwards
                       enum:
                         - '*'
                         - read

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -15191,6 +15191,16 @@ spec:
                   description: Additional admin-level capabilities for the Ceph object store user
                   nullable: true
                   properties:
+                    accounts:
+                      description: |-
+                        Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.3) onwards
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
                     amz-cache:
                       description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api
                       enum:
@@ -15297,6 +15307,16 @@ spec:
                       type: string
                     user-policy:
                       description: Add capabilities for user to change user policies. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                      enum:
+                        - '*'
+                        - read
+                        - write
+                        - read, write
+                      type: string
+                    userInfoWithoutKeys:
+                      description: |-
+                        Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+                        Note: Only supported from Ceph Squid (v19.2.0) onwards
                       enum:
                         - '*'
                         - read

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2484,6 +2484,16 @@ type ObjectUserCapSpec struct {
 	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
 	// Add capabilities for user to set rate limiter for user and bucket. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
 	RateLimit string `json:"ratelimit,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
+	// Add capabilities for user to fetch user info without keys. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+	// Note: Only supported from Ceph Squid (v19.2.0) onwards
+	UserInfoWithoutKeys string `json:"userInfoWithoutKeys,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Enum={"*","read","write","read, write"}
+	// Add capabilities for user to manage accounts. Documented in https://docs.ceph.com/en/latest/radosgw/admin/?#add-remove-admin-capabilities
+	// Note: Only supported from Ceph Squid (v19.2.3) onwards
+	Accounts string `json:"accounts,omitempty"`
 }
 
 // ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -49,10 +49,12 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	opmask "github.com/rook/rook/pkg/operator/ceph/object/user/opmask"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/log"
 )
@@ -65,6 +67,11 @@ const (
 // iamDisplayNamePattern is the pattern that must match for account users.
 // Account users are referenced by display name in IAM policy ARNs, so the name must be IAM-compatible.
 var iamDisplayNamePattern = regexp.MustCompile(`^[\w+=,.@-]+$`)
+
+var (
+	userInfoWithoutKeysMinCephVersion = cephver.CephVersion{Major: 19, Minor: 2, Extra: 0}
+	accountsMinCephVersion            = cephver.CephVersion{Major: 19, Minor: 2, Extra: 3}
+)
 
 // newMultisiteAdminOpsCtxFunc help us mocking the admin ops API client in unit test
 var newMultisiteAdminOpsCtxFunc = object.NewMultisiteAdminOpsContext
@@ -298,6 +305,12 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, *cephObjectStoreUser, errors.Wrap(err, "failed to populate cluster info")
 	}
 
+	runningCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.MonType)
+	if err != nil {
+		return reconcile.Result{}, *cephObjectStoreUser, errors.Wrapf(err, "failed to retrieve current ceph %q version", config.MonType)
+	}
+	r.clusterInfo.CephVersion = runningCephVersion
+
 	// Validate the object store has been initialized
 	err = r.initializeObjectStoreContext(cephObjectStoreUser)
 	if err != nil {
@@ -341,7 +354,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	// CR is not deleted, continue reconciling
 
 	// Generate user config
-	userConfig, err := generateUserConfig(cephObjectStoreUser)
+	userConfig, err := generateUserConfig(cephObjectStoreUser, r.clusterInfo.CephVersion)
 	if err != nil {
 		return reconcile.Result{}, *cephObjectStoreUser, errors.Wrapf(err, "failed to generate user config for %q", cephObjectStoreUser.Name)
 	}
@@ -554,7 +567,7 @@ func generateUserCaps(user *admin.User) string {
 	return caps
 }
 
-func generateUserConfig(user *cephv1.CephObjectStoreUser) (*admin.User, error) {
+func generateUserConfig(user *cephv1.CephObjectStoreUser, cephVersion cephver.CephVersion) (*admin.User, error) {
 	// Set DisplayName to match Name if DisplayName is not set
 	displayName := user.Spec.DisplayName
 	if len(displayName) == 0 {
@@ -622,6 +635,24 @@ func generateUserConfig(user *cephv1.CephObjectStoreUser) (*admin.User, error) {
 		}
 		if user.Spec.Capabilities.RateLimit != "" {
 			userConfig.UserCaps += fmt.Sprintf("ratelimit=%s;", user.Spec.Capabilities.RateLimit)
+		}
+		if user.Spec.Capabilities.UserInfoWithoutKeys != "" {
+			if !cephVersion.IsAtLeast(userInfoWithoutKeysMinCephVersion) {
+				log.NamedWarning(opcontroller.NsName(user.Namespace, user.Name), logger,
+					"capability user-info-without-keys requires Ceph %s or higher, but cluster is running %s",
+					userInfoWithoutKeysMinCephVersion.String(), cephVersion.String())
+			} else {
+				userConfig.UserCaps += fmt.Sprintf("user-info-without-keys=%s;", user.Spec.Capabilities.UserInfoWithoutKeys)
+			}
+		}
+		if user.Spec.Capabilities.Accounts != "" {
+			if !cephVersion.IsAtLeast(accountsMinCephVersion) {
+				log.NamedWarning(opcontroller.NsName(user.Namespace, user.Name), logger,
+					"capability accounts requires Ceph %s or higher, but cluster is running %s",
+					accountsMinCephVersion.String(), cephVersion.String())
+			} else {
+				userConfig.UserCaps += fmt.Sprintf("accounts=%s;", user.Spec.Capabilities.Accounts)
+			}
 		}
 	}
 

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/rook/rook/pkg/clusterd"
 	cephobject "github.com/rook/rook/pkg/operator/ceph/object"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,7 +95,8 @@ const (
 	"type": "rgw",
 	"mfa_ids": []
 }`
-	userCapsJSON = `[{"type":"users","perm":"read"}]`
+	userCapsJSON        = `[{"type":"users","perm":"read"}]`
+	cephMonVersionsJSON = `{"mon":{"ceph version 19.2.0 (3a54b2b6d167d4a2a19e003a705696) squid (stable)":1}}`
 )
 
 var (
@@ -134,6 +136,9 @@ func TestCephObjectStoreUserController(t *testing.T) {
 
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if args[0] == "versions" {
+				return cephMonVersionsJSON, nil
+			}
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -222,6 +227,9 @@ func TestCephObjectStoreUserController(t *testing.T) {
 
 		executor = &exectest.MockExecutor{
 			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				if args[0] == "versions" {
+					return cephMonVersionsJSON, nil
+				}
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}
@@ -516,7 +524,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 
 	t.Run("user without any Quotas or Capabilities", func(t *testing.T) {
 		objectUser.Name = name
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
@@ -524,7 +532,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 
 	t.Run("setting MaxBuckets for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxBuckets: &maxbucket}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
@@ -538,7 +546,7 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 			Roles:  "*",
 			Info:   "read, write",
 		}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
@@ -548,35 +556,35 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 	t.Run("setting MaxObjects for the user", func(t *testing.T) {
 		objectUser.Spec.Capabilities = nil
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxObjects: &maxobject}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("setting MaxSize for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxSize: &maxsize}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("resetting MaxSize and MaxObjects for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = nil
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("setting both MaxSize and MaxObjects for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxObjects: &maxobject, MaxSize: &maxsize}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
 	})
 	t.Run("resetting MaxSize and MaxObjects again for the user", func(t *testing.T) {
 		objectUser.Spec.Quotas = nil
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
@@ -590,10 +598,55 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 			Info:   "read, write",
 		}
 		objectUser.Spec.Quotas = &cephv1.ObjectUserQuotaSpec{MaxBuckets: &maxbucket, MaxObjects: &maxobject, MaxSize: &maxsize}
-		userConfig, err := generateUserConfig(objectUser)
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
 		require.NoError(t, err)
 		err = r.createOrUpdateCephUser(objectUser, userConfig)
 		assert.NoError(t, err)
+	})
+}
+
+func TestGenerateUserConfigCephVersionChecks(t *testing.T) {
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-user", Namespace: namespace},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store: store,
+		},
+	}
+
+	t.Run("user-info-without-keys skipped on Ceph older than v19.2.0", func(t *testing.T) {
+		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
+			UserInfoWithoutKeys: "read",
+		}
+		userConfig, err := generateUserConfig(objectUser, cephver.CephVersion{Major: 19, Minor: 1, Extra: 0})
+		assert.NoError(t, err)
+		assert.NotContains(t, userConfig.UserCaps, "user-info-without-keys=read;")
+	})
+
+	t.Run("user-info-without-keys allowed on Ceph v19.2.0", func(t *testing.T) {
+		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
+			UserInfoWithoutKeys: "write",
+		}
+		userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
+		assert.NoError(t, err)
+		assert.Contains(t, userConfig.UserCaps, "user-info-without-keys=write;")
+	})
+
+	t.Run("accounts skipped on Ceph older than v19.2.3", func(t *testing.T) {
+		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
+			Accounts: "*",
+		}
+		userConfig, err := generateUserConfig(objectUser, cephver.CephVersion{Major: 19, Minor: 2, Extra: 2})
+		assert.NoError(t, err)
+		assert.NotContains(t, userConfig.UserCaps, "accounts=*;")
+	})
+
+	t.Run("accounts allowed on Ceph v19.2.3", func(t *testing.T) {
+		objectUser.Spec.Capabilities = &cephv1.ObjectUserCapSpec{
+			Accounts: "*",
+		}
+		userConfig, err := generateUserConfig(objectUser, accountsMinCephVersion)
+		assert.NoError(t, err)
+		assert.Contains(t, userConfig.UserCaps, "accounts=*;")
 	})
 }
 


### PR DESCRIPTION
this commit add support for updating rgw caps with `user-info-without-key` and `accounts` to cephobjectstoreuser crd Adding the check for min ceph version from which these caps are available.

Co-Authoured-by:  Jiffin Tony Thottan <thottanjiffin@gmail.com>
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
