### PR TITLE
test: tag the shared store fixture pools with the rgw application

### DIFF
--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -240,6 +240,10 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 			Spec: cephv1.NamedBlockPoolSpec{
 				Name: v,
 				PoolSpec: cephv1.PoolSpec{
+					// These are rgw backing pools. Without an explicit application
+					// the operator defaults a CephBlockPool to "rbd" and runs
+					// `rbd pool init` on it, which misrepresents the store's pools.
+					Application: "rgw",
 					Replicated: cephv1.ReplicatedSpec{
 						Size:                   1,
 						RequireSafeReplicaSize: false,


### PR DESCRIPTION
### What changed

The `sharedstore` test fixture creates its RGW backing pools as `CephBlockPool`s without an `application`, so the operator defaults them to `rbd` and runs `rbd pool init` on them — only `.rgw.root` is special-cased to `rgw`. This sets `application: rgw` on every fixture pool so the store's backing pools carry representative metadata, matching `deploy/examples/object-shared-pools-test.yaml`.

The fixture is shared by the object suite, the smoke suite, and the (pending) upgrade suite; all three benefit.

### AI assistance

This was surfaced by an adversarial Codex review of the upgrade-suite conversion (#17936), which flagged that the fixture's pools carried `rbd` rather than `rgw` application metadata. Claude verified the operator's defaulting behavior and the canonical shared-pool manifest, and made the fix.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
